### PR TITLE
Always link pthread on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,12 +195,7 @@ if(MSVC)
     get_platform_name(VM_TARGET_OS)
     message(STATUS "Building for ${VM_TARGET_OS}")
     set(CMAKE_CURRENT_SOURCE_DIR_TO_OUT ${CMAKE_CURRENT_SOURCE_DIR})
-    
-    # Define WIN32_LEAN_AND_MEAN to exclude APIs such as Cryptography, DDE, RPC, Shell, and Windows Sockets
-    # They can be included if needed
-    # https://docs.microsoft.com/en-us/windows/win32/winprog/using-the-windows-headers
-    add_compile_definitions(WIN32_LEAN_AND_MEAN)
-    
+
 elseif(WIN)
     message(STATUS "Building for WINDOWS")
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ The build in Windows, uses Cygwin. This tool should be installed, and the follow
 - git
 - libtool
 
+To automate the Cygwin installation process there is `scripts\installCygwin.ps1` which downloads and installs a chosen version of cygwin and mingw for a given architecture. For example the following installs the latest `Cygwin (64 bit)` and `mingw64-x86_64-clang` compiler:
+```
+.\scripts\installCygwin.ps1 setup-x86_64.exe x86_64
+```
+Do not forget to set the execution policy to `Unrestricted` (from the Admin PowerShell) in order to being able run the `ps1` script:
+```
+Set-ExecutionPolicy -ExecutionPolicy Unrestricted
+````
+
+Bulding the VM:
 ```bash
 $ cmake .
 $ make install

--- a/cmake/Windows.cmake
+++ b/cmake/Windows.cmake
@@ -151,10 +151,8 @@ macro(add_required_libs_per_platform)
     # Disable Safe Structured Exception Handling
     #target_link_libraries(${VM_LIBRARY_NAME} "$<$<CXX_COMPILER_ID:MSVC>:-SAFESEH:NO>")
 
-
-	if(${CYGWIN})
-		target_link_libraries(${VM_LIBRARY_NAME} pthread)
-	endif()
+	# pthread is required by tffi and the vm itself. We should always link to it.
+	target_link_libraries(${VM_LIBRARY_NAME} pthread)
 	target_link_libraries(${VM_EXECUTABLE_NAME} Ole32)
 	target_link_libraries(${VM_EXECUTABLE_NAME} comctl32)
 	target_link_libraries(${VM_EXECUTABLE_NAME} uuid)

