### PR TITLE
Fix todo and toByDo printing

### DIFF
--- a/smalltalksrc/Slang-Tests/CSlangPrettyPrinterTest.class.st
+++ b/smalltalksrc/Slang-Tests/CSlangPrettyPrinterTest.class.st
@@ -314,7 +314,7 @@ CSlangPrettyPrinterTest >> testVisitForStatement [
 					        (CIncrementNode object: (CIdentifierNode name: 'j')) }).
 	print := self prettyPrint: for.
 
-	self assert: print trimBoth equals: 'for(i = 1, j = 2; i <= 10; i++, j++) {
+	self assert: print trimBoth equals: 'for (i = 1, j = 2; i <= 10; i++, j++) {
 	a = i % 2;
 	j++;
 }'

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -1408,7 +1408,7 @@ SlangBasicTranslationTest >> testSendFunctionCall [
 
 	"Case:
 	
-	[ 1 foo: 2. 3 foo: 4. var ] value"
+	1 foo: 2"
 
 	| translation |
 	translation := self translate: (TSendNode new
@@ -1417,6 +1417,25 @@ SlangBasicTranslationTest >> testSendFunctionCall [
 			                arguments: { (TConstantNode value: 2) }).
 
 	self assert: translation equals: 'foo(1, 2)'
+]
+
+{ #category : #'tests-sends' }
+SlangBasicTranslationTest >> testSendFunctionCallInOperation [
+
+	"Case:
+	
+	1 foo: 2 + 3"
+
+	| translation |
+	translation := self translate: (TSendNode new
+			                setSelector: #+
+			                receiver: (TSendNode new
+					                 setSelector: #foo
+					                 receiver: (TConstantNode value: 1)
+					                 arguments: { (TConstantNode value: 2) })
+			                arguments: { (TConstantNode value: 3) }).
+
+	self assert: translation equals: '(foo(1, 2)) + 3'
 ]
 
 { #category : #'tests-builtins' }
@@ -3049,6 +3068,84 @@ SlangBasicTranslationTest >> testSendToByDoWithNegativeStep [
 ]
 
 { #category : #'tests-builtins' }
+SlangBasicTranslationTest >> testSendToByDoWithOperationReceiver [
+
+	"(1 + 1 foo: 2) to: 10 by: 2 do: [ var := var -7 ]"
+
+	| translation send variable expression |
+	variable := TVariableNode new setName: 'var'.
+
+	expression := TSendNode new
+		              setSelector: #-
+		              receiver: variable
+		              arguments: { (TConstantNode value: 7) }.
+	send := TSendNode new
+		        setSelector: #to:by:do:
+		        receiver: (TSendNode new
+				         setSelector: #+
+				         receiver: (TConstantNode value: 1)
+				         arguments: { (TSendNode new
+						          setSelector: #foo
+						          receiver: (TConstantNode value: 1)
+						          arguments: { (TConstantNode value: 2) }) })
+		        arguments: { 
+				        (TConstantNode value: 10).
+				        (TConstantNode value: 2).
+				        (TStmtListNode new
+					         setArguments: #( i )
+					         statements:
+					         { (TAssignmentNode new
+						          setVariable: variable
+						          expression: expression) }) }.
+	translation := self translate: send.
+
+	self
+		assert: translation trimBoth
+		equals: 'for (i = 1 + (foo(1, 2)); i <= 10; i += 2) {
+	var -= 7;
+}'
+]
+
+{ #category : #'tests-builtins' }
+SlangBasicTranslationTest >> testSendToByDoWithOperationUpdate [
+
+	"1 to: 10 by: (1 + 1 foo: 2) do: [ var := var -7 ]"
+
+	| translation send variable expression |
+	variable := TVariableNode new setName: 'var'.
+
+	expression := TSendNode new
+		              setSelector: #-
+		              receiver: variable
+		              arguments: { (TConstantNode value: 7) }.
+	send := TSendNode new
+		        setSelector: #to:by:do:
+		        receiver: (TConstantNode value: 1)
+		        arguments: { 
+				        (TConstantNode value: 10).
+				        (TSendNode new
+					         setSelector: #+
+					         receiver: (TConstantNode value: 1)
+					         arguments: { (TSendNode new
+							          setSelector: #foo
+							          receiver: (TConstantNode value: 1)
+							          arguments: { (TConstantNode value: 2) }) }).
+				        (TStmtListNode new
+					         setArguments: #( i )
+					         statements:
+					         { (TAssignmentNode new
+						          setVariable: variable
+						          expression: expression) }) }.
+	translation := self translate: send.
+
+	self
+		assert: translation trimBoth
+		equals: 'for (i = 1; i <= 10; i += 1 + (foo(1, 2))) {
+	var -= 7;
+}'
+]
+
+{ #category : #'tests-builtins' }
 SlangBasicTranslationTest >> testSendToDo [
 
 	"1 to: 10 do: [ var := var -7 ]"
@@ -3144,7 +3241,42 @@ SlangBasicTranslationTest >> testSendToDoLimitExpressionHasSideEffect [
 
 	self
 		assert: translation trimBoth
-		equals: 'for (i = 1; i <= foo(var); i++) {
+		equals: 'for (i = 1; i <= (foo(var)); i++) {
+	var -= 7;
+}'
+]
+
+{ #category : #'tests-builtins' }
+SlangBasicTranslationTest >> testSendToDoWithOperationReceiver [
+
+	"(1 + 1 foo: 2) to: 10 do: [ var := var -7 ]"
+	| translation send variable expression |
+	variable := TVariableNode new setName: 'var'.
+
+	expression := TSendNode new
+		              setSelector: #-
+		              receiver: variable
+		              arguments: { (TConstantNode value: 7) }.
+	send := TSendNode new
+		        setSelector: #to:do:
+		        receiver: (TSendNode new
+				         setSelector: #+
+				         receiver: (TConstantNode value: 1)
+				         arguments: { (TSendNode new
+						          setSelector: #foo
+						          receiver: (TConstantNode value: 1)
+						          arguments: { (TConstantNode value: 2) }) })
+		        arguments: { 
+				        (TConstantNode value: 10).
+				        (TStmtListNode new
+					         setArguments: #( i )
+					         statements:
+					         { (TAssignmentNode new
+						          setVariable: variable
+						          expression: expression) }) }.
+	translation := self translate: send.
+
+	self assert: translation trimBoth equals: 'for (i = 1 + (foo(1, 2)); i <= 10; i++) {
 	var -= 7;
 }'
 ]

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -66,7 +66,7 @@ SlangBasicTranslationTest >> setUp [
 	
 	"Tell the generator this is the class we are generating.
 	That will make the generation dispatch to us to ask for configurations such as the number of small integer bits"
-	generator vmClass: self.
+	generator vmClass: nil.
 	numSmallIntegerTagBits := 42.
 ]
 
@@ -2959,7 +2959,7 @@ SlangBasicTranslationTest >> testSendToByDo [
 						          expression: expression) }) }.
 	translation := self translate: send.
 
-	self assert: translation trimBoth equals: 'for(i = 1; i <= 10; i += 2) {
+	self assert: translation trimBoth equals: 'for (i = 1; i <= 10; i += 2) {
 	var -= 7;
 }'
 ]
