### PR TITLE
Fixes in Ephemeron handling

### DIFF
--- a/smalltalksrc/Slang/CArrayOfLongsAccessor.class.st
+++ b/smalltalksrc/Slang/CArrayOfLongsAccessor.class.st
@@ -47,7 +47,7 @@ CArrayOfLongsAccessor >> at: index put: aValue [
 { #category : #'initialize-release' }
 CArrayOfLongsAccessor >> objectMemory: anObjectMemory at: anAddress [
 	objectMemory := anObjectMemory.
-	object := anObjectMemory memory.
+	object := anObjectMemory memoryManager.
 	offset := anAddress / anObjectMemory wordSize.
 	elementByteSize := anObjectMemory wordSize.
 	address := anAddress

--- a/smalltalksrc/Slang/CNewArrayAccessor.class.st
+++ b/smalltalksrc/Slang/CNewArrayAccessor.class.st
@@ -1,9 +1,8 @@
 Class {
 	#name : #CNewArrayAccessor,
-	#superclass : #Object,
+	#superclass : #CObjectAccessor,
 	#instVars : [
-		'address',
-		'manager'
+		'address'
 	],
 	#category : #'Slang-Types'
 }
@@ -33,16 +32,4 @@ CNewArrayAccessor >> address: anObject [
 CNewArrayAccessor >> asInteger [
 	
 	^ address
-]
-
-{ #category : #accessing }
-CNewArrayAccessor >> manager [
-
-	^ manager
-]
-
-{ #category : #accessing }
-CNewArrayAccessor >> manager: anObject [
-
-	manager := anObject
 ]

--- a/smalltalksrc/Slang/CNewArrayAccessor.class.st
+++ b/smalltalksrc/Slang/CNewArrayAccessor.class.st
@@ -1,0 +1,48 @@
+Class {
+	#name : #CNewArrayAccessor,
+	#superclass : #Object,
+	#instVars : [
+		'address',
+		'manager'
+	],
+	#category : #'Slang-Types'
+}
+
+{ #category : #'instance creation' }
+CNewArrayAccessor class >> on: anInteger manager: aVMMemoryManager [ 
+	
+	^ self new
+		address: anInteger;
+		manager: aVMMemoryManager;
+		yourself
+]
+
+{ #category : #accessing }
+CNewArrayAccessor >> address [
+
+	^ address
+]
+
+{ #category : #accessing }
+CNewArrayAccessor >> address: anObject [
+
+	address := anObject
+]
+
+{ #category : #accessing }
+CNewArrayAccessor >> asInteger [
+	
+	^ address
+]
+
+{ #category : #accessing }
+CNewArrayAccessor >> manager [
+
+	^ manager
+]
+
+{ #category : #accessing }
+CNewArrayAccessor >> manager: anObject [
+
+	manager := anObject
+]

--- a/smalltalksrc/Slang/SlangMemoryManager.class.st
+++ b/smalltalksrc/Slang/SlangMemoryManager.class.st
@@ -1,0 +1,246 @@
+Class {
+	#name : #SlangMemoryManager,
+	#superclass : #Object,
+	#instVars : [
+		'nextAvailableAddress',
+		'memoryMap',
+		'wordSize'
+	],
+	#category : #'Slang-Simulation'
+}
+
+{ #category : #allocating }
+SlangMemoryManager >> allocate: aSize [ 
+	
+	| allocatedAddress newMemoryRegion |
+	allocatedAddress := nextAvailableAddress.
+	nextAvailableAddress := nextAvailableAddress + aSize.
+	
+	"Warrantee that memory regions do not move, for simulation purposes with the FFI"
+	newMemoryRegion := ByteArray new: aSize.
+	newMemoryRegion pinInMemory.
+	
+	memoryMap at: allocatedAddress put: newMemoryRegion.
+	^ allocatedAddress
+]
+
+{ #category : #accessing }
+SlangMemoryManager >> copyFrom: start to: end [
+
+	| region |
+	region := self regionForAddress: start.
+	
+	^ region value
+		copyFrom: start - region key + 1
+		to: end - region key + 1
+]
+
+{ #category : #allocating }
+SlangMemoryManager >> free: anInteger [ 
+	
+	memoryMap removeKey: anInteger
+]
+
+{ #category : #accessing }
+SlangMemoryManager >> initialAddress: anInteger [ 
+	
+	nextAvailableAddress := anInteger
+]
+
+{ #category : #allocating }
+SlangMemoryManager >> initialize [
+
+	super initialize.
+	nextAvailableAddress := 0.
+	memoryMap := Dictionary new
+]
+
+{ #category : #'memory-access' }
+SlangMemoryManager >> long32At: address [
+	
+	^ self readSignedIntegerAt: address size: 4
+]
+
+{ #category : #'memory-access' }
+SlangMemoryManager >> long32At: address put: a32BitValue [
+	
+	^ self writeSignedInteger: a32BitValue at: address size: 4
+]
+
+{ #category : #'memory-access' }
+SlangMemoryManager >> long64At: address [
+	
+	^ self readSignedIntegerAt: address size: 8
+]
+
+{ #category : #'memory-access' }
+SlangMemoryManager >> long64At: address put: a64BitValue [
+	
+	^ self writeSignedInteger: a64BitValue at: address size: 8
+]
+
+{ #category : #'memory-access' }
+SlangMemoryManager >> longAt: address [
+	
+	^ self readSignedIntegerAt: address size: self wordSize
+]
+
+{ #category : #'memory-access' }
+SlangMemoryManager >> longAt: address put: aWordSizedValue [
+	
+	^ self writeSignedInteger: aWordSizedValue at: address size: self wordSize
+]
+
+{ #category : #'memory-access' }
+SlangMemoryManager >> readIntegerAt: address size: size signed: aBoolean [
+	
+	| memory |
+	"Check the access is aligned to the size we want to read"
+	address \\ size ~= 0 ifTrue: [self unalignedAccessError].
+	
+	"Get the memory region where the address is stored"
+	memory := self regionForAddress: address.
+	
+	^ memory value
+		integerAt: address - memory key + 1
+		size: size
+		signed: aBoolean
+]
+
+{ #category : #'memory-access' }
+SlangMemoryManager >> readSignedIntegerAt: address size: size [
+	
+	^ self readIntegerAt: address size: size signed: true
+]
+
+{ #category : #'memory-access' }
+SlangMemoryManager >> readUnsignedIntegerAt: address size: size [
+	
+	^ self readIntegerAt: address size: size signed: false
+]
+
+{ #category : #'memory-allocation' }
+SlangMemoryManager >> reallocate: originalAddress withSize: desiredSize [
+	
+	| newAddress oldRegion newRegion |
+	newAddress := self allocate: desiredSize.
+	oldRegion := memoryMap at: originalAddress.
+	newRegion := memoryMap at: newAddress.
+	newRegion replaceFrom: 1 to: oldRegion size with: oldRegion.
+	self free: originalAddress.
+	^ newAddress
+]
+
+{ #category : #'memory-access' }
+SlangMemoryManager >> regionForAddress: address [
+
+	^ memoryMap associations detect: [ :assoc | 
+		  address between: assoc key and: assoc key + assoc value size - 1 ]
+]
+
+{ #category : #enumerating }
+SlangMemoryManager >> regionsDo: aFullBlockClosure [ 
+	
+	memoryMap keysAndValuesDo: aFullBlockClosure
+]
+
+{ #category : #'memory-access' }
+SlangMemoryManager >> unsignedByteAt: anInteger [
+	
+	^ self readUnsignedIntegerAt: anInteger size: 1
+]
+
+{ #category : #'memory-access' }
+SlangMemoryManager >> unsignedByteAt: anAddress put: aValue [
+	
+	^ self writeUnsignedInteger: aValue at: anAddress size: 1
+]
+
+{ #category : #'memory-access' }
+SlangMemoryManager >> unsignedLong32At: address [
+
+	^ self readUnsignedIntegerAt: address size: 4
+]
+
+{ #category : #'memory-access' }
+SlangMemoryManager >> unsignedLong32At: address put: a32BitValue [ 
+
+	^ self writeUnsignedInteger: a32BitValue at: address size: 4
+]
+
+{ #category : #'memory-access' }
+SlangMemoryManager >> unsignedLong64At: address [
+
+	^ self readUnsignedIntegerAt: address size: 8
+]
+
+{ #category : #'memory-access' }
+SlangMemoryManager >> unsignedLong64At: address put: a64BitValue [ 
+
+	^ self writeUnsignedInteger: a64BitValue at: address size: 8
+]
+
+{ #category : #'memory-access' }
+SlangMemoryManager >> unsignedLongAt: address [
+	
+	^ self readUnsignedIntegerAt: address size: self wordSize
+]
+
+{ #category : #'memory-access' }
+SlangMemoryManager >> unsignedLongAt: address put: aValue [
+	
+	^ self writeUnsignedInteger: aValue at: address size: self wordSize
+]
+
+{ #category : #'memory-access' }
+SlangMemoryManager >> unsignedShortAt: anAddress [
+	
+	^ self readUnsignedIntegerAt: anAddress size: 2
+]
+
+{ #category : #'memory-access' }
+SlangMemoryManager >> unsignedShortAt: anAddress put: aValue [
+	
+	^ self writeUnsignedInteger: aValue at: anAddress size: 2
+]
+
+{ #category : #accessing }
+SlangMemoryManager >> wordSize [
+
+	^ wordSize
+]
+
+{ #category : #accessing }
+SlangMemoryManager >> wordSize: anObject [
+
+	wordSize := anObject
+]
+
+{ #category : #'memory-access' }
+SlangMemoryManager >> writeInteger: aValue at: address size: size signed: aBoolean [
+	
+	| memory |
+	"Check the access is aligned to the size we want to read"
+	address \\ size ~= 0 ifTrue: [self unalignedAccessError].
+	
+	"Get the memory region where the address is stored"
+	memory := self regionForAddress: address.
+	
+	^ memory value
+		integerAt: address - memory key + 1
+		put: aValue
+		size: size
+		signed: aBoolean
+]
+
+{ #category : #'memory-access' }
+SlangMemoryManager >> writeSignedInteger: aValue at: address size: size [
+	self haltIf: [address = 16848072].
+	^ self writeInteger: aValue at: address size: size signed: true
+]
+
+{ #category : #'memory-access' }
+SlangMemoryManager >> writeUnsignedInteger: aValue at: address size: size [
+	
+	^ self writeInteger: aValue at: address size: size signed: false
+]

--- a/smalltalksrc/Slang/SlangMemoryManager.class.st
+++ b/smalltalksrc/Slang/SlangMemoryManager.class.st
@@ -132,6 +132,12 @@ SlangMemoryManager >> reallocate: originalAddress withSize: desiredSize [
 ]
 
 { #category : #'memory-access' }
+SlangMemoryManager >> regionAtAddress: address [
+
+	^ memoryMap at: address
+]
+
+{ #category : #'memory-access' }
 SlangMemoryManager >> regionForAddress: address [
 
 	^ memoryMap associations detect: [ :assoc | 

--- a/smalltalksrc/Slang/VMMaker.class.st
+++ b/smalltalksrc/Slang/VMMaker.class.st
@@ -505,7 +505,7 @@ VMMaker >> couldNotOpenFile: fileName [
 { #category : #initialize }
 VMMaker >> createCodeGenerator [
 "set up a CCodeGenerator for this VMMaker"
-	^CCodeGenerator new
+	^MLVMCCodeGenerator new
 		vmMaker: self;
 		logger: logger;
 		options: optionsDictionary;

--- a/smalltalksrc/VMMaker/CogARMv8Compiler.class.st
+++ b/smalltalksrc/VMMaker/CogARMv8Compiler.class.st
@@ -5093,7 +5093,7 @@ CogARMv8Compiler >> outputMachineCodeAt: targetAddress [
 	<inline: true>
 	0 to: machineCodeSize - 1 by: 4 do:
 		[:j|
-		objectMemory long32At: targetAddress + j put: (machineCode at: j // 4)]
+		objectMemory memoryManager unsignedLong32At: targetAddress + j put: (machineCode at: j // 4)]
 ]
 
 { #category : #'generate machine code' }

--- a/smalltalksrc/VMMaker/CogBlockMethodSurrogate32.class.st
+++ b/smalltalksrc/VMMaker/CogBlockMethodSurrogate32.class.st
@@ -11,14 +11,14 @@ CogBlockMethodSurrogate32 class >> alignedByteSize [
 
 { #category : #accessing }
 CogBlockMethodSurrogate32 >> cbUsesInstVars [
-	^(((memory unsignedByteAt: address + 3 + baseHeaderSize) bitShift: -1) bitAnd: 16r1) ~= 0
+	^(((memory unsignedByteAt: address + 2 + baseHeaderSize) bitShift: -1) bitAnd: 16r1) ~= 0
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate32 >> cbUsesInstVars: aValue [
 	memory
-		unsignedByteAt: address + baseHeaderSize + 3
-		put: (((memory unsignedByteAt: address + baseHeaderSize + 3) bitAnd: 16rFD) + ((aValue ifTrue: [1] ifFalse: [0]) bitShift: 1)).
+		unsignedByteAt: address + baseHeaderSize + 2
+		put: (((memory unsignedByteAt: address + baseHeaderSize + 2) bitAnd: 16rFD) + ((aValue ifTrue: [1] ifFalse: [0]) bitShift: 1)).
 	^aValue
 ]
 
@@ -37,129 +37,129 @@ CogBlockMethodSurrogate32 >> cmIsUnlinked: aValue [
 
 { #category : #accessing }
 CogBlockMethodSurrogate32 >> cmNumArgs [
-	^memory unsignedByteAt: address + 1 + baseHeaderSize
+	^memory unsignedByteAt: address + 0 + baseHeaderSize
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate32 >> cmNumArgs: aValue [
 	^memory
-		unsignedByteAt: address + baseHeaderSize + 1
+		unsignedByteAt: address + baseHeaderSize + 0
 		put: aValue
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate32 >> cmRefersToYoung [
-	^(((memory unsignedByteAt: address + 2 + baseHeaderSize) bitShift: -3) bitAnd: 16r1) ~= 0
+	^(((memory unsignedByteAt: address + 1 + baseHeaderSize) bitShift: -3) bitAnd: 16r1) ~= 0
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate32 >> cmRefersToYoung: aValue [
 	memory
-		unsignedByteAt: address + baseHeaderSize + 2
-		put: (((memory unsignedByteAt: address + baseHeaderSize + 2) bitAnd: 16rF7) + ((aValue ifTrue: [1] ifFalse: [0]) bitShift: 3)).
+		unsignedByteAt: address + baseHeaderSize + 1
+		put: (((memory unsignedByteAt: address + baseHeaderSize + 1) bitAnd: 16rF7) + ((aValue ifTrue: [1] ifFalse: [0]) bitShift: 3)).
 	^aValue
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate32 >> cmType [
-	^(memory unsignedByteAt: address + 2 + baseHeaderSize) bitAnd: 16r7
+	^(memory unsignedByteAt: address + 1 + baseHeaderSize) bitAnd: 16r7
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate32 >> cmType: aValue [
 	self assert: (aValue between: 0 and: 16r7).
 	memory
-		unsignedByteAt: address + baseHeaderSize + 2
-		put: ((memory unsignedByteAt: address + baseHeaderSize + 2) bitAnd: 16rF8) + aValue.
+		unsignedByteAt: address + baseHeaderSize + 1
+		put: ((memory unsignedByteAt: address + baseHeaderSize + 1) bitAnd: 16rF8) + aValue.
 	^aValue
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate32 >> cmUsageCount [
-	^((memory unsignedByteAt: address + 2 + baseHeaderSize) bitShift: -5) bitAnd: 16r7
+	^((memory unsignedByteAt: address + 1 + baseHeaderSize) bitShift: -5) bitAnd: 16r7
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate32 >> cmUsageCount: aValue [
 	self assert: (aValue between: 0 and: 16r7).
 	memory
-		unsignedByteAt: address + baseHeaderSize + 2
-		put: ((memory unsignedByteAt: address + baseHeaderSize + 2) bitAnd: 16r1F) + (aValue bitShift: 5).
+		unsignedByteAt: address + baseHeaderSize + 1
+		put: ((memory unsignedByteAt: address + baseHeaderSize + 1) bitAnd: 16r1F) + (aValue bitShift: 5).
 	^aValue
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate32 >> cmUsesPenultimateLit [
-	^((memory unsignedByteAt: address + 3 + baseHeaderSize) bitAnd: 16r1) ~= 0
+	^((memory unsignedByteAt: address + 2 + baseHeaderSize) bitAnd: 16r1) ~= 0
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate32 >> cmUsesPenultimateLit: aValue [
 	memory
-		unsignedByteAt: address + baseHeaderSize + 3
-		put: (((memory unsignedByteAt: address + baseHeaderSize + 3) bitAnd: 16rFE) + (aValue ifTrue: [1] ifFalse: [0])).
+		unsignedByteAt: address + baseHeaderSize + 2
+		put: (((memory unsignedByteAt: address + baseHeaderSize + 2) bitAnd: 16rFE) + (aValue ifTrue: [1] ifFalse: [0])).
 	^aValue
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate32 >> cpicHasMNUCaseOrCMIsFullBlock [
-	^(((memory unsignedByteAt: address + 2 + baseHeaderSize) bitShift: -4) bitAnd: 16r1) ~= 0
+	^(((memory unsignedByteAt: address + 1 + baseHeaderSize) bitShift: -4) bitAnd: 16r1) ~= 0
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate32 >> cpicHasMNUCaseOrCMIsFullBlock: aValue [
 	memory
-		unsignedByteAt: address + baseHeaderSize + 2
-		put: (((memory unsignedByteAt: address + baseHeaderSize + 2) bitAnd: 16rEF) + ((aValue ifTrue: [1] ifFalse: [0]) bitShift: 4)).
+		unsignedByteAt: address + baseHeaderSize + 1
+		put: (((memory unsignedByteAt: address + baseHeaderSize + 1) bitAnd: 16rEF) + ((aValue ifTrue: [1] ifFalse: [0]) bitShift: 4)).
 	^aValue
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate32 >> homeOffset [
-	^memory unsignedShortAt: address + 1
+	^memory unsignedShortAt: address + 0
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate32 >> homeOffset: aValue [
 	^memory
-		unsignedShortAt: address + 1
+		unsignedShortAt: address + 0
 		put: aValue
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate32 >> padToWord [
-	^memory unsignedLongAt: address + 5
+	^memory unsignedLongAt: address + 4
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate32 >> padToWord: aValue [
 	^memory
-		unsignedLongAt: address + 5
+		unsignedLongAt: address + 4
 		put: aValue
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate32 >> stackCheckOffset [
-	^((memory unsignedShortAt: address + 3 + baseHeaderSize) bitShift: -4) bitAnd: 16rFFF
+	^((memory unsignedShortAt: address + 2 + baseHeaderSize) bitShift: -4) bitAnd: 16rFFF
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate32 >> stackCheckOffset: aValue [
 	self assert: (aValue between: 0 and: 16rFFF).
 	memory
-		unsignedShortAt: address + baseHeaderSize + 3
-		put: ((memory unsignedShortAt: address + baseHeaderSize + 3) bitAnd: 16rF) + (aValue bitShift: 4).
+		unsignedShortAt: address + baseHeaderSize + 2
+		put: ((memory unsignedShortAt: address + baseHeaderSize + 2) bitAnd: 16rF) + (aValue bitShift: 4).
 	^aValue
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate32 >> startpc [
-	^memory unsignedShortAt: address + 3
+	^memory unsignedShortAt: address + 2
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate32 >> startpc: aValue [
 	^memory
-		unsignedShortAt: address + 3
+		unsignedShortAt: address + 2
 		put: aValue
 ]

--- a/smalltalksrc/VMMaker/CogBlockMethodSurrogate64.class.st
+++ b/smalltalksrc/VMMaker/CogBlockMethodSurrogate64.class.st
@@ -11,14 +11,14 @@ CogBlockMethodSurrogate64 class >> alignedByteSize [
 
 { #category : #accessing }
 CogBlockMethodSurrogate64 >> cbUsesInstVars [
-	^(((memory unsignedByteAt: address + 3 + baseHeaderSize) bitShift: -1) bitAnd: 16r1) ~= 0
+	^(((memory unsignedByteAt: address + 2 + baseHeaderSize) bitShift: -1) bitAnd: 16r1) ~= 0
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate64 >> cbUsesInstVars: aValue [
 	memory
-		unsignedByteAt: address + baseHeaderSize + 3
-		put: (((memory unsignedByteAt: address + baseHeaderSize + 3) bitAnd: 16rFD) + ((aValue ifTrue: [1] ifFalse: [0]) bitShift: 1)).
+		unsignedByteAt: address + baseHeaderSize + 2
+		put: (((memory unsignedByteAt: address + baseHeaderSize + 2) bitAnd: 16rFD) + ((aValue ifTrue: [1] ifFalse: [0]) bitShift: 1)).
 	^aValue
 ]
 
@@ -37,129 +37,129 @@ CogBlockMethodSurrogate64 >> cmIsUnlinked: aValue [
 
 { #category : #accessing }
 CogBlockMethodSurrogate64 >> cmNumArgs [
-	^memory unsignedByteAt: address + 1 + baseHeaderSize
+	^memory unsignedByteAt: address + 0 + baseHeaderSize
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate64 >> cmNumArgs: aValue [
 	^memory
-		unsignedByteAt: address + baseHeaderSize + 1
+		unsignedByteAt: address + baseHeaderSize + 0
 		put: aValue
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate64 >> cmRefersToYoung [
-	^(((memory unsignedByteAt: address + 2 + baseHeaderSize) bitShift: -3) bitAnd: 16r1) ~= 0
+	^(((memory unsignedByteAt: address + 1 + baseHeaderSize) bitShift: -3) bitAnd: 16r1) ~= 0
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate64 >> cmRefersToYoung: aValue [
 	memory
-		unsignedByteAt: address + baseHeaderSize + 2
-		put: (((memory unsignedByteAt: address + baseHeaderSize + 2) bitAnd: 16rF7) + ((aValue ifTrue: [1] ifFalse: [0]) bitShift: 3)).
+		unsignedByteAt: address + baseHeaderSize + 1
+		put: (((memory unsignedByteAt: address + baseHeaderSize + 1) bitAnd: 16rF7) + ((aValue ifTrue: [1] ifFalse: [0]) bitShift: 3)).
 	^aValue
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate64 >> cmType [
-	^(memory unsignedByteAt: address + 2 + baseHeaderSize) bitAnd: 16r7
+	^(memory unsignedByteAt: address + 1 + baseHeaderSize) bitAnd: 16r7
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate64 >> cmType: aValue [
 	self assert: (aValue between: 0 and: 16r7).
 	memory
-		unsignedByteAt: address + baseHeaderSize + 2
-		put: ((memory unsignedByteAt: address + baseHeaderSize + 2) bitAnd: 16rF8) + aValue.
+		unsignedByteAt: address + baseHeaderSize + 1
+		put: ((memory unsignedByteAt: address + baseHeaderSize + 1) bitAnd: 16rF8) + aValue.
 	^aValue
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate64 >> cmUsageCount [
-	^((memory unsignedByteAt: address + 2 + baseHeaderSize) bitShift: -5) bitAnd: 16r7
+	^((memory unsignedByteAt: address + 1 + baseHeaderSize) bitShift: -5) bitAnd: 16r7
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate64 >> cmUsageCount: aValue [
 	self assert: (aValue between: 0 and: 16r7).
 	memory
-		unsignedByteAt: address + baseHeaderSize + 2
-		put: ((memory unsignedByteAt: address + baseHeaderSize + 2) bitAnd: 16r1F) + (aValue bitShift: 5).
+		unsignedByteAt: address + baseHeaderSize + 1
+		put: ((memory unsignedByteAt: address + baseHeaderSize + 1) bitAnd: 16r1F) + (aValue bitShift: 5).
 	^aValue
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate64 >> cmUsesPenultimateLit [
-	^((memory unsignedByteAt: address + 3 + baseHeaderSize) bitAnd: 16r1) ~= 0
+	^((memory unsignedByteAt: address + 2 + baseHeaderSize) bitAnd: 16r1) ~= 0
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate64 >> cmUsesPenultimateLit: aValue [
 	memory
-		unsignedByteAt: address + baseHeaderSize + 3
-		put: (((memory unsignedByteAt: address + baseHeaderSize + 3) bitAnd: 16rFE) + (aValue ifTrue: [1] ifFalse: [0])).
+		unsignedByteAt: address + baseHeaderSize + 2
+		put: (((memory unsignedByteAt: address + baseHeaderSize + 2) bitAnd: 16rFE) + (aValue ifTrue: [1] ifFalse: [0])).
 	^aValue
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate64 >> cpicHasMNUCaseOrCMIsFullBlock [
-	^(((memory unsignedByteAt: address + 2 + baseHeaderSize) bitShift: -4) bitAnd: 16r1) ~= 0
+	^(((memory unsignedByteAt: address + 1 + baseHeaderSize) bitShift: -4) bitAnd: 16r1) ~= 0
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate64 >> cpicHasMNUCaseOrCMIsFullBlock: aValue [
 	memory
-		unsignedByteAt: address + baseHeaderSize + 2
-		put: (((memory unsignedByteAt: address + baseHeaderSize + 2) bitAnd: 16rEF) + ((aValue ifTrue: [1] ifFalse: [0]) bitShift: 4)).
+		unsignedByteAt: address + baseHeaderSize + 1
+		put: (((memory unsignedByteAt: address + baseHeaderSize + 1) bitAnd: 16rEF) + ((aValue ifTrue: [1] ifFalse: [0]) bitShift: 4)).
 	^aValue
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate64 >> homeOffset [
-	^memory unsignedShortAt: address + 1
+	^memory unsignedShortAt: address + 0
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate64 >> homeOffset: aValue [
 	^memory
-		unsignedShortAt: address + 1
+		unsignedShortAt: address + 0
 		put: aValue
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate64 >> padToWord [
-	^memory unsignedLong64At: address + 5
+	^memory unsignedLong64At: address + 4
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate64 >> padToWord: aValue [
 	^memory
-		unsignedLong64At: address + 5
+		unsignedLong64At: address + 4
 		put: aValue
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate64 >> stackCheckOffset [
-	^((memory unsignedShortAt: address + 3 + baseHeaderSize) bitShift: -4) bitAnd: 16rFFF
+	^((memory unsignedShortAt: address + 2 + baseHeaderSize) bitShift: -4) bitAnd: 16rFFF
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate64 >> stackCheckOffset: aValue [
 	self assert: (aValue between: 0 and: 16rFFF).
 	memory
-		unsignedShortAt: address + baseHeaderSize + 3
-		put: ((memory unsignedShortAt: address + baseHeaderSize + 3) bitAnd: 16rF) + (aValue bitShift: 4).
+		unsignedShortAt: address + baseHeaderSize + 2
+		put: ((memory unsignedShortAt: address + baseHeaderSize + 2) bitAnd: 16rF) + (aValue bitShift: 4).
 	^aValue
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate64 >> startpc [
-	^memory unsignedShortAt: address + 3
+	^memory unsignedShortAt: address + 2
 ]
 
 { #category : #accessing }
 CogBlockMethodSurrogate64 >> startpc: aValue [
 	^memory
-		unsignedShortAt: address + 3
+		unsignedShortAt: address + 2
 		put: aValue
 ]

--- a/smalltalksrc/VMMaker/CogMethodSurrogate.class.st
+++ b/smalltalksrc/VMMaker/CogMethodSurrogate.class.st
@@ -113,7 +113,7 @@ CogMethodSurrogate >> at: anAddress memory: memoryArray headerSize: headerSize c
 { #category : #'instance initialization' }
 CogMethodSurrogate >> at: anAddress objectMemory: objectMemory cogit: aCogit [
 	address := anAddress.
-	memory := objectMemory memory.
+	memory := objectMemory memoryManager.
 	baseHeaderSize := objectMemory baseHeaderSize.
 	cogit := aCogit
 ]
@@ -195,15 +195,15 @@ CogMethodSurrogate >> nextOpenPIC: cogMethodSurrogateOrNil [
 { #category : #accessing }
 CogMethodSurrogate >> objectHeader [
 	^baseHeaderSize = 8
-		ifTrue: [memory long64At: address + 1]
-		ifFalse: [memory longAt: address + 1]
+		ifTrue: [memory long64At: address]
+		ifFalse: [memory longAt: address]
 ]
 
 { #category : #accessing }
 CogMethodSurrogate >> objectHeader: aValue [
 	^baseHeaderSize = 8
-		ifTrue: [memory long64At: address + 1 put: aValue]
-		ifFalse: [memory longAt: address + 1 put: aValue]
+		ifTrue: [memory long64At: address put: aValue]
+		ifFalse: [memory longAt: address put: aValue]
 ]
 
 { #category : #printing }

--- a/smalltalksrc/VMMaker/CogMethodSurrogate32.class.st
+++ b/smalltalksrc/VMMaker/CogMethodSurrogate32.class.st
@@ -47,60 +47,60 @@ CogMethodSurrogate32 class >> offsetOf: aByteSymbol [
 
 { #category : #accessing }
 CogMethodSurrogate32 >> blockEntryOffset [
-	^memory unsignedShortAt: address + 7 + baseHeaderSize
+	^memory unsignedShortAt: address + 6 + baseHeaderSize
 ]
 
 { #category : #accessing }
 CogMethodSurrogate32 >> blockEntryOffset: aValue [
 	^memory
-		unsignedShortAt: address + baseHeaderSize + 7
+		unsignedShortAt: address + baseHeaderSize + 6
 		put: aValue
 ]
 
 { #category : #accessing }
 CogMethodSurrogate32 >> blockSize [
-	^memory unsignedShortAt: address + 5 + baseHeaderSize
+	^memory unsignedShortAt: address + 4 + baseHeaderSize
 ]
 
 { #category : #accessing }
 CogMethodSurrogate32 >> blockSize: aValue [
 	^memory
-		unsignedShortAt: address + baseHeaderSize + 5
+		unsignedShortAt: address + baseHeaderSize + 4
 		put: aValue
 ]
 
 { #category : #accessing }
 CogMethodSurrogate32 >> methodHeader [
-	^memory unsignedLongAt: address + 13 + baseHeaderSize
+	^memory unsignedLongAt: address + 12 + baseHeaderSize
 ]
 
 { #category : #accessing }
 CogMethodSurrogate32 >> methodHeader: aValue [
 	^memory
-		unsignedLongAt: address + baseHeaderSize + 13
+		unsignedLongAt: address + baseHeaderSize + 12
 		put: aValue
 ]
 
 { #category : #accessing }
 CogMethodSurrogate32 >> methodObject [
-	^memory unsignedLongAt: address + 9 + baseHeaderSize
+	^memory unsignedLongAt: address + 8 + baseHeaderSize
 ]
 
 { #category : #accessing }
 CogMethodSurrogate32 >> methodObject: aValue [
 	^memory
-		unsignedLongAt: address + baseHeaderSize + 9
+		unsignedLongAt: address + baseHeaderSize + 8
 		put: aValue
 ]
 
 { #category : #accessing }
 CogMethodSurrogate32 >> selector [
-	^memory unsignedLongAt: address + 17 + baseHeaderSize
+	^memory unsignedLongAt: address + 16 + baseHeaderSize
 ]
 
 { #category : #accessing }
 CogMethodSurrogate32 >> selector: aValue [
 	^memory
-		unsignedLongAt: address + baseHeaderSize + 17
+		unsignedLongAt: address + baseHeaderSize + 16
 		put: aValue
 ]

--- a/smalltalksrc/VMMaker/CogMethodSurrogate64.class.st
+++ b/smalltalksrc/VMMaker/CogMethodSurrogate64.class.st
@@ -47,60 +47,60 @@ CogMethodSurrogate64 class >> offsetOf: aByteSymbol [
 
 { #category : #accessing }
 CogMethodSurrogate64 >> blockEntryOffset [
-	^memory unsignedShortAt: address + 7 + baseHeaderSize
+	^memory unsignedShortAt: address + 6 + baseHeaderSize
 ]
 
 { #category : #accessing }
 CogMethodSurrogate64 >> blockEntryOffset: aValue [
 	^memory
-		unsignedShortAt: address + baseHeaderSize + 7
+		unsignedShortAt: address + baseHeaderSize + 6
 		put: aValue
 ]
 
 { #category : #accessing }
 CogMethodSurrogate64 >> blockSize [
-	^memory unsignedShortAt: address + 5 + baseHeaderSize
+	^memory unsignedShortAt: address + 4 + baseHeaderSize
 ]
 
 { #category : #accessing }
 CogMethodSurrogate64 >> blockSize: aValue [
 	^memory
-		unsignedShortAt: address + baseHeaderSize + 5
+		unsignedShortAt: address + baseHeaderSize + 4
 		put: aValue
 ]
 
 { #category : #accessing }
 CogMethodSurrogate64 >> methodHeader [
-	^memory unsignedLong64At: address + 17 + baseHeaderSize
+	^memory unsignedLong64At: address + 16 + baseHeaderSize
 ]
 
 { #category : #accessing }
 CogMethodSurrogate64 >> methodHeader: aValue [
 	^memory
-		unsignedLong64At: address + baseHeaderSize + 17
+		unsignedLong64At: address + baseHeaderSize + 16
 		put: aValue
 ]
 
 { #category : #accessing }
 CogMethodSurrogate64 >> methodObject [
-	^memory unsignedLong64At: address + 9 + baseHeaderSize
+	^memory unsignedLong64At: address + 8 + baseHeaderSize
 ]
 
 { #category : #accessing }
 CogMethodSurrogate64 >> methodObject: aValue [
 	^memory
-		unsignedLong64At: address + baseHeaderSize + 9
+		unsignedLong64At: address + baseHeaderSize + 8
 		put: aValue
 ]
 
 { #category : #accessing }
 CogMethodSurrogate64 >> selector [
-	^memory unsignedLong64At: address + 25 + baseHeaderSize
+	^memory unsignedLong64At: address + 24 + baseHeaderSize
 ]
 
 { #category : #accessing }
 CogMethodSurrogate64 >> selector: aValue [
 	^memory
-		unsignedLong64At: address + baseHeaderSize + 25
+		unsignedLong64At: address + baseHeaderSize + 24
 		put: aValue
 ]

--- a/smalltalksrc/VMMaker/CogStackPage.class.st
+++ b/smalltalksrc/VMMaker/CogStackPage.class.st
@@ -54,7 +54,7 @@ CogStackPage class >> getter: getter bitPosition: bitPosition bitWidth: bitWidth
 			[s nextPutAll: 'stackPages surrogateAtAddress: ('].
 		s nextPutAll: 'memory ';
 		   nextPutAll: accessor;
-		   nextPutAll: 'At: address + '; print: startByte + 1.
+		   nextPutAll: 'At: address + '; print: startByte.
 		(typeOrNil notNil and: ['*StackPage*' match: typeOrNil]) ifTrue:
 			[s nextPut: $)]]
 
@@ -119,7 +119,7 @@ CogStackPage class >> setter: getter bitPosition: bitPosition bitWidth: bitWidth
 		(typeOrNil notNil and: ['*StackPage*' match: typeOrNil]) ifFalse:
 			[s nextPut: $^].
 		s nextPutAll: 'memory ';
-		   nextPutAll: accessor; nextPutAll: 'At: address + '; print: startByte + 1;
+		   nextPutAll: accessor; nextPutAll: 'At: address + '; print: startByte;
 		   nextPutAll: ' put: aValue'.
 		(typeOrNil notNil and: ['*StackPage*' match: typeOrNil]) ifTrue:
 			[s nextPutAll: ' asInteger.'; crtab: 1; nextPutAll: '^aValue']]

--- a/smalltalksrc/VMMaker/CogStackPageSurrogate.class.st
+++ b/smalltalksrc/VMMaker/CogStackPageSurrogate.class.st
@@ -26,7 +26,7 @@ CogStackPageSurrogate >> address [
 CogStackPageSurrogate >> address: theAddress simulator: aCoInterpreterSimulator zoneBase: base zoneLimit: limit [
 	address := theAddress.
 	stackPages := aCoInterpreterSimulator stackPages.
-	memory := aCoInterpreterSimulator memory.
+	memory := aCoInterpreterSimulator memoryManager.
 	zoneBase := base.
 	zoneLimit := limit
 ]

--- a/smalltalksrc/VMMaker/CogStackPageSurrogate32.class.st
+++ b/smalltalksrc/VMMaker/CogStackPageSurrogate32.class.st
@@ -25,128 +25,128 @@ Class {
 
 { #category : #accessing }
 CogStackPageSurrogate32 class >> alignedByteSize [
-	^40
+	^44
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate32 >> baseAddress [
-	^memory unsignedLongAt: address + 17
+	^memory unsignedLongAt: address + 16
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate32 >> baseAddress: aValue [
 	self assert: (address + 16 >= zoneBase and: [address + 19 < zoneLimit]).
-	^memory unsignedLongAt: address + 17 put: aValue
+	^memory unsignedLongAt: address + 16 put: aValue
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate32 >> baseFP [
-	^memory unsignedLongAt: address + 13
+	^memory unsignedLongAt: address + 12
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate32 >> baseFP: aValue [
 	self assert: (address + 12 >= zoneBase and: [address + 15 < zoneLimit]).
-	^memory unsignedLongAt: address + 13 put: aValue
+	^memory unsignedLongAt: address + 12 put: aValue
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate32 >> headFP [
-	^memory unsignedLongAt: address + 9
+	^memory unsignedLongAt: address + 8
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate32 >> headFP: aValue [
 	self assert: (address + 8 >= zoneBase and: [address + 11 < zoneLimit]).
-	^memory unsignedLongAt: address + 9 put: aValue
+	^memory unsignedLongAt: address + 8 put: aValue
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate32 >> headSP [
-	^memory unsignedLongAt: address + 5
+	^memory unsignedLongAt: address + 4
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate32 >> headSP: aValue [
 	self assert: (address + 4 >= zoneBase and: [address + 7 < zoneLimit]).
-	^memory unsignedLongAt: address + 5 put: aValue
+	^memory unsignedLongAt: address + 4 put: aValue
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate32 >> lastAddress [
-	^memory unsignedLongAt: address + 25
+	^memory unsignedLongAt: address + 24
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate32 >> lastAddress: aValue [
 	self assert: (address + 24 >= zoneBase and: [address + 27 < zoneLimit]).
-	^memory unsignedLongAt: address + 25 put: aValue
+	^memory unsignedLongAt: address + 24 put: aValue
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate32 >> nextPage [
-	^stackPages surrogateAtAddress: (memory unsignedLongAt: address + 33)
+	^stackPages surrogateAtAddress: (memory unsignedLongAt: address + 36)
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate32 >> nextPage: aValue [
-	self assert: (address + 32 >= zoneBase and: [address + 35 < zoneLimit]).
-	memory unsignedLongAt: address + 33 put: aValue asInteger.
+	self assert: (address + 36 >= zoneBase and: [address + 39 < zoneLimit]).
+	memory unsignedLongAt: address + 36 put: aValue asInteger.
 	^aValue
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate32 >> padToWord [
-	^memory longAt: address + 33
+	^memory longAt: address + 32
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate32 >> padToWord: aValue [
 	self assert: (address + 32 >= zoneBase and: [address + 35 < zoneLimit]).
-	^memory longAt: address + 33 put: aValue
+	^memory longAt: address + 32 put: aValue
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate32 >> prevPage [
-	^stackPages surrogateAtAddress: (memory unsignedLongAt: address + 37)
+	^stackPages surrogateAtAddress: (memory unsignedLongAt: address + 40)
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate32 >> prevPage: aValue [
-	self assert: (address + 36 >= zoneBase and: [address + 39 < zoneLimit]).
-	memory unsignedLongAt: address + 37 put: aValue asInteger.
+	self assert: (address + 40 >= zoneBase and: [address + 43 < zoneLimit]).
+	memory unsignedLongAt: address + 40 put: aValue asInteger.
 	^aValue
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate32 >> realStackLimit [
-	^memory unsignedLongAt: address + 21
+	^memory unsignedLongAt: address + 20
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate32 >> realStackLimit: aValue [
 	self assert: (address + 20 >= zoneBase and: [address + 23 < zoneLimit]).
-	^memory unsignedLongAt: address + 21 put: aValue
+	^memory unsignedLongAt: address + 20 put: aValue
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate32 >> stackLimit [
-	^memory unsignedLongAt: address + 1
+	^memory unsignedLongAt: address + 0
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate32 >> stackLimit: aValue [
 	self assert: (address + 0 >= zoneBase and: [address + 3 < zoneLimit]).
-	^memory unsignedLongAt: address + 1 put: aValue
+	^memory unsignedLongAt: address + 0 put: aValue
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate32 >> trace [
-	^memory longAt: address + 29
+	^memory longAt: address + 28
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate32 >> trace: aValue [
 	self assert: (address + 28 >= zoneBase and: [address + 31 < zoneLimit]).
-	^memory longAt: address + 29 put: aValue
+	^memory longAt: address + 28 put: aValue
 ]

--- a/smalltalksrc/VMMaker/CogStackPageSurrogate64.class.st
+++ b/smalltalksrc/VMMaker/CogStackPageSurrogate64.class.st
@@ -30,123 +30,123 @@ CogStackPageSurrogate64 class >> alignedByteSize [
 
 { #category : #accessing }
 CogStackPageSurrogate64 >> baseAddress [
-	^memory unsignedLong64At: address + 33
+	^memory unsignedLong64At: address + 32
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate64 >> baseAddress: aValue [
 	self assert: (address + 32 >= zoneBase and: [address + 39 < zoneLimit]).
-	^memory unsignedLong64At: address + 33 put: aValue
+	^memory unsignedLong64At: address + 32 put: aValue
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate64 >> baseFP [
-	^memory unsignedLong64At: address + 25
+	^memory unsignedLong64At: address + 24
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate64 >> baseFP: aValue [
 	self assert: (address + 24 >= zoneBase and: [address + 31 < zoneLimit]).
-	^memory unsignedLong64At: address + 25 put: aValue
+	^memory unsignedLong64At: address + 24 put: aValue
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate64 >> headFP [
-	^memory unsignedLong64At: address + 17
+	^memory unsignedLong64At: address + 16
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate64 >> headFP: aValue [
 	self assert: (address + 16 >= zoneBase and: [address + 23 < zoneLimit]).
-	^memory unsignedLong64At: address + 17 put: aValue
+	^memory unsignedLong64At: address + 16 put: aValue
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate64 >> headSP [
-	^memory unsignedLong64At: address + 9
+	^memory unsignedLong64At: address + 8
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate64 >> headSP: aValue [
 	self assert: (address + 8 >= zoneBase and: [address + 15 < zoneLimit]).
-	^memory unsignedLong64At: address + 9 put: aValue
+	^memory unsignedLong64At: address + 8 put: aValue
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate64 >> lastAddress [
-	^memory unsignedLong64At: address + 49
+	^memory unsignedLong64At: address + 48
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate64 >> lastAddress: aValue [
 	self assert: (address + 48 >= zoneBase and: [address + 55 < zoneLimit]).
-	^memory unsignedLong64At: address + 49 put: aValue
+	^memory unsignedLong64At: address + 48 put: aValue
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate64 >> nextPage [
-	^stackPages surrogateAtAddress: (memory unsignedLong64At: address + 61)
+	^stackPages surrogateAtAddress: (memory unsignedLong64At: address + 64)
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate64 >> nextPage: aValue [
-	self assert: (address + 60 >= zoneBase and: [address + 67 < zoneLimit]).
-	memory unsignedLong64At: address + 61 put: aValue asInteger.
+	self assert: (address + 64 >= zoneBase and: [address + 71 < zoneLimit]).
+	memory unsignedLong64At: address + 64 put: aValue asInteger.
 	^aValue
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate64 >> padToWord [
-	^memory longAt: address + 61
+	^memory longAt: address + 60
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate64 >> padToWord: aValue [
 	self assert: (address + 60 >= zoneBase and: [address + 63 < zoneLimit]).
-	^memory longAt: address + 61 put: aValue
+	^memory longAt: address + 60 put: aValue
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate64 >> prevPage [
-	^stackPages surrogateAtAddress: (memory unsignedLong64At: address + 69)
+	^stackPages surrogateAtAddress: (memory unsignedLong64At: address + 72)
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate64 >> prevPage: aValue [
-	self assert: (address + 68 >= zoneBase and: [address + 75 < zoneLimit]).
-	memory unsignedLong64At: address + 69 put: aValue asInteger.
+	self assert: (address + 72 >= zoneBase and: [address + 79 < zoneLimit]).
+	memory unsignedLong64At: address + 72 put: aValue asInteger.
 	^aValue
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate64 >> realStackLimit [
-	^memory unsignedLong64At: address + 41
+	^memory unsignedLong64At: address + 40
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate64 >> realStackLimit: aValue [
 	self assert: (address + 40 >= zoneBase and: [address + 47 < zoneLimit]).
-	^memory unsignedLong64At: address + 41 put: aValue
+	^memory unsignedLong64At: address + 40 put: aValue
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate64 >> stackLimit [
-	^memory unsignedLong64At: address + 1
+	^memory unsignedLong64At: address + 0
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate64 >> stackLimit: aValue [
 	self assert: (address + 0 >= zoneBase and: [address + 7 < zoneLimit]).
-	^memory unsignedLong64At: address + 1 put: aValue
+	^memory unsignedLong64At: address + 0 put: aValue
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate64 >> trace [
-	^memory longAt: address + 57
+	^memory longAt: address + 56
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate64 >> trace: aValue [
 	self assert: (address + 56 >= zoneBase and: [address + 59 < zoneLimit]).
-	^memory longAt: address + 57 put: aValue
+	^memory longAt: address + 56 put: aValue
 ]

--- a/smalltalksrc/VMMaker/Cogit.class.st
+++ b/smalltalksrc/VMMaker/Cogit.class.st
@@ -8341,11 +8341,11 @@ Cogit >> handleABICallOrJumpSimulationTrap: aProcessorSimulationTrap evaluable: 
 	processor
 		simulateLeafCallOf: aProcessorSimulationTrap address
 		nextpc: 16rBADF00D
-		memory: coInterpreter memory.
+		memory: nil.
 
 	evaluable valueWithArguments: (processor
 										postCallArgumentsNumArgs: evaluable numArgs
-										in: coInterpreter memory).
+										in: nil).
 
 	evaluable numArgs < 4 ifFalse: [ 1 halt  "If we have more parameters than the ones that fit in the registers"].
 
@@ -8383,7 +8383,7 @@ Cogit >> handleCallOrJumpSimulationTrap: aProcessorSimulationTrap [
 		ifFalse:
 			[processor
 				simulateJumpCallOf: aProcessorSimulationTrap address
-				memory: (memory := coInterpreter memory).
+				memory: nil.
 			 self recordInstruction: {'(simulated jump to '. aProcessorSimulationTrap address. '/'. function. ')'}].
 	savedFramePointer := coInterpreter framePointer.
 	savedStackPointer := coInterpreter stackPointer.
@@ -8394,7 +8394,7 @@ Cogit >> handleCallOrJumpSimulationTrap: aProcessorSimulationTrap [
 					[clickConfirm := false. self halt]].
 			   evaluable valueWithArguments: (processor
 												postCallArgumentsNumArgs: evaluable numArgs
-												in: memory)]
+												in: nil)]
 				on: ReenterMachineCode
 				do: [:ex| ex return: ex returnValue].
 			
@@ -11663,7 +11663,7 @@ Cogit >> shortcutTrampoline: aProcessorSimulationTrap to: aBlock [
 	processor
 		simulateLeafCallOf: aProcessorSimulationTrap address
 		nextpc: aProcessorSimulationTrap nextpc
-		memory: coInterpreter memory.
+		memory: nil.
 	coInterpreter
 		stackPointer: processor sp;
 		framePointer: processor fp.
@@ -11743,7 +11743,7 @@ Cogit >> simulateEnilopmart: enilopmartAddress numArgs: n [
 		smashRegistersWithValuesFrom: 16r80000000 by: objectMemory wordSize;
 		simulateLeafCallOf: enilopmartAddress
 		nextpc: 16rBADF00D
-		memory: coInterpreter memory.
+		memory: nil.
 	"If we're already simulating in the context of machine code then
 	 this will take us back to handleCallSimulationTrap:.  Otherwise
 	 start executing machine code in the simulator."
@@ -11773,7 +11773,7 @@ Cogit >> simulateLeafCallOf: someFunction [
 	processor
 		simulateLeafCallOf: someFunction
 		nextpc: 16rBADF00D0
-		memory: coInterpreter memory.
+		memory: nil.
 	
 	singleStep 
 		ifTrue: [ self notYetImplemented ].

--- a/smalltalksrc/VMMaker/Spur32BitMMLECoSimulator.class.st
+++ b/smalltalksrc/VMMaker/Spur32BitMMLECoSimulator.class.st
@@ -23,7 +23,7 @@ Spur32BitMMLECoSimulator >> bootstrapping: aBoolean [
 Spur32BitMMLECoSimulator >> byteAt: byteAddress [
 	| lowBits long32 |
 	lowBits := byteAddress bitAnd: 3.
-	long32 := self long32At: byteAddress - lowBits.
+	long32 := memoryManager unsignedLong32At: byteAddress - lowBits.
 	^(long32 bitShift: -8 * lowBits) bitAnd: 16rFF
 ]
 
@@ -236,8 +236,8 @@ Spur32BitMMLECoSimulator >> long64At: byteAddress [
 	"memory is a Bitmap, a 32-bit indexable array of bits"
 	| hiWord loWord |
 	byteAddress \\ 8 ~= 0 ifTrue: [self unalignedAccessError].
-	loWord := memory at: byteAddress // 4 + 1.
-	hiWord := memory at: byteAddress // 4 + 2.
+	loWord := memoryManager unsignedLong32At: byteAddress.
+	hiWord := memoryManager unsignedLong32At: byteAddress + 4.
 	^hiWord = 0
 		ifTrue: [loWord]
 		ifFalse: [(hiWord bitShift: 32) + loWord]
@@ -254,9 +254,8 @@ Spur32BitMMLECoSimulator >> long64At: byteAddress put: a64BitValue [
 
 { #category : #'memory access' }
 Spur32BitMMLECoSimulator >> longAt: byteAddress [
-	"Note: Adjusted for Smalltalk's 1-based array indexing."
-	byteAddress \\ 4 ~= 0 ifTrue: [self unalignedAccessError].
-	^memory at: byteAddress // 4 + 1
+
+	^memoryManager unsignedLong32At: byteAddress
 ]
 
 { #category : #'memory access' }
@@ -267,8 +266,7 @@ Spur32BitMMLECoSimulator >> longAt: byteAddress put: a32BitValue [
 	"((byteAddress between: 16rda8ac and: 16rda8c0)
 	 or: [byteAddress between: 16r8eb98 and: 16r8ebb0]) ifTrue:
 		[self halt]."
-	byteAddress \\ 4 ~= 0 ifTrue: [self unalignedAccessError].
-	^memory at: byteAddress // 4 + 1 put: a32BitValue
+	^ memoryManager unsignedLong32At: byteAddress put: a32BitValue
 ]
 
 { #category : #'image segment in/out' }

--- a/smalltalksrc/VMMaker/Spur32BitMMLESimulator.class.st
+++ b/smalltalksrc/VMMaker/Spur32BitMMLESimulator.class.st
@@ -252,8 +252,8 @@ Spur32BitMMLESimulator >> long64At: byteAddress [
 	"memory is a Bitmap, a 32-bit indexable array of bits"
 	| hiWord loWord |
 	byteAddress \\ 8 ~= 0 ifTrue: [self unalignedAccessError].
-	loWord := memory at: byteAddress // 4 + 1.
-	hiWord := memory at: byteAddress // 4 + 2.
+	loWord := memoryManager long32At: byteAddress.
+	hiWord := memoryManager long32At: byteAddress + 4.
 	^hiWord = 0
 		ifTrue: [loWord]
 		ifFalse: [(hiWord bitShift: 32) + loWord]
@@ -270,9 +270,8 @@ Spur32BitMMLESimulator >> long64At: byteAddress put: a64BitValue [
 
 { #category : #'memory access' }
 Spur32BitMMLESimulator >> longAt: byteAddress [
-	"Note: Adjusted for Smalltalk's 1-based array indexing."
-	byteAddress \\ 4 ~= 0 ifTrue: [self unalignedAccessError].
-	^memory at: byteAddress // 4 + 1
+
+	^ memoryManager unsignedLong32At: byteAddress
 ]
 
 { #category : #'memory access' }
@@ -282,8 +281,7 @@ Spur32BitMMLESimulator >> longAt: byteAddress put: a32BitValue [
 		[self halt]."
 	"(byteAddress between: 16r33FBB8 and: 16r33FBCF) ifTrue:
 		[self halt]."
-	byteAddress \\ 4 ~= 0 ifTrue: [self unalignedAccessError].
-	^memory at: byteAddress // 4 + 1 put: a32BitValue
+	memoryManager unsignedLong32At: byteAddress put: a32BitValue
 ]
 
 { #category : #'image segment in/out' }

--- a/smalltalksrc/VMMaker/Spur32BitMMLESimulator.class.st
+++ b/smalltalksrc/VMMaker/Spur32BitMMLESimulator.class.st
@@ -252,8 +252,8 @@ Spur32BitMMLESimulator >> long64At: byteAddress [
 	"memory is a Bitmap, a 32-bit indexable array of bits"
 	| hiWord loWord |
 	byteAddress \\ 8 ~= 0 ifTrue: [self unalignedAccessError].
-	loWord := memoryManager long32At: byteAddress.
-	hiWord := memoryManager long32At: byteAddress + 4.
+	loWord := memoryManager unsignedLong32At: byteAddress.
+	hiWord := memoryManager unsignedLong32At: byteAddress + 4.
 	^hiWord = 0
 		ifTrue: [loWord]
 		ifFalse: [(hiWord bitShift: 32) + loWord]

--- a/smalltalksrc/VMMaker/Spur32BitMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/Spur32BitMemoryManager.class.st
@@ -756,14 +756,6 @@ Spur32BitMemoryManager >> maxSmallInteger [
 	^16r3FFFFFFF
 ]
 
-{ #category : #simulation }
-Spur32BitMemoryManager >> memoryClass [
-	<doNotGenerate>
-	^SpurSimulatedMemory"self endianness == #little
-		ifTrue: [LittleEndianBitmap]
-		ifFalse: [Bitmap]"
-]
-
 { #category : #'interpreter access' }
 Spur32BitMemoryManager >> methodDictionaryHash: oop mask: mask [
 	<inline: true>

--- a/smalltalksrc/VMMaker/Spur64BitMMLECoSimulator.class.st
+++ b/smalltalksrc/VMMaker/Spur64BitMMLECoSimulator.class.st
@@ -222,9 +222,8 @@ Spur64BitMMLECoSimulator >> loadImageSegmentFrom: segmentWordArray outPointers: 
 
 { #category : #'memory access' }
 Spur64BitMMLECoSimulator >> long32At: byteAddress [
-	"Note: Adjusted for Smalltalk's 1-based array indexing."
-	byteAddress \\ 4 ~= 0 ifTrue: [self unalignedAccessError].
-	^memory at: byteAddress // 4 + 1
+	
+	^ memoryManager unsignedLong32At: byteAddress
 ]
 
 { #category : #'memory access' }
@@ -234,8 +233,7 @@ Spur64BitMMLECoSimulator >> long32At: byteAddress put: a32BitValue [
 		[self halt]."
 	"(byteAddress between: 16r33FBB8 and: 16r33FBCF) ifTrue:
 		[self halt]."
-	byteAddress \\ 4 ~= 0 ifTrue: [self unalignedAccessError].
-	^memory at: byteAddress // 4 + 1 put: a32BitValue
+	^ memoryManager unsignedLong32At: byteAddress put: a32BitValue
 ]
 
 { #category : #'memory access' }
@@ -243,8 +241,8 @@ Spur64BitMMLECoSimulator >> long64At: byteAddress [
 	"memory is a Bitmap, a 32-bit indexable array of bits"
 	| hiWord loWord |
 	byteAddress \\ 8 ~= 0 ifTrue: [self unalignedAccessError].
-	loWord := memory at: byteAddress // 4 + 1.
-	hiWord := memory at: byteAddress // 4 + 2.
+	loWord := memoryManager unsignedLong32At: byteAddress.
+	hiWord := memoryManager unsignedLong32At: byteAddress + 4.
 	^hiWord = 0
 		ifTrue: [loWord]
 		ifFalse: [(hiWord bitShift: 32) + loWord]
@@ -263,14 +261,13 @@ Spur64BitMMLECoSimulator >> long64At: byteAddress put: a64BitValue [
 Spur64BitMMLECoSimulator >> longAt: byteAddress [
 	"Answer the 64-bit word at byteAddress which must be 0 mod 4."
 
-	^self long64At: byteAddress
+	^ memoryManager unsignedLong64At: byteAddress
 ]
 
 { #category : #'memory access' }
 Spur64BitMMLECoSimulator >> longAt: byteAddress put: a64BitValue [
-	"Store the 64-bit value at byteAddress which must be 0 mod 8."
-	"byteAddress = 16r1F5AE8 ifTrue: [self halt]."
-	^self long64At: byteAddress put: a64BitValue
+	"Store an unsigned word-sized value at byteAddress which must be 0 mod 8."
+	^memoryManager unsignedLong64At: byteAddress put: a64BitValue
 ]
 
 { #category : #'image segment in/out' }

--- a/smalltalksrc/VMMaker/Spur64BitMMLESimulator.class.st
+++ b/smalltalksrc/VMMaker/Spur64BitMMLESimulator.class.st
@@ -225,9 +225,8 @@ Spur64BitMMLESimulator >> loadImageSegmentFrom: segmentWordArray outPointers: ou
 
 { #category : #'memory access' }
 Spur64BitMMLESimulator >> long32At: byteAddress [
-	"Note: Adjusted for Smalltalk's 1-based array indexing."
-	byteAddress \\ 4 ~= 0 ifTrue: [self unalignedAccessError].
-	^memory at: byteAddress // 4 + 1
+
+	^ memoryManager unsignedLong32At: byteAddress
 ]
 
 { #category : #'memory access' }
@@ -237,8 +236,7 @@ Spur64BitMMLESimulator >> long32At: byteAddress put: a32BitValue [
 		[self halt]."
 	"(byteAddress between: 16r33FBB8 and: 16r33FBCF) ifTrue:
 		[self halt]."
-	byteAddress \\ 4 ~= 0 ifTrue: [self unalignedAccessError].
-	^memory at: byteAddress // 4 + 1 put: a32BitValue
+	^ memoryManager unsignedLong32At: byteAddress put: a32BitValue
 ]
 
 { #category : #'memory access' }
@@ -246,8 +244,8 @@ Spur64BitMMLESimulator >> long64At: byteAddress [
 	"memory is a Bitmap, a 32-bit indexable array of bits"
 	| hiWord loWord |
 	byteAddress \\ 8 ~= 0 ifTrue: [self unalignedAccessError].
-	loWord := memory at: byteAddress // 4 + 1.
-	hiWord := memory at: byteAddress // 4 + 2.
+	loWord := memoryManager unsignedLong32At: byteAddress.
+	hiWord := memoryManager unsignedLong32At: byteAddress + 4.
 	^hiWord = 0
 		ifTrue: [loWord]
 		ifFalse: [(hiWord bitShift: 32) + loWord]

--- a/smalltalksrc/VMMaker/Spur64BitMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/Spur64BitMemoryManager.class.st
@@ -845,17 +845,6 @@ Spur64BitMemoryManager >> maxSmallInteger [
 	^16rFFFFFFFFFFFFFFF
 ]
 
-{ #category : #simulation }
-Spur64BitMemoryManager >> memoryClass [
-	"Answer the class to use for the memory inst var in simulation.
-	 Answer nil if a suitable class isn't available.  This version emulates 64-bit access given a 32-bit element array."
-	<doNotGenerate>
-	
-	^ SpurSimulatedMemory "self endianness == #little
-		ifTrue: [LittleEndianBitmap]
-		ifFalse: [Bitmap]"
-]
-
 { #category : #'interpreter access' }
 Spur64BitMemoryManager >> methodDictionaryHash: oop mask: mask [
 	<inline: true>

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -5775,7 +5775,7 @@ SpurMemoryManager >> freeTreeOverlapCheck [
 SpurMemoryManager >> freeUnscannedEphemerons [
 	"Free all the memory allocated to keep the unscanned ephemerons"
 	
-	memoryManager free: unscannedEphemerons start
+	self free: unscannedEphemerons start
 ]
 
 { #category : #'simulation only' }

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -619,7 +619,8 @@ Class {
 		'statScavenges',
 		'statShrinkMemory',
 		'statAllocatedBytes',
-		'statMaxAllocSegmentTime'
+		'statMaxAllocSegmentTime',
+		'unscannedEphemeronsQueueInitialSize'
 	],
 	#classVars : [
 		'BitsPerByte',
@@ -720,6 +721,7 @@ SpurMemoryManager class >> declareCVarsIn: aCCodeGenerator [
 	aCCodeGenerator
 		var: #freeListsMask type: #usqInt;
 		var: #freeLists type: #'sqInt *';
+		var: #unscannedEphemeronsQueueInitialSize declareC: 'int unscannedEphemeronsQueueInitialSize = 10000; /* 10k ephemerons by default */';
 		var: #objStackInvalidBecause type: #'char *';
 		var: #unscannedEphemerons type: #SpurContiguousObjStack;
 		var: #heapGrowthToSizeGCRatio type: #float;
@@ -856,13 +858,12 @@ SpurMemoryManager class >> initialize [
 	 in GC and it's good to keep their memory around.  So unused pages
 	 created by popping emptied pages are kept on the ObjStackFreex list.
 	 ObjStackNextx must be the last field for swizzleObjStackAt:."
-	ObjStackPageSlots := 4092. "+ double header = 16k bytes per page in 32-bits"
 	ObjStackTopx := 0.
 	ObjStackMyx := 1.
 	ObjStackFreex := 2.
 	ObjStackNextx := 3.
 	ObjStackFixedSlots := 4.
-	ObjStackLimit := ObjStackPageSlots - ObjStackFixedSlots.
+
 	"The hiddenHootsObject contains the classTable pages and up to 8 additional objects.
 	 Currently we use four; the three objStacks, the mark stack, the weaklings and the
 	 mourn queue, and the rememberedSet."
@@ -905,6 +906,22 @@ SpurMemoryManager class >> initializeCompactClassIndices [
 	ClassArrayCompactIndex := 51.
 	ClassByteStringCompactIndex := 52.
 	ClassBitmapCompactIndex := 53
+]
+
+{ #category : #'class initialization' }
+SpurMemoryManager class >> initializeMiscConstants [
+
+	"An obj stack is a stack of objects stored in a hidden root slot, such as
+	 the markStack or the ephemeronQueue.  It is a linked list of segments,
+	 with the hot end at the head of the list.  It is a word object.  The stack
+	 pointer is in ObjStackTopx and 0 means empty.  The list goes through
+	 ObjStackNextx. We don't want to shrink objStacks, since they're used
+	 in GC and it's good to keep their memory around.  So unused pages
+	 created by popping emptied pages are kept on the ObjStackFreex list.
+	 ObjStackNextx must be the last field for swizzleObjStackAt:."
+	ObjStackPageSlots := InitializationOptions
+		at: #ObjStackPageSlots ifAbsent: [4092]. "+ double header = 16k bytes per page in 32-bits"
+	ObjStackLimit := ObjStackPageSlots - ObjStackFixedSlots.
 ]
 
 { #category : #'class initialization' }
@@ -1951,19 +1968,16 @@ SpurMemoryManager >> allocateLargestFreeChunk [
 { #category : #testing }
 SpurMemoryManager >> allocateMemoryOfSize: memoryBytes [
 	<doNotGenerate>
-	| bytesPerElement |
-	bytesPerElement := (self memoryClass basicNew: 0) bytesPerElement.
-	memory := self memoryClass new: memoryBytes + bytesPerElement - 1 // bytesPerElement
-	
+
+	1halt.
+	^ self allocate: memoryBytes
 ]
 
 { #category : #testing }
 SpurMemoryManager >> allocateMemoryOfSize: memoryBytes initialAddress: initialAddress [
 	<doNotGenerate>
-	| bytesPerElement |
-	bytesPerElement := (self memoryClass basicNew: 0) bytesPerElement.
-	memory := self memoryClass new: memoryBytes + bytesPerElement - 1 // bytesPerElement.
-	memory initialAddress: initialAddress
+
+	^ memoryManager allocate: memoryBytes
 ]
 
 { #category : #'spur bootstrap' }
@@ -2004,28 +2018,39 @@ SpurMemoryManager >> allocateMemoryOfSize: memoryBytes newSpaceSize: newSpaceByt
 { #category : #asd }
 SpurMemoryManager >> allocateMemoryOfSize: memoryBytes newSpaceSize: newSpaceBytes stackSize: stackBytes codeSize: codeBytes methodCacheSize: methodCacheSize primitiveTraceLogSize: primitiveLogSize rumpCStackSize: rumpCStackSize initialAddress: initialAddress [
 
-		"Intialize the receiver for bootsraping an image.
+	"Intialize the receiver for bootsraping an image.
 	 Set up a large oldSpace and an empty newSpace and set-up freeStart and scavengeThreshold
 	 to allocate in oldSpace.  Later on (in initializePostBootstrap) freeStart and scavengeThreshold
 	 will be set to sane values."
+
 	<doNotGenerate>
-	self assert: (memoryBytes \\ self allocationUnit = 0
-				and: [newSpaceBytes \\ self allocationUnit = 0
-				and: [codeBytes \\ self allocationUnit = 0
-				and: [initialAddress \\ self allocationUnit = 0 ]]]).
-	self allocateMemoryOfSize: memoryBytes + newSpaceBytes + codeBytes + stackBytes + methodCacheSize + primitiveLogSize + rumpCStackSize initialAddress: initialAddress.
-	newSpaceStart := initialAddress + codeBytes + stackBytes + methodCacheSize + primitiveLogSize + rumpCStackSize.
-	endOfMemory := freeOldSpaceStart := initialAddress + memoryBytes + newSpaceBytes + codeBytes + stackBytes + methodCacheSize + primitiveLogSize + rumpCStackSize.
+	| allocatedMemory newSpaceStartOffset |
+	self assert: (memoryBytes \\ self allocationUnit = 0 and: [ 
+			 newSpaceBytes \\ self allocationUnit = 0 and: [ 
+				 codeBytes \\ self allocationUnit = 0 and: [ 
+					 initialAddress \\ self allocationUnit = 0 ] ] ]).
+	newSpaceStartOffset := codeBytes + stackBytes
+	                 + methodCacheSize + primitiveLogSize
+	                 + rumpCStackSize.
+	allocatedMemory := newSpaceStartOffset + newSpaceBytes + memoryBytes.
+	memory := self
+		allocateMemoryOfSize: allocatedMemory
+		initialAddress: initialAddress.
+	newSpaceStart := initialAddress + newSpaceStartOffset.
+	endOfMemory := freeOldSpaceStart := initialAddress + allocatedMemory.
 	"leave newSpace empty for the bootstrap"
 	freeStart := newSpaceBytes + newSpaceStart.
 	oldSpaceStart := newSpaceLimit := newSpaceBytes + newSpaceStart.
-	scavengeThreshold := memory size * memory bytesPerElement. "i.e. /don't/ scavenge."
+	scavengeThreshold := allocatedMemory. "i.e. /don't/ scavenge."
 	scavenger := SpurGenerationScavenger simulatorClass new.
 	scavenger manager: self.
-	scavenger newSpaceStart: newSpaceStart
-				newSpaceBytes: newSpaceBytes
-				survivorBytes: newSpaceBytes // self scavengerDenominator.
-	compactor := self class compactorClass simulatorClass new manager: self; yourself
+	scavenger
+		newSpaceStart: newSpaceStart
+		newSpaceBytes: newSpaceBytes
+		survivorBytes: newSpaceBytes // self scavengerDenominator.
+	compactor := self class compactorClass simulatorClass new
+		             manager: self;
+		             yourself
 ]
 
 { #category : #allocation }
@@ -4153,7 +4178,7 @@ SpurMemoryManager >> containsOnlyValidBecomeObjects: array1 and: array2 twoWay: 
 SpurMemoryManager >> convertToArray [
 	<doNotGenerate>
 	"I dont believe it -- this *just works*"
-
+1halt.
 	memory:= memory as: Array
 ]
 
@@ -5741,7 +5766,7 @@ SpurMemoryManager >> freeTreeOverlapCheck [
 SpurMemoryManager >> freeUnscannedEphemerons [
 	"Free all the memory allocated to keep the unscanned ephemerons"
 	
-	self addFreeChunkWithBytes: 50000 * self wordSize at: unscannedEphemerons start.
+	memoryManager free: unscannedEphemerons start
 ]
 
 { #category : #'simulation only' }
@@ -5830,7 +5855,6 @@ SpurMemoryManager >> globalGarbageCollect [
 	self runLeakCheckerFor: GCModeFull
 		excludeUnmarkedObjs: true
 		classIndicesShouldBeValid: true.
-
 	compactionStartUsecs := coInterpreter ioUTCMicrosecondsNow.
 	segmentManager prepareForGlobalSweep. "for notePinned:"
 	compactor compact.
@@ -6426,6 +6450,7 @@ SpurMemoryManager >> initialize [
 
 	"We can initialize things that are allocated but are lazily initialized."
 	unscannedEphemerons := SpurContiguousObjStack new.
+	unscannedEphemeronsQueueInitialSize := 10000. "10k by default"
 
 	"we can initialize things that are virtual in C."
 	scavenger := SpurGenerationScavenger simulatorClass new manager: self; yourself.
@@ -6616,11 +6641,13 @@ SpurMemoryManager >> initializeUnscannedEphemerons [
 	"Initialize unscannedEphemerons to use the largest free chunk
 	 or unused eden space, which ever is the larger."
 	
-	| largestFree |
-	largestFree := self allocateOldSpaceChunkOfBytes: 50000 * self wordSize "support 50K ephemerons".
+	| allocation |
+	"Allocate initially space for 10K ephemerons"
+	allocation := (self calloc: (self sizeof: #'void *') _: unscannedEphemeronsQueueInitialSize).
+	allocation ifNil: [ self error: 'Cannot allocate space for unscanned ephemerons' ].
 	unscannedEphemerons
-				start: largestFree;
-				limit: largestFree + 50000 * self wordSize.
+				start: allocation asInteger;
+				limit: allocation asInteger + ((self sizeof: #'void *') * unscannedEphemeronsQueueInitialSize).
 	unscannedEphemerons top: unscannedEphemerons start
 ]
 
@@ -8829,33 +8856,25 @@ SpurMemoryManager >> memmove: destAddress _: sourceAddress _: bytes [
 	dst := destAddress asInteger.
 	src := sourceAddress asInteger.
 	self assert: bytes \\ 8 + (dst \\ 8) + (src \\ 8) = 0.
-	memory bytesPerElement = 8
-		ifTrue:
-			[destAddress > sourceAddress
-				ifTrue:
-					[bytes - 8 to: 0 by: -8 do:
-						[:i| self long64At: dst + i put: (self long64At: src + i)]]
-				ifFalse:
-					[0 to: bytes - 8 by: 8 do:
-						[:i| self long64At: dst + i put: (self long64At: src + i)]]]
-		ifFalse:
-			[destAddress > sourceAddress
+	destAddress > sourceAddress
 				ifTrue:
 					[bytes - 4 to: 0 by: -4 do:
 						[:i| self long32At: dst + i put: (self long32At: src + i)]]
 				ifFalse:
 					[0 to: bytes - 4 by: 4 do:
-						[:i| self long32At: dst + i put: (self long32At: src + i)]]]
+						[:i| self long32At: dst + i put: (self long32At: src + i)]]
 ]
 
 { #category : #accessing }
 SpurMemoryManager >> memory [
 	<cmacro: '() GIV(memory)'>
+	1halt.
 	^memory
 ]
 
 { #category : #accessing }
 SpurMemoryManager >> memory: aValue [
+	1halt.
 	^memory := aValue
 ]
 
@@ -10852,8 +10871,17 @@ SpurMemoryManager >> pushOnUnscannedEphemeronsStack: anEphemeron [
 	 ephemeron as strong in this GC cycle."
 	<inline: false>
 	self assert: (self isEphemeron: anEphemeron).
-	unscannedEphemerons top >= unscannedEphemerons limit ifTrue:
-		[^false].
+	unscannedEphemerons top >= unscannedEphemerons limit ifTrue: [ | desiredSize reallocated |
+		"Reallocate and duplication"
+		desiredSize := (unscannedEphemerons limit - unscannedEphemerons start) * 2.
+		reallocated := self
+			realloc: unscannedEphemerons start
+			_: desiredSize.
+		reallocated ifNil: [ self error: 'Not enough room to grow unscannedEphemerons queue' ].
+		unscannedEphemerons limit: reallocated + desiredSize.
+		unscannedEphemerons top: reallocated + (unscannedEphemerons top - unscannedEphemerons start).
+		unscannedEphemerons start: reallocated ].
+
 	self longAt: unscannedEphemerons top put: anEphemeron.
 	unscannedEphemerons top: unscannedEphemerons top + self bytesPerOop.
 	^true
@@ -11057,9 +11085,9 @@ SpurMemoryManager >> relocateObjStackForPlanningCompactor: objStack [
 		 freeList := next].
 	
 	"Update the hidden roots object, the class table, to point to the relocated object stack"
-	self storePointer: (self fetchPointer: ObjStackMyx ofObject: objStack)
+	"self storePointer: (self fetchPointer: ObjStackMyx ofObject: objStack)
 		ofObject: hiddenRootsObj
-		withValue: result.
+		withValue: result."
 	
 	^ result
 ]
@@ -11995,6 +12023,7 @@ SpurMemoryManager >> sqAllocateMemorySegmentOfSize: segmentSize Above: minAddres
 	 depending on the number of segments.
 	 The delta will be the distance between segments to be bridged."
 	| delta newMemory start |
+	1halt.
 	self assert: segmentSize \\ memory bytesPerElement = 0.
 	delta := segmentManager numSegments odd ifTrue: [1024 * 1024] ifFalse: [0].
 	"A previous shrink may have freed up memory.  Don't bother to grow if there's already room.
@@ -13188,6 +13217,12 @@ SpurMemoryManager >> unpinObject: objOop [
 	^0
 ]
 
+{ #category : #accessing }
+SpurMemoryManager >> unscannedEphemeronsQueueInitialSize: anInteger [ 
+	
+	unscannedEphemeronsQueueInitialSize := anInteger
+]
+
 { #category : #initialization }
 SpurMemoryManager >> updateFreeLists [
 	"Snapshot did not guarantee the state of the freelist prevLink, so we need to update it.
@@ -13465,6 +13500,7 @@ SpurMemoryManager >> wordSizeClassIndexPun [
 { #category : #simulation }
 SpurMemoryManager >> writeEnableMemory [
 	<doNotGenerate>
+	1halt.
 	memory class == ReadOnlyArrayWrapper ifTrue:
 		[memory := memory array]
 ]
@@ -13478,6 +13514,7 @@ SpurMemoryManager >> writeImageSegmentsToFile: aBinaryStream [
 { #category : #simulation }
 SpurMemoryManager >> writeProtectMemory [
 	<doNotGenerate>
+	1halt.
 	memory class ~~ ReadOnlyArrayWrapper ifTrue:
 		[memory := ReadOnlyArrayWrapper around: memory]
 ]

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -857,8 +857,8 @@ SpurMemoryManager class >> initialize [
 	 created by popping emptied pages are kept on the ObjStackFreex list.
 	 ObjStackNextx must be the last field for swizzleObjStackAt:."
 	ObjStackPageSlots := 4092. "+ double header = 16k bytes per page in 32-bits"
-	ObjStackTopx := 0.
-	ObjStackMyx := 1.
+	ObjStackTopx := 1.
+	ObjStackMyx := 0.
 	ObjStackFreex := 2.
 	ObjStackNextx := 3.
 	ObjStackFixedSlots := 4.

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -863,6 +863,9 @@ SpurMemoryManager class >> initialize [
 	ObjStackFreex := 2.
 	ObjStackNextx := 3.
 	ObjStackFixedSlots := 4.
+	ObjStackPageSlots := InitializationOptions
+		at: #ObjStackPageSlots ifAbsent: [4092]. "+ double header = 16k bytes per page in 32-bits"
+	ObjStackLimit := ObjStackPageSlots - ObjStackFixedSlots.
 
 	"The hiddenHootsObject contains the classTable pages and up to 8 additional objects.
 	 Currently we use four; the three objStacks, the mark stack, the weaklings and the
@@ -906,22 +909,6 @@ SpurMemoryManager class >> initializeCompactClassIndices [
 	ClassArrayCompactIndex := 51.
 	ClassByteStringCompactIndex := 52.
 	ClassBitmapCompactIndex := 53
-]
-
-{ #category : #'class initialization' }
-SpurMemoryManager class >> initializeMiscConstants [
-
-	"An obj stack is a stack of objects stored in a hidden root slot, such as
-	 the markStack or the ephemeronQueue.  It is a linked list of segments,
-	 with the hot end at the head of the list.  It is a word object.  The stack
-	 pointer is in ObjStackTopx and 0 means empty.  The list goes through
-	 ObjStackNextx. We don't want to shrink objStacks, since they're used
-	 in GC and it's good to keep their memory around.  So unused pages
-	 created by popping emptied pages are kept on the ObjStackFreex list.
-	 ObjStackNextx must be the last field for swizzleObjStackAt:."
-	ObjStackPageSlots := InitializationOptions
-		at: #ObjStackPageSlots ifAbsent: [4092]. "+ double header = 16k bytes per page in 32-bits"
-	ObjStackLimit := ObjStackPageSlots - ObjStackFixedSlots.
 ]
 
 { #category : #'class initialization' }

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -857,8 +857,8 @@ SpurMemoryManager class >> initialize [
 	 created by popping emptied pages are kept on the ObjStackFreex list.
 	 ObjStackNextx must be the last field for swizzleObjStackAt:."
 	ObjStackPageSlots := 4092. "+ double header = 16k bytes per page in 32-bits"
-	ObjStackTopx := 1.
-	ObjStackMyx := 0.
+	ObjStackTopx := 0.
+	ObjStackMyx := 1.
 	ObjStackFreex := 2.
 	ObjStackNextx := 3.
 	ObjStackFixedSlots := 4.
@@ -6319,6 +6319,18 @@ SpurMemoryManager >> indexOf: anElement in: anObject [
 	^-1
 ]
 
+{ #category : #'obj stacks' }
+SpurMemoryManager >> indexOfObjStack: objStack [
+	
+	^ self fetchPointer: ObjStackMyx ofObject: objStack
+]
+
+{ #category : #'obj stacks' }
+SpurMemoryManager >> indexOfObjStack: objStack put: aValue [
+	
+	^ self storePointerUnchecked: ObjStackMyx ofObject: objStack withValue: aValue
+]
+
 { #category : #'header formats' }
 SpurMemoryManager >> indexablePointersFormat [
 	<api>
@@ -9658,6 +9670,20 @@ SpurMemoryManager >> objStack: objStack from: start do: aBlock [
 	^size
 ]
 
+{ #category : #'obj stacks' }
+SpurMemoryManager >> objStack: objStack pagesDo: aBlock [
+	"Evaluate aBinaryBlock with all indices and pages of elements in objStack"
+	<inline: true>
+	| objStackPage |
+	objStack = nilObj ifTrue:
+		[^self].
+	self eassert: [self isValidObjStack: objStack].
+	objStackPage := objStack.
+	[objStackPage ~= 0] whileTrue: [
+		aBlock value: objStackPage.
+		objStackPage := self fetchPointer: ObjStackNextx ofObject: objStackPage ]
+]
+
 { #category : #'object enumeration' }
 SpurMemoryManager >> objectAfter: objOop [
 	<api>
@@ -12706,6 +12732,18 @@ SpurMemoryManager >> thirtyTwoBitLongsClassIndexPun [
 	 its class index. The puns occupy indices 16 through 31."
 	<cmacro>
 	^18
+]
+
+{ #category : #'obj stacks' }
+SpurMemoryManager >> topIndexOfObjStack: objStack [
+	
+	^ self fetchPointer: ObjStackTopx ofObject: objStack
+]
+
+{ #category : #'obj stacks' }
+SpurMemoryManager >> topIndexOfObjStack: objStack put: aValue [
+	
+	^ self storePointerUnchecked: ObjStackTopx ofObject: objStack withValue: aValue
 ]
 
 { #category : #'obj stacks' }

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -11107,11 +11107,6 @@ SpurMemoryManager >> relocateObjStackForPlanningCompactor: objStack [
 			to: ObjStackFreex.
 		 freeList := next].
 	
-	"Update the hidden roots object, the class table, to point to the relocated object stack"
-	"self storePointer: (self fetchPointer: ObjStackMyx ofObject: objStack)
-		ofObject: hiddenRootsObj
-		withValue: result."
-	
 	^ result
 ]
 

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -6609,26 +6609,13 @@ SpurMemoryManager >> initializeUnscannedEphemerons [
 	"Initialize unscannedEphemerons to use the largest free chunk
 	 or unused eden space, which ever is the larger."
 	
-	| largestFree sizeOfUnusedEden |
-	largestFree := self allocateOldSpaceChunkOfBytes: 100000 * self wordSize "support 100000 ephemerons".
+	| largestFree |
+	largestFree := self allocateOldSpaceChunkOfBytes: 50000 * self wordSize "support 100000 ephemerons".
 	unscannedEphemerons
-				start: largestFree
+				start: largestFree "16906448"
 					+ self baseHeaderSize
-					+ (self freeChunkLargerIndex + 1 * self wordSize);
-				limit: (self addressAfter: largestFree).
-"	sizeOfUnusedEden := scavenger eden limit - freeStart.
-	(largestFree notNil
-	 and: [(self numSlotsOfAny: largestFree) > (sizeOfUnusedEden / self wordSize)])
-		ifTrue:
-			[unscannedEphemerons
-				start: largestFree
-					+ self baseHeaderSize
-					+ (self freeChunkLargerIndex + 1 * self wordSize);
-				limit: (self addressAfter: largestFree)]
-		ifFalse:
-			[unscannedEphemerons
-				start: freeStart;
-				limit: scavenger eden limit]."
+					+ (self freeChunkLargerIndex + 1 * self wordSize) "16906496";
+				limit: (self addressAfter: largestFree) 				 "16906456".
 	unscannedEphemerons top: unscannedEphemerons start
 ]
 
@@ -9689,6 +9676,13 @@ SpurMemoryManager >> objStack: objStack pagesDo: aBlock [
 		objStackPage := self fetchPointer: ObjStackNextx ofObject: objStackPage ]
 ]
 
+{ #category : #'obj stacks' }
+SpurMemoryManager >> objStackAt: objStackRootIndex [
+	"Return the object stack stored at index objStackRootIndex in the root class table"
+	
+	^ self fetchPointer: objStackRootIndex ofObject: hiddenRootsObj
+]
+
 { #category : #'object enumeration' }
 SpurMemoryManager >> objectAfter: objOop [
 	<api>
@@ -9749,6 +9743,13 @@ SpurMemoryManager >> objectBytesForSlots: numSlots [
 SpurMemoryManager >> objectMemory [
 	<doNotGenerate>
 	^self
+]
+
+{ #category : #'obj stacks' }
+SpurMemoryManager >> objectStackPageLimit [
+	<doNotGenerate>
+	"Return the limit of elements that can be pushed in a page of an object stack"
+	^ ObjStackLimit
 ]
 
 { #category : #'object enumeration' }
@@ -11048,7 +11049,13 @@ SpurMemoryManager >> relocateObjStackForPlanningCompactor: objStack [
 			from: ObjStackFreex
 			to: ObjStackFreex.
 		 freeList := next].
-	^relocated
+	
+	"Update the hidden roots object, the class table, to point to the relocated object stack"
+	self storePointer: (self fetchPointer: ObjStackMyx ofObject: objStack)
+		ofObject: hiddenRootsObj
+		withValue: result.
+	
+	^ result
 ]
 
 { #category : #compaction }

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -6610,8 +6610,13 @@ SpurMemoryManager >> initializeUnscannedEphemerons [
 	 or unused eden space, which ever is the larger."
 	
 	| largestFree sizeOfUnusedEden |
-	largestFree := self findLargestFreeChunk.
-	sizeOfUnusedEden := scavenger eden limit - freeStart.
+	largestFree := self allocateOldSpaceChunkOfBytes: 100000 * self wordSize "support 100000 ephemerons".
+	unscannedEphemerons
+				start: largestFree
+					+ self baseHeaderSize
+					+ (self freeChunkLargerIndex + 1 * self wordSize);
+				limit: (self addressAfter: largestFree).
+"	sizeOfUnusedEden := scavenger eden limit - freeStart.
 	(largestFree notNil
 	 and: [(self numSlotsOfAny: largestFree) > (sizeOfUnusedEden / self wordSize)])
 		ifTrue:
@@ -6623,7 +6628,7 @@ SpurMemoryManager >> initializeUnscannedEphemerons [
 		ifFalse:
 			[unscannedEphemerons
 				start: freeStart;
-				limit: scavenger eden limit].
+				limit: scavenger eden limit]."
 	unscannedEphemerons top: unscannedEphemerons start
 ]
 

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -5737,6 +5737,13 @@ SpurMemoryManager >> freeTreeOverlapCheck [
 					self assert: (start1 > end2 or: [start1 < start2])]]].
 ]
 
+{ #category : #'gc - global' }
+SpurMemoryManager >> freeUnscannedEphemerons [
+	"Free all the memory allocated to keep the unscanned ephemerons"
+	
+	self addFreeChunkWithBytes: 50000 * self wordSize at: unscannedEphemerons start.
+]
+
 { #category : #'simulation only' }
 SpurMemoryManager >> fullDisplayUpdate [
 	"hack around the CoInterpreter/ObjectMemory split refactoring"
@@ -6610,12 +6617,10 @@ SpurMemoryManager >> initializeUnscannedEphemerons [
 	 or unused eden space, which ever is the larger."
 	
 	| largestFree |
-	largestFree := self allocateOldSpaceChunkOfBytes: 50000 * self wordSize "support 100000 ephemerons".
+	largestFree := self allocateOldSpaceChunkOfBytes: 50000 * self wordSize "support 50K ephemerons".
 	unscannedEphemerons
-				start: largestFree "16906448"
-					+ self baseHeaderSize
-					+ (self freeChunkLargerIndex + 1 * self wordSize) "16906496";
-				limit: (self addressAfter: largestFree) 				 "16906456".
+				start: largestFree;
+				limit: largestFree + 50000 * self wordSize.
 	unscannedEphemerons top: unscannedEphemerons start
 ]
 
@@ -8675,6 +8680,7 @@ SpurMemoryManager >> markObjects: objectsShouldBeUnmarkedAndUnmarkedClassesShoul
 	self markAccessibleObjectsAndFireEphemerons.
 	self expungeDuplicateAndUnmarkedClasses: objectsShouldBeUnmarkedAndUnmarkedClassesShouldBeExpunged.
 	self nilUnmarkedWeaklingSlots.
+	self freeUnscannedEphemerons.
 	marking := false
 ]
 

--- a/smalltalksrc/VMMaker/SpurPlanningCompactor.class.st
+++ b/smalltalksrc/VMMaker/SpurPlanningCompactor.class.st
@@ -375,6 +375,7 @@ SpurPlanningCompactor >> endCompaction [
 	manager
 		unmarkSurvivingObjectsForCompact;
 		endSlidingCompaction.
+	self swapMournQueueFields.
 	self repinRememberedSet.
 	self releaseSavedFirstFieldsSpace
 ]
@@ -454,6 +455,9 @@ SpurPlanningCompactor >> initializeCompaction [
 	manager checkFreeSpace: GCModeFull.
 	self selectSavedFirstFieldsSpace.
 	self unpinRememberedSet.
+	
+	self swapMournQueueFields.
+	
 	manager
 		resetFreeListHeads;
 		totalFreeOldSpace: 0;
@@ -745,6 +749,23 @@ SpurPlanningCompactor >> shouldRemapObj: objOop [
 	^manager slidingCompactionShouldRemapObj: objOop
 ]
 
+{ #category : #compaction }
+SpurPlanningCompactor >> swapMournQueueFields [
+	
+	"Swap top and index before compaction.
+	This is meant to still have top available during compaction to iterate the mourn queue.
+	Otherwise, top will be overwritten during compaction to put the destination address if moved.
+	Restore it after compaction is done."
+	
+	"We swap top and index because the index is not used during compaction"
+	manager objStack: manager mournQueue pagesDo: [ :page | | top index |
+		top := manager topIndexOfObjStack: page.
+		index := manager indexOfObjStack: page.
+		manager topIndexOfObjStack: page put: index.
+		manager indexOfObjStack: page put: top.
+	].
+]
+
 { #category : #private }
 SpurPlanningCompactor >> thereAreObjectsToMove [
 	<inline: true>
@@ -891,12 +912,14 @@ SpurPlanningCompactor >> updatePointersInManagerHeapEntities [
 	"The special non-pointer objects containing pointers, which are the objStacks and the rememberedSet,
 	 must be updated manually since they will not be recognized as containing pointers in the normal sweep."
 
+	self swapMournQueueFields.
 	manager objStack: manager mournQueue do:
 		[:i :page| | mourner |
 		mourner := manager fetchPointer: i ofObject: page.
 		(manager isNonImmediate: mourner) ifTrue: [ | fwd |
 			fwd := manager fetchPointer: 0 ofObject: mourner.
 			manager storePointerUnchecked: i ofObject: page withValue: fwd ]].
+	self swapMournQueueFields.
 	
 	manager relocateObjStacksForPlanningCompactor.
 	(scavenger rememberedSetSize > 0

--- a/smalltalksrc/VMMaker/SpurPlanningCompactor.class.st
+++ b/smalltalksrc/VMMaker/SpurPlanningCompactor.class.st
@@ -375,7 +375,6 @@ SpurPlanningCompactor >> endCompaction [
 	manager
 		unmarkSurvivingObjectsForCompact;
 		endSlidingCompaction.
-	self swapMournQueueFields.
 	self repinRememberedSet.
 	self releaseSavedFirstFieldsSpace
 ]
@@ -456,9 +455,8 @@ SpurPlanningCompactor >> initializeCompaction [
 	self selectSavedFirstFieldsSpace.
 	self unpinRememberedSet.
 	
-	self swapMournQueueFields.
-	
 	manager
+		prepareObjStacksForPlanningCompactor;
 		resetFreeListHeads;
 		totalFreeOldSpace: 0;
 		beginSlidingCompaction.
@@ -749,23 +747,6 @@ SpurPlanningCompactor >> shouldRemapObj: objOop [
 	^manager slidingCompactionShouldRemapObj: objOop
 ]
 
-{ #category : #compaction }
-SpurPlanningCompactor >> swapMournQueueFields [
-	
-	"Swap top and index before compaction.
-	This is meant to still have top available during compaction to iterate the mourn queue.
-	Otherwise, top will be overwritten during compaction to put the destination address if moved.
-	Restore it after compaction is done."
-	
-	"We swap top and index because the index is not used during compaction"
-	manager objStack: manager mournQueue pagesDo: [ :page | | top index |
-		top := manager topIndexOfObjStack: page.
-		index := manager indexOfObjStack: page.
-		manager topIndexOfObjStack: page put: index.
-		manager indexOfObjStack: page put: top.
-	].
-]
-
 { #category : #private }
 SpurPlanningCompactor >> thereAreObjectsToMove [
 	<inline: true>
@@ -911,22 +892,11 @@ SpurPlanningCompactor >> updatePointersInInitialImmobileObjects [
 SpurPlanningCompactor >> updatePointersInManagerHeapEntities [
 	"The special non-pointer objects containing pointers, which are the objStacks and the rememberedSet,
 	 must be updated manually since they will not be recognized as containing pointers in the normal sweep."
-
-	self swapMournQueueFields.
-	manager objStack: manager mournQueue do:
-		[:i :page| | mourner |
-		mourner := manager fetchPointer: i ofObject: page.
-		(manager isNonImmediate: mourner) ifTrue: [ | fwd |
-			fwd := manager fetchPointer: 0 ofObject: mourner.
-			manager storePointerUnchecked: i ofObject: page withValue: fwd ]].
-	self swapMournQueueFields.
-	
 	manager relocateObjStacksForPlanningCompactor.
 	(scavenger rememberedSetSize > 0
 	 and: [self isMobile: firstFieldOfRememberedSet]) ifTrue:
 		[firstFieldOfRememberedSet := manager fetchPointer: 0 ofObject: firstFieldOfRememberedSet].
-	self relocateObjectsInHeapEntity: manager rememberedSetObj from: 1 to: scavenger rememberedSetSize - 1.
-	
+	self relocateObjectsInHeapEntity: manager rememberedSetObj from: 1 to: scavenger rememberedSetSize - 1
 	"Note that we /must not/ set the rememberedSetObj here since it is a slot in the hiddenRootsObj
 	 and will be updated normally in updatePointersInInitialImmobileObjects.  So do not do
 	(self isMobile: manager rememberedSetObj) ifTrue:

--- a/smalltalksrc/VMMaker/SpurPlanningCompactor.class.st
+++ b/smalltalksrc/VMMaker/SpurPlanningCompactor.class.st
@@ -890,11 +890,20 @@ SpurPlanningCompactor >> updatePointersInInitialImmobileObjects [
 SpurPlanningCompactor >> updatePointersInManagerHeapEntities [
 	"The special non-pointer objects containing pointers, which are the objStacks and the rememberedSet,
 	 must be updated manually since they will not be recognized as containing pointers in the normal sweep."
+
+	manager objStack: manager mournQueue do:
+		[:i :page| | mourner |
+		mourner := manager fetchPointer: i ofObject: page.
+		(manager isNonImmediate: mourner) ifTrue: [ | fwd |
+			fwd := manager fetchPointer: 0 ofObject: mourner.
+			manager storePointerUnchecked: i ofObject: page withValue: fwd ]].
+	
 	manager relocateObjStacksForPlanningCompactor.
 	(scavenger rememberedSetSize > 0
 	 and: [self isMobile: firstFieldOfRememberedSet]) ifTrue:
 		[firstFieldOfRememberedSet := manager fetchPointer: 0 ofObject: firstFieldOfRememberedSet].
-	self relocateObjectsInHeapEntity: manager rememberedSetObj from: 1 to: scavenger rememberedSetSize - 1
+	self relocateObjectsInHeapEntity: manager rememberedSetObj from: 1 to: scavenger rememberedSetSize - 1.
+	
 	"Note that we /must not/ set the rememberedSetObj here since it is a slot in the hiddenRootsObj
 	 and will be updated normally in updatePointersInInitialImmobileObjects.  So do not do
 	(self isMobile: manager rememberedSetObj) ifTrue:

--- a/smalltalksrc/VMMaker/SpurSegmentManager.class.st
+++ b/smalltalksrc/VMMaker/SpurSegmentManager.class.st
@@ -811,13 +811,12 @@ SpurSegmentManager >> writeSegment: segment nextSegment: nextSegment toFile: aBi
 							Image: 1
 							File: segment segSize
 							Write: aBinaryStream]
-					inSmalltalk:
-						[| bytesPerElement |
-						 bytesPerElement := manager memory bytesPerElement.
-						 aBinaryStream
+					inSmalltalk: [ | region |
+						region := (manager memoryManager regionForAddress: segment segStart).
+						aBinaryStream
 							next: segment segSize
-							putAll: manager memory memoryObject
-							startingAt: segment segStart - manager memory initialAddress + 1.
+							putAll: region value
+							startingAt: segment segStart - region key + 1.
 						 segment segSize].
 	manager
 		long64At: pier1 put: firstSavedBridgeWord;

--- a/smalltalksrc/VMMaker/SpurSimulatedMemory.class.st
+++ b/smalltalksrc/VMMaker/SpurSimulatedMemory.class.st
@@ -76,7 +76,7 @@ SpurSimulatedMemory >> initialAddress: anAddress [
 SpurSimulatedMemory >> initialize [
 
 	super initialize.
-	initialAddress := 2*1024*1024.
+	initialAddress := 0"2*1024*1024".
 ]
 
 { #category : #initialization }
@@ -147,6 +147,12 @@ SpurSimulatedMemory >> longAt: address put: aValue [
 SpurSimulatedMemory >> memoryObject [
 	
 	^ memoryObject
+]
+
+{ #category : #replacing }
+SpurSimulatedMemory >> replaceFrom: start to: stop with: replacement startingAt: repStart [ 
+	
+	memoryObject replaceFrom: start to: stop with: replacement memoryObject startingAt: repStart
 ]
 
 { #category : #accessing }

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -4769,19 +4769,6 @@ StackInterpreter >> closureIn: context numArgs: numArgs instructionPointer: init
 	^newClosure
 ]
 
-{ #category : #'primitive support' }
-StackInterpreter >> codeGeneratorToComputeAccessorDepth [
-
-	^ codeGeneratorToComputeAccessorDepth ifNil: [
-		^(VMMaker new
-			vmmakerConfiguration: VMMakerConfiguration;
-			buildCodeGeneratorForInterpreter: self class primitivesClass
-			includeAPIMethods: false
-			initializeClasses: false)
-				logger: self transcript;
-				yourself ]
-]
-
 { #category : #'as yet unclassified' }
 StackInterpreter >> codeGeneratorToComputeAccessorDepth: aCCodeGenerator [ 
 	<doNotGenerate>

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -4774,6 +4774,7 @@ StackInterpreter >> codeGeneratorToComputeAccessorDepth [
 
 	^ codeGeneratorToComputeAccessorDepth ifNil: [
 		^(VMMaker new
+			vmmakerConfiguration: VMMakerConfiguration;
 			buildCodeGeneratorForInterpreter: self class primitivesClass
 			includeAPIMethods: false
 			initializeClasses: false)
@@ -11156,15 +11157,7 @@ StackInterpreter >> okayInterpreterObjects [
 StackInterpreter >> openImageFileNamed: fileName [
 	"Attempt to open fileName or fileName, '.image'"
 	<doNotGenerate>
-	| f |
-	f := [FileStream readOnlyFileNamed: fileName]
-			on: FileDoesNotExistException
-			do: [:ex|
-				 ((fileName endsWith: '.image') not
-				  and: [(fileName, '.image') asFileReference exists]) ifFalse:
-					[ex pass].
-				 FileStream readOnlyFileNamed: fileName, '.image'].
-	^f ifNil: [self error: 'no image found'. nil].
+	^ fileName asFileReference binaryReadStream
 ]
 
 { #category : #simulation }

--- a/smalltalksrc/VMMaker/StackInterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreterPrimitives.class.st
@@ -8,6 +8,17 @@ Class {
 	#category : #'VMMaker-Interpreter'
 }
 
+{ #category : #initialization }
+StackInterpreterPrimitives >> allocateParameters: anInteger using: allocationBlock [
+	<inline: #always>
+
+	anInteger = 0 ifTrue: [ ^ nil ].
+
+	^ self
+		cCode: [ allocationBlock value: anInteger ]
+		inSmalltalk: [ CArrayAccessor on: (Array new: anInteger) ]
+]
+
 { #category : #'primitive support' }
 StackInterpreterPrimitives >> cloneContext: aContext [ 
 	| sz cloned spouseFP sp |

--- a/smalltalksrc/VMMaker/StackInterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreterPrimitives.class.st
@@ -8,20 +8,6 @@ Class {
 	#category : #'VMMaker-Interpreter'
 }
 
-{ #category : #'ffi - helpers' }
-StackInterpreterPrimitives >> allocateParameters: anInteger using: allocationBlock [
-	<inline: #always>
-
-	anInteger = 0 ifTrue: [ ^ nil ].
-
-	^ self
-		cCode: [ allocationBlock value: anInteger ]
-		inSmalltalk: [ | ptr | 
-			ptr := allocationBlock value: anInteger.
-			ptr setObject: (Array new: anInteger).
-			ptr]
-]
-
 { #category : #'primitive support' }
 StackInterpreterPrimitives >> cloneContext: aContext [ 
 	| sz cloned spouseFP sp |

--- a/smalltalksrc/VMMaker/StackInterpreterSimulator.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreterSimulator.class.st
@@ -1605,8 +1605,7 @@ StackInterpreterSimulator >> openOn: fileName extraMemory: extraBytes [
 	systemAttributes at: 1 put: fileName; at: 2 put: nil.
 
 	["begin ensure block..."
-	imageName := f fullName.
-	f binary.
+	imageName := fileName asFileReference fullName.
 
 	version := self getWord32FromFile: f swap: false.  "current version: 16r1968 (=6504) vive la revolucion!"
 	(self readableFormat: version)

--- a/smalltalksrc/VMMaker/StackInterpreterSimulator.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreterSimulator.class.st
@@ -399,6 +399,19 @@ StackInterpreterSimulator >> close [  "close any files that ST may have opened, 
 	pluginList do: [:assoc| | plugin | plugin := assoc value. plugin ~~ self ifTrue: [plugin close]]
 ]
 
+{ #category : #'primitive support' }
+StackInterpreterSimulator >> codeGeneratorToComputeAccessorDepth [
+
+	^ codeGeneratorToComputeAccessorDepth ifNil: [
+		^(VMMaker new
+			vmmakerConfiguration: VMMakerConfiguration;
+			buildCodeGeneratorForInterpreter: self class primitivesClass
+			includeAPIMethods: false
+			initializeClasses: false)
+				logger: self transcript;
+				yourself ]
+]
+
 { #category : #'simulation only' }
 StackInterpreterSimulator >> cogit [
 	"We don't have a cogit; try and get by on our own devices."

--- a/smalltalksrc/VMMaker/VMClass.class.st
+++ b/smalltalksrc/VMMaker/VMClass.class.st
@@ -4,6 +4,9 @@ I am an abstract superclass for all classes in the VM that want to maintain a so
 Class {
 	#name : #VMClass,
 	#superclass : #SlangClass,
+	#instVars : [
+		'memoryManager'
+	],
 	#classVars : [
 		'DefaultBase',
 		'InitializationOptions'
@@ -752,7 +755,8 @@ VMClass >> majorVersion [
 { #category : #'C library simulation' }
 VMClass >> malloc: size [
 	<doNotGenerate>
-	^CArrayAccessor on: (ByteArray new: size)
+	
+	^ CNewArrayAccessor on: (memoryManager allocate: size) manager: memoryManager
 ]
 
 { #category : #'C library simulation' }
@@ -820,6 +824,18 @@ VMClass >> memmove: destAddress _: sourceAddress _: bytes [
 		ifFalse:
 			[0 to: bytes - 4 by: 4 do:
 				[:i| self longAt: dst + i put: (self longAt: src + i)]]
+]
+
+{ #category : #accessing }
+VMClass >> memoryManager [
+	<doNotGenerate>
+	^ memoryManager
+]
+
+{ #category : #accessing }
+VMClass >> memoryManager: aMemoryManager [
+	<doNotGenerate>
+	memoryManager := aMemoryManager
 ]
 
 { #category : #'simulation support' }
@@ -977,6 +993,13 @@ VMClass >> promptNum: string [
 	s := s withBlanksTrimmed.
 	^s notEmpty ifTrue:
 		[Number readFrom: s readStream]
+]
+
+{ #category : #'C library simulation' }
+VMClass >> realloc: originalAddress _: desiredSize [
+
+	<doNotGenerate>
+	^ memoryManager reallocate: originalAddress withSize: desiredSize
 ]
 
 { #category : #arithmetic }

--- a/smalltalksrc/VMMaker/VMClass.class.st
+++ b/smalltalksrc/VMMaker/VMClass.class.st
@@ -4,6 +4,9 @@ I am an abstract superclass for all classes in the VM that want to maintain a so
 Class {
 	#name : #VMClass,
 	#superclass : #SlangClass,
+	#instVars : [
+		'memoryManager'
+	],
 	#classVars : [
 		'DefaultBase',
 		'InitializationOptions'

--- a/smalltalksrc/VMMaker/VMClass.class.st
+++ b/smalltalksrc/VMMaker/VMClass.class.st
@@ -754,8 +754,13 @@ VMClass >> majorVersion [
 { #category : #'C library simulation' }
 VMClass >> malloc: size [
 	<doNotGenerate>
-	
-	^ CNewArrayAccessor on: (memoryManager allocate: size) manager: memoryManager
+	| address region |
+	address := memoryManager allocate: size.
+	region := memoryManager regionAtAddress: address.
+	^ CNewArrayAccessor new
+		setObject: region;
+		address: address;
+		yourself
 ]
 
 { #category : #'C library simulation' }

--- a/smalltalksrc/VMMaker/VMStructType.class.st
+++ b/smalltalksrc/VMMaker/VMStructType.class.st
@@ -186,7 +186,7 @@ VMStructType class >> getter: getter bitPosition: bitPosition bitWidth: bitWidth
 		   nextPutAll: (#('Byte' 'Short' 'Long' 'Long')
 							at: endByte - startByte + 1
 							ifAbsent: ['Long64']);
-		  nextPutAll: 'At: address + '; print: startByte + 1.
+		  nextPutAll: 'At: address + '; print: startByte.
 		(self offsetForInstVar: getter) ifNotNil:
 			[:offsetExpr| s nextPutAll: ' + '; nextPutAll: offsetExpr].
 		shift ~= 0 ifTrue:
@@ -292,12 +292,12 @@ VMStructType class >> setter: getter bitPosition: bitPosition bitWidth: bitWidth
 		alignedPowerOf2 ifTrue:
 			[s nextPut: $^].
 		s nextPutAll: 'memory';
-		  crtab: 2; nextPutAll: accessor; print: startByte + 1.
+		  crtab: 2; nextPutAll: accessor; print: startByte.
 		s crtab: 2; nextPutAll: 'put: '.
 		typeOrNil ifNotNil:
 			[s nextPut: $(].
 		alignedPowerOf2 ifFalse:
-			[s nextPutAll: '((memory '; nextPutAll: accessor; print: startByte + 1;
+			[s nextPutAll: '((memory '; nextPutAll: accessor; print: startByte;
 			    nextPutAll: ') bitAnd: '; nextPutAll: (mask - ((1 << bitWidth - 1) << shift)) hex;
 			    nextPutAll: ') + '].
 		expr := typeOrNil caseOf: {

--- a/smalltalksrc/VMMakerTests/UnicornARMv5Simulator.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornARMv5Simulator.class.st
@@ -437,7 +437,7 @@ UnicornARMv5Simulator >> registerStateGetters [
 UnicornARMv5Simulator >> retpcIn: aMemory [ 
 	"The return address is on the stack, having been pushed by either
 	 simulateCallOf:nextpc:memory: or simulateJumpCallOf:memory:"
-	^aMemory unsignedLongAt: self fp + 5
+	^memory longAt: self fp + 4
 ]
 
 { #category : #registers }

--- a/smalltalksrc/VMMakerTests/UnicornARMv8Simulator.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornARMv8Simulator.class.st
@@ -248,7 +248,7 @@ UnicornARMv8Simulator >> registerStateGetters [
 { #category : #'as yet unclassified' }
 UnicornARMv8Simulator >> retpcIn: aMemory [ 
 
-	^ aMemory unsignedLongAt: self fp + 9 
+	^ memory longAt: self fp + 8
 ]
 
 { #category : #registers }

--- a/smalltalksrc/VMMakerTests/UnicornI386Simulator.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornI386Simulator.class.st
@@ -221,8 +221,8 @@ UnicornI386Simulator >> postCallArgumentsNumArgs: numArgs in: aMemory [
 	 beyond the pushed return address and saved frame pointer.
 	 For compatibility with Cog/Slang we answer unsigned values."
 
-	^ (9 to: numArgs * 4 + 5 by: 4) collect: [ :i | 
-		  aMemory unsignedLongAt: self ebp + i ]
+	^ (8 to: numArgs * 4 + 4 by: 4) collect: [ :i | 
+		  memory longAt: self ebp + i ]
 ]
 
 { #category : #registers }
@@ -240,7 +240,7 @@ UnicornI386Simulator >> registerList [
 { #category : #'as yet unclassified' }
 UnicornI386Simulator >> retpcIn: aMemory [
 
-	^ aMemory unsignedLongAt: self ebp + 5
+	^ memory longAt: self ebp + 4
 ]
 
 { #category : #registers }

--- a/smalltalksrc/VMMakerTests/UnicornProcessor.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornProcessor.class.st
@@ -97,8 +97,7 @@ UnicornProcessor >> initializeStackFor: aCompiler [
 	"Initialize the machine code simulator"
 	machineSimulator := UnicornSimulator perform: aCompiler backend class ISA asSymbol.
 	machineSimulator memory: aCompiler objectMemory.
-	aCompiler objectMemory memory memoryObject pinInMemory.
-	machineSimulator mapMemory: aCompiler objectMemory memory memoryObject at: aCompiler objectMemory memory initialAddress "just some address not 0".
+	machineSimulator mapMemoryInManager: aCompiler objectMemory memoryManager.
 	
 	"As for the ARMv8 Arm® Architecture Reference Manual
 	

--- a/smalltalksrc/VMMakerTests/UnicornSimulator.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornSimulator.class.st
@@ -149,7 +149,7 @@ UnicornSimulator >> disassembleFrom: anIndex opcodes: numberOfInstructions [
 	^ self disassembler
 		printImmediatesInHexa;
 		disassembleNext: numberOfInstructions
-		instructionsIn: (memory memory copyFrom: anIndex to: anIndex + (numberOfInstructions * 50) "rough estimate")
+		instructionsIn: (memory memoryManager copyFrom: anIndex to: anIndex + (numberOfInstructions * 50) "rough estimate")
 		startAddress: anIndex
 		pc: self instructionPointerValue
 ]
@@ -373,6 +373,14 @@ UnicornSimulator >> mapMemory: aMemory at: anAddress [
 		mapHostMemory: aMemory
 		atAddress: anAddress
 		withPermissions: UnicornConstants permissionAll.
+]
+
+{ #category : #'memory-mapping' }
+UnicornSimulator >> mapMemoryInManager: aSlangMemoryManager [
+
+	aSlangMemoryManager regionsDo: [ :startAddress :region |
+		self mapMemory: region at: startAddress
+	]
 ]
 
 { #category : #accessing }

--- a/smalltalksrc/VMMakerTests/VMObjectStackTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMObjectStackTest.class.st
@@ -1,0 +1,151 @@
+Class {
+	#name : #VMObjectStackTest,
+	#superclass : #VMSpurInitializedOldSpaceTest,
+	#category : #'VMMakerTests-MemoryTests'
+}
+
+{ #category : #tests }
+VMObjectStackTest >> testGrowingMournQueueUpdatesVMGlobalVariable [
+
+	
+	self testPushObjects: memory objectStackPageLimit + 1 inStackAtIndex: 4098"MournQueueRootIndex".
+	self assert: memory mournQueue equals: (memory objStackAt: 4098"MournQueueRootIndex")
+]
+
+{ #category : #tests }
+VMObjectStackTest >> testNewMournQueueIsEmpty [
+
+	| objStack |
+	objStack := memory ensureRoomOnObjStackAt: 4098 "MournQueueIndex".
+
+	self assert: (memory isEmptyObjStack: objStack)
+	
+]
+
+{ #category : #tests }
+VMObjectStackTest >> testNewObjectStackIsEmpty [
+
+	"Create an object stack at the position of the mark stack in the class table (4096)"
+	| objStack |
+	objStack := memory ensureRoomOnObjStackAt: 4096.
+
+	self assert: (memory isEmptyObjStack: objStack)
+	
+]
+
+{ #category : #tests }
+VMObjectStackTest >> testObjectsInMournQueueArePoppedInOrder [
+
+	| objStack |
+	objStack := memory ensureRoomOnObjStackAt: 4098 "MournQueueIndex".
+	1 to: memory objectStackPageLimit do: [ :i |
+		memory noCheckPush: (memory integerObjectOf: i) onObjStack: objStack.
+	].
+	memory objectStackPageLimit to: 1 by: -1 do: [ :i |
+		self assert: (memory popObjStack: objStack) equals: (memory integerObjectOf: i).
+	].
+]
+
+{ #category : #tests }
+VMObjectStackTest >> testObjectsInObjectStackArePoppedInOrder [
+
+	"Create an object stack at the position of the mark stack in the class table (4096)"
+	| objStack |
+	objStack := memory ensureRoomOnObjStackAt: 4096.
+	1 to: memory objectStackPageLimit do: [ :i |
+		memory noCheckPush: (memory integerObjectOf: i) onObjStack: objStack.
+	].
+	memory objectStackPageLimit to: 1 by: -1 do: [ :i |
+		self assert: (memory popObjStack: objStack) equals: (memory integerObjectOf: i).
+	].
+]
+
+{ #category : #tests }
+VMObjectStackTest >> testPopMournQueueReducesSize [
+
+	| objStack |
+	objStack := memory ensureRoomOnObjStackAt: 4098 "MournQueueIndex".
+	memory noCheckPush: memory trueObject onObjStack: objStack.
+	memory popObjStack: objStack.
+	self assert: (memory isEmptyObjStack: objStack)
+]
+
+{ #category : #tests }
+VMObjectStackTest >> testPopObjectInMournQueueReturnsInitiallyPushedObject [
+
+	| objStack |
+	objStack := memory ensureRoomOnObjStackAt: 4098 "MournQueueIndex".
+	memory noCheckPush: memory trueObject onObjStack: objStack.
+	self assert: (memory popObjStack: objStack) equals: memory trueObject
+]
+
+{ #category : #tests }
+VMObjectStackTest >> testPopObjectInStackReturnsInitiallyPushedObject [
+
+	"Create an object stack at the position of the mark stack in the class table (4096)"
+	| objStack |
+	objStack := memory ensureRoomOnObjStackAt: 4096.
+	memory noCheckPush: memory trueObject onObjStack: objStack.
+	self assert: (memory popObjStack: objStack) equals: memory trueObject
+]
+
+{ #category : #tests }
+VMObjectStackTest >> testPopObjectStackReducesSize [
+
+	"Create an object stack at the position of the mark stack in the class table (4096)"
+	| objStack |
+	objStack := memory ensureRoomOnObjStackAt: 4096.
+	memory noCheckPush: memory trueObject onObjStack: objStack.
+	memory popObjStack: objStack.
+	self assert: (memory isEmptyObjStack: objStack)
+]
+
+{ #category : #tests }
+VMObjectStackTest >> testPushObjects: n [
+
+	"Create an object stack at the position of the mark stack in the class table (4096)"
+	self testPushObjects: n inStackAtIndex: 4096
+]
+
+{ #category : #tests }
+VMObjectStackTest >> testPushObjects: n inStackAtIndex: objectStackIndex [
+
+	memory ensureRoomOnObjStackAt: objectStackIndex.
+	1 to: n do: [ :i |
+		memory
+			noCheckPush: (memory integerObjectOf: i)
+			onObjStack: (memory objStackAt: objectStackIndex).
+	].
+	self assert: (memory sizeOfObjStack: (memory objStackAt: objectStackIndex)) equals: n
+]
+
+{ #category : #tests }
+VMObjectStackTest >> testPushObjectsAboveObjectStackLimit [
+
+	self testPushObjects: memory objectStackPageLimit + 1
+]
+
+{ #category : #tests }
+VMObjectStackTest >> testPushObjectsToObjectStackLimit [
+
+	self testPushObjects: memory objectStackPageLimit
+]
+
+{ #category : #tests }
+VMObjectStackTest >> testPushToMournQueueIncreasesSize [
+
+	| objStack |
+	objStack := memory ensureRoomOnObjStackAt: 4098 "MournQueueIndex".
+	memory noCheckPush: memory trueObject onObjStack: objStack.
+	self assert: (memory sizeOfObjStack: objStack) equals: 1
+]
+
+{ #category : #tests }
+VMObjectStackTest >> testPushToObjectStackIncreasesSize [
+
+	"Create an object stack at the position of the mark stack in the class table (4096)"
+	| objStack |
+	objStack := memory ensureRoomOnObjStackAt: 4096.
+	memory noCheckPush: memory trueObject onObjStack: objStack.
+	self assert: (memory sizeOfObjStack: objStack) equals: 1
+]

--- a/smalltalksrc/VMMakerTests/VMSpurInitializedOldSpaceTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurInitializedOldSpaceTest.class.st
@@ -1,6 +1,9 @@
 Class {
 	#name : #VMSpurInitializedOldSpaceTest,
 	#superclass : #VMSpurMemoryManagerTest,
+	#instVars : [
+		'ourEphemeronClass'
+	],
 	#category : #'VMMakerTests-MemoryTests'
 }
 
@@ -19,7 +22,7 @@ VMSpurInitializedOldSpaceTest >> assertFreeListEmpty: aFreeListOop [
 { #category : #helpers }
 VMSpurInitializedOldSpaceTest >> createEphemeronClass [
 	ourEphemeronClass := self newObjectWithSlots: 3.
-	memory
+	memory 
 		storePointer: "InstanceSpecificationIndex" 2
 		ofObject: ourEphemeronClass
 		withValue: (memory integerObjectOf: Ephemeron format).

--- a/smalltalksrc/VMMakerTests/VMSpurInitializedOldSpaceTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurInitializedOldSpaceTest.class.st
@@ -17,6 +17,16 @@ VMSpurInitializedOldSpaceTest >> assertFreeListEmpty: aFreeListOop [
 ]
 
 { #category : #helpers }
+VMSpurInitializedOldSpaceTest >> createEphemeronClass [
+	ourEphemeronClass := self newObjectWithSlots: 3.
+	memory
+		storePointer: "InstanceSpecificationIndex" 2
+		ofObject: ourEphemeronClass
+		withValue: (memory integerObjectOf: Ephemeron format).
+	memory ensureBehaviorHash: ourEphemeronClass.
+]
+
+{ #category : #helpers }
 VMSpurInitializedOldSpaceTest >> createFreeChunkOfSize: aSize [
 
 	| address |
@@ -72,6 +82,17 @@ VMSpurInitializedOldSpaceTest >> largerNodeOf: aNode [
 	^ memory
 		fetchPointer: memory freeChunkLargerIndex
 		ofFreeChunk: aNode
+]
+
+{ #category : #helpers }
+VMSpurInitializedOldSpaceTest >> newEphemeronObject [
+
+"In pharo Ephemerons have 3 slots"
+	
+	^ self
+		newObjectWithSlots: 3
+		format: memory ephemeronFormat
+		classIndex: (memory ensureBehaviorHash: ourEphemeronClass)
 ]
 
 { #category : #helpers }

--- a/smalltalksrc/VMMakerTests/VMSpurMemoryManagerTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurMemoryManagerTest.class.st
@@ -441,6 +441,7 @@ VMSpurMemoryManagerTest >> setMethodClassIntoClassTable [
 
 { #category : #running }
 VMSpurMemoryManagerTest >> setUp [
+	| memoryManager |
 	super setUp.
 
 	"100 k at least to put the class table in the old space.
@@ -457,9 +458,15 @@ VMSpurMemoryManagerTest >> setUp [
 	emptyObjectSize := objectHeaderSize + 8 "minimum required single empty slot, to use for forwarders".
 	
 	"Set it to bootstrapping to allow smaller memories"
-	interpreter := self newInterpreter.
-	memory := interpreter objectMemory.
+	memoryManager := SlangMemoryManager new.
+	memoryManager initialAddress: initialAddress.
+	memoryManager wordSize: self wordSize.
 	
+	interpreter := self newInterpreter.
+	interpreter memoryManager: memoryManager.
+
+	memory := interpreter objectMemory.
+	memory memoryManager: memoryManager.	
 	memory coInterpreter: interpreter.
 	interpreter objectMemory: memory.
 	
@@ -481,7 +488,7 @@ VMSpurMemoryManagerTest >> setUp [
 	"Schedule a GC, so it does not try to schedule one"
 	memory needGCFlag: 1.
 	
-		methodBuilder := VMMethodBuilder new
+	methodBuilder := VMMethodBuilder new
 		interpreter: interpreter; 
 		memory: memory;
 		yourself.

--- a/smalltalksrc/VMMakerTests/VMSpurMemoryManagerTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurMemoryManagerTest.class.st
@@ -32,7 +32,7 @@ Class {
 VMSpurMemoryManagerTest class >> testParameters [ 
 
 	^ ParametrizedTestMatrix new
-			forSelector: #wordSize addOptions: { 4 . 8 };
+			forSelector: #wordSize addOptions: { 8 . 4 };
 			yourself
 ]
 

--- a/smalltalksrc/VMMakerTests/VMSpurOldSpaceGarbageCollectorTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurOldSpaceGarbageCollectorTest.class.st
@@ -33,6 +33,13 @@ VMSpurOldSpaceGarbageCollectorTest >> assertObjectWereReclaimed: aBlock [
 	self assert: initialSpace - sizeOfObject equals: memory totalFreeListBytes
 ]
 
+{ #category : #ephemerons }
+VMSpurOldSpaceGarbageCollectorTest >> initializationOptions [
+
+	^ super initializationOptions , { 
+		#ObjStackPageSlots . objectStackLimit }
+]
+
 { #category : #testing }
 VMSpurOldSpaceGarbageCollectorTest >> isValidFirstBridge [
 
@@ -162,7 +169,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testAnOldObjectReferencedFromVMVariableSho
 VMSpurOldSpaceGarbageCollectorTest >> testAnOldObjectReferencedFromVMVariableShouldBeMoved [
 
 	| anObjectOop hash |
-	1000 timesRepeat: [ self newOldSpaceObjectWithSlots: 0 ].
+	1 timesRepeat: [ self newOldSpaceObjectWithSlots: 0 ].
 	
 	anObjectOop := self newOldSpaceObjectWithSlots: 0.
 
@@ -226,7 +233,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testMultiPageMournQueue [
 	| ephemeronKey ephemeronContainer mourned numberJustOverLimit |
 	self createEphemeronClass.
 	numberJustOverLimit := objectStackLimit + 1.
-			
+
 	ephemeronKey := self newZeroSizedObject.
 	ephemeronContainer := self newObjectWithSlots: numberJustOverLimit.
 	1 to: numberJustOverLimit do: [ :i | | ephemeronObjectOop |
@@ -261,11 +268,13 @@ VMSpurOldSpaceGarbageCollectorTest >> testPageLimitMournQueue [
 	The mourn queue should grow with new pages to make them all fit.
 	Then we test we can extract all the objects from the queue"	
 
-	| ephemeronKey ephemeronContainer mourned objStackLimit |
+	| ephemeronKey ephemeronContainer mourned objStackLimit numberJustBelowLimit |
 	self createEphemeronClass.
+	numberJustBelowLimit := objectStackLimit - 1.
+	
 	ephemeronKey := self newZeroSizedObject.
-	ephemeronContainer := self newObjectWithSlots: 5000.
-	objStackLimit := 4088.
+	ephemeronContainer := self newObjectWithSlots: numberJustBelowLimit.
+	objStackLimit := numberJustBelowLimit.
 	1 to: objStackLimit do: [ :i | | ephemeronObjectOop |
 		ephemeronObjectOop := self newEphemeronObject.
 		memory

--- a/smalltalksrc/VMMakerTests/VMSpurOldSpaceGarbageCollectorTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurOldSpaceGarbageCollectorTest.class.st
@@ -37,6 +37,12 @@ VMSpurOldSpaceGarbageCollectorTest >> isValidFirstBridge [
 		isValidSegmentBridge: (memory segmentManager bridgeAt: 0)
 ]
 
+{ #category : #running }
+VMSpurOldSpaceGarbageCollectorTest >> runCaseManaged [ 
+
+	^ self runCase
+]
+
 { #category : #'tests-OldSpaceSize' }
 VMSpurOldSpaceGarbageCollectorTest >> testAllocateObjectBiggerThanSizeOfFreeSpace [
 
@@ -159,4 +165,78 @@ VMSpurOldSpaceGarbageCollectorTest >> testAnOldObjectReferencedFromVMVariableSho
 	
 	self deny: anObjectOop equals: self keptObjectInVMVariable1.
 	self assertHashOf: self keptObjectInVMVariable1 equals: hash
+]
+
+{ #category : #ephemerons }
+VMSpurOldSpaceGarbageCollectorTest >> testMultiPageMournQueue [
+
+	"This test Fires more ephemerons than those that fit in a single page of the mourn queue.
+	All ephemerons should be put in the mourn queue.
+	The mourn queue should grow with new pages to make them all fit.
+	Then we test we can extract all the objects from the queue"	
+
+	| ephemeronKey ephemeronContainer mourned numberJustOverLimit |
+	self createEphemeronClass.
+	ephemeronKey := self newZeroSizedObject.
+	ephemeronContainer := self newObjectWithSlots: 5000.
+	numberJustOverLimit := 5000.
+	1 to: numberJustOverLimit do: [ :i | | ephemeronObjectOop |
+		ephemeronObjectOop := self newEphemeronObject.
+		memory
+			storePointer: 0 "zero based"
+			ofObject: ephemeronObjectOop
+			withValue: ephemeronKey.
+		memory
+			storePointer: i - 1 "zero based"
+			ofObject: ephemeronContainer
+			withValue: ephemeronObjectOop
+	 ].
+	"Force object to not be collected by putting them in special variables"
+	self keepObjectInVMVariable1: ephemeronContainer.
+
+	self assert: memory validObjStacks.
+	memory fullGC.
+
+	mourned := 0.
+	[ memory dequeueMourner notNil ] whileTrue: [ mourned := mourned + 1 ].
+	self
+		assert: mourned
+		equals: numberJustOverLimit
+]
+
+{ #category : #ephemerons }
+VMSpurOldSpaceGarbageCollectorTest >> testPageLimitMournQueue [
+
+	"This test Fires more ephemerons than those that fit in a single page of the mourn queue.
+	All ephemerons should be put in the mourn queue.
+	The mourn queue should grow with new pages to make them all fit.
+	Then we test we can extract all the objects from the queue"	
+
+	| ephemeronKey ephemeronContainer mourned objStackLimit |
+	self createEphemeronClass.
+	ephemeronKey := self newZeroSizedObject.
+	ephemeronContainer := self newObjectWithSlots: 5000.
+	objStackLimit := 4088.
+	1 to: objStackLimit do: [ :i | | ephemeronObjectOop |
+		ephemeronObjectOop := self newEphemeronObject.
+		memory
+			storePointer: 0 "zero based"
+			ofObject: ephemeronObjectOop
+			withValue: ephemeronKey.
+		memory
+			storePointer: i - 1 "zero based"
+			ofObject: ephemeronContainer
+			withValue: ephemeronObjectOop
+	 ].
+	"Force object to not be collected by putting them in special variables"
+	self keepObjectInVMVariable1: ephemeronContainer.
+
+	self assert: memory validObjStacks.
+	memory fullGC.
+
+	mourned := 0.
+	[ memory dequeueMourner notNil ] whileTrue: [ mourned := mourned + 1 ].
+	self
+		assert: mourned
+		equals: objStackLimit
 ]

--- a/smalltalksrc/VMMakerTests/VMSpurOldSpaceGarbageCollectorTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurOldSpaceGarbageCollectorTest.class.st
@@ -1,6 +1,9 @@
 Class {
 	#name : #VMSpurOldSpaceGarbageCollectorTest,
 	#superclass : #VMSpurInitializedOldSpaceTest,
+	#instVars : [
+		'objectStackLimit'
+	],
 	#category : #'VMMakerTests-MemoryTests'
 }
 
@@ -41,6 +44,13 @@ VMSpurOldSpaceGarbageCollectorTest >> isValidFirstBridge [
 VMSpurOldSpaceGarbageCollectorTest >> runCaseManaged [ 
 
 	^ self runCase
+]
+
+{ #category : #ephemerons }
+VMSpurOldSpaceGarbageCollectorTest >> setUp [
+
+	objectStackLimit :=  10.
+	super setUp.
 ]
 
 { #category : #'tests-OldSpaceSize' }
@@ -168,7 +178,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testAnOldObjectReferencedFromVMVariableSho
 ]
 
 { #category : #ephemerons }
-VMSpurOldSpaceGarbageCollectorTest >> testMultiPageMournQueue [
+VMSpurOldSpaceGarbageCollectorTest >> testEphemeronOverflowUnscannedEphemeronQueue [
 
 	"This test Fires more ephemerons than those that fit in a single page of the mourn queue.
 	All ephemerons should be put in the mourn queue.
@@ -178,8 +188,47 @@ VMSpurOldSpaceGarbageCollectorTest >> testMultiPageMournQueue [
 	| ephemeronKey ephemeronContainer mourned numberJustOverLimit |
 	self createEphemeronClass.
 	ephemeronKey := self newZeroSizedObject.
-	ephemeronContainer := self newObjectWithSlots: 5000.
-	numberJustOverLimit := 5000.
+	ephemeronContainer := self newObjectWithSlots: 10.
+	numberJustOverLimit := 10.
+	1 to: numberJustOverLimit do: [ :i | | ephemeronObjectOop |
+		ephemeronObjectOop := self newEphemeronObject.
+		memory
+			storePointer: 0 "zero based"
+			ofObject: ephemeronObjectOop
+			withValue: ephemeronKey.
+		memory
+			storePointer: i - 1 "zero based"
+			ofObject: ephemeronContainer
+			withValue: ephemeronObjectOop
+	 ].
+	"Force object to not be collected by putting them in special variables"
+	self keepObjectInVMVariable1: ephemeronContainer.
+
+	self assert: memory validObjStacks.
+	memory unscannedEphemeronsQueueInitialSize: numberJustOverLimit - 1.
+	memory fullGC.
+
+	mourned := 0.
+	[ memory dequeueMourner notNil ] whileTrue: [ mourned := mourned + 1 ].
+	self
+		assert: mourned
+		equals: numberJustOverLimit
+]
+
+{ #category : #ephemerons }
+VMSpurOldSpaceGarbageCollectorTest >> testMultiPageMournQueue [
+
+	"This test Fires more ephemerons than those that fit in a single page of the mourn queue.
+	All ephemerons should be put in the mourn queue.
+	The mourn queue should grow with new pages to make them all fit.
+	Then we test we can extract all the objects from the queue"	
+
+	| ephemeronKey ephemeronContainer mourned numberJustOverLimit |
+	self createEphemeronClass.
+	numberJustOverLimit := objectStackLimit + 1.
+			
+	ephemeronKey := self newZeroSizedObject.
+	ephemeronContainer := self newObjectWithSlots: numberJustOverLimit.
 	1 to: numberJustOverLimit do: [ :i | | ephemeronObjectOop |
 		ephemeronObjectOop := self newEphemeronObject.
 		memory
@@ -232,6 +281,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testPageLimitMournQueue [
 	self keepObjectInVMVariable1: ephemeronContainer.
 
 	self assert: memory validObjStacks.
+	memory compactor recordMovements.
 	memory fullGC.
 
 	mourned := 0.

--- a/smalltalksrc/VMMakerTests/VMSpurScavengeEphemeronTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurScavengeEphemeronTest.class.st
@@ -7,27 +7,6 @@ Class {
 	#category : #'VMMakerTests-MemoryTests'
 }
 
-{ #category : #helpers }
-VMSpurScavengeEphemeronTest >> createEphemeronClass [
-	ourEphemeronClass := self newObjectWithSlots: 3.
-	memory
-		storePointer: "InstanceSpecificationIndex" 2
-		ofObject: ourEphemeronClass
-		withValue: (memory integerObjectOf: Ephemeron format).
-	memory ensureBehaviorHash: ourEphemeronClass.
-]
-
-{ #category : #helpers }
-VMSpurScavengeEphemeronTest >> newEphemeronObject [
-
-"In pharo Ephemerons have 3 slots"
-	
-	^ self
-		newObjectWithSlots: 3
-		format: memory ephemeronFormat
-		classIndex: (memory ensureBehaviorHash: ourEphemeronClass)
-]
-
 { #category : #'tests-ephemerons-globals' }
 VMSpurScavengeEphemeronTest >> testDequeueMournerWithOnlyOneEphemeronShouldEmptyMournQueue [
 	| ephemeronObjectOop nonEphemeronObjectOop |
@@ -85,6 +64,41 @@ VMSpurScavengeEphemeronTest >> testMournQueueEphemeronsAreRemappedInTheOldSpace 
 	
 	firedEphemeron := memory dequeueMourner.
 	self assert: firedEphemeron equals: (memory fetchPointer: 0 ofObject: self keptObjectInVMVariable1)
+]
+
+{ #category : #'tests-ephemerons-globals' }
+VMSpurScavengeEphemeronTest >> testMultiPageMournQueue [
+
+	"This test Fires more ephemerons than those that fit in a single page of the mourn queue.
+	All ephemerons should be put in the mourn queue.
+	The mourn queue should grow with new pages to make them all fit.
+	Then we test we can extract all the objects from the queue"	
+
+	| nonEphemeronObjectOop  ephemeronKey ephemeronContainer mourned |
+	self createEphemeronClass.
+	ephemeronKey := self newZeroSizedObject.
+	ephemeronContainer := self newObjectWithSlots: 5000.
+	1 to: 5000 do: [ :i | | ephemeronObjectOop |
+		ephemeronObjectOop := self newEphemeronObject.
+		memory
+			storePointer: 0 "zero based"
+			ofObject: ephemeronObjectOop
+			withValue: ephemeronKey.
+		memory
+			storePointer: i - 1 "zero based"
+			ofObject: ephemeronContainer
+			withValue: ephemeronObjectOop
+	 ].
+	"Force object to not be collected by putting them in special variables"
+	self keepObjectInVMVariable1: ephemeronContainer.
+
+	memory fullGC.
+
+	mourned := 0.
+	[ memory dequeueMourner notNil ] whileTrue: [ mourned := mourned + 1 ].
+	self
+		assert: mourned
+		equals: 5000
 ]
 
 { #category : #'tests-ephemerons-globals' }

--- a/smalltalksrc/VMMakerTests/VMSpurScavengeEphemeronTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurScavengeEphemeronTest.class.st
@@ -1,9 +1,6 @@
 Class {
 	#name : #VMSpurScavengeEphemeronTest,
 	#superclass : #VMSpurInitializedOldSpaceTest,
-	#instVars : [
-		'ourEphemeronClass'
-	],
 	#category : #'VMMakerTests-MemoryTests'
 }
 
@@ -26,79 +23,6 @@ VMSpurScavengeEphemeronTest >> testDequeueMournerWithOnlyOneEphemeronShouldEmpty
 	memory dequeueMourner.
 	self assert: memory dequeueMourner equals: nil
 	
-]
-
-{ #category : #'tests-ephemerons-globals' }
-VMSpurScavengeEphemeronTest >> testMournQueueEphemeronsAreRemappedInTheOldSpace [
-	| ephemeronObjectOop keyObject valueObject firedEphemeron objectKeepingEphemeron |
-	self createEphemeronClass.
-	
-	self newOldSpaceObjectWithSlots: 0. "random object to trigger compaction"
-	
-	objectKeepingEphemeron := self newObjectWithSlots: 1.	
-	valueObject := self newObjectWithSlots: 0.
-	keyObject := self newZeroSizedObject.
-	ephemeronObjectOop := self newEphemeronObject.
-	
-	"slots of the ephemeron, register is ignored"	
-	memory
-		storePointer: 0
-		ofObject: ephemeronObjectOop
-		withValue: keyObject.
-
-	memory
-		storePointer: 1
-		ofObject: ephemeronObjectOop
-		withValue: valueObject.
-	
-	"Link between the root and the ephemeron"
-	memory
-		storePointer: 0
-		ofObject: objectKeepingEphemeron
-		withValue: ephemeronObjectOop.
-
-	"Force object to not be collected by putting them in special variables"
-	self keepObjectInVMVariable1: objectKeepingEphemeron.
-	
-	memory fullGC.
-	
-	firedEphemeron := memory dequeueMourner.
-	self assert: firedEphemeron equals: (memory fetchPointer: 0 ofObject: self keptObjectInVMVariable1)
-]
-
-{ #category : #'tests-ephemerons-globals' }
-VMSpurScavengeEphemeronTest >> testMultiPageMournQueue [
-
-	"This test Fires more ephemerons than those that fit in a single page of the mourn queue.
-	All ephemerons should be put in the mourn queue.
-	The mourn queue should grow with new pages to make them all fit.
-	Then we test we can extract all the objects from the queue"	
-
-	| nonEphemeronObjectOop  ephemeronKey ephemeronContainer mourned |
-	self createEphemeronClass.
-	ephemeronKey := self newZeroSizedObject.
-	ephemeronContainer := self newObjectWithSlots: 5000.
-	1 to: 5000 do: [ :i | | ephemeronObjectOop |
-		ephemeronObjectOop := self newEphemeronObject.
-		memory
-			storePointer: 0 "zero based"
-			ofObject: ephemeronObjectOop
-			withValue: ephemeronKey.
-		memory
-			storePointer: i - 1 "zero based"
-			ofObject: ephemeronContainer
-			withValue: ephemeronObjectOop
-	 ].
-	"Force object to not be collected by putting them in special variables"
-	self keepObjectInVMVariable1: ephemeronContainer.
-
-	memory fullGC.
-
-	mourned := 0.
-	[ memory dequeueMourner notNil ] whileTrue: [ mourned := mourned + 1 ].
-	self
-		assert: mourned
-		equals: 5000
 ]
 
 { #category : #'tests-ephemerons-globals' }

--- a/smalltalksrc/VMMakerTests/VMSpurScavengeEphemeronTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurScavengeEphemeronTest.class.st
@@ -50,6 +50,44 @@ VMSpurScavengeEphemeronTest >> testDequeueMournerWithOnlyOneEphemeronShouldEmpty
 ]
 
 { #category : #'tests-ephemerons-globals' }
+VMSpurScavengeEphemeronTest >> testMournQueueEphemeronsAreRemappedInTheOldSpace [
+	| ephemeronObjectOop keyObject valueObject firedEphemeron objectKeepingEphemeron |
+	self createEphemeronClass.
+	
+	self newOldSpaceObjectWithSlots: 0. "random object to trigger compaction"
+	
+	objectKeepingEphemeron := self newObjectWithSlots: 1.	
+	valueObject := self newObjectWithSlots: 0.
+	keyObject := self newZeroSizedObject.
+	ephemeronObjectOop := self newEphemeronObject.
+	
+	"slots of the ephemeron, register is ignored"	
+	memory
+		storePointer: 0
+		ofObject: ephemeronObjectOop
+		withValue: keyObject.
+
+	memory
+		storePointer: 1
+		ofObject: ephemeronObjectOop
+		withValue: valueObject.
+	
+	"Link between the root and the ephemeron"
+	memory
+		storePointer: 0
+		ofObject: objectKeepingEphemeron
+		withValue: ephemeronObjectOop.
+
+	"Force object to not be collected by putting them in special variables"
+	self keepObjectInVMVariable1: objectKeepingEphemeron.
+	
+	memory fullGC.
+	
+	firedEphemeron := memory dequeueMourner.
+	self assert: firedEphemeron equals: (memory fetchPointer: 0 ofObject: self keptObjectInVMVariable1)
+]
+
+{ #category : #'tests-ephemerons-globals' }
 VMSpurScavengeEphemeronTest >> testNewEphemeronObjectShouldBeInstanceOfEphemeronClass [
 
 	| ephemeronObjectOop |

--- a/smalltalksrc/VMMakerTests/VMTestMockInterpreter.class.st
+++ b/smalltalksrc/VMMakerTests/VMTestMockInterpreter.class.st
@@ -8,6 +8,19 @@ Class {
 	#category : #VMMakerTests
 }
 
+{ #category : #initialization }
+VMTestMockInterpreter >> allocateParameters: anInteger using: allocationBlock [
+	<inline: #always>
+
+	anInteger = 0 ifTrue: [ ^ nil ].
+
+	^ self
+		cCode: [ allocationBlock value: anInteger ]
+		inSmalltalk: [ | ptr | 
+			ptr := CArrayAccessor on: (Array new: anInteger).
+			allocatedElements add: ptr ]
+]
+
 { #category : #'memory testing' }
 VMTestMockInterpreter >> allocatedElements [
 	

--- a/smalltalksrc/VMMakerTests/VMTestMockInterpreter.class.st
+++ b/smalltalksrc/VMMakerTests/VMTestMockInterpreter.class.st
@@ -8,17 +8,13 @@ Class {
 	#category : #VMMakerTests
 }
 
-{ #category : #initialization }
+{ #category : #'memory testing' }
 VMTestMockInterpreter >> allocateParameters: anInteger using: allocationBlock [
-	<inline: #always>
-
-	anInteger = 0 ifTrue: [ ^ nil ].
-
-	^ self
-		cCode: [ allocationBlock value: anInteger ]
-		inSmalltalk: [ | ptr | 
-			ptr := CArrayAccessor on: (Array new: anInteger).
-			allocatedElements add: ptr ]
+	
+	| allocated |
+	allocated := super allocateParameters: anInteger using: allocationBlock.
+	allocatedElements add: allocated.
+	^ allocated
 ]
 
 { #category : #'memory testing' }

--- a/smalltalksrc/VMMakerTests/VMTestMockInterpreter.class.st
+++ b/smalltalksrc/VMMakerTests/VMTestMockInterpreter.class.st
@@ -13,6 +13,8 @@ VMTestMockInterpreter >> allocateParameters: anInteger using: allocationBlock [
 	
 	| allocated |
 	allocated := super allocateParameters: anInteger using: allocationBlock.
+	allocated ifNil: [ ^ nil ].
+	
 	allocatedElements add: allocated.
 	^ allocated
 ]


### PR DESCRIPTION
Fixes for ephemerons with tests:
 - check unscanned ephemeron queue overflow
 - fix remapping of object stacks (which are non-pointer objects)
    - size of the object stack to be respected when iterating it
    - object stacks with multiple pages should be correctly remapped during compaction

Added proper malloc/realloc support in simulation