### PR TITLE
Fix type inference tests

### DIFF
--- a/smalltalksrc/Melchor/VMPluginCodeGenerator.class.st
+++ b/smalltalksrc/Melchor/VMPluginCodeGenerator.class.st
@@ -44,13 +44,12 @@ VMPluginCodeGenerator >> collectAndCheckInterpreterProxyInterfaceFor: selectors 
 							[(objectMemoryClass whichClassIncludesSelector: selector) ifNil:
 								[self vmmakerConfiguration interpreterProxyClass]]).
 		actual := self compileToTMethodSelector: selector in: self vmmakerConfiguration interpreterProxyClass.
-		{ actual. reference } do:
-			[:tMethod|
-			 tMethod recordDeclarationsIn: self.
-			 tMethod returnType ifNil:
-				[tMethod inferReturnTypeIn: self.
-				 tMethod returnType ifNil:
-					[tMethod returnType: #sqInt]]].
+		{ actual. reference } do: [:tMethod|
+			tMethod recordDeclarationsIn: self.
+			tMethod returnType ifNil: [
+				(SlangTyper on: self) inferReturnTypeOf: tMethod.
+				tMethod returnType ifNil: [
+					tMethod returnType: #sqInt ]]].
 		(reference returnType ~= actual returnType
 		 or: [(1 to: reference args size) anySatisfy:
 				[:i| (reference typeFor: (reference args at: i) in: self)

--- a/smalltalksrc/Slang-Tests/SlangAbstractTestCase.class.st
+++ b/smalltalksrc/Slang-Tests/SlangAbstractTestCase.class.st
@@ -7,6 +7,16 @@ Class {
 	#category : #'Slang-Tests'
 }
 
+{ #category : #asserting }
+SlangAbstractTestCase >> assertReturnTypeOf: aMethod equalsHarmonized: expectedType [
+
+	"The type inferencer harmonizes return types converting them to the closer sq* integer (either signed or unsigned)"
+	| harmonizedTypes |
+	harmonizedTypes := ccg harmonizeReturnTypesIn: { expectedType } asSet.
+	self assert: harmonizedTypes size = 1 description: 'There seems to be a type conflict'.
+	self assert: aMethod returnType equals: harmonizedTypes anyOne.
+]
+
 { #category : #running }
 SlangAbstractTestCase >> setUp [
 	super setUp.

--- a/smalltalksrc/Slang-Tests/SlangBasicTypeInferenceTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTypeInferenceTest.class.st
@@ -556,10 +556,8 @@ SlangBasicTypeInferenceTest >> testReturnTempBigNegativeIntegerConstantNode [
 	self assert: tMethod isNotNil.
 	self assert: (ccg typeFor: tMethod statements first in: tMethod) equals: #'long long'. " assignementNode "
 	self assert: (ccg typeFor: tMethod statements first value in: tMethod) equals: #'long long'. " value, constantNode "
-	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #sqInt. " variable, temporaryNode "
-	self assert: tMethod returnType equals: #sqInt.
-	
-	self assert: false "unexpected type conversion, shouldn't it be a sqLong?"
+	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #'long long'. " variable, temporaryNode "
+	self assert: tMethod returnType equals: #'long long'
 ]
 
 { #category : #'return-temp-assigned-message' }
@@ -581,10 +579,8 @@ SlangBasicTypeInferenceTest >> testReturnTempFalseConstantNode [
 	self assert: tMethod isNotNil.
 	self assert: (ccg typeFor: tMethod statements first in: tMethod) equals: #int. " assignementNode "
 	self assert: (ccg typeFor: tMethod statements first value in: tMethod) equals: #int. " value, constantNode "
-	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #sqInt. " variable, temporaryNode "
-	self assert: tMethod returnType equals: #sqInt.
-	
-	self assert: false "unexpected type conversion"
+	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #int. " variable, temporaryNode "
+	self assert: tMethod returnType equals: #int
 ]
 
 { #category : #'return-temp-assigned-message' }
@@ -606,10 +602,8 @@ SlangBasicTypeInferenceTest >> testReturnTempFloatConstantNode [
 	self assert: tMethod isNotNil.
 	self assert: (ccg typeFor: tMethod statements first in: tMethod) equals: #double. " assignementNode "
 	self assert: (ccg typeFor: tMethod statements first value in: tMethod) equals: #double. " value, constantNode "
-	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #sqInt. " variable, temporaryNode "
-	self assert: tMethod returnType equals: #sqInt.
-	
-	self assert: false "type lost"
+	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #double. " variable, temporaryNode "
+	self assert: tMethod returnType equals: #double
 ]
 
 { #category : #'return-temp-assigned-message' }
@@ -619,10 +613,8 @@ SlangBasicTypeInferenceTest >> testReturnTempFloatMessageNode [
 	
 	self assert: tMethod isNotNil.
 	self assert: (ccg typeFor: tMethod statements first in: tMethod) equals: #double.
-	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #sqInt.
-	self assert: tMethod returnType equals: #sqInt.
-	
-	self assert: false "wait what"
+	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #double.
+	self assert: tMethod returnType equals: #double
 ]
 
 { #category : #'return-temp-assigned-const' }
@@ -633,10 +625,8 @@ SlangBasicTypeInferenceTest >> testReturnTempIntEqual32ConstantNode [
 	self assert: tMethod isNotNil.
 	self assert: (ccg typeFor: tMethod statements first in: tMethod) equals: #'unsigned int'. " assignementNode "
 	self assert: (ccg typeFor: tMethod statements first value in: tMethod) equals: #'unsigned int'. " value, constantNode "
-	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #sqInt. " variable, temporaryNode "
-	self assert: tMethod returnType equals: #sqInt.
-	
-	self assert: false "unexpected type conversion"
+	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #'unsigned int'. " variable, temporaryNode "
+	self assert: tMethod returnType equals: #'unsigned int'
 ]
 
 { #category : #'return-temp-assigned-message' }
@@ -658,10 +648,8 @@ SlangBasicTypeInferenceTest >> testReturnTempIntEqual64ConstantNode [
 	self assert: tMethod isNotNil.
 	self assert: (ccg typeFor: tMethod statements first in: tMethod) equals: #'unsigned long long'. " assignementNode "
 	self assert: (ccg typeFor: tMethod statements first value in: tMethod) equals: #'unsigned long long'. " value, constantNode "
-	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #sqInt. " variable, temporaryNode "
-	self assert: tMethod returnType equals: #sqInt.
-	
-	self assert: false "unexpected type conversion, shouldn't it at least be an sqLong? or better, an uSqLong"
+	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #'unsigned long long'. " variable, temporaryNode "
+	self assert: tMethod returnType equals: #'unsigned long long'
 ]
 
 { #category : #'return-temp-assigned-message' }
@@ -683,10 +671,8 @@ SlangBasicTypeInferenceTest >> testReturnTempIntGreater64ConstantNode [
 	self assert: tMethod isNotNil.
 	self assert: (ccg typeFor: tMethod statements first in: tMethod) equals: #'long long'. " assignementNode "
 	self assert: (ccg typeFor: tMethod statements first value in: tMethod) equals: #'long long'. " value, constantNode "
-	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #sqInt. " variable, temporaryNode "
-	self assert: tMethod returnType equals: #sqInt.
-	
-	self assert: false "unexpected type conversion, shouldn't it be at least an sqLong?"
+	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #'long long'. " variable, temporaryNode "
+	self assert: tMethod returnType equals: #'long long'
 ]
 
 { #category : #'return-temp-assigned-message' }
@@ -708,10 +694,8 @@ SlangBasicTypeInferenceTest >> testReturnTempIntLesser32ConstantNode [
 	self assert: tMethod isNotNil.
 	self assert: (ccg typeFor: tMethod statements first in: tMethod) equals: #int. " assignementNode "
 	self assert: (ccg typeFor: tMethod statements first value in: tMethod) equals: #int. " value, constantNode "
-	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #sqInt. " variable, temporaryNode "
-	self assert: tMethod returnType equals: #sqInt.
-	
-	self assert: false "unexpected type conversion"
+	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #int. " variable, temporaryNode "
+	self assert: tMethod returnType equals: #int
 ]
 
 { #category : #'return-temp-assigned-message' }
@@ -733,10 +717,8 @@ SlangBasicTypeInferenceTest >> testReturnTempNilConstantNode [
 	self assert: tMethod isNotNil.
 	self assert: (ccg typeFor: tMethod statements first in: tMethod) equals: #int. " assignementNode "
 	self assert: (ccg typeFor: tMethod statements first value in: tMethod) equals: #int. " value, constantNode "
-	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #sqInt. " variable, temporaryNode "
-	self assert: tMethod returnType equals: #sqInt.
-	
-	self assert: false "unexpected type conversion"
+	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #int. " variable, temporaryNode "
+	self assert: tMethod returnType equals: #int
 ]
 
 { #category : #'return-temp-assigned-message' }
@@ -758,10 +740,8 @@ SlangBasicTypeInferenceTest >> testReturnTempSmallNegativeIntegerConstantNode [
 	self assert: tMethod isNotNil.
 	self assert: (ccg typeFor: tMethod statements first in: tMethod) equals: #int. " assignementNode "
 	self assert: (ccg typeFor: tMethod statements first value in: tMethod) equals: #int. " value, constantNode "
-	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #sqInt. " variable, temporaryNode "
-	self assert: tMethod returnType equals: #sqInt.
-	
-	self assert: false "unexpected type conversion"
+	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #int. " variable, temporaryNode "
+	self assert: tMethod returnType equals: #int
 ]
 
 { #category : #'return-temp-assigned-message' }
@@ -783,10 +763,8 @@ SlangBasicTypeInferenceTest >> testReturnTempStringConstantNode [
 	self assert: tMethod isNotNil.
 	self assert: (ccg typeFor: tMethod statements first in: tMethod) equals: #'char *'. " assignementNode "
 	self assert: (ccg typeFor: tMethod statements first value in: tMethod) equals: #'char *'. " value, constantNode "
-	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #sqInt. " variable, temporaryNode "
-	self assert: tMethod returnType equals: #sqInt.
-	
-	self assert: false "type lost"
+	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #'char *'. " variable, temporaryNode "
+	self assert: tMethod returnType equals: #'char *'
 ]
 
 { #category : #'return-temp-assigned-message' }
@@ -808,10 +786,8 @@ SlangBasicTypeInferenceTest >> testReturnTempTrueConstantNode [
 	self assert: tMethod isNotNil.
 	self assert: (ccg typeFor: tMethod statements first in: tMethod) equals: #int. " assignementNode "
 	self assert: (ccg typeFor: tMethod statements first value in: tMethod) equals: #int. " value, constantNode "
-	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #sqInt. " variable, temporaryNode "
-	self assert: tMethod returnType equals: #sqInt.
-	
-	self assert: false "Unexpected conversion"
+	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #int. " variable, temporaryNode "
+	self assert: tMethod returnType equals: #int
 ]
 
 { #category : #'return-temp-assigned-message' }

--- a/smalltalksrc/Slang-Tests/SlangBasicTypeInferenceTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTypeInferenceTest.class.st
@@ -31,22 +31,11 @@ Class {
 	#category : #'Slang-Tests'
 }
 
-{ #category : #helpers }
-SlangBasicTypeInferenceTest >> assertReturnTypeOf: aMethod equalsHarmonized: expectedType [
-
-	"The type inferencer harmonizes return types converting them to the closer sq* integer (either signed or unsigned)"
-	| harmonizedTypes |
-	harmonizedTypes := ccg harmonizeReturnTypesIn: { expectedType } asSet.
-	self assert: harmonizedTypes size = 1 description: 'There seems to be a type conflict'.
-	self assert: aMethod returnType equals: harmonizedTypes anyOne.
-]
-
 { #category : #running }
 SlangBasicTypeInferenceTest >> setUp [
 	super setUp.
 	ccg addClass: SlangBasicTypeInferenceTestClass.
 	ccg inferTypes.
-
 ]
 
 { #category : #constant }

--- a/smalltalksrc/Slang-Tests/SlangBasicTypeInferenceTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTypeInferenceTest.class.st
@@ -31,6 +31,16 @@ Class {
 	#category : #'Slang-Tests'
 }
 
+{ #category : #helpers }
+SlangBasicTypeInferenceTest >> assertReturnTypeOf: aMethod equalsHarmonized: expectedType [
+
+	"The type inferencer harmonizes return types converting them to the closer sq* integer (either signed or unsigned)"
+	| harmonizedTypes |
+	harmonizedTypes := ccg harmonizeReturnTypesIn: { expectedType } asSet.
+	self assert: harmonizedTypes size = 1 description: 'There seems to be a type conflict'.
+	self assert: aMethod returnType equals: harmonizedTypes anyOne.
+]
+
 { #category : #running }
 SlangBasicTypeInferenceTest >> setUp [
 	super setUp.
@@ -123,7 +133,7 @@ SlangBasicTypeInferenceTest >> testAnIntEqual64ConstantNode [
 { #category : #constant }
 SlangBasicTypeInferenceTest >> testAnIntGreater64ConstantNode [
 	| tMethod |
-	<expectedFailure>
+
 	tMethod := ccg methodNamed: #anIntGreater64ConstantNode.
 		
 	self assert: tMethod isNotNil.
@@ -557,7 +567,7 @@ SlangBasicTypeInferenceTest >> testReturnTempBigNegativeIntegerConstantNode [
 	self assert: (ccg typeFor: tMethod statements first in: tMethod) equals: #'long long'. " assignementNode "
 	self assert: (ccg typeFor: tMethod statements first value in: tMethod) equals: #'long long'. " value, constantNode "
 	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #'long long'. " variable, temporaryNode "
-	self assert: tMethod returnType equals: #'long long'
+	self assertReturnTypeOf: tMethod equalsHarmonized: #'long long'
 ]
 
 { #category : #'return-temp-assigned-message' }
@@ -580,7 +590,8 @@ SlangBasicTypeInferenceTest >> testReturnTempFalseConstantNode [
 	self assert: (ccg typeFor: tMethod statements first in: tMethod) equals: #int. " assignementNode "
 	self assert: (ccg typeFor: tMethod statements first value in: tMethod) equals: #int. " value, constantNode "
 	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #int. " variable, temporaryNode "
-	self assert: tMethod returnType equals: #int
+	
+	self assertReturnTypeOf: tMethod equalsHarmonized: #int
 ]
 
 { #category : #'return-temp-assigned-message' }
@@ -613,6 +624,7 @@ SlangBasicTypeInferenceTest >> testReturnTempFloatMessageNode [
 	
 	self assert: tMethod isNotNil.
 	self assert: (ccg typeFor: tMethod statements first in: tMethod) equals: #double.
+	self assert: (ccg typeFor: tMethod statements first expression in: tMethod) equals: #double.
 	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #double.
 	self assert: tMethod returnType equals: #double
 ]
@@ -626,7 +638,7 @@ SlangBasicTypeInferenceTest >> testReturnTempIntEqual32ConstantNode [
 	self assert: (ccg typeFor: tMethod statements first in: tMethod) equals: #'unsigned int'. " assignementNode "
 	self assert: (ccg typeFor: tMethod statements first value in: tMethod) equals: #'unsigned int'. " value, constantNode "
 	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #'unsigned int'. " variable, temporaryNode "
-	self assert: tMethod returnType equals: #'unsigned int'
+	self assertReturnTypeOf: tMethod equalsHarmonized: #'unsigned int'
 ]
 
 { #category : #'return-temp-assigned-message' }
@@ -649,7 +661,7 @@ SlangBasicTypeInferenceTest >> testReturnTempIntEqual64ConstantNode [
 	self assert: (ccg typeFor: tMethod statements first in: tMethod) equals: #'unsigned long long'. " assignementNode "
 	self assert: (ccg typeFor: tMethod statements first value in: tMethod) equals: #'unsigned long long'. " value, constantNode "
 	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #'unsigned long long'. " variable, temporaryNode "
-	self assert: tMethod returnType equals: #'unsigned long long'
+	self assertReturnTypeOf: tMethod equalsHarmonized: #'unsigned long long'
 ]
 
 { #category : #'return-temp-assigned-message' }
@@ -672,7 +684,7 @@ SlangBasicTypeInferenceTest >> testReturnTempIntGreater64ConstantNode [
 	self assert: (ccg typeFor: tMethod statements first in: tMethod) equals: #'long long'. " assignementNode "
 	self assert: (ccg typeFor: tMethod statements first value in: tMethod) equals: #'long long'. " value, constantNode "
 	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #'long long'. " variable, temporaryNode "
-	self assert: tMethod returnType equals: #'long long'
+	self assertReturnTypeOf: tMethod equalsHarmonized: #'long long'
 ]
 
 { #category : #'return-temp-assigned-message' }
@@ -695,7 +707,8 @@ SlangBasicTypeInferenceTest >> testReturnTempIntLesser32ConstantNode [
 	self assert: (ccg typeFor: tMethod statements first in: tMethod) equals: #int. " assignementNode "
 	self assert: (ccg typeFor: tMethod statements first value in: tMethod) equals: #int. " value, constantNode "
 	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #int. " variable, temporaryNode "
-	self assert: tMethod returnType equals: #int
+	
+	self assertReturnTypeOf: tMethod equalsHarmonized: #'int'
 ]
 
 { #category : #'return-temp-assigned-message' }
@@ -718,7 +731,8 @@ SlangBasicTypeInferenceTest >> testReturnTempNilConstantNode [
 	self assert: (ccg typeFor: tMethod statements first in: tMethod) equals: #int. " assignementNode "
 	self assert: (ccg typeFor: tMethod statements first value in: tMethod) equals: #int. " value, constantNode "
 	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #int. " variable, temporaryNode "
-	self assert: tMethod returnType equals: #int
+
+	self assertReturnTypeOf: tMethod equalsHarmonized: #int
 ]
 
 { #category : #'return-temp-assigned-message' }
@@ -741,7 +755,8 @@ SlangBasicTypeInferenceTest >> testReturnTempSmallNegativeIntegerConstantNode [
 	self assert: (ccg typeFor: tMethod statements first in: tMethod) equals: #int. " assignementNode "
 	self assert: (ccg typeFor: tMethod statements first value in: tMethod) equals: #int. " value, constantNode "
 	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #int. " variable, temporaryNode "
-	self assert: tMethod returnType equals: #int
+	
+	self assertReturnTypeOf: tMethod equalsHarmonized: #int
 ]
 
 { #category : #'return-temp-assigned-message' }
@@ -787,7 +802,8 @@ SlangBasicTypeInferenceTest >> testReturnTempTrueConstantNode [
 	self assert: (ccg typeFor: tMethod statements first in: tMethod) equals: #int. " assignementNode "
 	self assert: (ccg typeFor: tMethod statements first value in: tMethod) equals: #int. " value, constantNode "
 	self assert: (ccg typeFor: tMethod statements first variable in: tMethod) equals: #int. " variable, temporaryNode "
-	self assert: tMethod returnType equals: #int
+	
+	self assertReturnTypeOf: tMethod equalsHarmonized: #int
 ]
 
 { #category : #'return-temp-assigned-message' }

--- a/smalltalksrc/Slang-Tests/SlangTypeForArithmeticTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangTypeForArithmeticTest.class.st
@@ -11,8 +11,8 @@ Class {
 { #category : #running }
 SlangTypeForArithmeticTest >> setUp [
 	super setUp.
-	ccg addClass: SlangTypeForDereferenceTestClass
-
+	ccg addClass: SlangTypeForDereferenceTestClass.
+	ccg inferTypes.
 ]
 
 { #category : #tests }
@@ -21,7 +21,8 @@ SlangTypeForArithmeticTest >> testAtOnMatrix [
 	tMethod := ccg methodNamed: #aMethodReturningAnAtOnAMatrix.
 	
 	self assert: tMethod isNotNil.
-	self assert: (ccg typeFor: tMethod statements first expression in: tMethod) equals: #sqInt."at: node"
-	self assert: (ccg typeFor: tMethod statements first in: tMethod) equals: #sqInt."returnNode"
-	self assert: tMethod returnType equals: #sqInt. " euuu, looks weird. Did i do something wrong?"
+	self assert: (ccg typeFor: tMethod statements first expression in: tMethod) equals: #'int *'."at: node"
+	self assert: (ccg typeFor: tMethod statements first in: tMethod) equals: #'int *'."returnNode"
+	
+	self assertReturnTypeOf: tMethod equalsHarmonized: #'int *'
 ]

--- a/smalltalksrc/Slang-Tests/SlangTypeForDereferenceTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangTypeForDereferenceTest.class.st
@@ -19,9 +19,8 @@ SlangTypeForDereferenceTest >> testAtOnArray [
 	self assert: tMethod isNotNil.
 	self assert: (ccg typeFor: tMethod statements first expression in: tMethod) equals: #int."at: node"
 	self assert: (ccg typeFor: tMethod statements first in: tMethod) equals: #int."returnNode"
-	self assert: tMethod returnType equals: #sqInt.
 	
-	self assert: false. "Unexpected type conversion"
+	self assertReturnTypeOf: tMethod equalsHarmonized: #int
 ]
 
 { #category : #tests }
@@ -66,7 +65,6 @@ SlangTypeForDereferenceTest >> testTwoAtOnMatrix [
 	self assert: (ccg typeFor: tMethod statements first expression receiver in: tMethod) equals: #'int *'."inner at:"
 	self assert: (ccg typeFor: tMethod statements first expression in: tMethod) equals: #int."outer at:"
 	self assert: (ccg typeFor: tMethod statements first in: tMethod) equals: #int."return node"
-	self assert: tMethod returnType equals: #sqInt.
-
-	self assert: false. "Unexpected type conversion"
+	
+	self assertReturnTypeOf: tMethod equalsHarmonized: #int
 ]

--- a/smalltalksrc/Slang-Tests/SlangTypePromotionTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangTypePromotionTest.class.st
@@ -103,11 +103,7 @@ SlangTypePromotionTest >> testFloatAndNil [
 	secondType := nil.
 	resType := ccg promoteArithmeticTypes: firstType and: secondType.
 	
-	self assert: resType equals: #float.
-	
-	"this feels wrong"
-	"inconsistent with integer types too"
-	self assert: false.
+	self assert: resType equals: nil
 ]
 
 { #category : #'float-types' }
@@ -269,11 +265,7 @@ SlangTypePromotionTest >> testNilAndFloat [
 	secondType := #float.
 	resType := ccg promoteArithmeticTypes: firstType and: secondType.
 	
-	self assert: resType equals: #float.
-	
-	"this feels wrong"
-	"inconsistent with integer types too"
-	self assert: false.
+	self assert: resType equals: nil
 ]
 
 { #category : #general }

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -5114,7 +5114,10 @@ CCodeGenerator >> isSimpleType: aType [
 	"For the purposes of the read-before-written initializer, answer if
 	 aType is simple, e.g. not a structure, and array or an opaque type."
 	^(self isPointerCType: aType)
-	  or: [self isIntegralCType: aType]
+	  or: [ (self isIntegralCType: aType)
+		or: [ 
+			"The type affected to literal floating point numbers"
+			aType = #double ]]
 ]
 
 { #category : #inlining }

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -5804,6 +5804,11 @@ CCodeGenerator >> printUnboundVariableReferenceWarnings [
 
 { #category : #'type inference' }
 CCodeGenerator >> promoteArithmeticTypes: firstType and: secondType [
+	
+	"If either type is unknown, answer nil."
+	(firstType isNil or: [secondType isNil]) ifTrue:
+		[^nil].
+
 	"Answer the return type for an arithmetic send.  This is so that the inliner can still inline
 	 simple expressions.  Deal with pointer arithmetic, floating point arithmetic and promotion.
 	 It is important to choose deterministically to get stable source generation.
@@ -5813,9 +5818,7 @@ CCodeGenerator >> promoteArithmeticTypes: firstType and: secondType [
 		[^(firstType = #double or: [secondType = #double])
 			ifTrue: [#double]
 			ifFalse: [#float] "in C99 6.3.1.8, float+int, int is converted as a float"].
-	"deal with unknowns, answering nil."
-	(firstType isNil or: [secondType isNil]) ifTrue:
-		[^nil].
+
 	"Deal with integer promotion and arithmetic conversion"
 	^self promoteIntegerArithmeticTypes: firstType and: secondType
 ]

--- a/smalltalksrc/Slang/SlangTyper.class.st
+++ b/smalltalksrc/Slang/SlangTyper.class.st
@@ -16,6 +16,46 @@ SlangTyper class >> on: aCCodeGenerator [
 		yourself
 ]
 
+{ #category : #'type inference' }
+SlangTyper >> addTypesFor: node inMethod: method to: typeSet [
+	"Add the value types for the node to typeSet.
+	 Answer if any type was derived from an as-yet-untyped method or variable, which allows us to abort
+	 inferReturnTypeFromReturnsIn: if the return type depends on a yet-to-be-typed method or variable."
+	| expr |
+	expr := node.
+	[expr isAssignment or: [expr isStmtList]] whileTrue:
+		[expr isAssignment ifTrue:
+			[expr := expr variable].
+		 expr isStmtList ifTrue:
+			[expr := expr statements last]].
+	expr isSend ifTrue: [
+		(#(ifTrue: ifFalse: ifTrue:ifFalse: ifFalse:ifTrue:) includes: expr selector) ifTrue: [
+			^expr args
+				inject: false
+				into: [:asYetUntyped :block|
+					asYetUntyped | (self addTypesFor: block inMethod: method to: typeSet) ] ].
+		(codeGenerator returnTypeForSend: expr in: method ifNil: nil)
+			ifNil: [^(codeGenerator methodNamed: expr selector) notNil and: [expr selector ~~ method selector]]
+			ifNotNil:
+				[:type |
+				typeSet add: type.
+				^false]].
+	expr isVariable ifTrue:
+		[(codeGenerator typeOfVariable: expr name)
+			ifNotNil: [:type| typeSet add: type]
+			ifNil: [(typeSet add: (expr name = 'self'
+										ifTrue: [#void]
+										ifFalse: [ expr typeFrom: codeGenerator in: method ])) == #sqInt ifTrue:
+					[^true]]].
+	expr isConstant ifTrue:
+		[(expr value isInteger and: [expr value >= 0]) "cannot determine if signed or unsigned yet..."
+			ifTrue: [typeSet add: expr value]
+			ifFalse:
+				[(expr typeOrNilFrom: codeGenerator in: method) ifNotNil:
+					[:type | typeSet add: type]]].
+	^false
+]
+
 { #category : #accessing }
 SlangTyper >> codeGenerator [
 	^ codeGenerator
@@ -24,6 +64,77 @@ SlangTyper >> codeGenerator [
 { #category : #accessing }
 SlangTyper >> codeGenerator: aCCodeGenerator [ 
 	codeGenerator := aCCodeGenerator
+]
+
+{ #category : #'type inference' }
+SlangTyper >> inferReturnTypeFromReturnsOf: aMethod [
+	"Attempt to infer the return type of the receiver from returns in the parse tree."
+
+	"this for determining which returns have which return types:"
+	"aCodeGen
+		pushScope: declarations
+		while: [parseTree
+				nodesSelect: [:n| n isReturn]
+				thenCollect: [:n| | s |
+					s := Set new.
+					self addTypesFor: n expression to: s in: aCodeGen.
+					{n. s}]]"
+
+	codeGenerator maybeBreakForTestToInline: aMethod selector in: aMethod.
+	aMethod returnType ifNotNil: [ ^ self ].
+	codeGenerator
+		pushScope: aMethod declarations
+		while:
+			[| hasReturn returnTypes |
+			 hasReturn := false.
+			 returnTypes := Set new.
+			 "Debug:
+			 (| rettypes |
+			  rettypes := Dictionary new.
+			  parseTree nodesDo:
+				[:node|
+				node isReturn ifTrue:
+					[| types |
+					 self addTypesFor: node expression to: (types := Set new) in: aCodeGen.
+					 rettypes at: node expression put: types]].
+			  rettypes)"
+			 aMethod parseTree nodesDo:
+				[:node|
+				node isReturn ifTrue:
+					[hasReturn := true.
+					 "If we encounter a send of an as-yet-untyped method then abort,
+					  retrying and computing the type when that method is fully typed."
+					(self addTypesFor: node expression inMethod: aMethod to: returnTypes) ifTrue:
+						[^self]]].
+			returnTypes remove: #implicit ifAbsent: [].
+			returnTypes := codeGenerator harmonizeReturnTypesIn: returnTypes.
+			hasReturn
+				ifTrue:
+					[returnTypes size > 1 ifTrue:
+						[| message |
+						 message := String streamContents:
+										[:s|
+										 s nextPutAll: 'conflicting return types '.
+										 returnTypes
+											do: [:t| s nextPutAll: t]
+											separatedBy: [s nextPutAll: ', '].
+										 s nextPutAll: ' in '; nextPutAll: aMethod selector; cr].
+						 Notification signal: message.
+						 codeGenerator logger newLine; show: message].
+					 returnTypes size = 1 ifTrue:
+						[aMethod returnType: returnTypes anyOne]]
+				ifFalse:
+					[aMethod returnType: (codeGenerator implicitReturnTypeFor: aMethod selector)]]
+]
+
+{ #category : #'type inference' }
+SlangTyper >> inferReturnTypeOf: aMethod [
+	"Attempt to infer the return type of the receiver and answer if it changed."
+
+	| existingReturnType |
+	existingReturnType := aMethod returnType.
+	self inferReturnTypeFromReturnsOf: aMethod.
+	^existingReturnType ~= aMethod returnType
 ]
 
 { #category : #'type inference' }
@@ -60,15 +171,16 @@ SlangTyper >> inferTypesForImplicitlyTypedVariablesAndMethods [
 		m recordDeclarationsIn: codeGenerator.
 		(m returnType isNil
 		 and: [m isReturnConstant]) ifTrue:
-			[m inferReturnTypeIn: codeGenerator]].
+			[self inferReturnTypeOf: m]].
 
 	"now iterate until we reach a fixed point"
 	[| changedReturnType |
 	 changedReturnType := false.
 	 allMethods do:
 		[:m|
+		m selector = #returnTempFalseConstantNode ifTrue:[ TOTO := 1 ].
 		self inferTypesForImplicitlyTypedVariablesIn: m.
-		 (m inferReturnTypeIn: codeGenerator) ifTrue:
+		 (self inferReturnTypeOf: m) ifTrue:
 			[changedReturnType := true]].
 	 changedReturnType] whileTrue.
 
@@ -88,60 +200,66 @@ SlangTyper >> inferTypesForImplicitlyTypedVariablesAndMethods [
 
 { #category : #'type inference' }
 SlangTyper >> inferTypesForImplicitlyTypedVariablesIn: aMethod [
-	"infer types for untyped variables from assignments and arithmetic uses.
-	 For debugging answer a Dictionary from var to the nodes that determined types
-	 This for debugging:
-		(self copy inferTypesForImplicitlyTypedVariablesIn: aCodeGen)"
-	| alreadyExplicitlyTypedOrNotToBeTyped asYetUntyped mustBeSigned newDeclarations effectiveNodes |
+
+	" Infer types for untyped variables from assignments and arithmetic uses "
+
+	| alreadyExplicitlyTypedOrNotToBeTyped asYetUntyped mustBeSigned newDeclarations |
 	codeGenerator maybeBreakForTestToInline: aMethod selector in: aMethod.
-	alreadyExplicitlyTypedOrNotToBeTyped := aMethod declarations keys asSet.
-	asYetUntyped := aMethod locals copyWithoutAll: alreadyExplicitlyTypedOrNotToBeTyped.
+
+	alreadyExplicitlyTypedOrNotToBeTyped := aMethod declarations keys
+		                                        asSet.
+	asYetUntyped := aMethod locals copyWithoutAll:
+		                alreadyExplicitlyTypedOrNotToBeTyped.
 	mustBeSigned := Set new.
 	newDeclarations := Dictionary new.
-	effectiveNodes := Dictionary new. "this for debugging"
-	aMethod parseTree nodesDo:
-		[:node| | type var |
+
+	aMethod parseTree nodesDo: [ :node | 
+		| type var |
 		"If there is something of the form i >= 0, then i should be signed, not unsigned."
-		(node isSend
-		 and: [(aMethod locals includes: (var := node receiver variableNameOrNil))
-		 and: [(#(<= < >= >) includes: node selector)
-		 and: [node args first isConstant
-		 and: [node args first value = 0]]]]) ifTrue:
-			[mustBeSigned add: var.
-			 effectiveNodes at: var put: { #signed. node }, (effectiveNodes at: var ifAbsent: [#()])].
+		(node isSend and: [ 
+			 (aMethod locals includes: (var := node receiver variableNameOrNil)) 
+				 and: [ 
+					 (#( <= < >= > ) includes: node selector) and: [ 
+						 node args first isConstant and: [ node args first value = 0 ] ] ] ]) 
+			ifTrue: [ mustBeSigned add: var ].
+
 		"if an assignment to an untyped local of a known type, set the local's type to that type.
 		 Only observe known sends (methods in the current set) and typed local variables."
-		(node isAssignment
-		 and: [(aMethod locals includes: (var := node variable name))
-		 and: [(alreadyExplicitlyTypedOrNotToBeTyped includes: var) not]]) ifTrue: "don't be fooled by previously inferred types"
-		 	[type := node expression isSend
-						ifTrue: [codeGenerator returnTypeForSend: node expression in: aMethod ifNil: nil]
-						ifFalse: [aMethod typeFor: (node expression isAssignment
-													ifTrue: [node expression variable]
-													ifFalse: [node expression]) in: codeGenerator].
-			 type "If untyped, then cannot type the variable yet. A subsequent assignment may assign a subtype of what this type ends up being"
-				ifNil: "Further, if the type derives from an as-yet-untyped method, we must defer."
-					[alreadyExplicitlyTypedOrNotToBeTyped add: var.
-					 (node expression isSend
-					 and: [(codeGenerator methodNamed: node expression selector) notNil]) ifTrue:
-						[newDeclarations removeKey: var ifAbsent: nil]]
-				ifNotNil: "Merge simple types (but *don't* merge untyped vars); complex types must be defined by the programmer."
-					[(codeGenerator isSimpleType: type) ifTrue:
-						[(asYetUntyped includes: var)
-							ifTrue: [newDeclarations at: var put: type, ' ', var. asYetUntyped remove: var]
-							ifFalse:
-								[self mergeTypeOf: var in: newDeclarations with: type method: aMethod].
-						 effectiveNodes at: var put: { newDeclarations at: var. node }, (effectiveNodes at: var ifAbsent: [#()])]]]].
-	mustBeSigned do:
-		[:var|
-		 (newDeclarations at: var ifAbsent: nil) ifNotNil:
-			[:decl| | type |
-			 type := codeGenerator extractTypeFor: var fromDeclaration: decl.
-			 type first == $u ifTrue:
-				[newDeclarations at: var put: (self signedTypeForIntegralType: type), ' ', var]]].
-	newDeclarations keysAndValuesDo:
-		[:var :decl| aMethod declarations at: var put: decl].
-	^effectiveNodes
+		(node isAssignment and: [ 
+			 (aMethod locals includes: (var := node variable name)) and: [ 
+				 (alreadyExplicitlyTypedOrNotToBeTyped includes: var) not ] ]) 
+			ifTrue: [ "don't be fooled by previously inferred types"
+				type := self tryExtractTypeFromAssignmentNode: node inMethod: aMethod.
+				type
+					ifNil: [ "Further, if the type derives from an as-yet-untyped method, we must defer."
+						alreadyExplicitlyTypedOrNotToBeTyped add: var.
+						(node expression isSend and: [ 
+							 (codeGenerator methodNamed: node expression selector) notNil ]) 
+							ifTrue: [ newDeclarations removeKey: var ifAbsent: nil ] ]
+					ifNotNil: [ "Merge simple types (but *don't* merge untyped vars); complex types must be defined by the programmer."
+						(codeGenerator isSimpleType: type) ifTrue: [ 
+							(asYetUntyped includes: var)
+								ifTrue: [ 
+									newDeclarations at: var put: type , ' ' , var.
+									asYetUntyped remove: var ]
+								ifFalse: [ 
+									self
+										mergeTypeOf: var
+										in: newDeclarations
+										with: type
+										method: aMethod ] ] ] "If untyped, then cannot type the variable yet. A subsequent assignment may assign a subtype of what this type ends up being" ] ].
+
+
+	mustBeSigned do: [ :var | 
+		(newDeclarations at: var ifAbsent: nil) ifNotNil: [ :decl | 
+			| type |
+			type := codeGenerator extractTypeFor: var fromDeclaration: decl.
+			type first == $u ifTrue: [ 
+				newDeclarations
+					at: var
+					put: (self signedTypeForIntegralType: type) , ' ' , var ] ] ].
+	newDeclarations keysAndValuesDo: [ :var :decl | 
+		aMethod declarations at: var put: decl ]
 ]
 
 { #category : #'type inference' }
@@ -191,4 +309,21 @@ SlangTyper >> stopOnErrors [
 { #category : #accessing }
 SlangTyper >> stopOnErrors: anObject [
 	stopOnErrors := anObject
+]
+
+{ #category : #'type inference' }
+SlangTyper >> tryExtractTypeFromAssignmentNode: node inMethod: aMethod [
+
+	^ node expression isSend
+		  ifTrue: [ 
+			  codeGenerator
+				  returnTypeForSend: node expression
+				  in: aMethod
+				  ifNil: nil ]
+		  ifFalse: [ 
+			  (node expression isAssignment
+				   ifTrue: [ node expression variable ]
+				   ifFalse: [ node expression ])
+				  typeFrom: codeGenerator
+				  in: aMethod ]
 ]

--- a/smalltalksrc/Slang/SlangTyper.class.st
+++ b/smalltalksrc/Slang/SlangTyper.class.st
@@ -178,7 +178,6 @@ SlangTyper >> inferTypesForImplicitlyTypedVariablesAndMethods [
 	 changedReturnType := false.
 	 allMethods do:
 		[:m|
-		m selector = #returnTempFalseConstantNode ifTrue:[ TOTO := 1 ].
 		self inferTypesForImplicitlyTypedVariablesIn: m.
 		 (self inferReturnTypeOf: m) ifTrue:
 			[changedReturnType := true]].

--- a/smalltalksrc/Slang/TMethod.class.st
+++ b/smalltalksrc/Slang/TMethod.class.st
@@ -65,46 +65,6 @@ TMethod >> addTypeForSelf [
 					ifFalse: [typeForSelf, ' self'])]
 ]
 
-{ #category : #'type inference' }
-TMethod >> addTypesFor: node to: typeSet in: aCodeGen [
-	"Add the value types for the node to typeSet.
-	 Answer if any type was derived from an as-yet-untyped method or variable, which allows us to abort
-	 inferReturnTypeFromReturnsIn: if the return type depends on a yet-to-be-typed method or variable."
-	| expr |
-	expr := node.
-	[expr isAssignment or: [expr isStmtList]] whileTrue:
-		[expr isAssignment ifTrue:
-			[expr := expr variable].
-		 expr isStmtList ifTrue:
-			[expr := expr statements last]].
-	expr isSend ifTrue:
-		[(#(ifTrue: ifFalse: ifTrue:ifFalse: ifFalse:ifTrue:) includes: expr selector) ifTrue:
-			[^expr args
-				inject: false
-				into: [:asYetUntyped :block|
-					asYetUntyped | (self addTypesFor: block to: typeSet in: aCodeGen)]].
-		(aCodeGen returnTypeForSend: expr in: self ifNil: nil)
-			ifNil: [^(aCodeGen methodNamed: expr selector) notNil and: [expr selector ~~ selector]]
-			ifNotNil:
-				[:type |
-				typeSet add: type.
-				^false]].
-	expr isVariable ifTrue:
-		[(aCodeGen typeOfVariable: expr name)
-			ifNotNil: [:type| typeSet add: type]
-			ifNil: [(typeSet add: (expr name = 'self'
-										ifTrue: [#void]
-										ifFalse: [#sqInt])) == #sqInt ifTrue:
-					[^true]]].
-	expr isConstant ifTrue:
-		[(expr value isInteger and: [expr value >= 0]) "cannot determine if signed or unsigned yet..."
-			ifTrue: [typeSet add: expr value]
-			ifFalse:
-				[(expr typeOrNilFrom: aCodeGen in: self) ifNotNil:
-					[:type | typeSet add: type]]].
-	^false
-]
-
 { #category : #'inlining support' }
 TMethod >> addVarsDeclarationsAndLabelsOf: methodToBeInlined except: doNotRename [
 	"Prepare to inline the body of the given method into the receiver by making the args and locals of the argument to the receiver be locals of the receiver. Record any type declarations for these variables. Record labels. Assumes that the variables have already be renamed to avoid name clashes."
@@ -1124,77 +1084,6 @@ TMethod >> incompleteSendsIn: aCodeGen [
 				or: [aCodeGen isAssertSelector: node selector]]].
 
 	^{incompleteSends. inlineableSends}
-]
-
-{ #category : #'type inference' }
-TMethod >> inferReturnTypeFromReturnsIn: aCodeGen [
-	"Attempt to infer the return type of the receiver from returns in the parse tree."
-
-	"this for determining which returns have which return types:"
-	"aCodeGen
-		pushScope: declarations
-		while: [parseTree
-				nodesSelect: [:n| n isReturn]
-				thenCollect: [:n| | s |
-					s := Set new.
-					self addTypesFor: n expression to: s in: aCodeGen.
-					{n. s}]]"
-
-	aCodeGen maybeBreakForTestToInline: selector in: self.
-	returnType ifNotNil: [^self].
-	aCodeGen
-		pushScope: declarations
-		while:
-			[| hasReturn returnTypes |
-			 hasReturn := false.
-			 returnTypes := Set new.
-			 "Debug:
-			 (| rettypes |
-			  rettypes := Dictionary new.
-			  parseTree nodesDo:
-				[:node|
-				node isReturn ifTrue:
-					[| types |
-					 self addTypesFor: node expression to: (types := Set new) in: aCodeGen.
-					 rettypes at: node expression put: types]].
-			  rettypes)"
-			 parseTree nodesDo:
-				[:node|
-				node isReturn ifTrue:
-					[hasReturn := true.
-					 "If we encounter a send of an as-yet-untyped method then abort,
-					  retrying and computing the type when that method is fully typed."
-					 (self addTypesFor: node expression to: returnTypes in: aCodeGen) ifTrue:
-						[^self]]].
-			returnTypes remove: #implicit ifAbsent: [].
-			returnTypes := aCodeGen harmonizeReturnTypesIn: returnTypes.
-			hasReturn
-				ifTrue:
-					[returnTypes size > 1 ifTrue:
-						[| message |
-						 message := String streamContents:
-										[:s|
-										 s nextPutAll: 'conflicting return types '.
-										 returnTypes
-											do: [:t| s nextPutAll: t]
-											separatedBy: [s nextPutAll: ', '].
-										 s nextPutAll: ' in '; nextPutAll: selector; cr].
-						 Notification signal: message.
-						 aCodeGen logger newLine; show: message].
-					 returnTypes size = 1 ifTrue:
-						[self returnType: returnTypes anyOne]]
-				ifFalse:
-					[self returnType: (aCodeGen implicitReturnTypeFor: selector)]]
-]
-
-{ #category : #'type inference' }
-TMethod >> inferReturnTypeIn: aCodeGen [
-	"Attempt to infer the return type of the receiver and answer if it changed."
-
-	| existingReturnType |
-	existingReturnType := returnType.
-	self inferReturnTypeFromReturnsIn: aCodeGen.
-	^existingReturnType ~= returnType
 ]
 
 { #category : #initialization }
@@ -2586,7 +2475,6 @@ TMethod >> returnType: aString [
 	"Set the type of the values returned by this method.
 	 This string will be used in the C declaration of this function.
 	 If the type exists as a symbol, use that."
-
 	returnType := aString isSymbol
 					ifTrue: [aString]
 					ifFalse: [(Symbol findInterned: aString) ifNil: [aString]]

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -7584,6 +7584,7 @@ StackInterpreter >> getInterruptPending [
 StackInterpreter >> getLongFromFile: aFile swap: swapFlag [
 	"Answer the next 32 or 64 bit word read from aFile, byte-swapped according to the swapFlag."
 	<var: #aFile type: #sqImageFile>
+	<var: #w type: #usqInt>
 	| w |
 	w := 0.
 	self cCode: [self


### PR DESCRIPTION
- Fix type propagation to returns
- Integral return types are harmonized to sq* types (and should be tested as such)
- added `double` as a simple type: it is the type assigned to literal floating point values

Maybe @hogoww you're interested in taking a look, although the refactoring kind of hides the fixes (interesting line is  in https://github.com/pharo-project/opensmalltalk-vm/blob/e8ec9965ddffed55f1882dafa6bc91b1dd5f0e65/smalltalksrc/Slang/SlangTyper.class.st#L48)