### PR TITLE
Remove pushOutputFile / popOutputFile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,7 @@ check_include_files(sys/ndir.h HAVE_SYS_NDIR_H)
 check_include_files(sys/dir.h HAVE_SYS_DIR_H)
 check_include_files(sys/filio.h HAVE_SYS_FILIO_H)
 check_include_files(sys/time.h HAVE_SYS_TIME_H)
+check_include_files(execinfo.h HAVE_EXECINFO_H)
 
 check_include_files(dlfcn.h HAVE_DLFCN_H)
 check_library_exists(dl dlopen "" HAVE_LIBDL)

--- a/include/pharovm/config.h.in
+++ b/include/pharovm/config.h.in
@@ -7,7 +7,7 @@
 #define VM_NAME "@VM_NAME@"
 #define DEFAULT_IMAGE_NAME "@DEFAULT_IMAGE_NAME@"
 
-/* Availabilit of Functions */
+/* Availability of Functions */
 
 #cmakedefine HAVE_DIRENT_H
 #cmakedefine HAVE_FEATURES_H
@@ -17,6 +17,7 @@
 #cmakedefine HAVE_SYS_DIR_H
 #cmakedefine HAVE_SYS_FILIO_H
 #cmakedefine HAVE_SYS_TIME_H
+#cmakedefine HAVE_EXECINFO_H
 
 #cmakedefine AVE_DLFCN_H
 #cmakedefine HAVE_LIBDL

--- a/include/pharovm/debug.h
+++ b/include/pharovm/debug.h
@@ -34,3 +34,6 @@ EXPORT(void) installErrorHandlers();
 #define logError(...)	logMessage(LOG_ERROR, __FILENAME__, __FUNCTION__, __LINE__, __VA_ARGS__)
 
 #define LOG_SIZEOF(expr) logDebug("sizeof("#expr"): %ld", sizeof(expr))
+
+int vm_printf( const char * format, ... );
+void vm_setVMOutputStream(FILE * stream);

--- a/packaging/linux/bin/launch.sh.in
+++ b/packaging/linux/bin/launch.sh.in
@@ -26,8 +26,17 @@ fi
 # libc (e.g. through the FFI) then it must use the same version that the VM uses
 # and so it should take precedence over /lib libc.  This is done by setting
 # LD_LIBRARY_PATH appropriately, based on ldd's idea of the libc use by the VM.
+#Try extracting Libc
 LIBC_SO="`/usr/bin/ldd "$BIN/@VM_EXECUTABLE_NAME@" | /bin/fgrep /libc. | sed 's/^.*=> \([^ ]*\).*/\1/'`"
 PLATFORMLIBDIR=`expr "$LIBC_SO" : '\(.*\)/libc.*'`
