### PR TITLE
switch to tonel protocol (from gitlocal)

### DIFF
--- a/scripts/installVMMaker.st
+++ b/scripts/installVMMaker.st
@@ -1,5 +1,5 @@
 path := CommandLineArguments default commandLineArguments last.
 Metacello new
   baseline: 'VMMaker';
-	repository: 'gitlocal://' , path , '/smalltalksrc';
+	repository: 'tonel://' , path , '/smalltalksrc';
 	load


### PR DESCRIPTION
switch to tonel protocol for loading VMMaker. It should allow to build the VM on RaspberryPi and maybe make the building process working only from clone of the latest repository commit