@@ -2998,7 +2998,7 @@ SlangBasicTranslationTest >> testSendToByDoLimitExpressionHasSideEffect [
 
 	self
 		assert: translation trimBoth
-		equals: 'for(i = 1, toDoLimit = foo(var); i <= toDoLimit; i += 2) {
+		equals: 'for (i = 1, toDoLimit = foo(var); i <= toDoLimit; i += 2) {
 	var -= 7;
 }'
 ]
@@ -3028,7 +3028,7 @@ SlangBasicTranslationTest >> testSendToByDoWithNegativeStep [
 						          expression: expression) }) }.
 	translation := self translate: send.
 
-	self assert: translation trimBoth equals: 'for(i = 10; i >= 0; i += -2) {
+	self assert: translation trimBoth equals: 'for (i = 10; i >= 0; i += -2) {
 	var -= 7;
 }'
 ]
@@ -3057,7 +3057,7 @@ SlangBasicTranslationTest >> testSendToDo [
 						          expression: expression) }) }.
 	translation := self translate: send.
 
-	self assert: translation trimBoth equals: 'for(i = 1; i <= 10; i++) {
+	self assert: translation trimBoth equals: 'for (i = 1; i <= 10; i++) {
 	var -= 7;
 }'
 ]
@@ -3094,7 +3094,7 @@ SlangBasicTranslationTest >> testSendToDoAvoidUnderflowingOfLimitExpression [
 
 	self
 		assert: translation trimBoth
-		equals: 'for(i = 1; i < foo; i++) {
+		equals: 'for (i = 1; i < foo; i++) {
 	var -= 7;
 }'
 ]
