### PR TITLE
[pharo-project/opensmalltalk-vm#270] make sure that the platform name is x86_64

### DIFF
--- a/macros.cmake
+++ b/macros.cmake
@@ -25,7 +25,7 @@ endmacro()
 
 macro(get_platform_name VARNAME)
   # See https://github.com/pharo-project/opensmalltalk-vm/issues/270
-  if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x64")
+  if(${CMAKE_SYSTEM_PROCESSOR} MATCHES ".*64.*")
     set(${VARNAME} ${CMAKE_SYSTEM_NAME}-x86_64)
   else()
     set(${VARNAME} ${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR})

--- a/macros.cmake
+++ b/macros.cmake
@@ -24,7 +24,12 @@ macro(addIndependentLibraryWithRPATH NAME)
 endmacro()
 
 macro(get_platform_name VARNAME)
+  # See https://github.com/pharo-project/opensmalltalk-vm/issues/270
+  if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x64")
+    set(${VARNAME} ${CMAKE_SYSTEM_NAME}-x86_64)
+  else()
     set(${VARNAME} ${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR})
+  endif()
 endmacro()
 
 macro(get_full_platform_name_with_osx VARNAME)

--- a/macros.cmake
+++ b/macros.cmake
@@ -25,7 +25,7 @@ endmacro()
 
 macro(get_platform_name VARNAME)
   # See https://github.com/pharo-project/opensmalltalk-vm/issues/270
-  if(${CMAKE_SYSTEM_PROCESSOR} MATCHES ".*64.*")
+  if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "^(AMD64|x64)$")
     set(${VARNAME} ${CMAKE_SYSTEM_NAME}-x86_64)
   else()
     set(${VARNAME} ${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR})


### PR DESCRIPTION
Resolves https://github.com/pharo-project/opensmalltalk-vm/issues/270.
`MSVC_CXX_ARCHITECTURE_ID` may return `x64` on Windows when building with MSVC. This fix makes sure that pharo is built with consistent `x86_64` CMAKE_SYSTEM_PROCESSOR, otherwise it will fail to download third party libraries.