### PR TITLE
quickFix: changed a #jitMethod:selector:'s method class to be right

### DIFF
--- a/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitAbstractTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitAbstractTest.class.st
@@ -424,6 +424,16 @@ VMSimpleStackBasedCogitAbstractTest >> jitCompilerClass [
 	^ SimpleStackBasedCogit
 ]
 
+{ #category : #helpers }
+VMSimpleStackBasedCogitAbstractTest >> jitMethod: aPharoCompiledMethod selector: aSelectorOop [
+
+	| methodOop |
+	"We are using V3 bytecode, so we need to recompile the method"
+	methodOop := self createMethodOopFromPharoMethod:
+		             aPharoCompiledMethod.
+	^ cogit cog: methodOop selector: aSelectorOop
+]
+
 { #category : #running }
 VMSimpleStackBasedCogitAbstractTest >> jitOptions [
 

--- a/smalltalksrc/VMMakerTests/VMSpurMemoryManagerTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurMemoryManagerTest.class.st
@@ -164,16 +164,6 @@ VMSpurMemoryManagerTest >> interpreterClass [
 	^ StackInterpreterSimulatorLSB
 ]
 
-{ #category : #helpers }
-VMSpurMemoryManagerTest >> jitMethod: aPharoCompiledMethod selector: aSelectorOop [
-
-	| methodOop |
-	"We are using V3 bytecode, so we need to recompile the method"
-	methodOop := self createMethodOopFromPharoMethod:
-		             aPharoCompiledMethod.
-	^ cogit cog: methodOop selector: aSelectorOop
-]
-
 { #category : #tests }
 VMSpurMemoryManagerTest >> keepObjectInVMVariable1: anOop [
 	interpreter newMethod: anOop


### PR DESCRIPTION
[fix] Push down  #jitMethod:selector:, otherwise a IV (cogit) is unknown, and the method is not usable. (mostly used in machine code compaction tests)