### PR TITLE
fix-do-returnPrimitive-after-image-save

### DIFF
--- a/smalltalksrc/VMMaker/StackInterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreterPrimitives.class.st
@@ -262,6 +262,8 @@ StackInterpreterPrimitives >> doPrimitiveWorkerExtractReturnValue [
 
 	"2. Get the returnHolder from the task"
 	task := self getTaskFromAddress: taskAddress.
+	task ifNil: [ ^ self primitiveFailFor: PrimErrBadReceiver ].
+
 	returnHolder := task returnHolderAddress.
 
 	"3. Marshall the return value and push it in the stack"


### PR DESCRIPTION
Adding testing if the task is nil. This can happen if the image is saved in the middle of a return.

The external address is set to null, and this happens after the image has tested for it. Doing the test in the primitive does not hurt.