### PR TITLE
Add support for customizing the OS X icons.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,18 +304,11 @@ addLibraryWithRPATH(${VM_LIBRARY_NAME} ${VM_SOURCES})
 
 #If in OSX, configure creation of Bundle
 if(OSX)
-  set_source_files_properties(
-    "${CMAKE_CURRENT_SOURCE_DIR}/resources/mac/Pharo.icns"
-    PROPERTIES
-    MACOSX_PACKAGE_LOCATION Resources
-  )
-
   set_target_properties(
     ${VM_EXECUTABLE_NAME}
     PROPERTIES
     MACOSX_BUNDLE YES
     MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/resources/mac/Info.plist.in"
-    RESOURCE "${CMAKE_CURRENT_SOURCE_DIR}/resources/mac/Pharo.icns"
   )
 endif()
 

--- a/osx.cmake
+++ b/osx.cmake
@@ -25,8 +25,22 @@ set(EXTRACTED_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/memoryUnix.c
 )
 
+set_source_files_properties(
+  "${CMAKE_CURRENT_SOURCE_DIR}/resources/mac/${APPNAME}.icns"
+  "${CMAKE_CURRENT_SOURCE_DIR}/resources/mac/${APPNAME}Changes.icns"
+  "${CMAKE_CURRENT_SOURCE_DIR}/resources/mac/${APPNAME}Image.icns"
+  "${CMAKE_CURRENT_SOURCE_DIR}/resources/mac/${APPNAME}Sources.icns"
+  PROPERTIES
+  MACOSX_PACKAGE_LOCATION Resources
+)
+
 set(VM_FRONTEND_SOURCES
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/unixMain.c)
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/unixMain.c
+    "${CMAKE_CURRENT_SOURCE_DIR}/resources/mac/${APPNAME}.icns"
+    "${CMAKE_CURRENT_SOURCE_DIR}/resources/mac/${APPNAME}Changes.icns"
+    "${CMAKE_CURRENT_SOURCE_DIR}/resources/mac/${APPNAME}Image.icns"
+    "${CMAKE_CURRENT_SOURCE_DIR}/resources/mac/${APPNAME}Sources.icns"
+)
 
 configure_file(resources/mac/Info.plist.in build/includes/Info.plist)
 

--- a/resources/mac/Info.plist.in
+++ b/resources/mac/Info.plist.in
@@ -7,7 +7,7 @@
 	<key>CFBundleGetInfoString</key>
 	<string>@APPNAME@ VM</string>
 	<key>CFBundleIconFile</key>
-	<string>Pharo.icns</string>
+	<string>@APPNAME@.icns</string>
 	<key>CFBundleIdentifier</key>
 	<string>org.pharo.vm</string>
 	<key>CFBundleInfoDictionaryVersion</key>
@@ -34,7 +34,7 @@
 				<string>image</string>
 			</array>
 			<key>CFBundleTypeIconFile</key>
-			<string>Pharo.icns</string>
+			<string>@APPNAME@.icns</string>
 			<key>CFBundleTypeName</key>
 			<string>@APPNAME@ Image File</string>
 			<key>CFBundleTypeOSTypes</key>
@@ -50,9 +50,9 @@
 				<string>sources</string>
 			</array>
 			<key>CFBundleTypeIconFile</key>
-			<string>PharoSources.icns</string>
+			<string>@APPNAME@Sources.icns</string>
 			<key>CFBundleTypeName</key>
-			<string>Squeak Sources File</string>
+			<string>@APPNAME@ Sources File</string>
 			<key>CFBundleTypeOSTypes</key>
 			<array>
 				<string>STso</string>
@@ -66,9 +66,9 @@
 				<string>changes</string>
 			</array>
 			<key>CFBundleTypeIconFile</key>
-			<string>PharoChanges.icns</string>
+			<string>@APPNAME@Changes.icns</string>
 			<key>CFBundleTypeName</key>
-			<string>Squeak Changes File</string>
+			<string>@APPNAME@ Changes File</string>
 			<key>CFBundleTypeOSTypes</key>
 			<array>
 				<string>STch</string>


### PR DESCRIPTION
1.- This commit fixes the specification of the OS X application icons by adding them to the actual sources.
2.- This also allows to customize which icons can be used by using the APPNAME cmake variable.