### PR TITLE
176-Out-of-memory-messages-should-be-a-bit-more-talkative

### DIFF
--- a/include/pharovm/debug.h
+++ b/include/pharovm/debug.h
@@ -48,3 +48,5 @@ EXPORT(void) logMessageFromErrno(int level, const char* msg, const char* fileNam
 
 int vm_printf( const char * format, ... );
 void vm_setVMOutputStream(FILE * stream);
+
+EXPORT(void) printStatusAfterError();

--- a/smalltalksrc/VMMaker/SpurGenerationScavenger.class.st
+++ b/smalltalksrc/VMMaker/SpurGenerationScavenger.class.st
@@ -352,7 +352,7 @@ SpurGenerationScavenger >> copyToFutureSpace: survivor bytes: bytesInObject [
 SpurGenerationScavenger >> copyToOldSpace: survivor bytes: bytesInObject format: formatOfSurvivor [
 	"Copy survivor to oldSpace.  Answer the new oop of the object."
 	<inline: #never> "Should be too infrequent to lower icache density of copyAndForward:"
-	| nTenures startOfSurvivor newStart newOop |
+	| nTenures startOfSurvivor newStart newOop growResult |
 	self assert: (formatOfSurvivor = (manager formatOf: survivor)
 				and: [((manager isMarked: survivor) not or: [tenureCriterion = MarkOnTenure])
 				and: [tenureCriterion = TenureToShrinkRT
@@ -362,10 +362,13 @@ SpurGenerationScavenger >> copyToOldSpace: survivor bytes: bytesInObject format:
 	startOfSurvivor := manager startOfObject: survivor.
 	newStart := manager allocateOldSpaceChunkOfBytes: bytesInObject.
 	newStart ifNil:
-		[manager growOldSpaceByAtLeast: 0. "grow by growHeadroom"
+		[growResult := manager growOldSpaceByAtLeast: 0. "grow by growHeadroom"
 		 newStart := manager allocateOldSpaceChunkOfBytes: bytesInObject.
 		 newStart ifNil:
-			[self error: 'out of memory']].
+			[	growResult 
+					ifNil: [ self error: 'Could not allocate new object in the old space. It was not possible to allocate a new memory segment' ] 
+					ifNotNil: [ self error: 'Could not allocate new object in the old space' ]]].
+		
 	"manager checkFreeSpace."
 	manager memcpy: newStart asVoidPointer _: startOfSurvivor asVoidPointer _: bytesInObject.
 	newOop := newStart + (survivor - startOfSurvivor).

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -5912,12 +5912,15 @@ SpurMemoryManager >> growOldSpaceByAtLeast: minAmmount [
 	"Now apply the maxOldSpaceSize limit, if one is in effect."
 	maxOldSpaceSize > 0 ifTrue:
 		[total := segmentManager totalBytesInSegments.
-		 total >= maxOldSpaceSize ifTrue:
-			[^nil].
+		 total >= maxOldSpaceSize ifTrue:[
+			self logError: 'Could not allocate more memory. MaxOldSpaceSize reached.'.
+			^nil].
 		 headroom := maxOldSpaceSize - total.
 		 headroom < ammount ifTrue:
 			[headroom < (minAmmount + (self baseHeaderSize * 2 + self bridgeSize)) ifTrue:
-				[^nil].
+				[
+				self logError: 'Required space is bigger than the headroom. Could not allocate'.
+				^nil].
 			 ammount := headroom]].
 		 
 	start := coInterpreter ioUTCMicrosecondsNow.

--- a/smalltalksrc/VMMaker/VMClass.class.st
+++ b/smalltalksrc/VMMaker/VMClass.class.st
@@ -717,6 +717,13 @@ VMClass >> localNameFor: aString [
 	^ aString asFileReference basename
 ]
 
+{ #category : #'debug support' }
+VMClass >> logError: aMessage [
+	
+	<doNotGenerate>
+	Warning signal: aMessage
+]
+
 { #category : #'memory access' }
 VMClass >> long64AtPointer: pointer [
 	"This gets implemented by Macros in C, where its types will also be checked.

--- a/src/debug.c
+++ b/src/debug.c
@@ -39,6 +39,7 @@ EXPORT(int) getLogLevel(){
 
 void error(char *errorMessage){
     logError(errorMessage);
+	printStatusAfterError();
     abort();
 }
 

--- a/src/debugUnix.c
+++ b/src/debugUnix.c
@@ -9,6 +9,14 @@
 
 #endif
 
+#if __APPLE__
+
+#define _XOPEN_SOURCE
+#include <ucontext.h>
+
+#endif
+
+
 #ifdef HAVE_EXECINFO_H
 # include <execinfo.h>
 #endif
@@ -419,4 +427,17 @@ void reportStackState(const char *msg, char *date, int printAll, ucontext_t *uap
 #endif
 	fprintf(output,"\n\t(%s)\n", msg);
 	fflush(output);
+}
+
+EXPORT(void) printStatusAfterError(){
+	
+	ucontext_t uap;
+	
+	getcontext(&uap);
+	
+	int saved_errno = errno;
+
+	doReport("VM Error", &uap);
+
+	errno = saved_errno;
 }

--- a/src/debugWin.c
+++ b/src/debugWin.c
@@ -396,5 +396,33 @@ EXPORT(void) printRegisterState(PCONTEXT regs, FILE* output){
 }
 
 EXPORT(void) printStatusAfterError(){
-	printCrashDebugInformation(GetExceptionInformation());
+
+	char crashdumpFileName[PATH_MAX+1];
+	FILE *crashDumpFile;
+	crashdumpFileName[0] = 0;
+
+	//This is awful but replace the stdout to print all the messages in the file.
+	getCrashDumpFilenameInto(crashdumpFileName);
+	crashDumpFile = fopen(crashdumpFileName, "a+");
+	vm_setVMOutputStream(crashDumpFile);
+
+	fprintf(crashDumpFile, "\n\nAll Smalltalk process stacks (active first):\n");
+	fflush(crashDumpFile);
+
+	printAllStacks();
+
+	fprintf(crashDumpFile, "\nMost recent primitives\n");
+	dumpPrimTraceLog();
+
+	vm_setVMOutputStream(stderr);
+	fclose(crashDumpFile);
+
+	fprintf(stderr, "\n\nAll Smalltalk process stacks (active first):\n");
+	fflush(stderr);
+
+	printAllStacks();
+	fprintf(stderr, "\nMost recent primitives\n");
+	dumpPrimTraceLog();
+
+	fflush(stderr);
 }

--- a/src/debugWin.c
+++ b/src/debugWin.c
@@ -394,3 +394,7 @@ EXPORT(void) printRegisterState(PCONTEXT regs, FILE* output){
 			regs->Rip);
 #endif
 }
+
+EXPORT(void) printStatusAfterError(){
+	printCrashDebugInformation(GetExceptionInformation());
+}


### PR DESCRIPTION
Improving the logging of error messages when out of memory.
Also logging stack state after an error and before aborting.

Fix #176