### PR TITLE
enhancement/move-WIN32_LEAN_AND_MEAN-as-an-option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,12 @@ if(MSVC)
     get_platform_name(VM_TARGET_OS)
     message(STATUS "Building for ${VM_TARGET_OS}")
     set(CMAKE_CURRENT_SOURCE_DIR_TO_OUT ${CMAKE_CURRENT_SOURCE_DIR})
+    
+    # Define WIN32_LEAN_AND_MEAN to exclude APIs such as Cryptography, DDE, RPC, Shell, and Windows Sockets
+    # They can be included if needed
+    # https://docs.microsoft.com/en-us/windows/win32/winprog/using-the-windows-headers
+    add_compile_definitions(WIN32_LEAN_AND_MEAN)
+    
 elseif(WIN)
     message(STATUS "Building for WINDOWS")
 
@@ -228,6 +234,7 @@ elseif(WIN)
     # this one is important
     SET(CMAKE_SYSTEM_NAME Windows)
 
+    add_compile_definitions(WIN32_LEAN_AND_MEAN)
     add_compile_definitions(NO_ISNAN NO_SERVICE "'VM_LABEL(foo)=0'" LSB_FIRST=1 AllocationCheckFiller=0xADD4E55)
 
     #Setting minimal Windows Version to VISTA

--- a/extracted/plugins/FileAttributesPlugin/include/win/dirent.h
+++ b/extracted/plugins/FileAttributesPlugin/include/win/dirent.h
@@ -9,13 +9,6 @@
 #ifndef DIRENT_H
 #define DIRENT_H
 
- /*
-  * Include windows.h without Windows Sockets 1.1 to prevent conflicts with
-  * Windows Sockets 2.0.
-  */
-#ifndef WIN32_LEAN_AND_MEAN
-#   define WIN32_LEAN_AND_MEAN
-#endif
 #include <windows.h>
 
 #include <stdio.h>

--- a/src/fileDialogWin32.c
+++ b/src/fileDialogWin32.c
@@ -6,7 +6,6 @@
 
 #include "pharovm/fileDialog.h"
 #include "pharovm/stringUtilities.h"
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <Shobjidl.h>
 

--- a/src/pathUtilities.c
+++ b/src/pathUtilities.c
@@ -4,7 +4,6 @@
 #include <stdio.h>
 
 #ifdef _WIN32
-#   define WIN32_LEAN_AND_MEAN
 #   include <windows.h>
 #elif defined(__unix__) || defined(__MACH__) || defined(__APPLE__)
 #   include <unistd.h>

--- a/src/stringUtilities.c
+++ b/src/stringUtilities.c
@@ -26,7 +26,6 @@ vm_string_concat(const char *first, const char *second)
 }
 
 #ifdef _WIN32
-#   define WIN32_LEAN_AND_MEAN
 #   include <windows.h>
 
 uint16_t*

--- a/src/win32Main.c
+++ b/src/win32Main.c
@@ -1,6 +1,5 @@
 #include "pharovm/pharoClient.h"
 
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 int CALLBACK


### PR DESCRIPTION
Making WIN32_LEAN_AND_MEAN a compilation option, it should only affect the speed of the build process. Check https://docs.microsoft.com/en-us/windows/win32/winprog/using-the-windows-headers