### PR TITLE
[pharo-project/opensmalltalk-vm#281] add a simple error handling to installCygwin.ps1 and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ The build in Windows, uses Cygwin. This tool should be installed, and the follow
 - git
 - libtool
 
+To automate the Cygwin installation process there is `scripts\installCygwin.ps1` which downloads and installs a chosen version of cygwin and mingw for a given architecture. For example the following installs the latest `Cygwin (64 bit)` and `mingw64-x86_64-clang` compiler:
+```
+.\scripts\installCygwin.ps1 setup-x86_64.exe x86_64
+```
+Do not forget to set the execution policy to `Unrestricted` (from the Admin PowerShell) in order to being able run the `ps1` script:
+```
+Set-ExecutionPolicy -ExecutionPolicy Unrestricted
+````
+
+Bulding the VM:
 ```bash
 $ cmake .
 $ make install

--- a/scripts/installCygwin.ps1
+++ b/scripts/installCygwin.ps1
@@ -8,6 +8,24 @@ $installerURL = "http://cygwin.com/$installerName"
 $cygwinRoot = 'c:\cygwin'
 $cygwinMirror ="http://cygwin.mirror.constant.com"
 
+if($installerName -eq $null)
+ {
+	 $thisScript = $MyInvocation.MyCommand.Name
+     Write-Host "Cygwin installer name is not specified. Please choose an appropriate name based on http://cygwin.com/<installer_name>
+For example:
+	$thisScript setup-x86_64.exe <arch>"
+	 exit 1
+ }
+ 
+ if($cygwinArch -eq $null)
+ {
+	 $thisScript = $MyInvocation.MyCommand.Name
+     Write-Host " Mingw architecture is not specified. Please choose an appropriate name based on mingw64-<arch>-clang.
+For example:
+	$thisScript <installer_name> x86_64"
+	 exit 1
+ }
+
 # Download the cygwin installer.
 echo "Downloading the Cygwin installer from $installerURL"
 Invoke-WebRequest -UseBasicParsing -URI "$installerURL" -OutFile "$installerName"


### PR DESCRIPTION
Resolves https://github.com/pharo-project/opensmalltalk-vm/issues/281 by adding a very simple argument validation to let users know that the script requires 2 arguments:

<img width="1357" alt="Screen Shot 2021-06-20 at 12 11 59" src="https://user-images.githubusercontent.com/5487042/122670154-c9882180-d1c0-11eb-9a3a-b78c12cd2154.png">

Also update the README.md Windows instructions