### PR TITLE
Cast support for ifTrue:IfFalse: as argument and assignment as argument.

### DIFF
--- a/smalltalksrc/CAST/CExpressionNode.class.st
+++ b/smalltalksrc/CAST/CExpressionNode.class.st
@@ -1,6 +1,9 @@
 Class {
 	#name : #CExpressionNode,
 	#superclass : #CGLRAbstractNode,
+	#instVars : [
+		'needsParentheses'
+	],
 	#category : #'CAST-Nodes'
 }
 
@@ -25,8 +28,26 @@ CExpressionNode >> combineWithExpression: firstExpression [
 	^ result
 ]
 
+{ #category : #initialization }
+CExpressionNode >> initialize [
+	
+	needsParentheses := false
+]
+
 { #category : #testing }
 CExpressionNode >> isExpression [
 
 	^ true
+]
+
+{ #category : #accessing }
+CExpressionNode >> needsParentheses [
+
+	^ needsParentheses
+]
+
+{ #category : #accessing }
+CExpressionNode >> needsParentheses: aBoolean [
+
+	needsParentheses := aBoolean
 ]

--- a/smalltalksrc/Slang-Tests/CSlangPrettyPrinterTest.class.st
+++ b/smalltalksrc/Slang-Tests/CSlangPrettyPrinterTest.class.st
@@ -281,7 +281,7 @@ CSlangPrettyPrinterTest >> testVisitExpressionList [
 						           (CConstantNode value: 5).
 						           (CConstantNode value: 6) }) }).
 
-	self assert: print trimBoth equals: '(foo(1, 2) , foo(3, 4) , foo(5, 6))'
+	self assert: print trimBoth equals: '(foo(1, 2), foo(3, 4), foo(5, 6))'
 ]
 
 { #category : #'tests-visitor' }

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -58,6 +58,84 @@ SlangBasicTranslationTest >> slangTranslate: tast inStream: aWriteStream [
 		generator: generator
 ]
 
+{ #category : #'tests-send' }
+SlangBasicTranslationTest >> testAssignementAsExpression [
+
+	"y := a := false"
+	| translation send |
+	send := TAssignmentNode new
+		        setVariable: (TVariableNode new setName: 'y')
+		        expression: (TAssignmentNode new
+								           setVariable: (TVariableNode new setName: 'a')
+								           expression: (TConstantNode value: false)).
+	translation := self translate: send.
+
+	self assert: translation equals: 'y = (a = 0)'
+]
+
+{ #category : #'tests-send' }
+SlangBasicTranslationTest >> testAssignementAsExpressionWithExpressionBlock [
+	
+	"y := a := [ 1 foo: 2. 3 foo: 4. 5 foo: 6 ]"
+	"The assignment tested is in an other assignment in order to force it to be in argument form."
+	| translation send |
+	send := TAssignmentNode new
+		        setVariable: (TVariableNode new setName: 'y')
+		        expression: (TAssignmentNode new
+				         setVariable: (TVariableNode new setName: 'a')
+				         expression:
+					         (TStmtListNode new setArguments: #(  ) statements: { 
+							          (TSendNode new
+								           setSelector: #foo
+								           receiver: (TConstantNode value: 1)
+								           arguments: { (TConstantNode value: 2) }).
+							          (TSendNode new
+								           setSelector: #foo
+								           receiver: (TConstantNode value: 3)
+								           arguments: { (TConstantNode value: 4) }).
+							          (TSendNode new
+								           setSelector: #foo
+								           receiver: (TConstantNode value: 5)
+								           arguments: { (TConstantNode value: 6) }) })).
+	translation := self translate: send.
+
+	self assert: translation equals: 'y = (foo(1, 2), foo(3, 4), (a = foo(5, 6)))'
+]
+
+{ #category : #'tests-send' }
+SlangBasicTranslationTest >> testAssignementAsExpressionWithExpressionBlockWithLastStatementEqualToReceiver [
+
+	"y := a := [ 1 foo: 2. 3 foo: 4. 5 foo: 6. a]"
+
+	"The assignment tested is in an other assignment in order to force it to be in argument form."
+
+	| translation send |
+	send := TAssignmentNode new
+		        setVariable: (TVariableNode new setName: 'y')
+		        expression: (TAssignmentNode new
+				         setVariable: (TVariableNode new setName: 'a')
+				         expression:
+					         (TStmtListNode new setArguments: #(  ) statements: { 
+							          (TSendNode new
+								           setSelector: #foo
+								           receiver: (TConstantNode value: 1)
+								           arguments: { (TConstantNode value: 2) }).
+							          (TSendNode new
+								           setSelector: #foo
+								           receiver: (TConstantNode value: 3)
+								           arguments: { (TConstantNode value: 4) }).
+							          (TSendNode new
+								           setSelector: #foo
+								           receiver: (TConstantNode value: 5)
+								           arguments: { (TConstantNode value: 6) }).
+							          (TVariableNode new setName: 'a') })).
+	translation := self translate: send.
+
+	self
+		assert: translation
+		equals: 'y = (foo(1, 2), foo(3, 4), foo(5, 6), a)'
+]
+
 { #category : #'tests-blocks' }
 SlangBasicTranslationTest >> testBlockAsArgument [
 
@@ -1667,6 +1745,36 @@ SlangBasicTranslationTest >> testSendIfTrueIfFalse [
 ]
 
 { #category : #'tests-send' }
+SlangBasicTranslationTest >> testSendIfTrueIfFalseAsArgument [
+
+	| translation send |
+	send := TAssignmentNode new
+		        setVariable: (TVariableNode new setName: 'y')
+		        expression: (TSendNode new
+				         setSelector: #ifTrue:ifFalse:
+				         receiver: (TVariableNode new setName: 'x')
+				         arguments: { (TStmtListNode new setStatements: { 
+							          (TAssignmentNode new
+								           setVariable: (TVariableNode new setName: 'a')
+								           expression: (TConstantNode value: false)).
+							          (TAssignmentNode new
+								           setVariable: (TVariableNode new setName: 'c')
+								           expression: (TConstantNode value: 1)) }).
+								(TStmtListNode new setStatements: { 
+							          (TAssignmentNode new
+								           setVariable: (TVariableNode new setName: 'a')
+								           expression: (TConstantNode value: true)).
+							          (TAssignmentNode new
+								           setVariable: (TVariableNode new setName: 'c')
+								           expression: (TConstantNode value: 0)) }) }).
+	translation := self translate: send.
+
+	self assert: translation trimBoth equals: 'y = (x
+	 ? ((a = 0), (c = 1))
+	 : ((a = 1), (c = 0)))'
+]
+
+{ #category : #'tests-send' }
 SlangBasicTranslationTest >> testSendIfTrueIfFalseCollapseBothArmsOfConditional [
 
 	| translation send |
@@ -1722,6 +1830,31 @@ SlangBasicTranslationTest >> testSendIfTrueWithBlockReceiver [
 	translation := self translate: send.
 
 	self assert: translation trimBoth equals: 'if (((y = 0), x)) {
+	a = 0;
+	c = 1;
+}'
+]
+
+{ #category : #'tests-send' }
+SlangBasicTranslationTest >> testSendIfTrueWithReceiverBinaryOperation [
+
+	| translation send |
+	send := TSendNode new
+		        setSelector: #ifTrue:
+		        receiver: (TSendNode new
+				         setSelector: #&
+				         receiver: (TVariableNode new setName: 'a')
+				         arguments: { (TVariableNode new setName: 'b') })
+		        arguments: { (TStmtListNode new setStatements: { 
+					         (TAssignmentNode new
+						          setVariable: (TVariableNode new setName: 'a')
+						          expression: (TConstantNode value: false)).
+					         (TAssignmentNode new
+						          setVariable: (TVariableNode new setName: 'c')
+						          expression: (TConstantNode value: 1)) }) }.
+	translation := self translate: send.
+
+	self assert: translation trimBoth equals: 'if (a && b) {
 	a = 0;
 	c = 1;
 }'

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -2295,6 +2295,28 @@ CCodeGenerator >> generateCASTIfTrueIfFalse: tast [
 ]
 
 { #category : #'CAST translation' }
+CCodeGenerator >> generateCASTIfTrueIfFalseAsArgument: tast [
+
+	(self nilOrBooleanConstantReceiverOf: tast receiver)
+		ifNil: [
+			(tast arguments first isSameAs: tast arguments last) ifTrue: [ | expressionList |
+			expressionList := CExpressionListNode new.
+			tast receiver hasSideEffect ifTrue: [ expressionList add: (tast receiver asCASTExpressionIn: self) ].
+			expressionList add: (tast arguments first asCASTExpressionIn: self)
+			].
+			^ (CTernaryNode
+				   condition: (tast receiver asCASTExpressionIn: self)
+				   then: (tast arguments first asCASTExpressionIn: self)
+				   else: (tast arguments last asCASTExpressionIn: self))
+				  printOnMultipleLines: true;
+				  yourself ]
+		ifNotNil: [ :const | 
+			(const
+				 ifTrue: [ ^ tast arguments first ]
+				 ifFalse: [ ^ tast arguments last ]) asCASTExpressionIn: self ]
+]
+
+{ #category : #'CAST translation' }
 CCodeGenerator >> generateCASTInlineCppIfElse: tast [
 
 	^ self generateCASTInlineCppIfElse: tast asArgument: false
@@ -3442,9 +3464,9 @@ CCodeGenerator >> generateIfTrueIfFalseAsArgument: msgNode on: aStream indent: l
 			[(self tryToCollapseBothArmsOfConditionalExpression: msgNode on: aStream indent: level) ifFalse:
 				[aStream nextPut: $(.
 				 msgNode receiver emitCCodeAsExpressionOn: aStream level: level generator: self.
-				 aStream crtab: level + 1; nextPut: $?; space.
+				 aStream crtab: level + 1; nextPutAll: ' ? '.
 				 msgNode args first emitCCodeAsArgumentOn: aStream level: level + 2 generator: self.
-				 aStream crtab: level + 1; nextPut: $:; space.
+				 aStream crtab: level + 1; nextPutAll: ' : '.
 				 msgNode args last emitCCodeAsArgumentOn: aStream level: level + 2 generator: self.
 				 aStream nextPut: $)]]
 		ifNotNil:

--- a/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
+++ b/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
@@ -63,14 +63,14 @@ CSlangPrettyPrinter >> visitArrow: aPointerAccess [
 { #category : #generated }
 CSlangPrettyPrinter >> visitAssignment: anAssignment [
 
+	anAssignment needsParentheses ifTrue: [ stream nextPut: $( ].
 	anAssignment lvalue acceptVisitor: self.
 	stream
 		nextPutAll: ' ';
 		nextPutAll: anAssignment operator;
 		nextPutAll: ' '.
-
-
-	anAssignment rvalue acceptVisitor: self
+	anAssignment rvalue acceptVisitor: self.
+	anAssignment needsParentheses ifTrue: [ stream nextPut: $) ]
 ]
 
 { #category : #generated }
@@ -210,7 +210,7 @@ CSlangPrettyPrinter >> visitExpressionList: anExpressionList [
 
 	stream nextPut: $(.
 	anExpressionList expressions
-		do: [ :e | self printExpression: e ]
+		do: [ :e | e acceptVisitor: self ]
 		separatedBy: [ stream nextPutAll: ', ' ].
 	stream nextPut: $)
 ]
@@ -341,10 +341,10 @@ CSlangPrettyPrinter >> visitTernary: aTernary [
 	self printExpression: aTernary condition.
 	aTernary printOnMultipleLines ifTrue: [ stream crtab: level + 1 ].
 	stream nextPutAll: ' ? '.
-	self printExpression: aTernary then.
+	aTernary then acceptVisitor: self.
 	aTernary printOnMultipleLines ifTrue: [ stream crtab: level + 1 ].
 	stream nextPutAll: ' : '.
-	self printExpression: aTernary else.
+	aTernary else acceptVisitor: self.
 	stream nextPut: $)
 ]
 

--- a/smalltalksrc/Slang/TAssignmentNode.class.st
+++ b/smalltalksrc/Slang/TAssignmentNode.class.st
@@ -8,6 +8,16 @@ Class {
 	#category : #'Slang-AST'
 }
 
+{ #category : #'C code generation' }
+TAssignmentNode >> asCASTExpressionIn: aCodeGen [
+
+	(expression isStmtList and: [ expression statements size > 1 ]) 
+		ifTrue: [ ^ self asCASTStatementListExpansionAsExpression: aCodeGen ].
+	^ (self asCASTIn: aCodeGen)
+		  needsParentheses: true;
+		  yourself
+]
+
 { #category : #tranforming }
 TAssignmentNode >> asCASTIn: aBuilder [
 
@@ -52,6 +62,15 @@ TAssignmentNode >> asCASTIn: aBuilder [
 	^ CAssignmentNode
 		  lvalue: (variable asCASTIn: aBuilder)
 		  rvalue: (expression asCASTExpressionIn: aBuilder)
+]
+
+{ #category : #'C code generation' }
+TAssignmentNode >> asCASTStatementListExpansionAsExpression: aCodeGen [
+	(variable isSameAs: expression statements last) ifTrue:
+		[^ expression asCASTExpressionIn: aCodeGen].
+	^ expression copy
+		assignLastExpressionTo: variable;
+		asCASTExpressionIn: aCodeGen
 ]
 
 { #category : #'C code generation' }
@@ -188,7 +207,7 @@ TAssignmentNode >> emitStatementListExpansion: stmtList on: aStream level: level
 
 { #category : #'C code generation' }
 TAssignmentNode >> emitStatementListExpansionAsExpression: stmtList on: aStream level: level generator: aCodeGen [
-	stmtList statements last = variable ifTrue:
+	(variable isSameAs: stmtList statements last)  ifTrue:
 		[^expression emitCCodeAsExpressionOn: aStream level: level generator: aCodeGen].
 	stmtList copy
 		assignLastExpressionTo: variable;


### PR DESCRIPTION
Modify pretty printer for assignement, in order to match with Slang parentheses policy. 
Handle assignement translation as argument.