--- a/cmake/Windows.cmake
+++ b/cmake/Windows.cmake
@@ -5,12 +5,16 @@ set(VM_VERSION_FILEVERSION "${APPNAME}VM-${VERSION_MAJOR}.${VERSION_MINOR}.${VER
 
 set(Win32ResourcesFolder "${CMAKE_CURRENT_SOURCE_DIR}/resources/windows")
 
-# transform the path into a windows path with unix backslashes C:/bla/blu
-# this is the path required to send as argument to libraries outside of the control of cygwin (like pharo itself)
-execute_process(
-	COMMAND cygpath ${Win32ResourcesFolder} --mixed
-	OUTPUT_VARIABLE Win32ResourcesFolder_OUT
-	OUTPUT_STRIP_TRAILING_WHITESPACE)
+if(${CYGWIN})
+  # transform the path into a windows path with unix backslashes C:/bla/blu
+  # this is the path required to send as argument to libraries outside of the control of cygwin (like pharo itself)
+  execute_process(
+  	COMMAND cygpath ${Win32ResourcesFolder} --mixed
+  	OUTPUT_VARIABLE Win32ResourcesFolder_OUT
+  	OUTPUT_STRIP_TRAILING_WHITESPACE)
+else()
+  set(Win32ResourcesFolder_OUT ${Win32ResourcesFolder})
+endif()
 
 if(NOT Win32VMExecutableIcon)
     set(Win32VMExecutableIcon "${Win32ResourcesFolder_OUT}/Pharo.ico")

--- a/ffi/include/pThreadedFFI.h
+++ b/ffi/include/pThreadedFFI.h
@@ -9,7 +9,11 @@
 #include <stdio.h>
 #include <ffi.h>
 #if FEATURE_THREADED_FFI
-#include <pthread.h>
+#ifdef _WIN32
+# include <Windows.h>
+#else
+# include <pthread.h>
+#endif
 #endif
 #include <errno.h>
 #include <stdlib.h>

--- a/ffiTestLibrary/src/callbacks.c
+++ b/ffiTestLibrary/src/callbacks.c
@@ -1,6 +1,10 @@
 #include "callbacks.h"
 #if FEATURE_THREADED_FFI
-#include <pthread.h>
+#ifdef _WIN32
+# include <Windows.h>
+#else
+# include <pthread.h>
+#endif
 #endif //FEATURE_THREADED_FFI
 
 EXPORT(int) singleCallToCallback(SIMPLE_CALLBACK fun, int base){
@@ -32,7 +36,13 @@ static int value = 0;
 #if FEATURE_THREADED_FFI
 void* otherThread(void* aFunction){
 	SIMPLE_CALLBACK f = (SIMPLE_CALLBACK) aFunction;
+	
+#ifdef _WIN32
+	Sleep(3);
+#else
 	sleep(3);
+#endif
+
 	value = f(42);
 }
 #endif //FEATURE_THREADED_FFI

--- a/macros.cmake
+++ b/macros.cmake
@@ -25,7 +25,7 @@ endmacro()
 
 macro(get_platform_name VARNAME)
   # See https://github.com/pharo-project/opensmalltalk-vm/issues/270
-  if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x64")
+  if(${CMAKE_SYSTEM_PROCESSOR} MATCHES ".*64.*")
     set(${VARNAME} ${CMAKE_SYSTEM_NAME}-x86_64)
   else()
     set(${VARNAME} ${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR})

--- a/macros.cmake
+++ b/macros.cmake
@@ -25,7 +25,7 @@ endmacro()
 
 macro(get_platform_name VARNAME)
   # See https://github.com/pharo-project/opensmalltalk-vm/issues/270
-  if(${CMAKE_SYSTEM_PROCESSOR} MATCHES ".*64.*")
+  if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "^(AMD64|x64)$")
     set(${VARNAME} ${CMAKE_SYSTEM_NAME}-x86_64)
   else()
     set(${VARNAME} ${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR})

--- a/resources/windows/Pharo.rc.in
+++ b/resources/windows/Pharo.rc.in
@@ -1,6 +1,6 @@
 #include "windows.h"
 
-100 ICON @Win32VMExecutableIcon@
+100 ICON "@Win32VMExecutableIcon@"
 
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION     @VERSION_MAJOR@,@VERSION_MINOR@,@VERSION_PATCH@,0

--- a/resources/windows/PharoConsole.rc.in
+++ b/resources/windows/PharoConsole.rc.in
@@ -1,6 +1,6 @@
 #include "windows.h"
 
-100 ICON @Win32VMExecutableIcon@
+100 ICON "@Win32VMExecutableIcon@"
 
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION     @VERSION_MAJOR@,@VERSION_MINOR@,@VERSION_PATCH@,0

--- a/scripts/installCygwin.ps1
+++ b/scripts/installCygwin.ps1
@@ -8,6 +8,24 @@ $installerURL = "http://cygwin.com/$installerName"
 $cygwinRoot = 'c:\cygwin'
 $cygwinMirror ="http://cygwin.mirror.constant.com"
 
+if($installerName -eq $null)
+ {
+	 $thisScript = $MyInvocation.MyCommand.Name
+     Write-Host "Cygwin installer name is not specified. Please choose an appropriate name based on http://cygwin.com/<installer_name>
+For example:
+	$thisScript setup-x86_64.exe <arch>"
+	 exit 1
+ }
+ 
+ if($cygwinArch -eq $null)
+ {
+	 $thisScript = $MyInvocation.MyCommand.Name
+     Write-Host " Mingw architecture is not specified. Please choose an appropriate name based on mingw64-<arch>-clang.
+For example:
+	$thisScript <installer_name> x86_64"
+	 exit 1
+ }
+
 # Download the cygwin installer.
 echo "Downloading the Cygwin installer from $installerURL"
 Invoke-WebRequest -UseBasicParsing -URI "$installerURL" -OutFile "$installerName"

--- a/src/utils/setjmp-Windows-wrapper-X64.S
+++ b/src/utils/setjmp-Windows-wrapper-X64.S
@@ -1,0 +1,68 @@
+.model flat,stdcall ; Flat memory model
+option casemap:none ; Treat labels as case-sensitive
+
+.code
+
+_start:
+
+__setjmp_wrapper PROC
+    movq   (%rsp), %rdx		# rta
+    movq   %gs:0,  %rax		# SEH registration
+    movq   %rax,    0(%rcx)
+    movq   %rbx,    8(%rcx)
+    movq   %rsp,   16(%rcx)
+    movq   %rbp,   24(%rcx)
+    movq   %rsi,   32(%rcx)
+    movq   %rdi,   40(%rcx)
+    movq   %r12,   48(%rcx)
+    movq   %r13,   56(%rcx)
+    movq   %r14,   64(%rcx)
+    movq   %r15,   72(%rcx)
+    movq   %rdx,   80(%rcx) # %rip
+    movq   %rax,   88(%rcx)
+    movaps %xmm6,  96(%rcx)
+    movaps %xmm7, 112(%rcx)
+    movaps %xmm8, 128(%rcx)
+    movaps %xmm9, 144(%rcx)
+    movaps %xmm10,160(%rcx)
+    movaps %xmm11,176(%rcx)
+    movaps %xmm12,192(%rcx)
+    movaps %xmm13,208(%rcx)
+    movaps %xmm14,224(%rcx)
+    movaps %xmm15,240(%rcx)
+    xor    %rax, %rax		# return 0
+    ret
+__setjmp_wrapper ENDP
+
+__longjmp_wrapper PROC
+    movq     0(%rcx), %rax
+    movq     8(%rcx), %rbx
+    movq    16(%rcx), %rsp
+    movq    24(%rcx), %rbp
+    movq    32(%rcx), %rsi
+    movq    40(%rcx), %rdi
+    movq    48(%rcx), %r12
+    movq    56(%rcx), %r13
+    movq    64(%rcx), %r14
+    movq    72(%rcx), %r15
+    movq    80(%rcx), %r8
+    movaps  96(%rcx), %xmm6
+    movaps 112(%rcx), %xmm7
+    movaps 128(%rcx), %xmm8
+    movaps 144(%rcx), %xmm9
+    movaps 160(%rcx), %xmm10
+    movaps 176(%rcx), %xmm11
+    movaps 192(%rcx), %xmm12
+    movaps 208(%rcx), %xmm13
+    movaps 224(%rcx), %xmm14
+    movaps 240(%rcx), %xmm15
+    movq   %rax, %gs:0		# SEH registration
+    movl   %edx, %eax
+    test   %eax, %eax
+    jne    a
+    inc    %eax
+a:  movq   %r8, (%rsp)
+    ret
+__longjmp_wrapper ENDP
+
+END _start


### PR DESCRIPTION
Ath the moment, VM and TFFI both realy on pthread. Since we are not going to drop `pthread` dependency on Windows any time soo we should link to it, even if compiling outside of Cygwin. It is a responsibility of the user to provide the linkable library.