### PR TITLE
Add the support for building the VM under GitHub actions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -1,0 +1,117 @@
+name: Continuous integration
+on: [push, pull_request]
+
+jobs:
+    build-unixes:
+        name: Build Unixes
+        runs-on: ${{ matrix.variant.os }}
+        strategy:
+            matrix:
+                variant:
+                    - os: ubuntu-18.04
+                      appname: Pharo
+                      vmExecutable: pharo
+                    - os: macos-latest
+                      appname: Pharo
+                      vmExecutable: Pharo
+        env:
+            APPNAME: ${{matrix.variant.appname}}
+            VM_EXECUTABLE_NAME: ${{ matrix.variant.vmExecutable }}
+            CC: clang
+            CXX: clang++
+        steps:
+            - name: Install dependencies
+              if: matrix.variant.os == 'ubuntu-18.04'
+              run: sudo apt-get install uuid-dev
+
+            - uses: actions/checkout@v1
+
+            - name: CMake configuration
+              run: |
+                mkdir -p build
+                cd build
+                cmake .. -DAPPNAME=$APPNAME -DVM_EXECUTABLE_NAME=$VM_EXECUTABLE_NAME
+
+            - name: make
+              run: cd build && make
+            - name: make install
+              run: cd build && make install
+
+            - name: Package artifacts
+              run: |
+                cd build
+                make package
+                mkdir -p ../artifacts
+                cp -f build/packages/*.zip build/packages/*.sha1 ../artifacts
+            - name: Upload artifacts
+              uses: actions/upload-artifact@v1
+              with:
+                  name: build-artifacts
+                  path: artifacts
+
+            - name: Run tests
+              continue-on-error: true
+              run: scripts/runTests.sh
+            - name: Upload test results
+              continue-on-error: true
+              uses: actions/upload-artifact@v1
+              with:
+                  name: test-results
+                  path: test-results
+
+    build-windows-cygwin:
+        name: Build Windows Cygwin
+        runs-on: windows-2016
+        strategy:
+            matrix:
+                variant:
+                    - appname: Pharo
+                      vmExecutable: Pharo
+        env:
+            APPNAME: ${{matrix.variant.appname}}
+            VM_EXECUTABLE_NAME: ${{ matrix.variant.vmExecutable }}
+        steps:
+            - uses: actions/checkout@v1
+
+            - name: Install Cygwin
+              run: .\scripts\installCygwin.ps1 "setup-x86_64.exe" x86_64
+
+            - name: CMake configuration
+              run: |
+                mkdir -p build
+                cd build
+                cmake .. -DAPPNAME=$APPNAME -DVM_EXECUTABLE_NAME=$VM_EXECUTABLE_NAME
+              shell: pwsh.exe -File .\scripts\runScriptInCygwinBash.ps1 {0}
+
+            - name: make
+              run: cd build && make
+              shell: pwsh.exe -File .\scripts\runScriptInCygwinBash.ps1 {0}
+            - name: make install
+              run: cd build && make install
+              shell: pwsh.exe -File .\scripts\runScriptInCygwinBash.ps1 {0}
+
+            - name: Package artifacts
+              run: |
+                cd build
+                make package
+                mkdir -p ../artifacts
+                cp -f build/packages/*.zip build/packages/*.sha1 ../artifacts
+              shell: pwsh.exe -File .\scripts\runScriptInCygwinBash.ps1 {0}
+
+            - name: Upload artifacts
+              uses: actions/upload-artifact@v1
+              with:
+                  name: build-artifacts
+                  path: artifacts
+
+            - name: Run tests
+              continue-on-error: true
+              run: scripts/runTests.sh
+              shell: pwsh.exe -File .\scripts\runScriptInCygwinBash.ps1 {0}
+
+            - name: Upload test results
+              continue-on-error: true
+              uses: actions/upload-artifact@v1
+              with:
+                  name: test-results
+                  path: test-results

--- a/scripts/installCygwin.ps1
+++ b/scripts/installCygwin.ps1
@@ -1,0 +1,27 @@
+# Stop on errors
+$ErrorActionPreference = 'stop'
+
+# Parse some arguments and set some variables.
+$installerName = $args[0]
+$cygwinArch = $args[1]
+$installerURL = "http://cygwin.com/$installerName"
+$cygwinRoot = 'c:\cygwin'
+$cygwinMirror ="http://cygwin.mirror.constant.com"
+
+# Download the cygwin installer.
+echo "Downloading the Cygwin installer from $installerURL"
+Invoke-WebRequest -UseBasicParsing -URI "$installerURL" -OutFile "$installerName"
+
+# Install cygwin and the required packages.
+echo "Installing Cygwin packages"
+& ".\$installerName" -dgnqNO -R "$cygwinRoot" -s "$cygwinMirror" -l "$cygwinRoot\var\cache\setup" `
+    -P make `
+    -P cmake `
+    -P zip `
+    -P mingw64-$cygwinArch-clang `
+    -P unzip `
+    -P wget `
+    -P git `
+    -P patch | Out-Null
+
+echo "Cygwin installed under $cygwinRoot"

--- a/scripts/runScriptInCygwinBash.ps1
+++ b/scripts/runScriptInCygwinBash.ps1
@@ -1,0 +1,30 @@
+# Stop on errors
+$ErrorActionPreference = 'stop'
+
+# The script name
+$scriptFileName = $args[0]
+$cygwinRoot = 'c:\cygwin'
+$bashExecutable ="$cygwinRoot\bin\bash.exe"
+
+# Create a modified version of the script.
+$scriptContent = Get-Content -Path $scriptFileName | Out-String
+$modifiedScriptFileName = "$(New-TemporaryFile).sh"
+$cygwinModifiedScriptFileName = & "$cygwinRoot\bin\cygpath.exe" "$modifiedScriptFileName"
+$cygwinCWD = & "$cygwinRoot\bin\cygpath.exe" (Get-Location)
+$modifiedScriptContent = "#!/bin/bash --login
+cd $cygwinCWD
+export PATH=`"/usr/local/bin:/usr/bin:/cygdrive/c/windows/system32:/cygdrive/c/windows/system32/Wbem`"
+set -ex
+
+$scriptContent
+".Replace("`r`n","`n")
+
+Out-File -Encoding ASCII -NoNewline -InputObject $modifiedScriptContent $modifiedScriptFileName
+
+# Run the modified script.
+& $bashExecutable $cygwinModifiedScriptFileName
+
+# Reflect the last exit code
+if ((Test-Path -LiteralPath variable:\LASTEXITCODE)) {
+    exit $LASTEXITCODE
+}

--- a/scripts/runTests.sh
+++ b/scripts/runTests.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+set -ex
+
+TEST_PACKAGES=".*"
+
+extract_archive()
+{
+    ARCHIVE=$1
+    case $ARCHIVE in
+    *.zip)
+        unzip $ARCHIVE -d .
+        ;;
+    *.*gz)
+        tar -xvvzf $ARCHIVE
+        ;;
+    *.*bz2)
+        tar -xvvjf $ARCHIVE
+        ;;
+    *)
+        echo "Extraction of VM archive $ARCHIVE is unsupported."
+        exit 1
+        ;;
+    esac
+}
+
+fetch_image()
+{
+    case $APPNAME in
+    *)
+        wget -O - https://get.pharo.org/64/80 | bash
+        echo 80 > pharo.version
+        TEST_IMAGE_NAME=$(ls Pharo*.image)
+        ;;
+    esac
+}
+
+
+case $(uname) in
+Linux)
+    TEST_VM_STAGE_NAME="unix64"
+    if test "$APPNAME" = ""; then
+        APPNAME="Pharo"
+        VM_EXECUTABLE_NAME="pharo"
+    fi
+    TEST_VM_EXECUTABLE="./$VM_EXECUTABLE_NAME"
+    VM_ARCHIVE=../artifacts/${APPNAME}VM-*-linux*-bin.zip
+    ;;
+Darwin)
+    TEST_VM_STAGE_NAME="osx"
+    if test "$APPNAME" = ""; then
+        APPNAME="Pharo"
+        VM_EXECUTABLE_NAME="Pharo"
+    fi
+    TEST_VM_EXECUTABLE="./$VM_EXECUTABLE_NAME.app/Contents/MacOS/$VM_EXECUTABLE_NAME"
+    VM_ARCHIVE=../artifacts/${APPNAME}VM-*-mac*-bin.zip
+    ;;
+CYGWIN*)
+    TEST_VM_STAGE_NAME="win64"
+    if test "$APPNAME" = ""; then
+        APPNAME="Pharo"
+        VM_EXECUTABLE_NAME="Pharo"
+    fi
+    TEST_VM_EXECUTABLE="./${VM_EXECUTABLE_NAME}Console"
+    VM_ARCHIVE=../artifacts/${APPNAME}VM-*-win*-bin.zip
+    ;;
+*)
+    echo "Unsupported operating system $(uname) for running tests"
+    exit 0
+    ;;
+esac
+
+mkdir -p runTests
+cd runTests
+
+# Fetch VM
+extract_archive $VM_ARCHIVE
+
+# Fetch the image
+fetch_image
+
+# Run the tests
+PHARO_CI_TESTING_ENVIRONMENT=true $TEST_VM_EXECUTABLE $TEST_IMAGE_NAME test --junit-xml-output --stage-name=$APPNAME-$TEST_VM_STAGE_NAME "$TEST_PACKAGES" || echo "Warning, some tests are failing"
+
+# Copy the test results.
+mkdir -p ../test-results
+cp *.xml ../test-results


### PR DESCRIPTION
This PR ports the infrastructure that is currently being used by GToolkit for building the VM (but only "customized" for building the Pharo VM). The problem with using Jenkins is on setting up the different building slaves for all the platforms, specially for OS X where there are few cloud providers with Mac based virtual machines. As a plus, this facilitates anyone who forks this repository to have its own CI infrastructure automatically under GitHub, and by modifying the build matrix in the .yaml file it facilitates the customization and branding of the VM.