### PR TITLE
Add FreeBSD compatibility to the shell script wrapper.

### DIFF
--- a/platforms/unix/config/bin.squeak.sh.in
+++ b/platforms/unix/config/bin.squeak.sh.in
@@ -18,7 +18,7 @@ case "$BIN" in
 *) PLUGINS="`pwd`/$BIN"
 esac
 
-if [ $(uname -s) = "OpenBSD" ]; then
+if [ $(uname -s) = "OpenBSD" ] || [ $(uname -s) = "FreeBSD" ]; then
   LD_LIBRARY_PATH="$PLUGINS:${LD_LIBRARY_PATH}" exec $GDB "$BIN/squeak" "$@"
 fi
 

--- a/platforms/unix/config/squeak.sh.in
+++ b/platforms/unix/config/squeak.sh.in
@@ -18,7 +18,7 @@ case "$BIN" in
 *) PLUGINS="`pwd`/$BIN"
 esac
 
-if [ $(uname -s) = "OpenBSD" ]; then
+if [ $(uname -s) = "OpenBSD" ] || [ $(uname -s) = "FreeBSD" ]; then
   LD_LIBRARY_PATH="$PLUGINS:${LD_LIBRARY_PATH}" exec $GDB "$BIN/squeak" "$@"
 fi
 


### PR DESCRIPTION
This PR makes it possible to run the Linux distributions in a FreeBSD system with Linux compatibility enabled and all the required libraries installed.
Since FreeBSD supports Linux binary compatibility, it is possible to use Pharo on FreeBSD, provided the required linux-compat libraries are properly installed.
After a few weeks of use, the only incompatibility I have found is within the shell script wrapper. The same change as the one introduced for OpenBSD a few years ago solves this issue.
