### PR TITLE
Feature/stackvm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ endif()
 
 project(PharoVM)
 
+set(FLAVOUR CoInterpreterWithQueueFFI CACHE STRING "The kind of VM to generate. Possible values: StackVM, CogVM, CoInterpreterWithQueueFFI")
+
 # Configuration
 include(CheckIncludeFiles)
 include(CheckFunctionExists)
@@ -198,8 +200,6 @@ check_include_files(uuid/uuid.h HAVE_UUID_UUID_H)
 check_include_files(uuid.h HAVE_UUID_H)
 check_library_exists(uuid uuidgen "" HAVE_UUIDGEN)
 check_library_exists(uuid uuid_generate "" HAVE_UUID_GENERATE)
-
-set(FLAVOUR CoInterpreterWithQueueFFI)
 
 #Custom command that downloads a Pharo image and VM in ${VMMAKER_OUTPUT_PATH}
 add_custom_command(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,16 @@ project(PharoVM)
 
 set(FLAVOUR CoInterpreterWithQueueFFI CACHE STRING "The kind of VM to generate. Possible values: StackVM, CogVM, CoInterpreterWithQueueFFI")
 
+if(FLAVOUR MATCHES "StackVM")
+  set(VMSOURCEFILES ${CMAKE_CURRENT_BINARY_DIR}/generated/vm/src/gcc3x-interp.c)
+else()
+  set(VMSOURCEFILES ${CMAKE_CURRENT_BINARY_DIR}/generated/vm/src/cogit.c ${CMAKE_CURRENT_BINARY_DIR}/generated/vm/src/gcc3x-cointerp.c)
+endif()
+
+if(FLAVOUR MATCHES "CoInterpreterWithQueueFFI")
+  add_definitions(-DASYNC_FFI_QUEUE=1)
+endif()
+
 # Configuration
 include(CheckIncludeFiles)
 include(CheckFunctionExists)
@@ -120,6 +130,10 @@ set(CMAKE_CXX_FLAGS "-g ${COMMON_FLAGS} ${OPTIMIZATION_FLAGS} -DNDEBUG -DDEBUGVM
 add_definitions(-DIMMUTABILITY=1)
 add_definitions(-DCOGMTVM=0)
 add_definitions(-DPharoVM=1)
+
+#We require that VM_LABEL does nothing.
+#We should actually cleanup all the places where this is set/used in the VM
+add_definitions(-D"VM_LABEL\(foo\)=0")
 
 #
 # This definition is used to improve the logging of the messages, to cut-down the path
@@ -220,12 +234,10 @@ COMMENT "Generating VMMaker image")
 
 #Custom command that generates the vm source code from VMMaker into ${VMMAKER_OUTPUT_PATH} and copies it to ${CMAKE_CURRENT_SOURCE_DIR}
 add_custom_command(
-  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/generated/vm/src/cogit.c ${CMAKE_CURRENT_BINARY_DIR}/generated/vm/src/gcc3x-cointerp.c
+  OUTPUT ${VMSOURCEFILES}
   COMMAND ${VMMAKER_OUTPUT_PATH}/pharo ${VMMAKER_OUTPUT_PATH}/VMMaker.image eval \"PharoVMMaker generate: \#\'${FLAVOUR}\' outputDirectory: \'${CMAKE_CURRENT_BINARY_DIR_TO_OUT}\'\"
   MAIN_DEPENDENCY ${VMMAKER_OUTPUT_PATH}/VMMaker.image
   COMMENT "Generating VM files for flavour: ${FLAVOUR}")
-
-add_definitions(-DASYNC_FFI_QUEUE=1)
 
 #Generating config file
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/includes/config.h.in build/includes/config.h)
@@ -249,10 +261,7 @@ elseif(UNIX)
     include(unix.cmake)
 endif()
 
-set(GENERATED_SOURCES
-    ${CMAKE_CURRENT_BINARY_DIR}/generated/vm/src/cogit.c
-    ${CMAKE_CURRENT_BINARY_DIR}/generated/vm/src/gcc3x-cointerp.c
-)
+set(GENERATED_SOURCES ${VMSOURCEFILES})
 
 set(SUPPORT_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/src/debug.c

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ def runBuild(platform, configuration){
 	}
 }
 
