### PR TITLE
Use Visual Studio for debugging Linux headless vm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ pharo
 pharo-local/
 pharo-ui
 pharo-vm/
+/.vs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,27 +201,36 @@ check_library_exists(uuid uuid_generate "" HAVE_UUID_GENERATE)
 
 set(FLAVOUR CoInterpreterWithQueueFFI)
 
+# For reproducability and simplified caching, explicitly declare which image & VM are used to generate sources
+set(STABLE_BUILD_IMAGE     "Pharo7.0-SNAPSHOT-64bit-ccd1f64.image")
+set(STABLE_BUILD_IMAGE_ZIP "Pharo7.0-SNAPSHOT.build.166.sha.ccd1f64.arch.64bit.zip")
+if(UNIX)
+	set(STABLE_BUILD_VM_ZIP "pharo-linux-x86_64threaded-201901051900-7a3c6b6.zip")
+endif()
+
 #Custom command that downloads a Pharo image and VM in ${VMMAKER_OUTPUT_PATH}
 add_custom_command(
-  OUTPUT ${VMMAKER_OUTPUT_PATH}/Pharo.image ${VMMAKER_OUTPUT_PATH}/pharo
-  COMMAND wget -O - get.pharo.org/64/70 | bash
-  COMMAND wget -O - get.pharo.org/64/vm70 | bash
+  OUTPUT ${VMMAKER_OUTPUT_PATH}/${STABLE_BUILD_IMAGE}  ${VMMAKER_OUTPUT_PATH}/pharo
+  COMMAND wget --no-clobber -O /tmp/${STABLE_BUILD_IMAGE_ZIP} files.pharo.org/image/70/${STABLE_BUILD_IMAGE_ZIP} || true
+  COMMAND wget --no-clobber -O /tmp/${STABLE_BUILD_VM_ZIP} files.pharo.org/vm/pharo-spur64/linux/${STABLE_BUILD_VM_ZIP} || true
+  COMMAND unzip -o -d . /tmp/${STABLE_BUILD_IMAGE_ZIP} 
+  COMMAND unzip -o -d . /tmp/${STABLE_BUILD_VM_ZIP}   
   WORKING_DIRECTORY ${VMMAKER_OUTPUT_PATH}
   COMMENT "Downloading Pharo 70")
 
 add_custom_command(
   OUTPUT ${VMMAKER_OUTPUT_PATH}/VMMaker.image
-  COMMAND ./pharo Pharo.image --save --quit ${CMAKE_CURRENT_SOURCE_DIR_TO_OUT}/scripts/installVMMaker.st ${CMAKE_CURRENT_SOURCE_DIR_TO_OUT}
-  COMMAND ./pharo Pharo.image save VMMaker --delete-old
-  MAIN_DEPENDENCY ${VMMAKER_OUTPUT_PATH}/Pharo.image
-  DEPENDS ${VMMAKER_OUTPUT_PATH}/Pharo.image
+  COMMAND ./pharo -nodisplay ${STABLE_BUILD_IMAGE} --save --quit ${CMAKE_CURRENT_SOURCE_DIR_TO_OUT}/scripts/installVMMaker.st ${CMAKE_CURRENT_SOURCE_DIR_TO_OUT}
+  COMMAND ./pharo -nodisplay ${STABLE_BUILD_IMAGE} save VMMaker --delete-old
+  MAIN_DEPENDENCY ${VMMAKER_OUTPUT_PATH}/${STABLE_BUILD_IMAGE}
+  DEPENDS ${VMMAKER_OUTPUT_PATH}/${STABLE_BUILD_IMAGE}
   WORKING_DIRECTORY ${VMMAKER_OUTPUT_PATH}
-COMMENT "Generating VMMaker image")
+  COMMENT "Generating VMMaker image")
 
 #Custom command that generates the vm source code from VMMaker into ${VMMAKER_OUTPUT_PATH} and copies it to ${CMAKE_CURRENT_SOURCE_DIR}
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/generated/vm/src/cogit.c ${CMAKE_CURRENT_BINARY_DIR}/generated/vm/src/gcc3x-cointerp.c
-  COMMAND ${VMMAKER_OUTPUT_PATH}/pharo ${VMMAKER_OUTPUT_PATH}/VMMaker.image eval \"PharoVMMaker generate: \#\'${FLAVOUR}\' outputDirectory: \'${CMAKE_CURRENT_BINARY_DIR_TO_OUT}\'\"
+  COMMAND ${VMMAKER_OUTPUT_PATH}/pharo -nodisplay ${VMMAKER_OUTPUT_PATH}/VMMaker.image eval \"PharoVMMaker generate: \#\'${FLAVOUR}\' outputDirectory: \'${CMAKE_CURRENT_BINARY_DIR_TO_OUT}\'\"
   MAIN_DEPENDENCY ${VMMAKER_OUTPUT_PATH}/VMMaker.image
   COMMENT "Generating VM files for flavour: ${FLAVOUR}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,28 +202,29 @@ check_library_exists(uuid uuid_generate "" HAVE_UUID_GENERATE)
 set(FLAVOUR CoInterpreterWithQueueFFI)
 
 # For reproducability and simplified caching, explicitly declare which image & VM are used to generate sources
