### PR TITLE
Small performance improvements

### DIFF
--- a/smalltalksrc/VMMaker/DoubleWordArray.extension.st
+++ b/smalltalksrc/VMMaker/DoubleWordArray.extension.st
@@ -24,7 +24,7 @@ DoubleWordArray >> long64At: byteIndex [
 		ifTrue:
 			[value := self at: wordIndex]
 		ifFalse:
-			[high := ((self at: wordIndex + 1) bitAnd: (1 bitShift: (lowBits bitShift: 3)) - 1) bitShift: 8 - (lowBits bitShift: 3).
+			[high := ((self at: wordIndex + 1) bitAnd: (1 bitShift: (lowBits bitShift: 3)) - 1) bitShift: ((8 - lowBits) bitShift: 3).
 			 low := (self at: wordIndex) bitShift: lowBits * -8.
 			 high = 0 ifTrue:
 				[^low].
@@ -44,9 +44,9 @@ DoubleWordArray >> long64At: byteIndex put: aValue [
 	allOnes := 16rFFFFFFFFFFFFFFFF.
 	(lowBits := byteIndex - 1 bitAnd: 7) = 0 ifTrue:
 		[^self at: wordIndex put: (aValue >= 0 ifTrue: [aValue] ifFalse: [aValue bitAnd: allOnes])].
-	mask := allOnes bitShift: 8 - lowBits * -8.
+	mask := allOnes bitShift: ((lowBits-8) bitShift:3).
 	self at: wordIndex put: (((self at: wordIndex) bitAnd: mask) bitXor: ((aValue bitShift: lowBits * 8) bitAnd: allOnes - mask)).
-	self at: wordIndex + 1 put: (((self at: wordIndex + 1) bitAnd: allOnes - mask) bitXor: (allOnes bitAnd: ((aValue bitShift: 8 - lowBits * -8) bitAnd: mask))).
+	self at: wordIndex + 1 put: (((self at: wordIndex + 1) bitAnd: allOnes - mask) bitXor: (allOnes bitAnd: ((aValue bitShift: ((lowBits-8) bitShift:3)) bitAnd: mask))).
 	^aValue
 ]
 

--- a/smalltalksrc/VMMaker/DoubleWordArray.extension.st
+++ b/smalltalksrc/VMMaker/DoubleWordArray.extension.st
@@ -18,12 +18,13 @@ DoubleWordArray class >> defaultIntegerBaseInDebugger [
 { #category : #'*VMMaker-JITSimulation' }
 DoubleWordArray >> long64At: byteIndex [
 	| lowBits wordIndex value high low |
+
 	wordIndex := byteIndex - 1 // 8 + 1.
 	(lowBits := byteIndex - 1 \\ 8) = 0
 		ifTrue:
 			[value := self at: wordIndex]
 		ifFalse:
-			[high := ((self at: wordIndex + 1) bitAnd: (1 bitShift: lowBits * 8) - 1) bitShift: 8 - lowBits * 8.
+			[high := ((self at: wordIndex + 1) bitAnd: (1 bitShift: (lowBits bitShift: 3)) - 1) bitShift: 8 - (lowBits bitShift: 3).
 			 low := (self at: wordIndex) bitShift: lowBits * -8.
 			 high = 0 ifTrue:
 				[^low].

--- a/smalltalksrc/VMMaker/Spur64BitMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/Spur64BitMemoryManager.class.st
@@ -865,14 +865,16 @@ Spur64BitMemoryManager >> newInputEventAccessorOfSize: numElements [
 	<doNotGenerate>
 	self flag: #endianness.
 	^(CPluggableAccessor on: (WordArray new: 16))
-		atBlock: [:obj :idx| | v |
-				v := (obj at: idx - 1 * 2 + 1) + ((obj at: idx - 1 * 2 + 2) << 32).
+		atBlock: [:obj :idx| | v pidx2 |
+				pidx2 := (idx - 1) * 2.
+				v := (obj at: pidx2 + 1) + ((obj at: pidx2 + 2) << 32).
 				v >> 63 > 0 ifTrue:
 					[v := v - (1 << 64)].
 				v]
-		atPutBlock: [:obj :idx :val|
-					obj at: idx - 1 * 2 + 1 put: (val bitAnd: 16rFFFFFFFF).
-					obj at: idx - 1 * 2 + 2 put: (val >> 32 bitAnd: 16rFFFFFFFF).
+		atPutBlock: [:obj :idx :val| |pidx2|
+					pidx2 := (idx - 1) * 2.
+					obj at: pidx2 + 1 put: (val bitAnd: 16rFFFFFFFF).
+					obj at: pidx2 + 2 put: (val >> 32 bitAnd: 16rFFFFFFFF).
 					val];
 		objectSize: 8
 ]

--- a/smalltalksrc/VMMaker/SpurSegmentManager.class.st
+++ b/smalltalksrc/VMMaker/SpurSegmentManager.class.st
@@ -92,7 +92,8 @@ SpurSegmentManager >> addSegmentOfSize: ammount [
 			Above: (self firstGapOfSizeAtLeast: ammount)
 			AllocatedSizeInto: (self cCode: [self addressOf: allocatedSize]
 									inSmalltalk: [[:sz| allocatedSize := sz]])) ifNotNil:
-		[:segAddress| | newSegIndex newSeg |
+		[:segAddress| | newSegIndex newSeg numSegmentsM1 |
+		numSegmentsM1 := numSegments - 1.
 		 newSegIndex := self insertSegmentFor: segAddress asUnsignedIntegerPtr.
 		 "Simulation insertion code duplicates entries if newSegIndex ~= numSegments - 1"
 		 self cCode: '' inSmalltalk: [segments at: newSegIndex put: SpurSegmentInfo new].
@@ -103,16 +104,16 @@ SpurSegmentManager >> addSegmentOfSize: ammount [
 			swizzle: 0. "Required in the C version only"
 		 self assert: self segmentOverlap not. "self printSegmentAddresses."
 		 self bridgeFrom: (self addressOf: (segments at: newSegIndex - 1)) to: newSeg.
-		 self bridgeFrom: newSeg to: (newSegIndex = (numSegments - 1) ifFalse:
+		 self bridgeFrom: newSeg to: (newSegIndex = (numSegmentsM1) ifFalse:
 										[self addressOf: (segments at: newSegIndex + 1)]).
 		 totalHeapSizeIncludingBridges := totalHeapSizeIncludingBridges + allocatedSize.
 		 "test isInMemory:"
-		 0 to: numSegments - 1 do:
+		 0 to: numSegmentsM1 do:
 			[:i|
 			self assert: (self isInSegments: (segments at: i) segStart).
 			self assert: (self isInSegments: (segments at: i) segLimit - manager wordSize).
 			self assert: ((self isInSegments: (segments at: i) segLimit) not
-						or: [i < (numSegments - 1)
+						or: [i < (numSegmentsM1)
 							and: [(segments at: i) segLimit = (segments at: i + 1) segStart]]).
 			self assert: ((self isInSegments: (segments at: i) segStart - manager wordSize) not
 							or: [i > 0


### PR DESCRIPTION
Not a dealer maker, but a performance improvement after all.
More a proof of concept than a real improvement.

I've seen that there're lots of sites where these 2 patterns can be done:

1.- Multiplications by 2,4 or 8
C compiler don't translate them to bitshifting because of sign and checks, put if we know we are computing addresses and it's safe we can use bitshift instead of multiplication.
While it's not a big deal, multiplications use more clock cicles than bitshifting, so we get a small improvement each time these routines are called.

2.- Repeated values as operations

For example in one of the commits the expression "numSegments - 1" was used to build a loop and on a condition inside it.
Extracting it's value in a variable will compute it only once.

