### PR TITLE
[fix] fix usage of images in the simulation

### DIFF
--- a/smalltalksrc/VMMaker/CogVMSimulator.class.st
+++ b/smalltalksrc/VMMaker/CogVMSimulator.class.st
@@ -2632,8 +2632,6 @@ CogVMSimulator >> openOn: fileName extraMemory: extraBytes [
 	systemAttributes at: 1 put: fileName; at: 2 put: nil.
 
 	["begin ensure block..."
-	imageName := f fullName.
-	f binary.
 
 	version := self getWord32FromFile: f swap: false.  "current version: 16r1968 (=6504) vive la revolucion!"
 	(self readableFormat: version)
@@ -2728,6 +2726,7 @@ CogVMSimulator >> openOn: fileName extraMemory: extraBytes [
 							ifFalse: [allocationReserve])].
 
 	objectMemory allocateMemoryOfSize: vmRequiredMemorySize + heapSize.	
+	objectMemory memory initialAddress: 0.
 	
 	heapBase := objectMemory
 					setHeapBase: objectMemory memory initialAddress + vmRequiredMemorySize
@@ -3536,6 +3535,11 @@ CogVMSimulator >> setImageHeaderFlagsFrom: headerFlags [
 	^self perform: #setImageHeaderFlagsFrom:
 		withArguments: {headerFlags}
 		inSuperclass: (cogThreadManager ifNil: [CoInterpreterPrimitives] ifNotNil: [CoInterpreterMT])
+]
+
+{ #category : #accessing }
+CogVMSimulator >> setImageName: aString [ 
+	imageName := aString
 ]
 
 { #category : #'multi-threading simulation switch' }

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -11157,14 +11157,11 @@ StackInterpreter >> openImageFileNamed: fileName [
 	"Attempt to open fileName or fileName, '.image'"
 	<doNotGenerate>
 	| f |
-	f := [FileStream readOnlyFileNamed: fileName]
-			on: FileDoesNotExistException
-			do: [:ex|
-				 ((fileName endsWith: '.image') not
-				  and: [(fileName, '.image') asFileReference exists]) ifFalse:
-					[ex pass].
-				 FileStream readOnlyFileNamed: fileName, '.image'].
-	^f ifNil: [self error: 'no image found'. nil].
+	f := fileName asFileReference.
+	f exists ifFalse: [ (fileName, '.image') asFileReference exists ].
+	f exists ifFalse: [ self error: 'no image found'. nil ].
+	self setImageName: fileName.
+	^ f binaryReadStream 
 ]
 
 { #category : #simulation }
@@ -14386,6 +14383,13 @@ StackInterpreter >> setImageHeaderFlagsFrom: headerFlags [
 	"noThreadingOfGUIThread := headerFlags anyMask: 32. specific to CoInterpreterMT"
 	newFinalization := headerFlags anyMask: 64.
 	sendWheelEvents := headerFlags anyMask: 128
+]
+
+{ #category : #'simulation support' }
+StackInterpreter >> setImageName: aString [ 
+	<doNotGenerate>
+	"Simulation support for when running it with an image"
+	self shouldNotImplement 
 ]
 
 { #category : #'primitive support' }

--- a/smalltalksrc/VMMaker/StackInterpreterSimulator.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreterSimulator.class.st
@@ -1605,8 +1605,6 @@ StackInterpreterSimulator >> openOn: fileName extraMemory: extraBytes [
 	systemAttributes at: 1 put: fileName; at: 2 put: nil.
 
 	["begin ensure block..."
-	imageName := f fullName.
-	f binary.
 
 	version := self getWord32FromFile: f swap: false.  "current version: 16r1968 (=6504) vive la revolucion!"
 	(self readableFormat: version)
@@ -1682,6 +1680,7 @@ StackInterpreterSimulator >> openOn: fileName extraMemory: extraBytes [
 		memoryLimit: heapBase + heapSize
 		endOfMemory: heapBase + dataSize. "bogus for Spur"
 	objectMemory allocateMemoryOfSize: objectMemory memoryLimit.
+	objectMemory memory initialAddress: 0.
 	"read in the image in bulk, then swap the bytes if necessary"
 	f position: headerSize.
 	count := objectMemory readHeapFromImageFile: f dataBytes: dataSize.
@@ -2292,6 +2291,11 @@ StackInterpreterSimulator >> setClickStepBreakBlock [
 { #category : #'spur bootstrap' }
 StackInterpreterSimulator >> setDisplayForm: aForm [
 	displayForm := aForm
+]
+
+{ #category : #accessing }
+StackInterpreterSimulator >> setImageName: aString [ 
+	imageName := aString
 ]
 
 { #category : #'debug printing' }

--- a/smalltalksrc/VMMaker/StackMTInterpreterSimulator.class.st
+++ b/smalltalksrc/VMMaker/StackMTInterpreterSimulator.class.st
@@ -1613,8 +1613,6 @@ StackMTInterpreterSimulator >> openOn: fileName extraMemory: extraBytes [
 	systemAttributes at: 1 put: fileName; at: 2 put: nil.
 
 	["begin ensure block..."
-	imageName := f fullName.
-	f binary.
 
 	version := self getWord32FromFile: f swap: false.  "current version: 16r1968 (=6504) vive la revolucion!"
 	(self readableFormat: version)
@@ -1690,6 +1688,7 @@ StackMTInterpreterSimulator >> openOn: fileName extraMemory: extraBytes [
 		memoryLimit: heapBase + heapSize
 		endOfMemory: heapBase + dataSize. "bogus for Spur"
 	objectMemory allocateMemoryOfSize: objectMemory memoryLimit.
+	objectMemory memory initialAddress: 0.
 	"read in the image in bulk, then swap the bytes if necessary"
 	f position: headerSize.
 	count := objectMemory readHeapFromImageFile: f dataBytes: dataSize.

--- a/smalltalksrc/VMMakerTests/VMSpurMemoryManagerTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurMemoryManagerTest.class.st
@@ -524,7 +524,8 @@ VMSpurMemoryManagerTest >> setUpScheduler [
 
 { #category : #running }
 VMSpurMemoryManagerTest >> setUpUsingImage [
-
+	"/!\ Only runnable with a wordsize equals to your image's (needs disabling parametizing of wordsize) /!\"
+	
 	"This is an alternate setUp using an image to correctly initialize memory/interpreter.
 	Currently not used by default, as some tests still fails, but is usable.
 	For example, we could test that all test are working on both a specific setup, and image load one.
@@ -535,8 +536,7 @@ VMSpurMemoryManagerTest >> setUpUsingImage [
 		
 	"You currently have to setup the path by hand, I do not rememeber/know how to get the directory from a repository, to do a correct relative path
 	Sorry :3"
-	self halt.
-	interpreter openOn: 'fileToPath'.
+	interpreter openOn: 'YourImageHere.image'.
 	interpreter initStackPages.
 	interpreter loadInitialContext.
 	
@@ -546,14 +546,15 @@ VMSpurMemoryManagerTest >> setUpUsingImage [
 	newSpaceSize := memory oldSpaceStart -memory newSpaceStart.
 	oldSpaceSize := memory oldSpaceSize.
 	
-	stackBuilder := VMStackBuilder new
-		interpreter: interpreter; 
-		memory: memory;
-		yourself.
-				
 	methodBuilder := VMMethodBuilder new
 		interpreter: interpreter; 
 		memory: memory;
+		yourself.
+
+	stackBuilder := VMStackBuilder new
+		interpreter: interpreter; 
+		memory: memory;
+		methodBuilder: methodBuilder;
 		yourself.
 		
 ]

--- a/smalltalksrc/VMMakerTests/VMSpurOldSpaceGarbageCollectorTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurOldSpaceGarbageCollectorTest.class.st
@@ -132,6 +132,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testAnOldObjectNotReferencedShouldBeCollec
 { #category : #tests }
 VMSpurOldSpaceGarbageCollectorTest >> testAnOldObjectReferencedFromVMVariableShouldBeKept [
 	| anObjectOop |
+	memory fullGC.
 	
 	anObjectOop := self newOldSpaceObjectWithSlots: 0.
 

--- a/smalltalksrc/VMMakerTests/VMSpurOldSpaceStructureTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurOldSpaceStructureTest.class.st
@@ -15,7 +15,7 @@ VMSpurOldSpaceStructureTest >> testNewMemoryOldSpaceSingleSegmentShouldBeHaveSam
 
 	self
 		assert: memory segmentManager segments first segSize
-		equals: oldSpaceSize
+		equals: memory oldSpaceSize
 ]
 
 { #category : #tests }

--- a/smalltalksrc/VMMakerTests/VMSpurScavengerTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurScavengerTest.class.st
@@ -369,13 +369,14 @@ VMSpurScavengerTest >> testOverflowRememberedSetShouldMakeItGrow [
 	originalLimit := memory scavenger rememberedSetLimit.
 
 	"Create as many objects for the remembered set + 1"
-	oldObjectRootAddress := self newObjectWithSlots: originalLimit + 1.
+	oldObjectRootAddress := self newOldSpaceObjectWithSlots: originalLimit + 1.
 	1 to: originalLimit + 1 do: [ :i | 
 		memory
 			storePointer: i - 1
 			ofObject: oldObjectRootAddress
 			withValue: (self newObjectWithSlots: 1).
 	].
+
 	"Flush them to the old space"
 	memory coInterpreter method: oldObjectRootAddress.
 	memory flushNewSpace.


### PR DESCRIPTION
fixes issue #158.
2 fixes: 
- Loading an image doesn't use the deprecated Streams anymore.
- In the SpurSimulatedMemory, the initialAddress has been changed for the simulation.
  When loading an image however, it's expecting that the initialAddress is 0.
  Therefore, when loading the image, it's now setting initial address to 0.

/!\ ONLY tested with the StackInterpreterSimulator /!\
Still, Copied for the StackMTInterpreterSimulator/CogVMSimulator to retain last known working behavior.

Pierre