### PR TITLE
Improving the Windows Error printing handler

### DIFF
--- a/include/pharovm/debug.h
+++ b/include/pharovm/debug.h
@@ -14,6 +14,8 @@
 #define LOG_TRACE		5
 
 EXPORT(void) logLevel(int level);
+EXPORT(int) getLogLevel();
+
 EXPORT(void) logMessage(int level, const char* fileName, const char* functionName, int line, ...);
 EXPORT(void) logAssert(const char* fileName, const char* functionName, int line, char* msg);
 

--- a/include/pharovm/debug.h
+++ b/include/pharovm/debug.h
@@ -17,6 +17,7 @@ EXPORT(void) logLevel(int level);
 EXPORT(void) logMessage(int level, const char* fileName, const char* functionName, int line, ...);
 EXPORT(void) logAssert(const char* fileName, const char* functionName, int line, char* msg);
 
+EXPORT(void) registerCurrentThreadToHandleExceptions();
 EXPORT(void) installErrorHandlers();
 
 //This variable is set externally by CMAKE

--- a/src/client.c
+++ b/src/client.c
@@ -217,6 +217,8 @@ runVMThread(void* p)
     }
     //setFlagVMRunOnWorkerThread(flagVMRunOnWorkerThread);
 
+    registerCurrentThreadToHandleExceptions();
+
     vm_run_interpreter();
 	return NULL;
 }

--- a/src/debug.c
+++ b/src/debug.c
@@ -24,6 +24,10 @@ EXPORT(void) logLevel(int value){
 	max_error_level = value;
 }
 
+EXPORT(int) getLogLevel(){
+	return max_error_level;
+}
+
 void error(char *errorMessage){
     logError(errorMessage);
     abort();

--- a/src/debugUnix.c
+++ b/src/debugUnix.c
@@ -82,6 +82,12 @@ void sigsegv(int sig, siginfo_t *info, ucontext_t *uap)
 	abort();
 }
 
+/*
+ * Useful if we want to filter which are the threads to monitor
+ */
+EXPORT(void) registerCurrentThreadToHandleExceptions(){
+
+}
 
 EXPORT(void) installErrorHandlers(){
 	struct sigaction sigusr1_handler_action, sigsegv_handler_action;

--- a/src/debugWin.c
+++ b/src/debugWin.c
@@ -52,6 +52,10 @@ isExceptionAReasonForCrashing(LPEXCEPTION_POINTERS exp) {
 		}
 	}
 
+	if(getLogLevel() < LOG_WARN){
+		return 0;
+	}
+
 	if(!found)
 		return 0;
 
@@ -88,7 +92,7 @@ EXPORT(LONG) CALLBACK customExceptionHandler(LPEXCEPTION_POINTERS exp){
 
 	printCrashDebugInformation(exp);
 
-   	return EXCEPTION_CONTINUE_SEARCH;
+	return EXCEPTION_CONTINUE_SEARCH;
 }
 
 void installErrorHandlers(){

--- a/src/debugWin.c
+++ b/src/debugWin.c
@@ -54,11 +54,12 @@ EXPORT(LONG) CALLBACK customExceptionHandler(LPEXCEPTION_POINTERS exp){
 		return EXCEPTION_CONTINUE_SEARCH;
 
 	printCrashDebugInformation(exp);
-   	return EXCEPTION_EXECUTE_HANDLER;
+
+   	return EXCEPTION_CONTINUE_SEARCH;
 }
 
 void installErrorHandlers(){
-	AddVectoredExceptionHandler(1 /*CALL_FIRST*/,customExceptionHandler);
+	AddVectoredExceptionHandler(0 /*CALL_LAST*/,customExceptionHandler);
 }
 
 


### PR DESCRIPTION
The exception handle should be the last called, and it should continue the search if executed.