### PR TITLE
refactor CMakeLists.txt build options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,27 @@ set(VERSION_PATCH 0)
 
 message("CMAKE_GENERATOR=${CMAKE_GENERATOR}")
 
+# Build options
+option(FEATURE_FFI                   "Enable FFI"                                            ON)
+option(FEATURE_THREADED_FFI          "Enable Threaded (running in another thread) FFI"       ON)
+option(FEATURE_NETWORK               "Enable network and sockets"                            ON)
+option(FEATURE_LIB_SDL2              "Build SDL2 support"                                    ON)
+option(FEATURE_LIB_CAIRO             "Build Cairo support"                                   ON)
+option(FEATURE_LIB_FREETYPE2         "Build freetype2 support"                               ON)
+option(FEATURE_LIB_GIT2              "Build LibGit2 support"                                 ON)
+option(GENERATE_SOURCES              "If it generates the sources"                           ON)
+option(ALWAYS_INTERACTIVE            "Be interactive by default"                            OFF)
+option(BUILD_BUNDLE                  "Builds a bundle with all dependencies"                 ON)
+option(FEATURE_COMPILE_GNUISATION    "Use gcc gnu extensions to compile the VM"              ON)
+option(PHARO_DEPENDENCIES_PREFER_DOWNLOAD_BINARIES        "Prefer downloading dependencies"              OFF)
+option(FEATURE_COMPILE_INLINE_MEMORY_ACCESSORS             "Use inline memory accessors instead of macros" ON)
+
+   set(APPNAME                      "Pharo"         CACHE STRING                 "VM Application name")
+   set(FLAVOUR                      "CoInterpreter" CACHE STRING                 "The kind of VM to generate. Possible values: StackVM, CoInterpreter")
+   set(PHARO_LIBRARY_PATH           "@executable_path/Plugins" CACHE STRING      "The RPATH to use in the build")
+   set(ICEBERG_DEFAULT_REMOTE       "scpUrl"        CACHE STRING                 "If Iceberg uses HTTPS (httpsUrl) or tries first with SSH (scpUrl)")
+
+
 # Visual Studio stores user build settings in file 'CmakeSettings.json'.  We would like to manage that via a project template.
 # To push out new template, update 'template_uuid' field in 'template_file' with value from https://www.uuidgenerator.net/
 set(user_file "${CMAKE_SOURCE_DIR}/CMakeSettings.json" )
@@ -47,7 +68,6 @@ else()
 endif()
 
 # BUILD VM
-set(APPNAME Pharo CACHE STRING "VM Application name")
 
 # Configure CMake to load our modules
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
@@ -137,25 +157,6 @@ if(MSVC AND NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
         list(APPEND SUPPORT_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/${ASM_FILENAME}.obj)
     endif()
 endif()
-
-set(FLAVOUR CoInterpreter CACHE STRING "The kind of VM to generate. Possible values: StackVM, CoInterpreter")
-set(GENERATE_SOURCES TRUE CACHE BOOL "If it generates the sources")
-set(ALWAYS_INTERACTIVE FALSE CACHE BOOL "If this VM will always add interactive or not. If it is set, the headless parameter is not by default true")
-set(FEATURE_FFI TRUE CACHE BOOL "Configure and compile support for FFI in the VM")
-set(FEATURE_THREADED_FFI TRUE CACHE BOOL "Configure and compile support for Threaded (running in another thread) FFI in the VM")
-set(FEATURE_NETWORK TRUE CACHE BOOL "Configure and compile support for network and sockets in the VM")
-set(FEATURE_COMPILE_GNUISATION TRUE CACHE BOOL "Use gcc gnu extensions to compile the VM")
-set(FEATURE_COMPILE_INLINE_MEMORY_ACCESSORS TRUE CACHE BOOL "Use inline memory accessors instead of macros")
-
-set(PHARO_DEPENDENCIES_PREFER_DOWNLOAD_BINARIES FALSE CACHE BOOL "Prefer downloading dependencies")
-set(BUILD_BUNDLE TRUE CACHE BOOL "Builds a bundle with all dependencies (locally built or downloaded) copied next to the VM")
-set(FEATURE_LIB_SDL2 TRUE CACHE BOOL "Build SDL2 support")
-set(FEATURE_LIB_CAIRO TRUE CACHE BOOL "Build Cairo support")
-set(FEATURE_LIB_FREETYPE2 TRUE CACHE BOOL "Build Cairo support")
-set(FEATURE_LIB_GIT2 TRUE CACHE BOOL "Build LibGit2 support")
-
-set(PHARO_LIBRARY_PATH "@executable_path/Plugins" CACHE STRING "The RPATH to use in the build")
-set(ICEBERG_DEFAULT_REMOTE "scpUrl" CACHE STRING "If Iceberg uses HTTPS (httpsUrl) or tries first with SSH (scpUrl)")
 
 # If we are generating sources, set the source dir as the generation source dir.
 # Otherwise set it to by default to the current source dir, parametrizable

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,8 @@ option(FEATURE_LIB_SDL2              "Build SDL2 support"                       
 option(FEATURE_LIB_CAIRO             "Build Cairo support"                                   ON)
 option(FEATURE_LIB_FREETYPE2         "Build freetype2 support"                               ON)
 option(FEATURE_LIB_GIT2              "Build LibGit2 support"                                 ON)
+# PTHREADW32_DIR should be set to the location of the PTHREADW32
+option(FEATURE_LIB_PTHREADW32        "Windows only, link to win32 version of pthread"       OFF)
 option(GENERATE_SOURCES              "If it generates the sources"                           ON)
 option(ALWAYS_INTERACTIVE            "Be interactive by default"                            OFF)
 option(BUILD_BUNDLE                  "Builds a bundle with all dependencies"                 ON)


### PR DESCRIPTION
This PR refactors the build options by using `option()` for boolean values and moves options closer to the top of the file