### PR TITLE
Adding version extraction when GIT is not there

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,9 +55,8 @@ set(APPNAME Pharo CACHE STRING "VM Application name")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # Extract VCS information
-get_commit_hash(GIT_COMMIT_HASH)
-get_git_describe(GIT_DESCRIBE)
-get_git_date(GIT_COMMIT_DATE)
+include(cmake/versionExtraction.cmake)
+extractVCSInformation(GIT_COMMIT_HASH GIT_DESCRIBE GIT_COMMIT_DATE)
 
 #Variable used to set the VM date
 set(BUILT_FROM "${GIT_DESCRIBE} - Commit: ${GIT_COMMIT_HASH} - Date: ${GIT_COMMIT_DATE}")

--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -43,6 +43,11 @@ install(DIRECTORY
     COMPONENT c-src
 )
 
+install(FILES
+	"${CMAKE_CURRENT_BINARY_DIR}/version.info"
+	DESTINATION pharo-vm
+	COMPONENT c-src)
+
 #List all cmake files
 file(GLOB SUPPORT_CMAKE_FILES
   "${CMAKE_CURRENT_SOURCE_DIR}/*.cmake"
@@ -54,6 +59,20 @@ install(FILES
     DESTINATION pharo-vm
     COMPONENT c-src
 )
+
+if(GENERATE_SOURCES)
+	#Define generated files as elements in the c-src component for packaging
+	install(DIRECTORY
+		${CMAKE_CURRENT_BINARY_DIR}/generated/
+		DESTINATION pharo-vm/generated/
+		COMPONENT c-src)
+
+	install(
+		DIRECTORY "${GENERATED_SOURCE_DIR}/generated/32/vm/include/"
+		DESTINATION include/pharovm
+		COMPONENT include
+	FILES_MATCHING PATTERN *.h)
+endif()
 
 get_platform_name(FULL_PLATFORM_NAME)
 

--- a/cmake/versionExtraction.cmake
+++ b/cmake/versionExtraction.cmake
@@ -1,0 +1,43 @@
+macro(get_commit_hash VARNAME)
+    execute_process(
+        COMMAND git log -1 --format=%h
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE ${VARNAME}
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+endmacro()
+
+macro(get_git_describe VARNAME)
+    execute_process(
+        COMMAND git describe --always
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE ${VARNAME}
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+endmacro()
+
+macro(get_git_date VARNAME)
+    execute_process(
+        COMMAND git log -1 --format=%ai
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE ${VARNAME}
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+endmacro()
+
+macro(extractVCSInformation COMMIT_VARNAME DESCRIBE_VARNAME COMMIT_DATE_VARNAME)
+	get_commit_hash(${COMMIT_VARNAME})
+	get_git_describe(${DESCRIBE_VARNAME})
+	get_git_date(${COMMIT_DATE_VARNAME})
+
+	if("${${COMMIT_VARNAME}}" STREQUAL "")
+		#If I don't have information I try to get it from the version.info file next to the sources (if one)
+		message(STATUS "I couldn't get version information from git, using the version.info next to the sources")
+		file(STRINGS ${CMAKE_CURRENT_SOURCE_DIR}/version.info FILECONTENT LIMIT_COUNT 3)
+		list(GET FILECONTENT 0 ${COMMIT_VARNAME})
+		list(GET FILECONTENT 1 ${DESCRIBE_VARNAME})
+		list(GET FILECONTENT 2 ${COMMIT_DATE_VARNAME})
+	else()
+		#If I have information for the Commit ID, I store it in the version.info file
+		file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/version.info ${${COMMIT_VARNAME}}\n)
+		file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/version.info ${${DESCRIBE_VARNAME}}\n)
+		file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/version.info ${${COMMIT_DATE_VARNAME}})
+	endif()
+endmacro()

--- a/cmake/vmmaker.cmake
+++ b/cmake/vmmaker.cmake
@@ -118,18 +118,6 @@ if(GENERATE_SOURCES)
         COMMAND ${VMMAKER_VM} --headless ${VMMAKER_IMAGE} eval \"PharoVMMaker generate: \#\'${FLAVOUR}\' outputDirectory: \'${CMAKE_CURRENT_BINARY_DIR_TO_OUT}\'\"
         DEPENDS build_vmmaker_get_image
         COMMENT "Generating VM files for flavour: ${FLAVOUR}")
-
-    #Define generated files as elements in the c-src component for packaging
-    install(DIRECTORY
-    ${CMAKE_CURRENT_BINARY_DIR}/generated/
-    DESTINATION pharo-vm/generated/
-    COMPONENT c-src)
-
-    install(
-    DIRECTORY "${GENERATED_SOURCE_DIR}/generated/32/vm/include/"
-    DESTINATION include/pharovm
-    COMPONENT include
-    FILES_MATCHING PATTERN *.h)
     
     add_custom_target(vmmaker DEPENDS build_vmmaker_get_image)
     add_custom_target(generate-sources DEPENDS ${VMSOURCEFILES} ${PLUGIN_GENERATED_FILES})

--- a/macros.cmake
+++ b/macros.cmake
@@ -83,29 +83,6 @@ macro(add_third_party_dependency NAME)
     add_third_party_dependency_with_baseurl(${NAME} ${BASE_URL})
 endmacro()
 
-macro(get_commit_hash VARNAME)
-    execute_process(
-        COMMAND git log -1 --format=%h
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        OUTPUT_VARIABLE ${VARNAME}
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-endmacro()
-
-macro(get_git_describe VARNAME)
-    execute_process(
-        COMMAND git describe --always
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        OUTPUT_VARIABLE ${VARNAME}
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-endmacro()
-
-macro(get_git_date VARNAME)
-    execute_process(
-        COMMAND git log -1 --format=%ai
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        OUTPUT_VARIABLE ${VARNAME}
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-endmacro()
 
 #
 # Compatibility with old CMAKE versions to remove, as fast as posible


### PR DESCRIPTION
Adding version extraction when GIT is not there, keeping the version info with the source