-def runTests(platform, configuration){
+def runTests(platform, configuration, packages){
 	cleanWs()
 
 	stage("Tests-${platform}-${configuration}"){
@@ -79,15 +79,15 @@ def runTests(platform, configuration){
           
           if(isWindows()){
             runInCygwin "cd runTests && unzip ../build/build/packages/PharoVM-*-${vmDir}64-bin.zip -d ."
-            runInCygwin "PHARO_CI_TESTING_ENVIRONMENT=true cd runTests && ./PharoConsole.exe Pharo.image test --junit-xml-output --stage-name=win64-${configuration} '.*'"
+            runInCygwin "PHARO_CI_TESTING_ENVIRONMENT=true cd runTests && ./PharoConsole.exe Pharo.image test --junit-xml-output --stage-name=win64-${configuration} '${packages}'"
     	  }else{
             shell "unzip ../build/build/packages/PharoVM-*-${vmDir}64-bin.zip -d ."
 
             if(platform == 'osx'){
-              shell "PHARO_CI_TESTING_ENVIRONMENT=true ./Pharo.app/Contents/MacOS/Pharo Pharo.image test --junit-xml-output --stage-name=osx64-${configuration} '.*'"
+              shell "PHARO_CI_TESTING_ENVIRONMENT=true ./Pharo.app/Contents/MacOS/Pharo Pharo.image test --junit-xml-output --stage-name=osx64-${configuration} '${packages}'"
     		}			
             if(platform == 'unix'){
-              shell "PHARO_CI_TESTING_ENVIRONMENT=true ./pharo Pharo.image test --junit-xml-output --stage-name=unix64-${configuration} '.*'" 
+              shell "PHARO_CI_TESTING_ENVIRONMENT=true ./pharo Pharo.image test --junit-xml-output --stage-name=unix64-${configuration} '${packages}'" 
             }
     	  }
     		junit allowEmptyResults: true, testResults: "*.xml"
@@ -169,7 +169,7 @@ try{
 		tests[platform] = {
 			node(platform){
 				timeout(30){
-					runTests(platform, "CoInterpreterWithQueueFFI")
+					runTests(platform, "CoInterpreterWithQueueFFI", ".*")
 				}
 			}
 		}
@@ -184,8 +184,8 @@ try{
   }
   tests["StackVM"] = {
     node('osx'){
-      timeout(30){
-        runTests('osx', "StackVM")
+      timeout(40){
+        runTests('osx', "StackVM", "Kernel.*")
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ def runBuild(platform, configuration){
     }
 
 
-	stage("Build-${platform}"){
+	stage("Build-${platform}-${configuration}"){
     if(isWindows()){
       runInCygwin "mkdir build"
       runInCygwin "cd build && cmake -DFLAVOUR=${configuration} ../repository"

--- a/smalltalksrc/VMMaker/VMStructType.class.st
+++ b/smalltalksrc/VMMaker/VMStructType.class.st
@@ -284,52 +284,63 @@ VMStructType class >> offsetForInstVar: instVarName [
 { #category : #translation }
 VMStructType class >> printTypedefOn: aStream [
 	aStream nextPutAll: 'typedef struct '.
-	self needsTypeTag ifTrue:
-		[aStream nextPutAll: self structTagName; space].
-	aStream nextPut: ${; cr.
-	self instVarNamesAndTypesForTranslationDo:
-		[:ivn :typeArg| | type |
-		ivn first == $#
-			ifTrue: [aStream nextPutAll: ivn]
-			ifFalse:
-				[type := typeArg.
-				 #(BytesPerWord BaseHeaderSize BytesPerOop) do:
-					[:sizeConstant| | index sizeConstantSize |
-					(type notNil
-					and: [(index := type indexOf: sizeConstant ifAbsent: 0) > 0]) ifTrue:
-						[sizeConstantSize  := VMBasicConstants classPool at: sizeConstant.
-						type := (type at: index + 1) = sizeConstantSize ifTrue:
-									[type := type copyReplaceFrom: index to: index + 1 with: #().
-									 type size = 1 ifTrue: [type first] ifFalse: [type]]]].
-				 type ifNotNil:
-					[type isArray
-						ifTrue:
-							[aStream tab: 1.
-							 aStream nextPutAll: type first.
-							 (type first last isSeparator or: [type first last = $*]) ifFalse:
-								[aStream tab: 2].
-							 aStream nextPutAll: ivn.
-							 type last first isSeparator ifFalse:
-								[aStream space].
-							 aStream nextPutAll: type last]
-						ifFalse:
-							[aStream tab: 1.
-							 aStream nextPutAll: type.
-							 (type last isSeparator or: [type last = $*]) ifFalse:
-								[aStream tab: 1].
-							 aStream nextPutAll: ivn]].
-				 aStream nextPut: $;].
-		 aStream cr].
+	self needsTypeTag
+		ifTrue: [ aStream
+				nextPutAll: self structTagName;
+				space ].
+	aStream
+		nextPut: ${;
+		cr.
+	self
+		instVarNamesAndTypesForTranslationDo: [ :ivn :typeArg | 
+			| type |
+			ivn first == $#
+				ifTrue: [ aStream nextPutAll: ivn ]
+				ifFalse: [ type := typeArg.
+					#(BytesPerWord BaseHeaderSize BytesPerOop)
+						do: [ :sizeConstant | 
+							| index sizeConstantSize |
+							(type notNil
+								and: [ (index := type indexOf: sizeConstant ifAbsent: 0) > 0 ])
+								ifTrue: [ sizeConstantSize := VMBasicConstants classPool at: sizeConstant.
+									type := (type at: index + 1) = sizeConstantSize
+										ifTrue: [ type := type copyReplaceFrom: index to: index + 1 with: #().
+											type size = 1
+												ifTrue: [ type first ]
+												ifFalse: [ type ] ] ] ].
+					type
+						ifNotNil: [ type isArray
+								ifTrue: [ aStream tab: 1.
+									aStream nextPutAll: type first.
+									(type first last isSeparator or: [ type first last = $* ])
+										ifFalse: [ aStream tab: 2 ].
+									aStream nextPutAll: ivn.
+									type last first isSeparator
+										ifFalse: [ aStream space ].
+									aStream nextPutAll: type last ]
+								ifFalse: [ aStream tab: 1.
+									aStream nextPutAll: type.
+									(type last isSeparator or: [ type last = $* ])
+										ifFalse: [ aStream tab: 1 ].
+									aStream nextPutAll: ivn ] ].
+					aStream nextPut: $; ].
+			aStream cr ].
 	aStream
 		nextPutAll: ' } ';
 		nextPutAll: self structTypeName;
 		nextPut: $;;
 		cr.
-	self name ~= self structTypeName ifTrue:
-		[(self withAllSuperclasses copyUpThrough: (self class whichClassIncludesSelector: #structTypeName) theNonMetaClass) do:
-			[:structClass|
-			 aStream cr; nextPutAll: '#define '; nextPutAll: structClass name; space; nextPutAll: self structTypeName].
-		 aStream cr].
+	self name ~= self structTypeName
+		ifTrue: [ (self withAllSuperclasses
+				copyUpThrough: (self class whichClassIncludesSelector: #structTypeName) instanceSide)
+				do: [ :structClass | 
+					aStream
+						cr;
+						nextPutAll: '#define ';
+						nextPutAll: structClass name;
+						space;
+						nextPutAll: self structTypeName ].
+			aStream cr ].
 	aStream flush
 ]
 

--- a/smalltalksrc/VMMakerCompatibilityForPharo6/MockEmptyVMStruct.class.st
+++ b/smalltalksrc/VMMakerCompatibilityForPharo6/MockEmptyVMStruct.class.st
@@ -1,0 +1,14 @@
+"
+I am a mock empty struct used for testing purposes
+"
+Class {
+	#name : #MockEmptyVMStruct,
+	#superclass : #VMStructType,
+	#category : #'VMMakerCompatibilityForPharo6-Tests'
+}
+
+{ #category : #translation }
+MockEmptyVMStruct class >> instVarNamesAndTypesForTranslationDo: aBlockClosure [ 
+
+	"Do nothing, I have no instance variables"
+]

--- a/smalltalksrc/VMMakerCompatibilityForPharo6/MockEmptyVMStructWithRedefinedStructName.class.st
+++ b/smalltalksrc/VMMakerCompatibilityForPharo6/MockEmptyVMStructWithRedefinedStructName.class.st
@@ -1,0 +1,11 @@
+Class {
+	#name : #MockEmptyVMStructWithRedefinedStructName,
+	#superclass : #MockEmptyVMStruct,
+	#category : #'VMMakerCompatibilityForPharo6-Tests'
+}
+
+{ #category : #translation }
+MockEmptyVMStructWithRedefinedStructName class >> structTypeName [
+
+	^ 'RedefinedStruct'
+]

--- a/smalltalksrc/VMMakerCompatibilityForPharo6/PharoVMMaker.class.st
+++ b/smalltalksrc/VMMakerCompatibilityForPharo6/PharoVMMaker.class.st
@@ -88,6 +88,27 @@ PharoVMMaker >> generateCoInterpreterWithQueueFFI [
 		including: #() ] valueSupplyingAnswer:true.
 ]
 
+{ #category : #generation }
+PharoVMMaker >> generateStackVM [
+
+	| interpreterClass | 
+
+	VMMaker initializeForPharo.
+	interpreterClass := StackInterpreter.
+	(interpreterClass bindingOf: #COGMTVM) value: false.
+
+	[ VMMaker
+		generateMainVM: interpreterClass
+		and: StackToRegisterMappingCogit
+		with: #(COGMTVM false
+				ObjectMemory Spur64BitMemoryManager
+				MULTIPLEBYTECODESETS true
+				bytecodeTableInitializer initializeBytecodeTableForSqueakV3PlusClosuresSistaV1Hybrid)
+		to: self outputDirectory / 'generated'
+		platformDir: self outputDirectory / 'generated'
+		including: #() ] valueSupplyingAnswer:true.
+]
+
 { #category : #accessing }
 PharoVMMaker >> outputDirectory [
 	^ outputDirectory

--- a/smalltalksrc/VMMakerCompatibilityForPharo6/VMCodeGenerationTest.class.st
+++ b/smalltalksrc/VMMakerCompatibilityForPharo6/VMCodeGenerationTest.class.st
@@ -129,6 +129,30 @@ else {
 ]
 
 { #category : #tests }
+VMCodeGenerationTest >> testEmptyStructTypeDef [
+
+	| typedef |
+	typedef := String streamContents: [:str | MockEmptyVMStruct printTypedefOn: str ].
+	self
+		assert: typedef trimBoth
+		equals: 'typedef struct {
+ } MockEmptyVMStruct;' trimBoth
+]
+
+{ #category : #tests }
+VMCodeGenerationTest >> testEmptyStructWithRedefinedStructNameTypeDef [
+
+	| typedef |
+	typedef := String streamContents: [:str | MockEmptyVMStructWithRedefinedStructName printTypedefOn: str ].
+	self
+		assert: typedef trimBoth
+		equals: 'typedef struct {
+ } RedefinedStruct;
+
+#define MockEmptyVMStructWithRedefinedStructName RedefinedStruct' trimBoth
+]
+
+{ #category : #tests }
 VMCodeGenerationTest >> testLoopVariableIsTemp [
 
 	| translation method codeGenerator result |

--- a/src/utils.c
+++ b/src/utils.c
@@ -374,6 +374,7 @@ void bzero(void *s, size_t n){
 }
 #endif
 
+#ifdef COGVM
 /*
  * Cog has already captured CStackPointer  before calling this routine.  Record
  * the original value, capture the pointers again and determine if CFramePointer
@@ -393,6 +394,7 @@ isCFramePointerInUse()
 	assert(CStackPointer < currentCSP);
 	return CFramePointer >= CStackPointer && CFramePointer <= currentCSP;
 }
+#endif // COGVM
 
 /* Answer an approximation of the size of the redzone (if any).  Do so by
  * sending a signal to the process and computing the difference between the


### PR DESCRIPTION
Make flavour configurable by doing:

```bash
$ cmake -DFLAVOUR=StackVM .
```

- Add Struct typedef generation tests to avoid warnings (see changes in VMMakerCompat)
- source files to compile depend on the flavour of the VM (see changes in CMakeLists.txt)
- scope cog dependant functions to cog builds (see changes in utils.c)
- make stackvm build and test in CI (see changes in JenkinsFile)