### PR TITLE
Bug fix: typo in the OS X file open dialog.

### DIFF
--- a/src/fileDialogMac.m
+++ b/src/fileDialogMac.m
@@ -44,7 +44,7 @@ vm_file_dialog_run_modal_open(VMFileDialog *dialog)
             {
                 dialog->succeeded = true;
                 dialog->selectedFileName = strdup([url.path UTF8String]);
-				break;
+                break;
             }
         }
     }

--- a/src/fileDialogMac.m
+++ b/src/fileDialogMac.m
@@ -42,8 +42,9 @@ vm_file_dialog_run_modal_open(VMFileDialog *dialog)
         {
             if([url isFileURL])
             {
-                dialog->succeeded = false;
+                dialog->succeeded = true;
                 dialog->selectedFileName = strdup([url.path UTF8String]);
+				break;
             }
         }
     }


### PR DESCRIPTION
Fix a typo in the OS X open file dialog abstraction which makes the dialog to always fail.