### PR TITLE
fixing-ffi-for-largeIntegers-parameters

### DIFF
--- a/smalltalksrc/VMMaker/StackInterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreterPrimitives.class.st
@@ -463,13 +463,21 @@ StackInterpreterPrimitives >> marshallAndPushReturnValueFrom: returnHolder ofTyp
 		caseOf: {
 			[ FFI_TYPE_SINT8 ] 	-> [ self pop: argumentsAndReceiverCount thenPushInteger: (objectMemory readSINT8AtPointer: returnHolder) ].
 			[ FFI_TYPE_SINT16 ] 	-> [ self pop: argumentsAndReceiverCount thenPushInteger: (objectMemory readSINT16AtPointer: returnHolder) ].
-			[ FFI_TYPE_SINT32 ] 	-> [ self pop: argumentsAndReceiverCount thenPushInteger: (objectMemory readSINT32AtPointer: returnHolder) ].
-			[ FFI_TYPE_SINT64 ] 	-> [ self pop: argumentsAndReceiverCount thenPushInteger: (objectMemory readSINT64AtPointer: returnHolder) ].
+			[ FFI_TYPE_SINT32 ] 	-> [ self 
+													pop: argumentsAndReceiverCount 
+													thenPush: (objectMemory signed32BitIntegerFor: (objectMemory readSINT32AtPointer: returnHolder)) ].
+			[ FFI_TYPE_SINT64 ] 	-> [ self 
+													pop: argumentsAndReceiverCount 
+													thenPush: (objectMemory signed64BitIntegerFor: (objectMemory readSINT64AtPointer: returnHolder)) ].
 
 			[ FFI_TYPE_UINT8 ] 	-> [ self pop: argumentsAndReceiverCount thenPushInteger: (objectMemory readUINT8AtPointer: returnHolder) ].
 			[ FFI_TYPE_UINT16 ] 	-> [ self pop: argumentsAndReceiverCount thenPushInteger: (objectMemory readUINT16AtPointer: returnHolder) ].
-			[ FFI_TYPE_UINT32 ] 	-> [ self pop: argumentsAndReceiverCount thenPushInteger: (objectMemory readUINT32AtPointer: returnHolder) ].
-			[ FFI_TYPE_UINT64 ] 	-> [ self pop: argumentsAndReceiverCount thenPushInteger: (objectMemory readUINT64AtPointer: returnHolder) ].
+			[ FFI_TYPE_UINT32 ] 	-> [ self 
+													pop: argumentsAndReceiverCount 
+													thenPush: (objectMemory positive32BitIntegerFor: (objectMemory readUINT32AtPointer: returnHolder)) ].
+			[ FFI_TYPE_UINT64 ] 	-> [ self 
+													pop: argumentsAndReceiverCount 
+													thenPush: (objectMemory positive64BitIntegerFor: (objectMemory readUINT64AtPointer: returnHolder)) ].
 
 			[ FFI_TYPE_POINTER ] 	-> [ self pop: argumentsAndReceiverCount thenPush: (objectMemory newExternalAddressWithValue: (objectMemory readPointerAtPointer: returnHolder)) ].
 
@@ -576,9 +584,14 @@ StackInterpreterPrimitives >> marshallSInt32From: argumentArrayOop at: index int
 { #category : #'ffi - helpers' }
 StackInterpreterPrimitives >> marshallSInt64From: argumentArrayOop at: index into: holder [
 
-	| intHolder |
+	| intHolder value |
+	
+	value := self signed64BitValueOf: (objectMemory fetchPointer: index ofObject: argumentArrayOop).
+	
+	self failed ifTrue: [ ^ self ].
+		
 	intHolder := self cCoerce: holder to: #'int64_t *'.
-	intHolder at: 0 put: (self fetchInteger: index ofObject: argumentArrayOop ).
+	intHolder at: 0 put: value.
 		
 ]
 
@@ -655,10 +668,12 @@ StackInterpreterPrimitives >> marshallUInt32From: argumentArrayOop at: index int
 StackInterpreterPrimitives >> marshallUInt64From: argumentArrayOop at: index into: holder [
 
 	| intHolder value |
-	
-	value := self fetchInteger: index ofObject: argumentArrayOop.
-	value < 0 ifTrue: [ ^ self primitiveFailFor: PrimErrBadArgument ].
-		
+
+	value := self positive64BitValueOf:( objectMemory fetchPointer: index ofObject: argumentArrayOop ).	
+
+	self failed
+		ifTrue: [ ^ self ].
+			
 	intHolder := self cCoerce: holder to: #'uint64_t *'.
 	intHolder at: 0 put: value.
 		

--- a/smalltalksrc/VMMakerTests/VMFFIArgumentMarshallingTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMFFIArgumentMarshallingTest.class.st
@@ -141,6 +141,50 @@ VMFFIArgumentMarshallingTest >> testCalloutWithSINT32PositiveOutOfRangeProducesB
 ]
 
 { #category : #'tests - parameters marshalling' }
+VMFFIArgumentMarshallingTest >> testCalloutWithSINT64ArgumentWithLargeNegativeValueIsMarshalledCorrectly [
+
+	| aValue |
+	aValue := interpreter objectMemory minSmallInteger - 2.
+
+	self
+		doTestFuntionWithArgumentType: interpreter libFFI sint64
+		smalltalkValue: (interpreter signed64BitIntegerFor: aValue)
+		expectedValue: aValue
+]
+
+{ #category : #'tests - parameters marshalling' }
+VMFFIArgumentMarshallingTest >> testCalloutWithSINT64ArgumentWithLargePositiveHigherThan8BytesFails [
+
+	| aValue newLargeInteger |
+	aValue := UINT64_MAX * 2.
+	newLargeInteger := memory
+							eeInstantiateSmallClassIndex: ClassLargePositiveIntegerCompactIndex
+							format: (memory byteFormatForNumBytes: aValue size)
+							numSlots: (aValue size / memory bytesPerOop) ceiling asInteger.
+
+	0 to: 8 do: [ :i | 
+		memory storeByte: i ofObject: newLargeInteger withValue: (aValue byteAt: i + 1) ].
+
+	self
+		doTestFuntionWithArgumentType: interpreter libFFI sint64
+		smalltalkValue: newLargeInteger
+		failsWith: PrimErrBadArgument
+]
+
+{ #category : #'tests - parameters marshalling' }
+VMFFIArgumentMarshallingTest >> testCalloutWithSINT64ArgumentWithLargePositiveValueIsMarshalledCorrectly [
+
+	| aValue |
+	aValue := interpreter objectMemory maxSmallInteger + 2.
+
+	self
+		doTestFuntionWithArgumentType: interpreter libFFI sint64
+		smalltalkValue: (interpreter signed64BitIntegerFor: aValue)
+		expectedValue: aValue
+
+]
+
+{ #category : #'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithSINT64ArgumentWithNegativeValueIsMarshalledCorrectly [
 
 	self
@@ -287,6 +331,37 @@ VMFFIArgumentMarshallingTest >> testCalloutWithUINT32WithPositiveOutOfRangeFails
 		doTestFuntionWithArgumentType: interpreter libFFI uint32
 		smalltalkValue: valueToStore
 		failsWith: PrimErrBadArgument
+]
+
+{ #category : #'tests - parameters marshalling' }
+VMFFIArgumentMarshallingTest >> testCalloutWithUINT64ArgumentWithLargePositiveHigherThan8BytesFails [
+
+	| aValue newLargeInteger |
+	aValue := UINT64_MAX * 2.
+	newLargeInteger := memory
+							eeInstantiateSmallClassIndex: ClassLargePositiveIntegerCompactIndex
+							format: (memory byteFormatForNumBytes: aValue size)
+							numSlots: (aValue size / memory bytesPerOop) ceiling asInteger.
+
+	0 to: 8 do: [ :i | 
+		memory storeByte: i ofObject: newLargeInteger withValue: (aValue byteAt: i + 1) ].
+
+	self
+		doTestFuntionWithArgumentType: interpreter libFFI uint64
+		smalltalkValue: newLargeInteger
+		failsWith: PrimErrBadArgument
+]
+
+{ #category : #'tests - parameters marshalling' }
+VMFFIArgumentMarshallingTest >> testCalloutWithUINT64ArgumentWithLargePositiveValueIsMarshalledCorrectly [
+
+	| aValue |
+	aValue := interpreter objectMemory maxSmallInteger + 2.
+
+	self
+		doTestFuntionWithArgumentType: interpreter libFFI uint64
+		smalltalkValue: (interpreter signed64BitIntegerFor: aValue)
+		expectedValue: aValue
 ]
 
 { #category : #'tests - parameters marshalling' }

--- a/smalltalksrc/VMMakerTests/VMFFIReturnMarshallingTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMFFIReturnMarshallingTest.class.st
@@ -16,6 +16,26 @@ VMFFIReturnMarshallingTest >> doTestCalloutWithReturnType: aLibFFIType returnVal
 	self subclassResponsibility
 ]
 
+{ #category : #utils }
+VMFFIReturnMarshallingTest >> doTestCalloutWithReturnType: aLibFFIType returnValue: valueToReturn expectedLargeIntegerValue: expectedValue [ 
+
+	self
+		doTestCalloutWithReturnType: aLibFFIType
+		returnValue: valueToReturn
+		asserting: [ 	
+				self assert: interpreter primFailCode equals: 0.
+				expectedValue > 0 
+					ifTrue: [self 
+							assert: (memory classIndexOf: interpreter stackTop) 
+							equals: ClassLargePositiveIntegerCompactIndex]
+					ifFalse: [self 
+							assert: (memory classIndexOf: interpreter stackTop) 
+							equals: ClassLargeNegativeIntegerCompactIndex  ].
+						
+				self assert: (interpreter signed64BitValueOf: interpreter stackTop) equals: expectedValue ].
+
+]
+
 { #category : #'tests - marshalling return' }
 VMFFIReturnMarshallingTest >> doTestCalloutWithReturnType: aLibFFIType returnValue: valueToReturn expectedSmalltalkValue: expectedValue [
 
@@ -24,7 +44,9 @@ VMFFIReturnMarshallingTest >> doTestCalloutWithReturnType: aLibFFIType returnVal
 		returnValue: valueToReturn
 		asserting: [ 	
 				self assert: interpreter primFailCode equals: 0.
-				self assert: interpreter stackTop equals: expectedValue ].
+				self assert: (memory integerValueOf: interpreter stackTop) <= memory maxSmallInteger.
+				self assert: (memory integerValueOf: interpreter stackTop) >= memory minSmallInteger.
+				self assert: (memory integerValueOf: interpreter stackTop) equals: expectedValue ].
 
 ]
 
@@ -94,16 +116,42 @@ VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningSINT16PushSmallIntege
 	self
 		doTestCalloutWithReturnType: interpreter libFFI sint16
 		returnValue: INT16_MAX - 1
-		expectedSmalltalkValue: (memory integerObjectOf: INT16_MAX - 1)
+		expectedSmalltalkValue: INT16_MAX - 1
+]
+
+{ #category : #'tests - marshalling return' }
+VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningSINT32PushLargeInteger [
+
+	| value |
+	value := wordSize = 8 ifTrue: [ ^ self skip ].
+
+	self
+		doTestCalloutWithReturnType: interpreter libFFI sint32
+		returnValue: INT32_MAX - 1
+		expectedLargeIntegerValue: INT32_MAX - 1
 ]
 
 { #category : #'tests - marshalling return' }
 VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningSINT32PushSmallInteger [
 
+	| value |
+	value := wordSize = 8 
+		ifTrue: [ INT32_MAX - 1 ] 
+		ifFalse: [ memory maxSmallInteger ].
+
 	self
 		doTestCalloutWithReturnType: interpreter libFFI sint32
-		returnValue: INT32_MAX - 1
-		expectedSmalltalkValue: (memory integerObjectOf: INT32_MAX - 1)
+		returnValue: value
+		expectedSmalltalkValue: value
+]
+
+{ #category : #'tests - marshalling return' }
+VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningSINT64PushLargeInteger [
+
+	self
+		doTestCalloutWithReturnType: interpreter libFFI sint64
+		returnValue: INT64_MAX - 1
+		expectedLargeIntegerValue: INT64_MAX - 1
 ]
 
 { #category : #'tests - marshalling return' }
@@ -111,8 +159,8 @@ VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningSINT64PushSmallIntege
 
 	self
 		doTestCalloutWithReturnType: interpreter libFFI sint64
-		returnValue: INT64_MAX - 1
-		expectedSmalltalkValue: (memory integerObjectOf: INT64_MAX - 1)
+		returnValue: memory maxSmallInteger
+		expectedSmalltalkValue: memory maxSmallInteger
 ]
 
 { #category : #'tests - marshalling return' }
@@ -121,7 +169,7 @@ VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningSINT8PushSmallInteger
 	self
 		doTestCalloutWithReturnType: interpreter libFFI sint8
 		returnValue: INT8_MAX - 1
-		expectedSmalltalkValue: (memory integerObjectOf: INT8_MAX - 1)
+		expectedSmalltalkValue: INT8_MAX - 1
 ]
 
 { #category : #'tests - marshalling return' }
@@ -130,16 +178,42 @@ VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningUINT16PushSmallIntege
 	self
 		doTestCalloutWithReturnType: interpreter libFFI uint16
 		returnValue: INT16_MAX - 1
-		expectedSmalltalkValue: (memory integerObjectOf: INT16_MAX - 1)
+		expectedSmalltalkValue: INT16_MAX - 1
+]
+
+{ #category : #'tests - marshalling return' }
+VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningUINT32PushLargeInteger [
+
+	| value |
+	value := wordSize = 8 ifTrue: [ ^ self skip ].
+
+	self
+		doTestCalloutWithReturnType: interpreter libFFI uint32
+		returnValue: INT32_MAX - 1
+		expectedLargeIntegerValue: INT32_MAX - 1
 ]
 
 { #category : #'tests - marshalling return' }
 VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningUINT32PushSmallInteger [
 
+	| value |
+	value := wordSize = 8 
+		ifTrue: [ INT32_MAX - 1 ] 
+		ifFalse: [ memory maxSmallInteger ].
+
 	self
 		doTestCalloutWithReturnType: interpreter libFFI uint32
-		returnValue: INT32_MAX - 1
-		expectedSmalltalkValue: (memory integerObjectOf: INT32_MAX - 1)
+		returnValue: value
+		expectedSmalltalkValue: value
+]
+
+{ #category : #'tests - marshalling return' }
+VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningUINT64PushLargeInteger [
+
+	self
+		doTestCalloutWithReturnType: interpreter libFFI uint64
+		returnValue: INT64_MAX 
+		expectedLargeIntegerValue:  INT64_MAX 
 ]
 
 { #category : #'tests - marshalling return' }
@@ -147,8 +221,8 @@ VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningUINT64PushSmallIntege
 
 	self
 		doTestCalloutWithReturnType: interpreter libFFI uint64
-		returnValue: INT64_MAX - 1
-		expectedSmalltalkValue: (memory integerObjectOf: INT64_MAX - 1)
+		returnValue: memory maxSmallInteger 
+		expectedSmalltalkValue:  memory maxSmallInteger 
 ]
 
 { #category : #'tests - marshalling return' }
@@ -157,5 +231,5 @@ VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningUINT8PushSmallInteger
 	self
 		doTestCalloutWithReturnType: interpreter libFFI uint8
 		returnValue: INT8_MAX - 1
-		expectedSmalltalkValue: (memory integerObjectOf: INT8_MAX - 1)
+		expectedSmalltalkValue: INT8_MAX - 1
 ]

--- a/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
@@ -424,6 +424,21 @@ VMPrimitiveTest >> testPrimitiveAtPutFailsForNonIndexableObject [
 	self assert: interpreter primFailCode equals: PrimErrBadReceiver. 
 ]
 
+{ #category : #'tests - primitiveAtPut' }
+VMPrimitiveTest >> testPrimitiveAtPutFailsForNonIntegerArgument [
+	| class objectInstance |
+	class := self newClassInOldSpaceWithSlots: 0 instSpec: memory nonIndexablePointerFormat.
+	objectInstance := memory instantiateClass: class.
+	
+	interpreter push: objectInstance.
+	interpreter push: memory falseObject.
+	interpreter push: memory falseObject.
+	interpreter primitiveAtPut.
+	
+	self assert: interpreter failed.
+	self assert: interpreter primFailCode equals: PrimErrBadArgument. 
+]
+
 { #category : #'tests - primitiveImmutability' }
 VMPrimitiveTest >> testPrimitiveAtPutFailsIfObjectIsContext [
 
@@ -445,21 +460,6 @@ VMPrimitiveTest >> testPrimitiveAtPutFailsIfObjectIsContext [
 	self assert: interpreter failed.
 	"2 is the bad receiver exception in the special object array for the primFailCode"
 	self assert: interpreter primFailCode equals: 2. 
-]
-
-{ #category : #'tests - primitiveAtPut' }
-VMPrimitiveTest >> testPrimitiveAtPutFailsForNonIntegerArgument [
-	| class objectInstance |
-	class := self newClassInOldSpaceWithSlots: 0 instSpec: memory nonIndexablePointerFormat.
-	objectInstance := memory instantiateClass: class.
-	
-	interpreter push: objectInstance.
-	interpreter push: memory falseObject.
-	interpreter push: memory falseObject.
-	interpreter primitiveAtPut.
-	
-	self assert: interpreter failed.
-	self assert: interpreter primFailCode equals: PrimErrBadArgument. 
 ]
 
 { #category : #'tests - primitiveAtPut' }


### PR DESCRIPTION
Adding tests and marshalling processing of LargeInteger when 32/64 bits in 32 bits platforms, and 64 bits in 64 bits platforms