### PR TITLE
remove inline from worker_dispatch_callout

### DIFF
--- a/ffi/src/worker/worker.c
+++ b/ffi/src/worker/worker.c
@@ -112,7 +112,7 @@ void worker_release(Worker *worker) {
     worker_add_call((Worker*)worker, task);
 }
 
-inline void worker_dispatch_callout(Worker *worker, WorkerTask *task) {
+void worker_dispatch_callout(Worker *worker, WorkerTask *task) {
     worker_add_call(worker, task);
 }
 


### PR DESCRIPTION
This is a funny one.

`worker.c >> worker_dispatch_callout()` is marked as `inline` and is called from `workerPrimitives.c`. However, Clang is smart enough to not create `worker_dispatch_callout` function at all, it literaly inlines it. However, it turns out that `worker_dispatch_callout` is called from the other object file which results in the linker error:

```
 lld-link : error : undefined symbol: worker_dispatch_callout [C:\Users\syrel\Desktop\gtoolkit-vm\build\PharoVMCore.vcxproj]
```