### PR TITLE
[pharo-project/opensmalltalk-vm#275] remove WIN32_LEAN_AND_MEAN as it breaks the sdl2 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,12 +195,7 @@ if(MSVC)
     get_platform_name(VM_TARGET_OS)
     message(STATUS "Building for ${VM_TARGET_OS}")
     set(CMAKE_CURRENT_SOURCE_DIR_TO_OUT ${CMAKE_CURRENT_SOURCE_DIR})
-    
-    # Define WIN32_LEAN_AND_MEAN to exclude APIs such as Cryptography, DDE, RPC, Shell, and Windows Sockets
-    # They can be included if needed
-    # https://docs.microsoft.com/en-us/windows/win32/winprog/using-the-windows-headers
-    add_compile_definitions(WIN32_LEAN_AND_MEAN)
-    
+
 elseif(WIN)
     message(STATUS "Building for WINDOWS")
 


### PR DESCRIPTION
Resolves https://github.com/pharo-project/opensmalltalk-vm/issues/275.

SDL2 redefines `WIN32_LEAN_AND_MEAN` which results in the compiler warnings and subsequently in the build error. In my opinion, it is better to not declare `WIN32_LEAN_AND_MEAN` in the root `CMakeLists.txt` as it may disable some features from the `Windows.h` also for the included sub projects.
Since the vm is a quite small (code-wise) C project the build speed gains due to `WIN32_LEAN_AND_MEAN` are marginal, while a chance for unexpected behavior is high.