-set(STABLE_BUILD_IMAGE     "Pharo7.0-SNAPSHOT-64bit-ccd1f64.image")
-set(STABLE_BUILD_IMAGE_ZIP "Pharo7.0-SNAPSHOT.build.166.sha.ccd1f64.arch.64bit.zip")
+set(DOWNLOAD_CACHE /tmp)
+set(BUILDER_IMAGE     "Pharo7.0-SNAPSHOT-64bit-ccd1f64.image")
+set(BUILDER_IMAGE_ZIP "Pharo7.0-SNAPSHOT.build.166.sha.ccd1f64.arch.64bit.zip")
 if(UNIX)
-	set(STABLE_BUILD_VM_ZIP "pharo-linux-x86_64threaded-201901051900-7a3c6b6.zip")
+	set(BUILDER_VM_ZIP "pharo-linux-x86_64threaded-201901051900-7a3c6b6.zip")
 endif()
 
 #Custom command that downloads a Pharo image and VM in ${VMMAKER_OUTPUT_PATH}
 add_custom_command(
-  OUTPUT ${VMMAKER_OUTPUT_PATH}/${STABLE_BUILD_IMAGE}  ${VMMAKER_OUTPUT_PATH}/pharo
-  COMMAND wget --no-clobber -O /tmp/${STABLE_BUILD_IMAGE_ZIP} files.pharo.org/image/70/${STABLE_BUILD_IMAGE_ZIP} || true
-  COMMAND wget --no-clobber -O /tmp/${STABLE_BUILD_VM_ZIP} files.pharo.org/vm/pharo-spur64/linux/${STABLE_BUILD_VM_ZIP} || true
-  COMMAND unzip -o -d . /tmp/${STABLE_BUILD_IMAGE_ZIP} 
-  COMMAND unzip -o -d . /tmp/${STABLE_BUILD_VM_ZIP}   
+  OUTPUT ${VMMAKER_OUTPUT_PATH}/${BUILDER_IMAGE}  ${VMMAKER_OUTPUT_PATH}/pharo
+  COMMAND wget --no-clobber -O ${DOWNLOAD_CACHE}/${BUILDER_IMAGE_ZIP} files.pharo.org/image/70/${BUILDER_IMAGE_ZIP} || true
+  COMMAND wget --no-clobber -O ${DOWNLOAD_CACHE}/${BUILDER_VM_ZIP} files.pharo.org/vm/pharo-spur64/linux/${BUILDER_VM_ZIP} || true
+  COMMAND unzip -o -d . ${DOWNLOAD_CACHE}/${BUILDER_IMAGE_ZIP} 
+  COMMAND unzip -o -d . ${DOWNLOAD_CACHE}/${BUILDER_VM_ZIP}   
   WORKING_DIRECTORY ${VMMAKER_OUTPUT_PATH}
   COMMENT "Downloading Pharo 70")
 
 add_custom_command(
   OUTPUT ${VMMAKER_OUTPUT_PATH}/VMMaker.image
-  COMMAND ./pharo -nodisplay ${STABLE_BUILD_IMAGE} --save --quit ${CMAKE_CURRENT_SOURCE_DIR_TO_OUT}/scripts/installVMMaker.st ${CMAKE_CURRENT_SOURCE_DIR_TO_OUT}
-  COMMAND ./pharo -nodisplay ${STABLE_BUILD_IMAGE} save VMMaker --delete-old
-  MAIN_DEPENDENCY ${VMMAKER_OUTPUT_PATH}/${STABLE_BUILD_IMAGE}
-  DEPENDS ${VMMAKER_OUTPUT_PATH}/${STABLE_BUILD_IMAGE}
+  COMMAND ./pharo -nodisplay ${BUILDER_IMAGE} --save --quit ${CMAKE_CURRENT_SOURCE_DIR_TO_OUT}/scripts/installVMMaker.st ${CMAKE_CURRENT_SOURCE_DIR_TO_OUT}
+  COMMAND ./pharo -nodisplay ${BUILDER_IMAGE} save VMMaker --delete-old
+  MAIN_DEPENDENCY ${VMMAKER_OUTPUT_PATH}/${BUILDER_IMAGE}
+  DEPENDS ${VMMAKER_OUTPUT_PATH}/${BUILDER_IMAGE}
   WORKING_DIRECTORY ${VMMAKER_OUTPUT_PATH}
   COMMENT "Generating VMMaker image")
 

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -25,7 +25,8 @@
       "inheritEnvironments": [ "linux_x64" ],
       "wslPath": "C:\\Users\\Ben\\AppData\\Local\\Microsoft\\WindowsApps\\ubuntu1804.exe",
       "addressSanitizerRuntimeFlags": "detect_leaks=0",
