### PR TITLE
Set instruction pointer automatically

### DIFF
--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -15929,6 +15929,13 @@ StackInterpreter >> metaclassNumSlots [
 	^metaclassNumSlots
 ]
 
+{ #category : #'as yet unclassified' }
+StackInterpreter >> method [
+
+	<doNotGenerate>
+	^ method
+]
+
 { #category : #accessing }
 StackInterpreter >> method: oop [
 	<doNotGenerate>

--- a/smalltalksrc/VMMaker/StackInterpreterSimulator.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreterSimulator.class.st
@@ -919,6 +919,23 @@ StackInterpreterSimulator >> interpret [
 	^nil
 ]
 
+{ #category : #'as yet unclassified' }
+StackInterpreterSimulator >> interpretUntilReturn [
+	self shouldBeImplemented.
+]
+
+{ #category : #'as yet unclassified' }
+StackInterpreterSimulator >> interpretWhile: aFullBlockClosure [ 
+	self internalizeIPandSP.
+	self fetchNextBytecode.
+	[aFullBlockClosure value] whileTrue:
+		[self dispatchOn: currentBytecode in: BytecodeTable.
+		 self incrementByteCount].
+	localIP := localIP - 1.
+	"undo the pre-increment of IP before returning"
+	self externalizeIPandSP
+]
+
 { #category : #'stack pages' }
 StackInterpreterSimulator >> interpreterAllocationReserveBytes [
 	^bootstrapping

--- a/smalltalksrc/VMMakerTests/MethodBuilderTest.class.st
+++ b/smalltalksrc/VMMakerTests/MethodBuilderTest.class.st
@@ -41,6 +41,54 @@ MethodBuilderTest >> testBuildEmptyMethodIsCompiledMethod [
 ]
 
 { #category : #running }
+MethodBuilderTest >> testBytecodeAtForMethodWithNoLiteral [
+	| bytecodeAddress |
+	literals := { }.
+	method := methodBuilder newMethod 
+		bytecodes: #[ 1 2 3 4 5 6 7 8 9 ];
+		literals: literals;
+		buildMethod.
+
+	bytecodeAddress := methodBuilder bytecodeAt: 1 forMethod: method.
+	
+	self assert: (memory byteAt: bytecodeAddress) equals: 1
+]
+
+{ #category : #running }
+MethodBuilderTest >> testBytecodeAtForMethodWithOneLiteral [
+	| bytecodeAddress |
+	literals := { 1 }.
+	method := methodBuilder newMethod 
+		bytecodes: #[ 1 2 3 4 5 6 7 8 9 ];
+		literals: literals;
+		buildMethod.
+
+	bytecodeAddress := methodBuilder bytecodeAt: 1 forMethod: method.
+	
+	self assert: (memory byteAt: bytecodeAddress) equals: 1
+]
+
+{ #category : #running }
+MethodBuilderTest >> testBytecodeAtForMethodWithTwoLiteral [
+	| bytecodeAddress |
+	literals := { 1. 2 }.
+	method := methodBuilder newMethod 
+		bytecodes: #[ 1 2 3 4 5 6 7 8 9 ];
+		literals: literals;
+		buildMethod.
+
+		bytecodeAddress := methodBuilder bytecodeAt: 1 forMethod: method.
+	
+	self assert: (memory byteAt: bytecodeAddress) equals: 1
+]
+
+{ #category : #running }
+MethodBuilderTest >> testGeneratingCompiledMethod [
+	method := methodBuilder newMethod bytecodes: #[ 1 2 3 4 5 6 7 8 ]; buildMethod.
+	self assert: (memory isCompiledMethod: method).
+]
+
+{ #category : #running }
 MethodBuilderTest >> testInstanciateMethodShouldTakeOneSlotForEightBytecodes [
 	method := methodBuilder newMethod bytecodes: #[ 1 2 3 4 5 6 7 8 ]; buildMethod.
 
@@ -54,4 +102,18 @@ MethodBuilderTest >> testInstanciateMethodShouldTakeTwoSlotForNineBytecodes [
 
 	"should equal the header (1) + the number of bytecodes divided by 8"
 	self assert: methodBuilder slotSize equals: 3.
+]
+
+{ #category : #running }
+MethodBuilderTest >> testSecondBytecodeAtForMethodWithOneLiteral [
+	| bytecodeAddress |
+	literals := { 1 }.
+	method := methodBuilder newMethod 
+		bytecodes: #[ 1 2 3 4 5 6 7 8 9 ];
+		literals: literals;
+		buildMethod.
+
+	bytecodeAddress := methodBuilder bytecodeAt: 2 forMethod: method.
+	
+	self assert: (memory byteAt: bytecodeAddress) equals: 2
 ]

--- a/smalltalksrc/VMMakerTests/StackBuilderTest.class.st
+++ b/smalltalksrc/VMMakerTests/StackBuilderTest.class.st
@@ -175,6 +175,17 @@ StackBuilderTest >> testHeadFramePointerCallerIsNotBaseFramePointer [
 		equals: stackBuilder page baseFP
 ]
 
+{ #category : #'test-VMstate' }
+StackBuilderTest >> testInstructionPointerIsSetBeforeFirstBytecodeOfLastMethodPushed [
+
+	method := methodBuilder newMethod buildMethod.
+	stackBuilder addNewFrame method: method. 
+	stackBuilder buildStack.
+	
+	self assert: interpreter instructionPointer
+		equals: (methodBuilder bytecodeAt: 0 forMethod: method)
+]
+
 { #category : #'test-order' }
 StackBuilderTest >> testOrderArgument1InBaseFrame [
 	self assert: (interpreter stackPages longAtPointer: interpreter stackPage baseFP + (self offsetArgument1FromBaseFP * memory bytesPerOop))

--- a/smalltalksrc/VMMakerTests/VMBlockTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMBlockTest.class.st
@@ -49,10 +49,8 @@ VMBlockTest >> testPushClosureBytecodePushesClosure [
 		method: methodOop;
 		receiver: memory trueObject.
 	stackBuilder buildStack.
-	methodHeader := memory methodHeaderOf: methodOop.
-
-	interpreter instructionPointer:
-		(interpreter initialIPForHeader: methodHeader method: methodOop) - 1.
+	
+	interpreter instructionPointer: (methodBuilder bytecodeAt: 0 forMethod: methodOop).
 	interpreter interpretWhile: [ interpreter method = methodOop ].
 
 	self

--- a/smalltalksrc/VMMakerTests/VMBlockTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMBlockTest.class.st
@@ -1,0 +1,61 @@
+Class {
+	#name : #VMBlockTest,
+	#superclass : #VMInterpreterTests,
+	#pools : [
+		'VMObjectIndices',
+		'VMSqueakClassIndices'
+	],
+	#category : #'VMMakerTests-InterpreterTests'
+}
+
+{ #category : #supports }
+VMBlockTest >> anEmptyMethod [
+]
+
+{ #category : #supports }
+VMBlockTest >> installBlockClosureClass [
+		| aClass |
+	aClass := self
+		newClassInOldSpaceWithSlots: 0
+		instSpec: BlockClosure instSpec.
+	memory setHashBitsOf: aClass to: ClassBlockClosureCompactIndex.
+	memory
+		storePointer: ClassBlockClosureCompactIndex
+		ofObject: memory classTableFirstPage
+		withValue: aClass
+]
+
+{ #category : #supports }
+VMBlockTest >> methodReturningABlock [
+	
+	^ []
+	
+]
+
+{ #category : #testing }
+VMBlockTest >> testPushClosureBytecodePushesClosure [
+
+	| methodOop methodHeader previousMethodOop |
+	methodOop := self createMethodOopFromPharoMethod:
+		             self class >> #methodReturningABlock.
+
+	previousMethodOop := self createMethodOopFromPharoMethod:
+		                     self class >> #anEmptyMethod.
+
+	self installBlockClosureClass.
+	"We want to avoid baseFrameReturn (base frame initialisation)"
+	stackBuilder addNewFrame method: previousMethodOop.
+	stackBuilder addNewFrame
+		method: methodOop;
+		receiver: memory trueObject.
+	stackBuilder buildStack.
+	methodHeader := memory methodHeaderOf: methodOop.
+
+	interpreter instructionPointer:
+		(interpreter initialIPForHeader: methodHeader method: methodOop) - 1.
+	interpreter interpretWhile: [ interpreter method = methodOop ].
+
+	self
+		assert: (memory fetchClassOf: interpreter stackTop)
+		equals: (memory classAtIndex: ClassBlockClosureCompactIndex)
+]

--- a/smalltalksrc/VMMakerTests/VMBlockTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMBlockTest.class.st
@@ -46,12 +46,13 @@ VMBlockTest >> methodReturningABlock [
 VMBlockTest >> testBlockClosureClassIsOnlyInSpecialObjectArrayShouldStillInstantiate [
 
 	| methodOop methodHeader previousMethodOop |
+	previousMethodOop := self createMethodOopFromPharoMethod:
+		                     self class >> #anEmptyMethod.
+
 	methodOop := self createMethodOopFromPharoMethod:
 		             self class >> #methodReturningABlock.
 
-	previousMethodOop := self createMethodOopFromPharoMethod:
-		                     self class >> #anEmptyMethod.
-	"To force the use of the specialObjectArray"	
+	"To force the use of the specialObjectArray"
 	ClassBlockClosureCompactIndex := 0.
 	self installBlockClosureClassInSplOnly.
 	"We want to avoid baseFrameReturn (base frame initialisation)"
@@ -62,8 +63,6 @@ VMBlockTest >> testBlockClosureClassIsOnlyInSpecialObjectArrayShouldStillInstant
 	stackBuilder buildStack.
 	methodHeader := memory methodHeaderOf: methodOop.
 
-	interpreter instructionPointer:
-		(interpreter initialIPForHeader: methodHeader method: methodOop) - 1.
 	interpreter interpretWhile: [ interpreter method = methodOop ].
 
 	self
@@ -75,11 +74,11 @@ VMBlockTest >> testBlockClosureClassIsOnlyInSpecialObjectArrayShouldStillInstant
 VMBlockTest >> testPushClosureBytecodePushesClosure [
 
 	| methodOop previousMethodOop |
-	methodOop := self createMethodOopFromPharoMethod:
-		             self class >> #methodReturningABlock.
-
 	previousMethodOop := self createMethodOopFromPharoMethod:
 		                     self class >> #anEmptyMethod.
+
+	methodOop := self createMethodOopFromPharoMethod:
+		             self class >> #methodReturningABlock.
 
 	self installBlockClosureClass.
 	"We want to avoid baseFrameReturn (base frame initialisation)"

--- a/smalltalksrc/VMMakerTests/VMBlockTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMBlockTest.class.st
@@ -74,7 +74,7 @@ VMBlockTest >> testBlockClosureClassIsOnlyInSpecialObjectArrayShouldStillInstant
 { #category : #testing }
 VMBlockTest >> testPushClosureBytecodePushesClosure [
 
-	| methodOop methodHeader previousMethodOop |
+	| methodOop previousMethodOop |
 	methodOop := self createMethodOopFromPharoMethod:
 		             self class >> #methodReturningABlock.
 
@@ -89,7 +89,6 @@ VMBlockTest >> testPushClosureBytecodePushesClosure [
 		receiver: memory trueObject.
 	stackBuilder buildStack.
 	
-	interpreter instructionPointer: (methodBuilder bytecodeAt: 0 forMethod: methodOop).
 	interpreter interpretWhile: [ interpreter method = methodOop ].
 
 	self

--- a/smalltalksrc/VMMakerTests/VMBlockTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMBlockTest.class.st
@@ -12,7 +12,7 @@ Class {
 VMBlockTest >> anEmptyMethod [
 ]
 
-{ #category : #supports }
+{ #category : #helpers }
 VMBlockTest >> installBlockClosureClass [
 		| aClass |
 	aClass := self
@@ -25,11 +25,50 @@ VMBlockTest >> installBlockClosureClass [
 		withValue: aClass
 ]
 
+{ #category : #helpers }
+VMBlockTest >> installBlockClosureClassInSplOnly [
+		| aClass |
+	aClass := self
+		newClassInOldSpaceWithSlots: 0
+		instSpec: BlockClosure instSpec.
+	memory setHashBitsOf: aClass to: ClassBlockClosureCompactIndex.
+	memory splObj: ClassBlockClosure put: aClass
+]
+
 { #category : #supports }
 VMBlockTest >> methodReturningABlock [
 	
 	^ []
 	
+]
+
+{ #category : #tests }
+VMBlockTest >> testBlockClosureClassIsOnlyInSpecialObjectArrayShouldStillInstantiate [
+
+	| methodOop methodHeader previousMethodOop |
+	methodOop := self createMethodOopFromPharoMethod:
+		             self class >> #methodReturningABlock.
+
+	previousMethodOop := self createMethodOopFromPharoMethod:
+		                     self class >> #anEmptyMethod.
+	"To force the use of the specialObjectArray"	
+	ClassBlockClosureCompactIndex := 0.
+	self installBlockClosureClassInSplOnly.
+	"We want to avoid baseFrameReturn (base frame initialisation)"
+	stackBuilder addNewFrame method: previousMethodOop.
+	stackBuilder addNewFrame
+		method: methodOop;
+		receiver: memory trueObject.
+	stackBuilder buildStack.
+	methodHeader := memory methodHeaderOf: methodOop.
+
+	interpreter instructionPointer:
+		(interpreter initialIPForHeader: methodHeader method: methodOop) - 1.
+	interpreter interpretWhile: [ interpreter method = methodOop ].
+
+	self
+		assert: (memory fetchClassOf: interpreter stackTop)
+		equals: (memory classAtIndex: ClassBlockClosureCompactIndex)
 ]
 
 { #category : #testing }

--- a/smalltalksrc/VMMakerTests/VMFrameBuilder.class.st
+++ b/smalltalksrc/VMMakerTests/VMFrameBuilder.class.st
@@ -56,7 +56,9 @@ Class {
 		'previousFrameArgsSize',
 		'argumentSize',
 		'myFramePointer',
-		'myStackPointer'
+		'myStackPointer',
+		'vmMethodBuilder',
+		'methodBuilder'
 	],
 	#category : #'VMMakerTests-Builders'
 }
@@ -174,6 +176,21 @@ VMFrameBuilder >> initializeWithInterpreter: anInterpreter andMemory: aMemory [
 	argumentSize := 0.
 ]
 
+{ #category : #initialization }
+VMFrameBuilder >> initializeWithInterpreter: anInterpreter andMemory: aMemory andMethodBuilder: aMethodBuilder [
+	memory := aMemory.
+	interpreter := anInterpreter. "allow to not care if it's for a cog or stack interpreter"
+	methodBuilder := aMethodBuilder.
+	method := memory nilObject.
+	context := memory nilObject.
+	receiver := memory nilObject.
+	temps := OrderedCollection new.
+	stack := OrderedCollection new.
+
+	previousFrameArgsSize := 0. " set by the StackBuilder"
+	argumentSize := 0.
+]
+
 { #category : #accesing }
 VMFrameBuilder >> instructionPointer [
 	^ instructionPointer
@@ -216,7 +233,8 @@ VMFrameBuilder >> method [
 
 { #category : #accessing }
 VMFrameBuilder >> method: anOop [
-	method := anOop
+	method := anOop.
+	(memory isCompiledMethod: anOop) ifTrue: [ interpreter instructionPointer: (methodBuilder bytecodeAt: 0 forMethod: anOop)]
 ]
 
 { #category : #accessing }
@@ -313,4 +331,16 @@ VMFrameBuilder >> temps [
 { #category : #accessing }
 VMFrameBuilder >> temps: anObject [
 	temps := anObject
+]
+
+{ #category : #accessing }
+VMFrameBuilder >> vmMethodBuilder [
+
+	^ vmMethodBuilder
+]
+
+{ #category : #accessing }
+VMFrameBuilder >> vmMethodBuilder: anObject [
+
+	vmMethodBuilder := anObject
 ]

--- a/smalltalksrc/VMMakerTests/VMFrameBuilder.class.st
+++ b/smalltalksrc/VMMakerTests/VMFrameBuilder.class.st
@@ -58,7 +58,8 @@ Class {
 		'myFramePointer',
 		'myStackPointer',
 		'vmMethodBuilder',
-		'methodBuilder'
+		'methodBuilder',
+		'isSuspended'
 	],
 	#category : #'VMMakerTests-Builders'
 }
@@ -90,8 +91,14 @@ VMFrameBuilder >> argumentSize: anObject [
 ]
 
 { #category : #configuring }
+VMFrameBuilder >> beSuspended [
+	isSuspended := true
+]
+
+{ #category : #configuring }
 VMFrameBuilder >> beSuspendedAt: anInstructionPointer [
-	instructionPointer := anInstructionPointer 
+	instructionPointer := anInstructionPointer.
+	self beSuspended
 ]
 
 { #category : #accessing }
@@ -163,20 +170,6 @@ VMFrameBuilder >> gtInspectorItemsIn: composite [
 ]
 
 { #category : #initialization }
-VMFrameBuilder >> initializeWithInterpreter: anInterpreter andMemory: aMemory [
-	memory := aMemory.
-	interpreter := anInterpreter. "allow to not care if it's for a cog or stack interpreter"
-	method := memory nilObject.
-	context := memory nilObject.
-	receiver := memory nilObject.
-	temps := OrderedCollection new.
-	stack := OrderedCollection new.
-
-	previousFrameArgsSize := 0. " set by the StackBuilder"
-	argumentSize := 0.
-]
-
-{ #category : #initialization }
 VMFrameBuilder >> initializeWithInterpreter: anInterpreter andMemory: aMemory andMethodBuilder: aMethodBuilder [
 	memory := aMemory.
 	interpreter := anInterpreter. "allow to not care if it's for a cog or stack interpreter"
@@ -186,12 +179,14 @@ VMFrameBuilder >> initializeWithInterpreter: anInterpreter andMemory: aMemory an
 	receiver := memory nilObject.
 	temps := OrderedCollection new.
 	stack := OrderedCollection new.
-
+	instructionPointer := 0.
+	isSuspended := false.
+	
 	previousFrameArgsSize := 0. " set by the StackBuilder"
 	argumentSize := 0.
 ]
 
-{ #category : #accesing }
+{ #category : #accessing }
 VMFrameBuilder >> instructionPointer [
 	^ instructionPointer
 ]
@@ -218,7 +213,7 @@ VMFrameBuilder >> isSingle [
 
 { #category : #testing }
 VMFrameBuilder >> isSuspended [
-	^ instructionPointer isNil
+	^ isSuspended
 ]
 
 { #category : #context }
@@ -233,8 +228,7 @@ VMFrameBuilder >> method [
 
 { #category : #accessing }
 VMFrameBuilder >> method: anOop [
-	method := anOop.
-	(memory isCompiledMethod: anOop) ifTrue: [ interpreter instructionPointer: (methodBuilder bytecodeAt: 0 forMethod: anOop)]
+	method := anOop
 ]
 
 { #category : #accessing }
@@ -275,6 +269,7 @@ VMFrameBuilder >> pushFrame [
 { #category : #building }
 VMFrameBuilder >> pushYourself [
 	interpreter push: method.
+	self setInstructionPointerBeforeFirstBytecode.
 	self pushFlags.
 	self pushFrame.
 	self pushCurrentFramesStack.
@@ -286,7 +281,7 @@ VMFrameBuilder >> pushYourself [
 				ofObject: context
 				withValue: (interpreter withSmallIntegerTags: page baseFP)	""SenderIndex"" ]."
 				
-	instructionPointer ifNotNil: [ interpreter push: instructionPointer ].
+	isSuspended ifTrue: [ interpreter push: instructionPointer ].
 	
 	myStackPointer:= interpreter stackPointer.
 	myFramePointer := interpreter framePointer.
@@ -303,6 +298,17 @@ VMFrameBuilder >> receiver: anObject [
 	receiver := anObject
 ]
 
+{ #category : #building }
+VMFrameBuilder >> setInstructionPointerBeforeFirstBytecode [
+
+	"If possible, setting IP to before the first bytecode, so it is ready for fetchNextBytecode"
+
+	((memory isCompiledMethod: method) and: [ instructionPointer = 0 ]) 
+		ifTrue: [ 
+			instructionPointer := methodBuilder bytecodeAt: 0 forMethod: method.
+			interpreter instructionPointer: instructionPointer ]
+]
+
 { #category : #accessing }
 VMFrameBuilder >> stack [
 	^ stack
@@ -313,7 +319,7 @@ VMFrameBuilder >> stack: anObject [
 	stack := anObject
 ]
 
-{ #category : #accesing }
+{ #category : #accessing }
 VMFrameBuilder >> stackPointer [
 	^ myStackPointer
 ]

--- a/smalltalksrc/VMMakerTests/VMLookUpTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMLookUpTest.class.st
@@ -397,10 +397,8 @@ VMLookUpTest >> testPrimitivePerformFindsMethodOop [
 	interpreter argumentCount: 1.
 	interpreter primitivePerform.
 	
-	self assert: interpreter newMethod equals: methodOop.
-	self assert: interpreter instructionPointer equals: methodOop + 8 + 8 - 1 "+ header object + header of compiledMethod - (1)"
- 	
-	"(1) the Instruction Pointer is set to be just before the bytecode to execute, so fetchNextBytecode will fetch the first bytecode ( #justActivateNewMethod: )"
+	self assert: interpreter newMethod equals: methodOop
+
 ]
 
 { #category : #tests }
@@ -421,7 +419,8 @@ VMLookUpTest >> testPrimitivePerformSetsIPBeforeFirstBytecode [
 	interpreter argumentCount: 1.
 	interpreter primitivePerform.
 	
-	self assert: interpreter instructionPointer equals: methodOop + 8 + 8 - 1 "+ header object + header of compiledMethod - (1)"
- 	
+	"Minus one because it's *before* first bytecode"
+	self assert: interpreter instructionPointer 
+		equals: (methodBuilder bytecodeAt: 1 forMethod: methodOop) - 1.
 
 ]

--- a/smalltalksrc/VMMakerTests/VMMethodBuilder.class.st
+++ b/smalltalksrc/VMMakerTests/VMMethodBuilder.class.st
@@ -31,6 +31,16 @@ VMMethodBuilder >> buildMethodHeader [
 		+ (isPrimitive asBit << 16)
 ]
 
+{ #category : #helper }
+VMMethodBuilder >> bytecodeAt: anIndex forMethod: aMethodOop [
+	| methodHeader |
+	"1 based"
+	methodHeader := memory methodHeaderOf: aMethodOop.
+
+	^ (interpreter initialIPForHeader: methodHeader method: aMethodOop) + anIndex - 1.
+
+]
+
 { #category : #accessing }
 VMMethodBuilder >> bytecodes [
 	^ bytecodes

--- a/smalltalksrc/VMMakerTests/VMPrimitiveCallAbstractTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveCallAbstractTest.class.st
@@ -4,8 +4,7 @@ Class {
 	#instVars : [
 		'baseMethodIP',
 		'baseFrame',
-		'baseMethod',
-		'v3Method'
+		'baseMethod'
 	],
 	#category : #'VMMakerTests-JitTests'
 }
@@ -75,22 +74,6 @@ VMPrimitiveCallAbstractTest >> jitCompilerClass [
 VMPrimitiveCallAbstractTest >> jitMethod: aPharoCompiledMethod [ 
 
 	^ self jitMethod: aPharoCompiledMethod selector: memory nilObject
-]
-
-{ #category : #helpers }
-VMPrimitiveCallAbstractTest >> jitMethod: aPharoCompiledMethod selector: aSelectorOop [
-
-	| methodOop |
-	
-	"We are using V3 bytecode, so we need to recompile the method"
-	v3Method := aPharoCompiledMethod methodClass compiler
-							encoderClass: EncoderForV3PlusClosures;
-							options: #(-optionFullBlockClosure);
-							compile: aPharoCompiledMethod sourceCode.
-	
-	methodOop := methodBuilder fillFromPharoMethod: v3Method; buildMethod.
-
-	^ cogit cog: methodOop selector: aSelectorOop
 ]
 
 { #category : #'methods under test' }

--- a/smalltalksrc/VMMakerTests/VMSpurMemoryManagerTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurMemoryManagerTest.class.st
@@ -483,16 +483,16 @@ VMSpurMemoryManagerTest >> setUp [
 	"Schedule a GC, so it does not try to schedule one"
 	memory needGCFlag: 1.
 	
-	stackBuilder := VMStackBuilder new
-		interpreter: interpreter; 
-		memory: memory;
-		yourself.
-				
-	methodBuilder := VMMethodBuilder new
+		methodBuilder := VMMethodBuilder new
 		interpreter: interpreter; 
 		memory: memory;
 		yourself.
 
+	stackBuilder := VMStackBuilder new
+		interpreter: interpreter; 
+		memory: memory;
+		methodBuilder: methodBuilder;
+		yourself.
 ]
 
 { #category : #running }

--- a/smalltalksrc/VMMakerTests/VMSpurMemoryManagerTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurMemoryManagerTest.class.st
@@ -16,7 +16,8 @@ Class {
 		'methodCacheSize',
 		'rumpCStackSize',
 		'wordSize',
-		'methodBuilder'
+		'methodBuilder',
+		'v3Method'
 	],
 	#pools : [
 		'VMBasicConstants',
@@ -48,6 +49,21 @@ VMSpurMemoryManagerTest >> createActiveProcess [
 	"Create a new process with the 4 mandatory instance variables and set it as active process"
 	memory storePointer: ActiveProcessIndex ofObject: processorOop withValue:  (self newObjectWithSlots: 4).
 
+]
+
+{ #category : #helpers }
+VMSpurMemoryManagerTest >> createMethodOopFromPharoMethod: aPharoCompiledMethod [
+
+	| methodOop |
+	v3Method := aPharoCompiledMethod methodClass compiler
+		            encoderClass: EncoderForV3PlusClosures;
+		            options: #( - optionFullBlockClosure );
+		            compile: aPharoCompiledMethod sourceCode.
+
+	methodOop := methodBuilder
+		             fillFromPharoMethod: v3Method;
+		             buildMethod.
+	^ methodOop
 ]
 
 { #category : #accessing }
@@ -139,6 +155,16 @@ VMSpurMemoryManagerTest >> interpreter [
 { #category : #helpers }
 VMSpurMemoryManagerTest >> interpreterClass [ 
 	^ StackInterpreterSimulatorLSB
+]
+
+{ #category : #helpers }
+VMSpurMemoryManagerTest >> jitMethod: aPharoCompiledMethod selector: aSelectorOop [
+
+	| methodOop |
+	"We are using V3 bytecode, so we need to recompile the method"
+	methodOop := self createMethodOopFromPharoMethod:
+		             aPharoCompiledMethod.
+	^ cogit cog: methodOop selector: aSelectorOop
 ]
 
 { #category : #tests }

--- a/smalltalksrc/VMMakerTests/VMStackBuilder.class.st
+++ b/smalltalksrc/VMMakerTests/VMStackBuilder.class.st
@@ -48,7 +48,7 @@ VMStackBuilder >> addNewFrame [
 	| frame |
 	"'add' a new frame in the sense of an OrderedCollection, which will be iterated with #do:
 	The last frame added, will be the stackTop"
-	frame := VMFrameBuilder new initializeWithInterpreter: interpreter andMemory: memory.
+	frame := VMFrameBuilder new initializeWithInterpreter: interpreter andMemory: memory andMethodBuilder: methodBuilder.
 	frames add: frame.
 	^ frame "the frame is then configured by the caller"
 ]
@@ -98,6 +98,18 @@ VMStackBuilder >> initialize [
 	super initialize.
 	frames := OrderedCollection new. "will be treated in reverse"
 	args := OrderedCollection new.
+]
+
+{ #category : #accessing }
+VMStackBuilder >> methodBuilder [
+
+	^ methodBuilder
+]
+
+{ #category : #accessing }
+VMStackBuilder >> methodBuilder: anObject [
+
+	methodBuilder := anObject
 ]
 
 { #category : #accessing }
@@ -169,7 +181,7 @@ VMStackBuilder >> setInterpreterVariables [
 	interpreter setStackPageAndLimit: page.
 	interpreter setStackPointersFromPage: page.
 	interpreter internalizeIPandSP.
-
+	
 	lastFrame := frames last.
 	interpreter method: lastFrame method.
 

--- a/smalltalksrc/VMMakerTests/VMStackBuilder.class.st
+++ b/smalltalksrc/VMMakerTests/VMStackBuilder.class.st
@@ -32,7 +32,8 @@ Class {
 	#instVars : [
 		'page',
 		'frames',
-		'args'
+		'args',
+		'methodBuilder'
 	],
 	#category : #'VMMakerTests-Builders'
 }
@@ -164,7 +165,7 @@ VMStackBuilder >> pushFrames [
 
 { #category : #build }
 VMStackBuilder >> setInterpreterVariables [
-	| lastFrame methodHeader methodOop |
+	| lastFrame |
 	interpreter setStackPageAndLimit: page.
 	interpreter setStackPointersFromPage: page.
 	interpreter internalizeIPandSP.

--- a/smalltalksrc/VMMakerTests/VMStackBuilder.class.st
+++ b/smalltalksrc/VMMakerTests/VMStackBuilder.class.st
@@ -171,8 +171,7 @@ VMStackBuilder >> setInterpreterVariables [
 
 	lastFrame := frames last.
 	interpreter method: lastFrame method.
-	interpreter instructionPointer:
-		(interpreter initialIPForHeader: methodHeader method: methodOop) - 1.
+
 ]
 
 { #category : #accessing }

--- a/smalltalksrc/VMMakerTests/VMStackBuilder.class.st
+++ b/smalltalksrc/VMMakerTests/VMStackBuilder.class.st
@@ -171,8 +171,6 @@ VMStackBuilder >> setInterpreterVariables [
 
 	lastFrame := frames last.
 	interpreter method: lastFrame method.
-	interpreter instructionPointer:
-		(interpreter initialIPForHeader: methodHeader method: methodOop) - 1.
 ]
 
 { #category : #accessing }

--- a/smalltalksrc/VMMakerTests/VMStackBuilder.class.st
+++ b/smalltalksrc/VMMakerTests/VMStackBuilder.class.st
@@ -164,13 +164,15 @@ VMStackBuilder >> pushFrames [
 
 { #category : #build }
 VMStackBuilder >> setInterpreterVariables [
-	| lastFrame |
+	| lastFrame methodHeader methodOop |
 	interpreter setStackPageAndLimit: page.
 	interpreter setStackPointersFromPage: page.
 	interpreter internalizeIPandSP.
 
 	lastFrame := frames last.
 	interpreter method: lastFrame method.
+	interpreter instructionPointer:
+		(interpreter initialIPForHeader: methodHeader method: methodOop) - 1.
 ]
 
 { #category : #accessing }

--- a/smalltalksrc/VMMakerTests/VMStackMappingTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMStackMappingTest.class.st
@@ -11,7 +11,7 @@ VMStackMappingTest >> buildStackFromFrames [
 		method := methodBuilder newMethod buildMethod.
 		stackBuilder addNewFrame 
 			method: method;
-			beSuspendedAt: method + 17.
+			beSuspended
 		].
 
 	stackBuilder buildStack.


### PR DESCRIPTION
When building a stack, the instruction pointer is set automatically to before the first bytecode.
This is relying on the #129 being merged.