+
+#If empty try extracting Musl
+if [ "$PLATFORMLIBDIR" = "" ]; then
+{
+	LIBC_SO="`/usr/bin/ldd "$BIN/@VM_EXECUTABLE_NAME@" | /bin/fgrep libc. | sed 's/^.*=> \([^ ]*\).*/\1/'`"
+	PLATFORMLIBDIR=`expr "$LIBC_SO" : '\(.*\)/ld-musl.*'`
+}
+fi
 
 if [ "$PLATFORMLIBDIR" = "" ]; then
 {

--- a/packaging/linux/launch.sh.in
+++ b/packaging/linux/launch.sh.in
@@ -26,8 +26,18 @@ fi
 # libc (e.g. through the FFI) then it must use the same version that the VM uses
 # and so it should take precedence over /lib libc.  This is done by setting
 # LD_LIBRARY_PATH appropriately, based on ldd's idea of the libc use by the VM.
+
+#Try extracting Libc
 LIBC_SO="`/usr/bin/ldd "$BIN/@VM_EXECUTABLE_NAME@" | /bin/fgrep /libc. | sed 's/^.*=> \([^ ]*\).*/\1/'`"
 PLATFORMLIBDIR=`expr "$LIBC_SO" : '\(.*\)/libc.*'`
+
+#If empty try extracting Musl
+if [ "$PLATFORMLIBDIR" = "" ]; then
+{
+	LIBC_SO="`/usr/bin/ldd "$BIN/@VM_EXECUTABLE_NAME@" | /bin/fgrep libc. | sed 's/^.*=> \([^ ]*\).*/\1/'`"
+	PLATFORMLIBDIR=`expr "$LIBC_SO" : '\(.*\)/ld-musl.*'`
+}
+fi
 
 if [ "$PLATFORMLIBDIR" = "" ]; then
 {

--- a/smalltalksrc/VMMaker/CoInterpreter.class.st
+++ b/smalltalksrc/VMMaker/CoInterpreter.class.st
@@ -6600,7 +6600,7 @@ CoInterpreter >> printMethodCacheFor: thing [
 			 self cCode: [] inSmalltalk: [self transcript ensureCr].
 			 self printNum: i; space; printHexnp: i; cr; tab.
 			 (objectMemory isBytesNonImm: s)
-				ifTrue: [self cCode: 'printf("%" PRIxSQPTR " %.*s\n", s, (int)(numBytesOf(s)), (char *)firstIndexableField(s))'
+				ifTrue: [self cCode: 'vm_printf("%" PRIxSQPTR " %.*s\n", s, (int)(numBytesOf(s)), (char *)firstIndexableField(s))'
 						inSmalltalk: [self printHex: s; space; print: (self stringOf: s); cr]]
 				ifFalse: [self shortPrintOop: s].
 			 self tab.

--- a/smalltalksrc/VMMaker/CogObjectRepresentationForSqueakV3.class.st
+++ b/smalltalksrc/VMMaker/CogObjectRepresentationForSqueakV3.class.st
@@ -31,8 +31,8 @@ CogObjectRepresentationForSqueakV3 class >> defaultObjectMemoryClass [
 
 { #category : #'class initialization' }
 CogObjectRepresentationForSqueakV3 class >> initialize [
-	RootBit ifNil: [ObjectMemory initializeObjectHeaderConstants].
-	RootBitDigitLength := RootBit digitLength
+	RootBit ifNil: [ ObjectMemory initializeObjectHeaderConstants ].
+	RootBitDigitLength := RootBit bytesCount
 ]
 
 { #category : #accessing }

--- a/smalltalksrc/VMMaker/Cogit.class.st
+++ b/smalltalksrc/VMMaker/Cogit.class.st
@@ -10754,7 +10754,7 @@ Cogit >> previousInstruction [
 
 { #category : #printing }
 Cogit >> print: aString [
-	<cmacro: '(aString) printf("%s", aString)'>
+	<cmacro: '(aString) vm_printf("%s", aString)'>
 	coInterpreter transcript print: aString
 ]
 
@@ -10927,7 +10927,7 @@ Cogit >> printMethodHeader: cogMethod on: aStream [
 
 { #category : #printing }
 Cogit >> printNum: n [
-	<cmacro: '(n) printf("%" PRIdSQINT, (sqInt) (n))'>
+	<cmacro: '(n) vm_printf("%" PRIdSQINT, (sqInt) (n))'>
 	coInterpreter transcript printNum: n
 ]
 

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -1862,9 +1862,9 @@ void
 warning(char *s) { /* Print an error message but don''t necessarily exit. */
 	if (erroronwarn) error(s);
 	if (warnpid)
-		printf("\n%s pid %ld\n", s, (long)warnpid);
+		vm_printf("\n%s pid %ld\n", s, (long)warnpid);
 	else
-		printf("\n%s\n", s);
+		vm_printf("\n%s\n", s);
 }
 void
 warningat(char *s, int l) { /* ditto with line number. */
@@ -1878,9 +1878,9 @@ warningat(char *s, int l) { /* ditto with line number. */
 void
 invalidCompactClassError(char *s) { /* Print a (compact) class index error message and exit. */
 #if SPURVM
-	printf("\nClass %s does not have the required class index\n", s);
+	vm_printf("\nClass %s does not have the required class index\n", s);
 #else
-	printf("\nClass %s does not have the required compact class index\n", s);
+	vm_printf("\nClass %s does not have the required compact class index\n", s);
 #endif
 	exit(-1);
 }
@@ -10200,10 +10200,10 @@ StackInterpreter >> longPrintOop: oop [
 			 startIP to: lastIndex do:
 				[:index| | byte |
 				column = 1 ifTrue:
-					[self cCode: 'printf("0x%08" PRIxSQPTR ": ", (usqIntptr_t)(oop+BaseHeaderSize+index-1))'
+					[self cCode: 'vm_printf("0x%08" PRIxSQPTR ": ", (usqIntptr_t)(oop+BaseHeaderSize+index-1))'
 						inSmalltalk: [self print: (oop+objectMemory baseHeaderSize+index-1) hex; print: ': ']].
 				byte := objectMemory fetchByte: index - 1 ofObject: oop.
-				self cCode: 'printf(" %02x/%-3d", (int)byte,(int)byte)'
+				self cCode: 'vm_printf(" %02x/%-3d", (int)byte,(int)byte)'
 					inSmalltalk: [self space; print: (byte radix: 16); printChar: $/; printNum: byte].
 				column := column + 1.
 				column > bytecodesPerLine ifTrue:
@@ -16471,7 +16471,7 @@ StackInterpreter >> methodArg: index [
 	<doNotGenerate> "Obsolete; was never used; replaced with methodReturnBool: in the VirtualMachine struct."
 	self deprecated.
 	index > argumentCount + 1 ifTrue:
-		[self cCode: 'fprintf(stderr,"[VM]: Attempt to access method args beyond range\n")'.
+		[self cCode: 'vm_printf("[VM]: Attempt to access method args beyond range\n")'.
 		self printCallStack.
 		self primitiveFail.
 		^0].
@@ -17587,9 +17587,12 @@ StackInterpreter >> primitiveObject: actualReceiver perform: selector withArgume
 { #category : #'debug printing' }
 StackInterpreter >> print: s [
 	"For testing in Smalltalk, this method should be overridden in a subclass."
+
 	<api>
 	<var: #s type: #'char *'>
-	self cCode: 'fputs(s, stdout)'
+	self
+		cCode: 'vm_printf(s)'
+		inSmalltalk: [ self subclassResponsibility ]
 ]
 
 { #category : #'debug printing' }
@@ -17883,7 +17886,7 @@ StackInterpreter >> printExternalHeadFrame [
 { #category : #'debug printing' }
 StackInterpreter >> printFloat: f [
 	"For testing in Smalltalk, this method should be overridden in a subclass."
-	<cmacro: '(f) printf("%g", f)'>
+	<cmacro: '(f) vm_printf("%g", f)'>
 	self print: f
 ]
 
@@ -18138,7 +18141,7 @@ StackInterpreter >> printHex: n [
 	<var: #buf declareC: 'char buf[37]'> "large enough for a 64-bit value in hex plus the null plus 16 spaces"
 	self cCode: 'memset(buf,'' '',36)' inSmalltalk: [buf := 'doh!'].
 	len := self cCode: 'sprintf(buf + 2 + 2 * BytesPerWord, "0x%" PRIxSQPTR, (usqIntptr_t)(n))'.
-	self cCode: 'printf("%s", buf + len)'.
+	self cCode: 'vm_printf("%s", buf + len)'.
 	len touch: buf
 ]
 
@@ -18219,7 +18222,7 @@ StackInterpreter >> printMethodCacheFor: thing [
 			[self cCode: [] inSmalltalk: [self transcript ensureCr].
 			 self printNum: i; space; printHexnp: i; cr; tab.
 			 (objectMemory isBytesNonImm: s)
-				ifTrue: [self cCode: 'printf("%" PRIxSQPTR " %.*s\n", s, (int)(numBytesOf(s)), (char *)firstIndexableField(s))'
+				ifTrue: [self cCode: 'vm_printf("%" PRIxSQPTR " %.*s\n", s, (int)(numBytesOf(s)), (char *)firstIndexableField(s))'
 						inSmalltalk: [self printHex: s; space; print: (self stringOf: s); cr]]
 				ifFalse: [self shortPrintOop: s].
 			 self tab.
@@ -18306,7 +18309,7 @@ StackInterpreter >> printNameOfClass: classOop count: cnt [
 StackInterpreter >> printNum: n [
 	"For testing in Smalltalk, this method should be overridden in a subclass."
 
-	self cCode: 'printf("%ld", (long) n)'.
+	self cCode: 'vm_printf("%ld", (long) n)'.
 ]
 
 { #category : #'debug printing' }
@@ -18390,10 +18393,10 @@ StackInterpreter >> printOop: oop [
 			 startIP to: lastIndex do:
 				[:index| | byte |
 				column = 1 ifTrue:
-					[self cCode: 'printf("0x%08" PRIxSQPTR ": ", (usqIntptr_t)(oop+BaseHeaderSize+index-1))'
+					[self cCode: 'vm_printf("0x%08" PRIxSQPTR ": ", (usqIntptr_t)(oop+BaseHeaderSize+index-1))'
 						inSmalltalk: [self print: (oop+objectMemory baseHeaderSize+index-1) hex; print: ': ']].
 				byte := objectMemory fetchByte: index - 1 ofObject: oop.
-				self cCode: 'printf(" %02x/%-3d", (int)byte,(int)byte)'
+				self cCode: 'vm_printf(" %02x/%-3d", (int)byte,(int)byte)'
 					inSmalltalk: [self space; print: (byte radix: 16); printChar: $/; printNum: byte].
 				column := column + 1.
 				column > bytecodesPerLine ifTrue:
@@ -20609,15 +20612,15 @@ StackInterpreter >> shortPrintOop: oop [
 	(objectMemory isImmediate: oop) ifTrue:
 		[(objectMemory isIntegerObject: oop) ifTrue:
 			[self
-				cCode: 'printf("=%ld\n", (long)integerValueOf(oop))'
+				cCode: 'vm_printf("=%ld\n", (long)integerValueOf(oop))'
 				inSmalltalk: [self print: (self shortPrint: oop); cr]].
 		 (objectMemory isImmediateCharacter: oop) ifTrue:
 			[self
-				cCode: 'printf("=$%ld ($%lc)\n", (long)characterValueOf(oop), (wint_t)characterValueOf(oop))'
+				cCode: 'vm_printf("=$%ld ($%lc)\n", (long)characterValueOf(oop), (wint_t)characterValueOf(oop))'
 				inSmalltalk: [self print: (self shortPrint: oop); cr]].
 		 (objectMemory isImmediateFloat: oop) ifTrue:
 			[self
-				cCode: 'printf("=%g\n", floatValueOf(oop))'
+				cCode: 'vm_printf("=%g\n", floatValueOf(oop))'
 				inSmalltalk: [self print: '='; printFloat: (objectMemory floatValueOf: oop); cr]].
 		 ^self].
 	(objectMemory addressCouldBeObj: oop) ifFalse:

--- a/src/debug.c
+++ b/src/debug.c
@@ -131,29 +131,27 @@ char *getVersionInfo(int verbose)
  *  This SHOULD be rewritten passing the FILE* as a parameter.
  */
 
-#define STDOUT_STACK_SZ 5
-static int stdoutStackIdx = -1;
-static FILE stdoutStack[STDOUT_STACK_SZ];
+static FILE* outputStream = NULL;
 
 void
-pushOutputFile(FILE* aFile)
-{
-	if (stdoutStackIdx + 2 >= STDOUT_STACK_SZ) {
-		fprintf(stderr,"output file stack is full.\n");
-		return;
-	}
-	stdoutStack[++stdoutStackIdx] = *stdout;
-	*stdout = *aFile;
+vm_setVMOutputStream(FILE * stream){
+	fflush(outputStream);
+	outputStream = stream;
 }
 
-void
-popOutputFile()
-{
-	if (stdoutStackIdx < 0) {
-		fprintf(stderr,"output file stack is empty.\n");
-		return;
+int
+vm_printf(const char * format, ... ){
+
+	va_list list;
+	va_start(list, format);
+
+	if(outputStream == NULL){
+		outputStream = stdout;
 	}
 
-	fflush(stdout);
-	*stdout = stdoutStack[stdoutStackIdx--];
+	int returnValue = vfprintf(outputStream, format, list);
+
+	va_end(list);
+
+	return returnValue;
 }

--- a/src/debugUnix.c
+++ b/src/debugUnix.c
@@ -9,7 +9,9 @@
 
 #endif
 
-#include <execinfo.h>
+#ifdef HAVE_EXECINFO_H
+# include <execinfo.h>
+#endif
 
 #include <signal.h>
 
@@ -219,7 +221,7 @@ void reportStackState(const char *msg, char *date, int printAll, ucontext_t *uap
 		return;
 #endif
 
-#if !defined(NOEXECINFO)
+#ifdef HAVE_EXECINFO_H
 	fprintf(output,"C stack backtrace & registers:\n");
 	if (uap) {
 		addrs[0] = printRegisterState(uap, output);

--- a/src/debugUnix.c
+++ b/src/debugUnix.c
@@ -23,9 +23,6 @@ void printCallStack();
 char* GetAttributeString(int idx);
 void reportStackState(const char *msg, char *date, int printAll, ucontext_t *uap, FILE* output);
 
-void pushOutputFile(FILE* aFile);
-void popOutputFile();
-
 char * getVersionInfo(int verbose);
 void getCrashDumpFilenameInto(char *buf);
 
@@ -42,11 +39,11 @@ void doReport(char* fault, ucontext_t *uap){
 	//This is awful but replace the stdout to print all the messages in the file.
 	getCrashDumpFilenameInto(crashdumpFileName);
 	crashDumpFile = fopen(crashdumpFileName, "a+");
-	pushOutputFile(crashDumpFile);
+	vm_setVMOutputStream(crashDumpFile);
 
 	reportStackState(fault, ctimebuf, 1, uap, crashDumpFile);
 
-	popOutputFile();
+	vm_setVMOutputStream(stdout);
 	fclose(crashDumpFile);
 
 	reportStackState(fault, ctimebuf, 1, uap, stderr);

--- a/src/debugWin.c
+++ b/src/debugWin.c
@@ -2,9 +2,6 @@
 #include <Windows.h>
 #include <DbgHelp.h>
 
-void pushOutputFile(FILE* aFile);
-void popOutputFile();
-
 void ifValidWriteBackStackPointersSaveTo(void *theCFP, void *theCSP, char **savedFPP, char **savedSPP);
 
 void printAllStacks();
@@ -57,11 +54,11 @@ EXPORT(void) printCrashDebugInformation(LPEXCEPTION_POINTERS exp){
 	//This is awful but replace the stdout to print all the messages in the file.
 	getCrashDumpFilenameInto(crashdumpFileName);
 	crashDumpFile = fopen(crashdumpFileName, "a+");
-	pushOutputFile(crashDumpFile);
+	vm_setVMOutputStream(crashDumpFile);
 
 	reportStackState(exp, date, crashDumpFile);
 
-	popOutputFile();
+	vm_setVMOutputStream(stdout);
 	fclose(crashDumpFile);
 
 	reportStackState(exp, date, stdout);


### PR DESCRIPTION
Introducing a vm_printf that will use a configurable stream.

Useful to remove pushOutputFile / popOutputFile which relies on breaking the encapsulation of FILE in Libc