@@ -3129,7 +3129,7 @@ SlangBasicTranslationTest >> testSendToDoLimitExpressionHasSideEffect [
 
 	self
 		assert: translation trimBoth
-		equals: 'for(i = 1; i <= foo(var); i++) {
+		equals: 'for (i = 1; i <= foo(var); i++) {
 	var -= 7;
 }'
 ]

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -4178,12 +4178,12 @@ CCodeGenerator >> generateToByDo: msgNode on: aStream indent: level [
 	limitExpr := msgNode args first.
 	aStream nextPutAll: 'for (', iterationVar, ' = '.
 	self noteUsedVariableName: iterationVar.
-	self emitCExpression: msgNode receiver on: aStream.
+	msgNode receiver emitCCodeAsExpressionOn: aStream level: level generator: self.
 	mayHaveSideEffects := msgNode args size = 4. "See TMethod>>prepareMethodIn:"
 	mayHaveSideEffects ifTrue:
 		[limitVar := msgNode args last.
 		 aStream nextPutAll: ', ', limitVar name, ' = '.
-		 self emitCExpression: limitExpr on: aStream.
+		limitExpr emitCCodeAsExpressionOn: aStream level: level generator: self.
 		 limitExpr := limitVar].
 	aStream nextPutAll: '; ', iterationVar.
 	step := msgNode args at: 2.
@@ -4191,7 +4191,7 @@ CCodeGenerator >> generateToByDo: msgNode on: aStream indent: level [
 		negative: (self stepExpressionIsNegative: step)
 		on: aStream.
 	aStream nextPutAll: '; ', iterationVar, ' += '.
-	self emitCExpression: step on: aStream.
+	step emitCCodeAsExpressionOn: aStream level: level generator: self.
 	aStream nextPutAll: ') '.
 	blockExpr emitCCodeOn: aStream level: level generator: self.
 ]
@@ -4223,7 +4223,7 @@ CCodeGenerator >> generateToDo: msgNode on: aStream indent: level [
 	].
 	iterationVar := msgNode args last args first.
 	aStream nextPutAll: 'for (', iterationVar, ' = '.
-	self emitCExpression: msgNode receiver on: aStream.
+	msgNode receiver emitCCodeAsExpressionOn: aStream level: level generator: self.
 	aStream nextPutAll: '; ', iterationVar.
 	self generateToByDoLimitExpression: msgNode args first negative: false on: aStream.
 	aStream nextPutAll: '; ', iterationVar, '++) '.

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -4170,10 +4170,8 @@ CCodeGenerator >> generateToByDo: msgNode on: aStream indent: level [
 		on: aStream.
 	aStream nextPutAll: '; ', iterationVar, ' += '.
 	self emitCExpression: step on: aStream.
-	aStream nextPutAll: ') {'; cr.
-	blockExpr emitCCodeOn: aStream level: level + 1 generator: self.
-	aStream tab: level.
-	aStream nextPut: $}
+	aStream nextPutAll: ') '.
+	blockExpr emitCCodeOn: aStream level: level generator: self.
 ]
 
 { #category : #'C translation' }
@@ -4206,10 +4204,8 @@ CCodeGenerator >> generateToDo: msgNode on: aStream indent: level [
 	self emitCExpression: msgNode receiver on: aStream.
 	aStream nextPutAll: '; ', iterationVar.
 	self generateToByDoLimitExpression: msgNode args first negative: false on: aStream.
-	aStream nextPutAll: '; ', iterationVar, '++) {'; cr.
-	msgNode args last emitCCodeOn: aStream level: level + 1 generator: self.
-	level timesRepeat: [ aStream tab ].
-	aStream nextPutAll: '}'.
+	aStream nextPutAll: '; ', iterationVar, '++) '.
+	msgNode args last emitCCodeOn: aStream level: level generator: self.
 ]
 
 { #category : #'C translation' }

--- a/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
+++ b/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
@@ -25,15 +25,15 @@ CSlangPrettyPrinter >> initialize [
 { #category : #generated }
 CSlangPrettyPrinter >> printExpression: cAST [
 
-	(cAST isLeaf
-		or: [ cAST isFunctionCall
-			"Cast expressions already contain their own parentheses"
-			or: [ cAST isCastExpression ] ])
+	(cAST isLeaf 
+		"Cast expressions already contain their own parentheses"
+		or: [ cAST isCastExpression ])
 		ifTrue: [ cAST acceptVisitor: self ]
 		ifFalse: [ 
 			stream nextPut: $(.
 			cAST acceptVisitor: self.
 			stream nextPut: $) ]
+	
 ]
 
 { #category : #generated }

--- a/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
+++ b/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
@@ -220,7 +220,7 @@ CSlangPrettyPrinter >> visitExpressionList: anExpressionList [
 { #category : #generated }
 CSlangPrettyPrinter >> visitForStatement: aForStatement [
 
-	stream nextPutAll: 'for('.
+	stream nextPutAll: 'for ('.
 	aForStatement init
 		do: [ :e | e acceptVisitor: self ]
 		separatedBy: [ stream nextPutAll: ', ' ].


### PR DESCRIPTION
Remove parentheses in toDo and toByDo, where it is not needed. In fact, there are assignments in the C For statement header, CAST print all assignements the same way, whatever the context. But in Slang, it adds parenteses in the expression of assignement when the assignment is in a For statement header. For consistency, I removed it.
Correct curly braces printing for toDo and toByDo.