### PR TITLE
Always link pthread on Windows

### DIFF
--- a/cmake/FindPThreadW32.cmake
+++ b/cmake/FindPThreadW32.cmake
@@ -1,0 +1,36 @@
+# - Try to find pthread (win32) define the variables for the binaries/headers and include 
+#
+# Once done this will define
+#  PTHREADW32_FOUND - System has pthread-win32
+#  PTHREADW32::lib - Imported target for the pthread-win32
+
+message(STATUS "PTHREADW32_DIR: ${PTHREADW32_DIR}")
+find_library(PTHREADW32_LIBRARY NAMES pthreads
+    PATHS $ENV{PTHREADW32_DIR} ${PTHREADW32_DIR}
+    PATH_SUFFIXES lib
+    HINTS ${PC_PTHREADW32_LIBDIR} ${PC_PTHREADW32_LIBRARY_DIRS}
+)
+
+find_path(PTHREADW32_INCLUDE_DIR pthread.h
+     PATHS $ENV{PTHREADW32_DIR} ${PTHREADW32_DIR}
+     PATH_SUFFIXES include
+     HINTS ${PC_PTHREADW32_INCLUDEDIR} ${PC_PTHREADW32_INCLUDE_DIRS}
+)
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set PTHREADW32_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(PTHREADW32 DEFAULT_MSG
+                                  PTHREADW32_LIBRARY PTHREADW32_INCLUDE_DIR)
+mark_as_advanced(PTHREADW32_INCLUDE_DIR PTHREADW32_LIBRARY)
+
+set(PTHREADW32_LIBRARIES ${PTHREADW32_LIBRARY})
+set(PTHREADW32_INCLUDE_DIRS ${PTHREADW32_INCLUDE_DIR})
+
+if(PTHREADW32_FOUND AND NOT TARGET PTHREADW32::lib)
+    add_library(PTHREADW32::lib STATIC IMPORTED)
+    set_target_properties(PTHREADW32::lib PROPERTIES
+            IMPORTED_LOCATION "${PTHREADW32_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES "${PTHREADW32_INCLUDE_DIR}"
+    )
+endif()

--- a/cmake/Windows.cmake
+++ b/cmake/Windows.cmake
@@ -147,10 +147,8 @@ macro(add_required_libs_per_platform)
     # Disable Safe Structured Exception Handling
     #target_link_libraries(${VM_LIBRARY_NAME} "$<$<CXX_COMPILER_ID:MSVC>:-SAFESEH:NO>")
 
-
-	if(${CYGWIN})
-		target_link_libraries(${VM_LIBRARY_NAME} pthread)
-	endif()
+	# pthread is required by tffi and the vm itself. We should always link to it.
+	target_link_libraries(${VM_LIBRARY_NAME} pthread)
 	target_link_libraries(${VM_EXECUTABLE_NAME} Ole32)
 	target_link_libraries(${VM_EXECUTABLE_NAME} comctl32)
 	target_link_libraries(${VM_EXECUTABLE_NAME} uuid)

--- a/cmake/Windows.cmake
+++ b/cmake/Windows.cmake
@@ -150,11 +150,19 @@ macro(add_required_libs_per_platform)
 	target_link_libraries(${VM_LIBRARY_NAME} uuid)
     # Disable Safe Structured Exception Handling
     #target_link_libraries(${VM_LIBRARY_NAME} "$<$<CXX_COMPILER_ID:MSVC>:-SAFESEH:NO>")
-
-
-	if(${CYGWIN})
+	
+	# pthread is required by tffi and the vm itself. We should always link to it.
+	if (${FEATURE_LIB_PTHREADW32})		
+		find_package(PTHREADW32)
+		if(PTHREADW32_FOUND)
+			target_link_libraries(${VM_LIBRARY_NAME} PTHREADW32::lib)
+		else()
+			message(FATAL_ERROR "PTHREADW32 not found. Provide the path in PTHREADW32_DIR env.variable")
+		endif()
+	else()
 		target_link_libraries(${VM_LIBRARY_NAME} pthread)
 	endif()
+
 	target_link_libraries(${VM_EXECUTABLE_NAME} Ole32)
 	target_link_libraries(${VM_EXECUTABLE_NAME} comctl32)
 	target_link_libraries(${VM_EXECUTABLE_NAME} uuid)


### PR DESCRIPTION
At the moment, VM and TFFI both realy on pthread. Since we are not going to drop pthread dependency on Windows any time soo we should link to it, even if compiling outside of Cygwin. It is a responsibility of the user to provide the linkable library.