-      "variables": []
+      "variables": [],
+      "intelliSenseMode": "linux-gcc-x64"
     }
   ]
 }

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,31 @@
+﻿{
+  "configurations": [
+    {
+      "name": "x64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": "",
+      "variables": []
+    },
+    {
+      "name": "WSL-Debug",
+      "generator": "Unix Makefiles",
+      "configurationType": "Debug",
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeExecutable": "/usr/bin/cmake",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "linux_x64" ],
+      "wslPath": "C:\\Users\\Ben\\AppData\\Local\\Microsoft\\WindowsApps\\ubuntu1804.exe",
+      "addressSanitizerRuntimeFlags": "detect_leaks=0",
+      "variables": []
+    }
+  ]
+}

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,18 +1,6 @@
 ﻿{
   "configurations": [
     {
-      "name": "x64-Debug",
-      "generator": "Ninja",
-      "configurationType": "Debug",
-      "inheritEnvironments": [ "msvc_x64_x64" ],
-      "buildRoot": "${projectDir}\\out\\build\\${name}",
-      "installRoot": "${projectDir}\\out\\install\\${name}",
-      "cmakeCommandArgs": "",
-      "buildCommandArgs": "-v",
-      "ctestCommandArgs": "",
-      "variables": []
-    },
-    {
       "name": "WSL-Debug",
       "generator": "Unix Makefiles",
       "configurationType": "Debug",

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -11,7 +11,7 @@
       "buildCommandArgs": "",
       "ctestCommandArgs": "",
       "inheritEnvironments": [ "linux_x64" ],
-      "wslPath": "C:\\Users\\Ben\\AppData\\Local\\Microsoft\\WindowsApps\\ubuntu1804.exe",
+      "wslPath": "${env.LOCALAPPDATA}\\Microsoft\\WindowsApps\\ubuntu1804.exe",
       "addressSanitizerRuntimeFlags": "detect_leaks=0",
       "variables": [],
       "intelliSenseMode": "linux-gcc-x64"

--- a/unix.cmake
+++ b/unix.cmake
@@ -39,7 +39,10 @@ endmacro()
 
 macro(configure_installables INSTALL_COMPONENT)
     set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_SOURCE_DIR}/build/dist")
-    
+
+	# Use RPATH so that "libPharoVMCore.so" can be found in current directory
+	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath='$ORIGIN'")
+
     install(
       DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/packaging/linux/"
       DESTINATION "./"


### PR DESCRIPTION
Visual Studio is a pretty good tool, and it integrates well with building and debugging on Linux boxes, with Windows Subsystem for Linux (this PR) and also apparently remote Linux (I haven't tried).  I believe it could also build/debug on remote OSX.  This opens the possibility of having multiple configuations for Windows, remote Linux, remote OSX and interactively switching between these to debug each one from the same Windows desktop.

More background...
http://forum.world.st/Debugging-Pharo-Headless-Linux-VM-using-Visual-Studio-running-on-Windows-td5102902.html

Also btw, Visual Studio has a "linux_arm" toolset that can be configured, so potentially could debug Pharo VM on a headless Raspberry Pi from the same Windows desktop.