### PR TITLE
[pharo-project/opensmalltalk-vm#283] only transform into Windows path if we build under Cygwin

### DIFF
--- a/cmake/Windows.cmake
+++ b/cmake/Windows.cmake
@@ -5,12 +5,16 @@ set(VM_VERSION_FILEVERSION "${APPNAME}VM-${VERSION_MAJOR}.${VERSION_MINOR}.${VER
 
 set(Win32ResourcesFolder "${CMAKE_CURRENT_SOURCE_DIR}/resources/windows")
 
-# transform the path into a windows path with unix backslashes C:/bla/blu
-# this is the path required to send as argument to libraries outside of the control of cygwin (like pharo itself)
-execute_process(
-	COMMAND cygpath ${Win32ResourcesFolder} --mixed
-	OUTPUT_VARIABLE Win32ResourcesFolder_OUT
-	OUTPUT_STRIP_TRAILING_WHITESPACE)
+if(${CYGWIN})
+  # transform the path into a windows path with unix backslashes C:/bla/blu
+  # this is the path required to send as argument to libraries outside of the control of cygwin (like pharo itself)
+  execute_process(
+  	COMMAND cygpath ${Win32ResourcesFolder} --mixed
+  	OUTPUT_VARIABLE Win32ResourcesFolder_OUT
+  	OUTPUT_STRIP_TRAILING_WHITESPACE)
+else()
+  set(Win32ResourcesFolder_OUT ${Win32ResourcesFolder})
+endif()
 
 if(NOT Win32VMExecutableIcon)
     set(Win32VMExecutableIcon "${Win32ResourcesFolder_OUT}/Pharo.ico")

--- a/resources/windows/Pharo.rc.in
+++ b/resources/windows/Pharo.rc.in
@@ -1,6 +1,6 @@
 #include "windows.h"
 
-100 ICON @Win32VMExecutableIcon@
+100 ICON "@Win32VMExecutableIcon@"
 
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION     @VERSION_MAJOR@,@VERSION_MINOR@,@VERSION_PATCH@,0

--- a/resources/windows/PharoConsole.rc.in
+++ b/resources/windows/PharoConsole.rc.in
@@ -1,6 +1,6 @@
 #include "windows.h"
 
-100 ICON @Win32VMExecutableIcon@
+100 ICON "@Win32VMExecutableIcon@"
 
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION     @VERSION_MAJOR@,@VERSION_MINOR@,@VERSION_PATCH@,0


### PR DESCRIPTION
Resolves https://github.com/pharo-project/opensmalltalk-vm/issues/283.
The path should be transformed into Windows format only if we build under Cygwin.