### PR TITLE
Limit the gloablSessionID (which is signed 64 bits) to 31 bits

### DIFF
--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -8176,6 +8176,18 @@ StackInterpreter >> initializeExtraClassInstVarIndices [
 ]
 
 { #category : #initialization }
+StackInterpreter >> initializeGlobalSessionID [
+	"Initialize the globalSessionID.
+	To ensure compatibility with old plugins, keep the value to a postive signed 32 bit integer"
+
+	[globalSessionID = 0] whileTrue:
+		[globalSessionID := self
+			cCode: [((self time: #NULL) + self ioMSecs) bitAnd: 16r7FFFFFFF]
+			inSmalltalk: [((self time: #NULL) + self ioMSecs) bitAnd: 16r7FFFFFFF]].
+
+]
+
+{ #category : #initialization }
 StackInterpreter >> initializeInterpreter: bytesToShift [
 	"Initialize Interpreter state before starting execution of a new image."
 	interpreterProxy := self sqGetInterpreterProxy.
@@ -8191,10 +8203,7 @@ StackInterpreter >> initializeInterpreter: bytesToShift [
 	self initialCleanup.
 	profileSemaphore := profileProcess := profileMethod := objectMemory nilObject.
 	interruptKeycode := 2094. "cmd-. as used for Mac but no other OS"
-	[globalSessionID = 0] whileTrue:
-		[globalSessionID := self
-								cCode: [(self time: #NULL) + self ioMSecs]
-								inSmalltalk: [(Random new next * (SmallInteger maxVal min: 16rFFFFFFFF)) asInteger]].
+	self initializeGlobalSessionID.
 	metaAccessorDepth := -2.
 	super initializeInterpreter: bytesToShift
 ]

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -8193,8 +8193,8 @@ StackInterpreter >> initializeInterpreter: bytesToShift [
 	interruptKeycode := 2094. "cmd-. as used for Mac but no other OS"
 	[globalSessionID = 0] whileTrue:
 		[globalSessionID := self
-								cCode: [(self time: #NULL) + self ioMSecs]
-								inSmalltalk: [(Random new next * (SmallInteger maxVal min: 16rFFFFFFFF)) asInteger]].
+								cCode: [((self time: #NULL) + self ioMSecs) bitAnd: 16r7FFFFFFF]
+								inSmalltalk: [(Random new next * (SmallInteger maxVal min: 16r7FFFFFFF)) asInteger]].
 	metaAccessorDepth := -2.
 	super initializeInterpreter: bytesToShift
 ]

--- a/smalltalksrc/VMMaker/StackInterpreterSimulator.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreterSimulator.class.st
@@ -2590,6 +2590,13 @@ StackInterpreterSimulator >> testWithFramePrint [
 	self test
 ]
 
+{ #category : #'I/O primitives support' }
+StackInterpreterSimulator >> time: ignored [
+	"Simulate the glibc time() function"
+
+	^ DateAndTime now asUnixTime 
+]
+
 { #category : #UI }
 StackInterpreterSimulator >> toggleTranscript [
 	| transcriptPane |

--- a/smalltalksrc/VMMakerTests/VMSessionIdTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSessionIdTest.class.st
@@ -1,0 +1,28 @@
+Class {
+	#name : #VMSessionIdTest,
+	#superclass : #VMInterpreterTests,
+	#category : #'VMMakerTests-InterpreterTests'
+}
+
+{ #category : #tests }
+VMSessionIdTest >> testGlobalSessionID [
+	"The globalSessionID is stored as a 64 bit number, but for compatibility with older plugins, is restricted to postive signed 32 bit values"
+	| vm predicted diff |
+
+	"The globalSessionID is the Unix time at startup + startMicroseconds.
+	The simulator allows startMicroseconds to be set, so we can force the value to have the top bit set in a 32 bit signed integer"
+	vm := StackInterpreterSimulator newWithOptions: { 
+		#ObjectMemory -> #Spur64BitMemoryManager.
+		#startMicroseconds -> 16r80000000. } asDictionary.
+	vm initializeGlobalSessionID.
+
+	"Check that startMicroseconds is the expected value"
+	self assert: vm ioUTCStartMicroseconds equals: 16r80000000.
+	"Check that the globalSessionID is close to what we expect (allowing for a generous execution time"
+	predicted := DateAndTime now asUnixTime + (vm ioUTCMicroseconds // 1000).
+	diff := (predicted - vm getThisSessionID) abs.
+	self assert: diff < 180.
+
+	"Ensure that bit 32 isn't set"
+	self assert: vm getThisSessionID < 16r80000000.
+]


### PR DESCRIPTION
avoiding comparison issues when the ID is stored as a signed 32 bit integer.

E.g. in `UnixOSProcessPlugin`.

Issue: pharo-project/opensmalltalk-vm#233