### PR TITLE
Cast support for ifTrue: as expressions

### DIFF
--- a/smalltalksrc/CAST/CASTParserTests.class.st
+++ b/smalltalksrc/CAST/CASTParserTests.class.st
@@ -198,7 +198,7 @@ CASTParserTests >> testParseArrayDeclarationWithInitializer [
 
 	declarator := declaration declarators first.
 	self assert: declarator isInitializerDeclarator.
-	self assert: declarator initializer isCall.
+	self assert: declarator initializer isFunctionCall.
 
 	"Inside the initializer declarator is the array declarator"
 	declarator := declarator declarator.
@@ -252,7 +252,7 @@ CASTParserTests >> testParseCall [
 	expression := self parseExpression: 'toto()'.
 	
 	self assert: expression isExpression.
-	self assert: expression isCall.
+	self assert: expression isFunctionCall.
 	self assert: expression identifier name equals: 'toto'.
 	self assert: expression arguments isEmpty.
 ]
@@ -264,10 +264,10 @@ CASTParserTests >> testParseCallWithArguments [
 	expression := self parseExpression: 'toto(1, foo(), 1+2)'.
 	
 	self assert: expression isExpression.
-	self assert: expression isCall.
+	self assert: expression isFunctionCall.
 	self assert: expression identifier name equals: 'toto'.
 	self assert: expression arguments first isConstant.
-	self assert: expression arguments second isCall.
+	self assert: expression arguments second isFunctionCall.
 	self assert: expression arguments third isBinaryOperation.
 ]
 
@@ -290,7 +290,7 @@ CASTParserTests >> testParseCommaSeparatedExpression [
 	commaSeparatedExpression := expression rvalue.
 	self assert: commaSeparatedExpression isCommaSeparatedExpression.
 	self assert: commaSeparatedExpression expressions first isConstant.
-	self assert: commaSeparatedExpression expressions second isCall.
+	self assert: commaSeparatedExpression expressions second isFunctionCall.
 	self assert: commaSeparatedExpression expressions third isBinaryOperation.
 ]
 

--- a/smalltalksrc/CAST/CAbstractNodeVisitor.class.st
+++ b/smalltalksrc/CAST/CAbstractNodeVisitor.class.st
@@ -115,6 +115,11 @@ CAbstractNodeVisitor >> visitExpression: anExpression [
 ]
 
 { #category : #generated }
+CAbstractNodeVisitor >> visitExpressionList: anExpressionList [
+	^ self visitAbstract: anExpressionList
+]
+
+{ #category : #generated }
 CAbstractNodeVisitor >> visitExpressionStatement: anExpressionStatement [
 	^ self visitAbstract: anExpressionStatement
 ]

--- a/smalltalksrc/CAST/CCallNode.class.st
+++ b/smalltalksrc/CAST/CCallNode.class.st
@@ -55,7 +55,7 @@ CCallNode >> initialize [
 ]
 
 { #category : #testing }
-CCallNode >> isCall [
+CCallNode >> isFunctionCall [
 	
 	^ true
 ]

--- a/smalltalksrc/CAST/CConstantNode.class.st
+++ b/smalltalksrc/CAST/CConstantNode.class.st
@@ -44,6 +44,12 @@ CConstantNode >> isConstant [
 	^ true
 ]
 
+{ #category : #testing }
+CConstantNode >> isLeaf [
+	
+	^ true
+]
+
 { #category : #generated }
 CConstantNode >> value [
 	^ value

--- a/smalltalksrc/CAST/CExpressionListNode.class.st
+++ b/smalltalksrc/CAST/CExpressionListNode.class.st
@@ -15,6 +15,11 @@ CExpressionListNode >> , anotherExpression [
 ]
 
 { #category : #adding }
+CExpressionListNode >> acceptVisitor: anAbstractVisitor [
+	^ anAbstractVisitor visitExpressionList: self
+]
+
+{ #category : #adding }
 CExpressionListNode >> add: anExpression [
 	
 	expressions add: anExpression

--- a/smalltalksrc/CAST/CGLRAbstractNode.class.st
+++ b/smalltalksrc/CAST/CGLRAbstractNode.class.st
@@ -32,3 +32,9 @@ CGLRAbstractNode >> isIdentifier [
 	
 	^ false
 ]
+
+{ #category : #testing }
+CGLRAbstractNode >> isLeaf [
+	
+	^ false
+]

--- a/smalltalksrc/CAST/CGLRAbstractNode.class.st
+++ b/smalltalksrc/CAST/CGLRAbstractNode.class.st
@@ -22,7 +22,19 @@ CGLRAbstractNode >> ambiguous: aNode [
 ]
 
 { #category : #testing }
+CGLRAbstractNode >> isBinaryOperation [
+	
+	^ false
+]
+
+{ #category : #testing }
 CGLRAbstractNode >> isConstant [
+	
+	^ false
+]
+
+{ #category : #testing }
+CGLRAbstractNode >> isFunctionCall [
 	
 	^ false
 ]

--- a/smalltalksrc/CAST/CIdentifierNode.class.st
+++ b/smalltalksrc/CAST/CIdentifierNode.class.st
@@ -44,6 +44,12 @@ CIdentifierNode >> isIdentifier [
 	^ true
 ]
 
+{ #category : #testing }
+CIdentifierNode >> isLeaf [
+	
+	^ true
+]
+
 { #category : #accessing }
 CIdentifierNode >> name [
 	

--- a/smalltalksrc/CAST/CStringLiteralNode.class.st
+++ b/smalltalksrc/CAST/CStringLiteralNode.class.st
@@ -22,6 +22,12 @@ CStringLiteralNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitStringLiteral: self
 ]
 
+{ #category : #generated }
+CStringLiteralNode >> isLeaf [
+
+	^ true
+]
+
 { #category : #accessing }
 CStringLiteralNode >> needsDoubleQuotes [
 

--- a/smalltalksrc/CAST/CTernaryNode.class.st
+++ b/smalltalksrc/CAST/CTernaryNode.class.st
@@ -4,7 +4,8 @@ Class {
 	#instVars : [
 		'condition',
 		'else',
-		'then'
+		'then',
+		'printOnMultipleLines'
 	],
 	#category : #'CAST-Nodes'
 }
@@ -16,6 +17,7 @@ CTernaryNode class >> condition: aCondition then: thenExpression else: elseExpre
 		  condition: aCondition;
 		  then: thenExpression;
 		  else: elseExpression;
+		  printOnMultipleLines: false;
 		  yourself
 ]
 
@@ -55,6 +57,18 @@ CTernaryNode >> else: aCGLRAbstractNode [
 { #category : #generated }
 CTernaryNode >> isTernary [
 	^ true
+]
+
+{ #category : #accessing }
+CTernaryNode >> printOnMultipleLines [
+
+	^ printOnMultipleLines
+]
+
+{ #category : #accessing }
+CTernaryNode >> printOnMultipleLines: aBoolean [
+
+	printOnMultipleLines := aBoolean
 ]
 
 { #category : #generated }

--- a/smalltalksrc/Slang-Tests/CSlangPrettyPrinterTest.class.st
+++ b/smalltalksrc/Slang-Tests/CSlangPrettyPrinterTest.class.st
@@ -134,7 +134,7 @@ CSlangPrettyPrinterTest >> testVisitCastExpressionDouble [
 			          right: (CIdentifierNode name: 'b')).
 
 
-	self assert: print equals: '(double)a / b'
+	self assert: print equals: '((double)a) / b'
 ]
 
 { #category : #'tests-visitor' }
@@ -258,6 +258,30 @@ CSlangPrettyPrinterTest >> testVisitEmptyStatement [
 	self assert: print equals: ''
 
 
+]
+
+{ #category : #'tests-visitor' }
+CSlangPrettyPrinterTest >> testVisitExpressionList [
+
+	| print |
+	print := self prettyPrint: (CExpressionListNode new expressions:
+			          { (CCallNode
+				           identifier: (CIdentifierNode name: 'foo')
+				           arguments: { 
+						           (CConstantNode value: 1).
+						           (CConstantNode value: 2) }).
+						(CCallNode
+				           identifier: (CIdentifierNode name: 'foo')
+				           arguments: { 
+						           (CConstantNode value: 3).
+						           (CConstantNode value: 4) }).
+						(CCallNode
+				           identifier: (CIdentifierNode name: 'foo')
+				           arguments: { 
+						           (CConstantNode value: 5).
+						           (CConstantNode value: 6) }) }).
+
+	self assert: print trimBoth equals: '(foo(1, 2) , foo(3, 4) , foo(5, 6))'
 ]
 
 { #category : #'tests-visitor' }

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -59,6 +59,43 @@ SlangBasicTranslationTest >> slangTranslate: tast inStream: aWriteStream [
 ]
 
 { #category : #'tests-blocks' }
+SlangBasicTranslationTest >> testBlockAsArgument [
+
+	"Case:
+	
+	[ 1 foo: 2. 3 foo: 4. 5 foo: 6 ] value ifTrue: [ a := b ]"
+	"In order to test the translation of a block as an argument, the block is given as condition of an if."
+	| translation variable expression |
+	variable := TVariableNode new setName: 'var'.
+	expression := TStmtListNode new setArguments: #(  ) statements: { 
+			              (TSendNode new
+				               setSelector: #foo
+				               receiver: (TConstantNode value: 1)
+				               arguments: { (TConstantNode value: 2) }).
+			              (TSendNode new
+				               setSelector: #foo
+				               receiver: (TConstantNode value: 3)
+				               arguments: { (TConstantNode value: 4) }).
+			              (TSendNode new
+				               setSelector: #foo
+				               receiver: (TConstantNode value: 5)
+				               arguments: { (TConstantNode value: 6) }) }.
+	translation := self translate: (TSendNode new
+			                setSelector: #ifTrue:
+			                receiver: (TSendNode new setSelector: #value receiver: expression arguments: {})
+			                arguments: { (TStmtListNode new setStatements: { 
+						                 (TAssignmentNode new
+							                  setVariable: (TVariableNode new setName: 'a')
+							                  expression: (TVariableNode new setName: 'b')) }) }).
+
+	self
+		assert: translation trimBoth
+		equals: 'if ((foo(1, 2), foo(3, 4), foo(5, 6))) {
+	a = b;
+}'
+]
+
+{ #category : #'tests-blocks' }
 SlangBasicTranslationTest >> testBlockValue [
 
 	"Case:
@@ -1566,21 +1603,39 @@ SlangBasicTranslationTest >> testSendIfTrue [
 SlangBasicTranslationTest >> testSendIfTrueAsArgument [
 
 	| translation send |
-	send := TAssignmentNode new setVariable: (TVariableNode new setName: 'y') expression:  (TSendNode new
-		        setSelector: #ifTrue:
-		        receiver: (TVariableNode new setName: 'x')
-		        arguments: { (TStmtListNode new setStatements: { 
-					         (TAssignmentNode new
-						          setVariable: (TVariableNode new setName: 'a')
-						          expression: (TConstantNode value: false)).
-					         (TAssignmentNode new
-						          setVariable: (TVariableNode new setName: 'c')
-						          expression: (TConstantNode value: 1)) }) }).
+	send := TAssignmentNode new
+		        setVariable: (TVariableNode new setName: 'y')
+		        expression: (TSendNode new
+				         setSelector: #ifTrue:
+				         receiver: (TVariableNode new setName: 'x')
+				         arguments: { (TStmtListNode new setStatements: { 
+							          (TAssignmentNode new
+								           setVariable: (TVariableNode new setName: 'a')
+								           expression: (TConstantNode value: false)).
+							          (TAssignmentNode new
+								           setVariable: (TVariableNode new setName: 'c')
+								           expression: (TConstantNode value: 1)) }) }).
 	translation := self translate: send.
 
 	self assert: translation trimBoth equals: 'y = (x
-	 ? ((a = 0) , (c = 1))
+	 ? ((a = 0), (c = 1))
 	 : 0)'
+]
+
+{ #category : #'tests-send' }
+SlangBasicTranslationTest >> testSendIfTrueAsArgumentWithReceiverTrueConstant [
+
+	| translation send |
+	generator generateDeadCode: false.
+	send := TAssignmentNode new
+		        setVariable: (TVariableNode new setName: 'y')
+		        expression: (TSendNode new
+				         setSelector: #ifTrue:
+				         receiver: (TConstantNode value: true)
+				         arguments: { (TConstantNode value: 1) }).
+	translation := self translate: send.
+
+	self assert: translation trimBoth equals: 'y = 1'
 ]
 
 { #category : #'tests-send' }

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -1563,6 +1563,27 @@ SlangBasicTranslationTest >> testSendIfTrue [
 ]
 
 { #category : #'tests-send' }
+SlangBasicTranslationTest >> testSendIfTrueAsArgument [
+
+	| translation send |
+	send := TAssignmentNode new setVariable: (TVariableNode new setName: 'y') expression:  (TSendNode new
+		        setSelector: #ifTrue:
+		        receiver: (TVariableNode new setName: 'x')
+		        arguments: { (TStmtListNode new setStatements: { 
+					         (TAssignmentNode new
+						          setVariable: (TVariableNode new setName: 'a')
+						          expression: (TConstantNode value: false)).
+					         (TAssignmentNode new
+						          setVariable: (TVariableNode new setName: 'c')
+						          expression: (TConstantNode value: 1)) }) }).
+	translation := self translate: send.
+
+	self assert: translation trimBoth equals: 'y = (x
+	 ? ((a = 0) , (c = 1))
+	 : 0)'
+]
+
+{ #category : #'tests-send' }
 SlangBasicTranslationTest >> testSendIfTrueIfFalse [
 
 	| translation send |
@@ -1621,6 +1642,31 @@ SlangBasicTranslationTest >> testSendIfTrueIfFalseCollapseBothArmsOfConditional 
 
 	self assert: translation trimBoth equals: 'foo(x, 7);
 {
+	a = 0;
+	c = 1;
+}'
+]
+
+{ #category : #'tests-send' }
+SlangBasicTranslationTest >> testSendIfTrueWithBlockReceiver [
+
+	| translation send |
+	send := TSendNode new
+		        setSelector: #ifTrue:
+		        receiver: (TStmtListNode new setStatements: { (TAssignmentNode new
+						          setVariable: (TVariableNode new setName: 'y')
+						          expression: (TConstantNode value: false)).
+								TVariableNode new setName: 'x' })
+		        arguments: { (TStmtListNode new setStatements: { 
+					         (TAssignmentNode new
+						          setVariable: (TVariableNode new setName: 'a')
+						          expression: (TConstantNode value: false)).
+					         (TAssignmentNode new
+						          setVariable: (TVariableNode new setName: 'c')
+						          expression: (TConstantNode value: 1)) }) }.
+	translation := self translate: send.
+
+	self assert: translation trimBoth equals: 'if (((y = 0), x)) {
 	a = 0;
 	c = 1;
 }'
@@ -2225,7 +2271,7 @@ SlangBasicTranslationTest >> testSendSequentialAndWithConstantReceiverTrue [
 						          arguments: { (TVariableNode new setName: 'b') }) }) }.
 	translation := self translate: send.
 
-	self assert: translation equals: '1 && ((1 + 2, a == b))'
+	self assert: translation equals: '1 && ((1 + 2 , a == b))'
 ]
 
 { #category : #'tests-assignment' }

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -2915,6 +2915,33 @@ CCodeGenerator >> generateCASTValue: tast [
 ]
 
 { #category : #'CAST translation' }
+CCodeGenerator >> generateCASTValueAsArgument: tast [
+
+	"Reduce [:formal ... :formalN| body ] value: actual ... value: actualN
+	 to body with formals substituted for by actuals."
+	| substitution substitutionDict newLabels |
+	self assert: tast receiver isStmtList.
+	self assert: tast receiver args size = tast args size.
+	substitution := tast receiver copy.
+	substitution renameLabelsForInliningInto: currentMethod.
+	substitutionDict := Dictionary new: tast args size * 2.
+	tast receiver args
+		with: tast args
+		do: [ :argName :exprNode | 
+		substitutionDict at: argName put: exprNode ].
+	newLabels := Set withAll: currentMethod labels.
+	substitution nodesDo: [ :node | 
+		node isLabel ifTrue: [ 
+			node label ifNotNil: [ :label | newLabels add: label ] ] ].
+	"now add the new labels so that a subsequent inline of
+	 the same block will be renamed with different labels."
+	currentMethod labels: newLabels.
+	^ substitution
+		  bindVariablesIn: substitutionDict;
+		  asCASTExpressionIn: self
+]
+
+{ #category : #'CAST translation' }
 CCodeGenerator >> generateCASTWhile: boolean loop: tast [
 
 	| condition |
@@ -4521,9 +4548,13 @@ CCodeGenerator >> initializeCASTTranslationDictionary [
 	#cCode:inSmalltalk:		#generateCASTInlineCCodeAsArgument:
 	#cppIf:ifTrue:ifFalse:	#generateCASTInlineCppIfElseAsArgument:
 	#cppIf:ifTrue:			#generateCASTInlineCppIfElseAsArgument:
+				
+	#value					#generateCASTValueAsArgument:
+	#value:					#generateCASTValueAsArgument:
+	#value:value:			#generateCASTValueAsArgument:
 	).
 
-	castAsArgumentTranslationDict := Dictionary new: 8.
+	castAsArgumentTranslationDict := Dictionary new: 15.
 	1 to: pairs size by: 2 do: [:i |
 		castAsArgumentTranslationDict at: (pairs at: i) put: (pairs at: i + 1)].
 

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -2095,15 +2095,34 @@ CCodeGenerator >> generateCASTFlag: tast [
 ]
 
 { #category : #utilities }
-CCodeGenerator >> generateCASTForBuiltinConstructFor: msgNode [
-	"Generate CAST for a message node assuming it is a built in construct.
-	If the message node can not be translated as a built in construct, return nil. 
-	"
+CCodeGenerator >> generateCASTForBuiltinAsArgumentConstructFor: msgNode [
+
+	"Generate CAST argument form for a message node assuming it is a built-in construct.
+	If the message node can not be translated as an argument, try to generate normal CAST form for this built-in.
+	Otherwise return nil."
 
 	| action |
-	(self shouldGenerateAsInterpreterProxySend: msgNode) ifTrue:
-		[^nil].
-	action := castTranslationDict at: msgNode selector ifAbsent: [ ^nil ].
+	(self shouldGenerateAsInterpreterProxySend: msgNode) ifTrue: [ ^ nil ].
+	action := castAsArgumentTranslationDict
+		          at: msgNode selector
+		          ifAbsent: [ 
+		          castTranslationDict
+			          at: msgNode selector
+			          ifAbsent: [ ^ nil ] ].
+	^ self perform: action with: msgNode
+]
+
+{ #category : #utilities }
+CCodeGenerator >> generateCASTForBuiltinConstructFor: msgNode [
+
+	"Generate CAST for a message node assuming it is a built-in construct.
+	If the message node can not be translated as a built-in construct, return nil."
+
+	| action |
+	(self shouldGenerateAsInterpreterProxySend: msgNode) ifTrue: [ ^ nil ].
+	action := castTranslationDict
+		          at: msgNode selector
+		          ifAbsent: [ ^ nil ].
 	^ self perform: action with: msgNode
 ]
 
@@ -2244,7 +2263,7 @@ CCodeGenerator >> generateCASTIfTrue: tast [
 	^ (self nilOrBooleanConstantReceiverOf: tast receiver)
 		  ifNil: [ 
 			  CIfStatementNode
-				  if: (tast receiver asCASTIn: self)
+				  if: (tast receiver asCASTExpressionIn: self)
 				  then: (tast arguments first asCASTIn: self) ]
 		  ifNotNil: [ :const | 
 			  const
@@ -2255,10 +2274,18 @@ CCodeGenerator >> generateCASTIfTrue: tast [
 { #category : #'CAST translation' }
 CCodeGenerator >> generateCASTIfTrueAsArgument: tast [
 
-	^ CTernaryNode
-		  condition: (tast receiver asCASTIn: self)
-		  then: (tast arguments first asCASTIn: self)
-		  else: (CConstantNode value: 0)
+	(self nilOrBooleanConstantReceiverOf: tast receiver)
+		ifNil: [ 
+			^ (CTernaryNode
+				   condition: (tast receiver asCASTExpressionIn: self)
+				   then: (tast arguments first asCASTExpressionIn: self)
+				   else: (CConstantNode value: 0))
+				  printOnMultipleLines: true;
+				  yourself ]
+		ifNotNil: [ :const | 
+			const
+				ifTrue: [ ^ tast arguments first asCASTExpressionIn: self ]
+				ifFalse: [ ^ CConstantNode value: (self cLiteralFor: nil) ] ]
 ]
 
 { #category : #'CAST translation' }
@@ -3349,9 +3376,9 @@ CCodeGenerator >> generateIfTrueAsArgument: msgNode on: aStream indent: level [
 		ifNil:
 			[aStream nextPut: $(.
 			 msgNode receiver emitCCodeAsArgumentOn: aStream level: level generator: self.
-			 aStream crtab: level + 1; nextPut: $?; space.
+			 aStream crtab: level + 1; nextPutAll: ' ? '.
 			 msgNode args first emitCCodeAsArgumentOn: aStream level: level + 2 generator: self.
-			 aStream crtab: level + 1; nextPutAll: ': 0)']
+			 aStream crtab: level + 1; nextPutAll: ' : 0)']
 		ifNotNil:
 			[:const|
 			const

--- a/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
+++ b/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
@@ -25,7 +25,7 @@ CSlangPrettyPrinter >> initialize [
 { #category : #generated }
 CSlangPrettyPrinter >> printExpression: cAST [
 
-	cAST isLeaf
+	(cAST isLeaf or: [ cAST isFunctionCall ])
 		ifTrue: [ cAST acceptVisitor: self ]
 		ifFalse: [ 
 			stream nextPut: $(.
@@ -110,9 +110,7 @@ CSlangPrettyPrinter >> visitCastExpression: aCastExpression [
 	stream nextPut: $(.
 	aCastExpression type acceptVisitor: self.
 	stream nextPut: $).
-	stream nextPut: $(.
-	aCastExpression expression acceptVisitor: self.
-	stream nextPut: $)
+	self printExpression: aCastExpression expression
 ]
 
 { #category : #generated }
@@ -205,6 +203,16 @@ CSlangPrettyPrinter >> visitDoStatement: aDoStatement [
 { #category : #generated }
 CSlangPrettyPrinter >> visitEmptyStatement: anEmptyStatement [
 	"Nothing to print."
+]
+
+{ #category : #generated }
+CSlangPrettyPrinter >> visitExpressionList: anExpressionList [
+
+	stream nextPut: $(.
+	anExpressionList expressions
+		do: [ :e | self printExpression: e ]
+		separatedBy: [ stream nextPutAll: ', ' ].
+	stream nextPut: $)
 ]
 
 { #category : #generated }

--- a/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
+++ b/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
@@ -23,6 +23,17 @@ CSlangPrettyPrinter >> initialize [
 ]
 
 { #category : #generated }
+CSlangPrettyPrinter >> printExpression: cAST [
+
+	cAST isLeaf
+		ifTrue: [ cAST acceptVisitor: self ]
+		ifFalse: [ 
+			stream nextPut: $(.
+			cAST acceptVisitor: self.
+			stream nextPut: $) ]
+]
+
+{ #category : #generated }
 CSlangPrettyPrinter >> visitArray: anArrayAcess [
 
 	anArrayAcess array acceptVisitor: self.
@@ -64,23 +75,16 @@ CSlangPrettyPrinter >> visitAssignment: anAssignment [
 
 { #category : #generated }
 CSlangPrettyPrinter >> visitBinary: aBinary [
-	| leftParenthesises rightParenthesises |
 	
-	leftParenthesises := (aBinary left isConstant or: [ aBinary left isIdentifier ]).
-	rightParenthesises := (aBinary right isConstant or: [ aBinary right isIdentifier ]).
 	
-	leftParenthesises ifFalse: [ stream nextPutAll: '(' ].
-	aBinary left acceptVisitor: self.
-	leftParenthesises ifFalse: [ stream nextPutAll: ')' ].
+	self printExpression: aBinary left.
 	
 	stream
 		nextPutAll: ' ';
 		nextPutAll: aBinary operator;
 		nextPutAll: ' '.
 		
-	rightParenthesises ifFalse: [ stream nextPutAll: '(' ].
-	aBinary right acceptVisitor: self.
-	rightParenthesises ifFalse: [ stream nextPutAll: ')' ].
+	self printExpression: aBinary right
 ]
 
 { #category : #generated }
@@ -323,14 +327,16 @@ CSlangPrettyPrinter >> visitStringLiteral: aStringLiteral [
 ]
 
 { #category : #generated }
-CSlangPrettyPrinter >> visitTernary: aTarnary [
+CSlangPrettyPrinter >> visitTernary: aTernary [
 
-	stream nextPutAll: '(('.
-	aTarnary condition acceptVisitor: self.
-	stream nextPutAll: ') ? '.
-	aTarnary then acceptVisitor: self.
+	stream nextPutAll: '('.
+	self printExpression: aTernary condition.
+	aTernary printOnMultipleLines ifTrue: [ stream crtab: level + 1 ].
+	stream nextPutAll: ' ? '.
+	self printExpression: aTernary then.
+	aTernary printOnMultipleLines ifTrue: [ stream crtab: level + 1 ].
 	stream nextPutAll: ' : '.
-	aTarnary else acceptVisitor: self.
+	self printExpression: aTernary else.
 	stream nextPut: $)
 ]
 

--- a/smalltalksrc/Slang/TAssignmentNode.class.st
+++ b/smalltalksrc/Slang/TAssignmentNode.class.st
@@ -45,7 +45,7 @@ TAssignmentNode >> asCASTIn: aBuilder [
 		^ CAssignmentNode
 			  lvalue: (variable asCASTIn: aBuilder)
 			  operator: expression selector , '='
-			  rvalue: (expression arguments first asCASTIn: aBuilder) ].
+			  rvalue: (expression arguments first asCASTExpressionIn: aBuilder) ].
 	(expression isSend and: [ expression isValueExpansion ]) ifTrue: [ 
 		^ self asCASTValueExpansionIn: aBuilder ].
 

--- a/smalltalksrc/Slang/TSendNode.class.st
+++ b/smalltalksrc/Slang/TSendNode.class.st
@@ -89,6 +89,18 @@ TSendNode >> asCASTAsFunctionCallIn: aCodeGen [
 ]
 
 { #category : #tranforming }
+TSendNode >> asCASTExpressionIn: aCCodeGenerator [
+
+	| construct |
+	construct := aCCodeGenerator 
+		             generateCASTForBuiltinAsArgumentConstructFor: self.
+	construct ifNil: [ 
+		construct := (self asCASTAsFieldReferenceIn: aCCodeGenerator) ifNotNil: [ :e | e] ifNil: [ 
+			self asCASTAsFunctionCallIn: aCCodeGenerator ]].
+	^ construct
+]
+
+{ #category : #tranforming }
 TSendNode >> asCASTIn: aCCodeGenerator [
 
 	| construct |

--- a/smalltalksrc/Slang/TStmtListNode.class.st
+++ b/smalltalksrc/Slang/TStmtListNode.class.st
@@ -200,7 +200,7 @@ TStmtListNode >> emitCCodeAsExpressionOn: aStream level: level generator: aCodeG
 		p2 := aStream position.
 		(idx < size and: [p2 > p1]) ifTrue:
 			[((self endsWithCloseBracket: aStream)
-			  or: [s isComment]) ifFalse: [aStream nextPutAll: ', '].
+			  or: [s isComment]) ifFalse: [aStream nextPutAll: ' , '].
 			 ]].
 	aStream nextPut: $)
 ]

--- a/smalltalksrc/Slang/TStmtListNode.class.st
+++ b/smalltalksrc/Slang/TStmtListNode.class.st
@@ -82,19 +82,14 @@ TStmtListNode >> args [
 { #category : #tranforming }
 TStmtListNode >> asCASTExpressionIn: aBuilder [
 
-	| comma |
-	comma := CBinaryOperatorNode new operator: ','.
-	statements size == 1
-		ifTrue: [ ^statements first asCASTExpressionIn: aBuilder ]
-		ifFalse: [ 
-			comma left: (statements first asCASTExpressionIn: aBuilder).
-			comma right: (statements second asCASTExpressionIn: aBuilder).
-			3 to: statements size do: [ :i | 
-				comma := CBinaryOperatorNode
-					         operator: ','
-					         left: comma
-					         right: ((statements at: i) asCASTExpressionIn: aBuilder) ] ].
-	^comma
+	| expressionList |
+	expressionList := CExpressionListNode new.
+	statements size == 1 ifTrue: [ 
+		^ statements first asCASTExpressionIn: aBuilder ].
+	statements withIndexDo: [ :node :idx | 
+		(node isLeaf and: [ node isLabel not and: [ idx < statements size ] ]) 
+			ifFalse: [ expressionList , (node asCASTExpressionIn: aBuilder) ] ].
+	^ expressionList
 ]
 
 { #category : #tranforming }
@@ -200,7 +195,7 @@ TStmtListNode >> emitCCodeAsExpressionOn: aStream level: level generator: aCodeG
 		p2 := aStream position.
 		(idx < size and: [p2 > p1]) ifTrue:
 			[((self endsWithCloseBracket: aStream)
-			  or: [s isComment]) ifFalse: [aStream nextPutAll: ' , '].
+			  or: [s isComment]) ifFalse: [aStream nextPutAll: ', '].
 			 ]].
 	aStream nextPut: $)
 ]


### PR DESCRIPTION
Simplify translation of expression lists introducing an expression list class.
Using expression lists to translate ifTrue as a value using a ternary operator (?:)