### PR TITLE
Added tests and translation on Labelled Comment nodes

### DIFF
--- a/smalltalksrc/CAST/CASTParserTests.class.st
+++ b/smalltalksrc/CAST/CASTParserTests.class.st
@@ -488,6 +488,30 @@ CASTParserTests >> testParseIntegerConstant [
 	self assert: firstStatement value equals: '17'.
 ]
 
+{ #category : #'tests-control flow' }
+CASTParserTests >> testParseLabelledEmptyStatement [
+
+	| statement |
+	statement := self parseStatement: 'label:;'.
+
+	self assert: statement isLabelledStatement.
+	self assert: statement label name equals: 'label'.
+	self assert: statement case isNil.
+	self assert: statement statement isEmptyStatement
+]
+
+{ #category : #'tests-control flow' }
+CASTParserTests >> testParseLabelledStatement [
+
+	| statement |
+	statement := self parseStatement: 'label: 1+2;'.
+
+	self assert: statement isLabelledStatement.
+	self assert: statement label name equals: 'label'.
+	self assert: statement case isNil.
+	self assert: statement statement isBinaryOperation
+]
+
 { #category : #'tests-numbers' }
 CASTParserTests >> testParseLongIntegerConstantConstant [
 

--- a/smalltalksrc/CAST/CCompoundStatementNode.class.st
+++ b/smalltalksrc/CAST/CCompoundStatementNode.class.st
@@ -5,8 +5,7 @@ Class {
 		'declarations',
 		'statements',
 		'needsBrackets',
-		'needsCarriageReturn',
-		'needsSeparator'
+		'needsCarriageReturn'
 	],
 	#category : #'CAST-Nodes'
 }
@@ -112,18 +111,6 @@ CCompoundStatementNode >> needsCarriageReturn [
 CCompoundStatementNode >> needsCarriageReturn: aBoolean [
 
 	needsCarriageReturn := aBoolean
-]
-
-{ #category : #accessing }
-CCompoundStatementNode >> needsSeparator [
-
-	^ needsSeparator
-]
-
-{ #category : #accessing }
-CCompoundStatementNode >> needsSeparator: aBoolean [
-
-	needsSeparator := aBoolean
 ]
 
 { #category : #generated }

--- a/smalltalksrc/CAST/CExpressionNode.class.st
+++ b/smalltalksrc/CAST/CExpressionNode.class.st
@@ -30,7 +30,7 @@ CExpressionNode >> combineWithExpression: firstExpression [
 
 { #category : #initialization }
 CExpressionNode >> initialize [
-	
+	super initialize.
 	needsParentheses := false
 ]
 

--- a/smalltalksrc/CAST/CGLRAbstractNode.class.st
+++ b/smalltalksrc/CAST/CGLRAbstractNode.class.st
@@ -1,6 +1,9 @@
 Class {
 	#name : #CGLRAbstractNode,
 	#superclass : #SmaCCParseNode,
+	#instVars : [
+		'needsSeparator'
+	],
 	#category : #CAST
 }
 
@@ -19,6 +22,19 @@ CGLRAbstractNode >> ambiguous: aNode [
 		ifTrue: [ self children
 				with: aNode children
 				do: [ :n1 :n2 | n1 ambiguous: n2 ] ]
+]
+
+{ #category : #testing }
+CGLRAbstractNode >> comments [
+
+	^ super comments ifNil: [ #() ]
+]
+
+{ #category : #testing }
+CGLRAbstractNode >> initialize [
+
+	super initialize.
+	needsSeparator := true
 ]
 
 { #category : #testing }
@@ -63,8 +79,14 @@ CGLRAbstractNode >> isUnaryOperation [
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : #accessing }
 CGLRAbstractNode >> needsSeparator [
-	"By default all statements require a separator"
-	^ true
+
+	^ needsSeparator
+]
+
+{ #category : #accessing }
+CGLRAbstractNode >> needsSeparator: aBoolean [
+
+	needsSeparator := aBoolean
 ]

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -875,6 +875,65 @@ SlangBasicTranslationTest >> testGoto [
 	self assert: translation equals: 'goto lab'
 ]
 
+{ #category : #'tests-labels' }
+SlangBasicTranslationTest >> testLabel [
+
+	| label translation |
+	label := TLabeledCommentNode label: 'aLabel'.
+	translation := self translate: label.
+
+	self assert: translation equals: 'aLabel:
+;'
+]
+
+{ #category : #'tests-labels' }
+SlangBasicTranslationTest >> testLabelWithASMLabelDoesNotOutputOutsideInterpret [
+
+	| label translation |
+	label := TLabeledCommentNode new asmLabel: 'vm_label'.
+	translation := self translate: label.
+
+	self assert: translation equals: ''
+]
+
+{ #category : #'tests-labels' }
+SlangBasicTranslationTest >> testLabelWithASMLabelWithinInterpret [
+
+	| label translation |
+	generator currentMethod: (TMethod new
+		selector: #interpret;
+		yourself).
+	
+	label := TLabeledCommentNode new asmLabel: 'vm_label'.
+	translation := self translate: label.
+
+	self assert: translation equals: 'VM_LABEL(vm_label);'
+]
+
+{ #category : #'tests-labels' }
+SlangBasicTranslationTest >> testLabelWithComment [
+
+	| label translation |
+	label := TLabeledCommentNode withComment: 'some comment'.
+	translation := self translate: label.
+
+	self assert: translation equals: '/* some comment */'
+]
+
+{ #category : #'tests-labels' }
+SlangBasicTranslationTest >> testLabelWithCommentWithPreviousCommentMarkingAnInline [
+
+	| label translation |
+	
+	"If the previous comment marked an inline, do not output anything"
+	generator previousCommentMarksInlining: true.
+	
+	label := TLabeledCommentNode withComment: 'some comment'.
+	translation := self translate: label.
+
+	self assert: translation equals: ''
+]
+
 { #category : #'tests-case' }
 SlangBasicTranslationTest >> testNonContiguousCaseStatementWithSameBodyAreCollapsedInSameCase [
 

--- a/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
+++ b/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
@@ -22,6 +22,17 @@ CSlangPrettyPrinter >> initialize [
 	level := 0
 ]
 
+{ #category : #visiting }
+CSlangPrettyPrinter >> printComments: aListOfComments [
+
+	aListOfComments do: [ :e |
+		stream
+			nextPutAll: '/* ';
+			nextPutAll: e;
+			nextPutAll: ' */'.
+	] separatedBy: [ stream cr ].
+]
+
 { #category : #generated }
 CSlangPrettyPrinter >> printExpression: cAST [
 
@@ -215,6 +226,7 @@ CSlangPrettyPrinter >> visitDoStatement: aDoStatement [
 { #category : #generated }
 CSlangPrettyPrinter >> visitEmptyStatement: anEmptyStatement [
 	"Nothing to print."
+	self printComments: anEmptyStatement comments
 ]
 
 { #category : #generated }
@@ -305,16 +317,29 @@ CSlangPrettyPrinter >> visitInitializer: anInitializer [
 { #category : #generated }
 CSlangPrettyPrinter >> visitLabeledStatement: aLabeledStatement [
 
-	aLabeledStatement case = 'default'
-		ifTrue: [ stream nextPutAll: 'default' ]
-		ifFalse: [ stream
-			nextPutAll: 'case ';
-			print: aLabeledStatement case ].
-	
-	stream
-		nextPutAll: ':';
-		crtab: level.
+	"Case and labels are overloaded in the same node..."
+	aLabeledStatement case ifNotNil: [
+		aLabeledStatement case = 'default'
+			ifTrue: [ stream nextPutAll: 'default' ]
+			ifFalse: [ stream
+				nextPutAll: 'case ';
+				print: aLabeledStatement case ]].
+
+	aLabeledStatement label ifNotNil: [
+		stream nextPutAll: aLabeledStatement label name ].
+
+	(aLabeledStatement case notNil or: [ aLabeledStatement label notNil ])
+		ifTrue: [ stream nextPutAll: ':' ].
+
+	self printComments: aLabeledStatement comments.
+
+	stream crtab: level.
+
 	aLabeledStatement statement acceptVisitor: self.
+
+	"Close the statement here to keep compatibility with slang"
+	((aLabeledStatement case notNil or: [ aLabeledStatement label notNil ]) and: [ aLabeledStatement statement needsSeparator ])
+		ifTrue: [ stream nextPutAll: ';']
 ]
 
 { #category : #generated }

--- a/smalltalksrc/Slang/TLabeledCommentNode.class.st
+++ b/smalltalksrc/Slang/TLabeledCommentNode.class.st
@@ -1,3 +1,6 @@
+"
+some comment
+"
 Class {
 	#name : #TLabeledCommentNode,
 	#superclass : #TParseNode,
@@ -7,6 +10,56 @@ Class {
 	],
 	#category : #'Slang-AST'
 }
+
+{ #category : #accessing }
+TLabeledCommentNode class >> label: aLabel [
+
+	^ self new
+		setLabel: aLabel;
+		yourself
+]
+
+{ #category : #accessing }
+TLabeledCommentNode class >> withComment: aComment [
+
+	^ self new
+		setComment: aComment;
+		yourself
+]
+
+{ #category : #tranforming }
+TLabeledCommentNode >> asCASTIn: aBuilder [
+
+	| result |
+	result := CCompoundStatementNode new.
+	result needsBrackets: false.
+
+	label ifNotNil: [ 	| labelledNode |
+		labelledNode := CLabeledStatementNode new.		
+		labelledNode label: (CIdentifierNode name: label).
+		labelledNode statement: CEmptyStatementNode new.
+		result add: labelledNode ].	
+
+
+	comment ifNotNil: [ | commentNode |
+		(aBuilder previousCommentMarksInlining: (label isNil and: [asmLabel isNil and: [comment beginsWith: 'begin ']]))
+			ifTrue: [ ^ result ].
+		commentNode := CEmptyStatementNode new.
+		commentNode comments: { self comment }.
+		commentNode needsSeparator: false.
+		result add: commentNode.
+		aBuilder previousCommenter: self].
+
+	(asmLabel notNil "only output labels in the interpret function."
+	 and: [aBuilder currentMethod selector == #interpret]) ifTrue: [ | asmLabelNode |
+		asmLabelNode := CCallNode
+			identifier: (CIdentifierNode name: 'VM_LABEL')
+			arguments: { CIdentifierNode name: asmLabel }.
+		result add: asmLabelNode
+	].	
+
+	^ result
+]
 
 { #category : #accessing }
 TLabeledCommentNode >> asmLabel [
@@ -24,16 +77,20 @@ TLabeledCommentNode >> asmLabel: labelString [
 TLabeledCommentNode >> emitCCodeOn: aStream level: level generator: aCodeGen [
 	"Emit a C comment with optional label."
 
+	| didOutputComment |
+	didOutputComment := false.
 	self printOptionalLabelOn: aStream.
 	comment ifNotNil:
 		[(aCodeGen previousCommentMarksInlining: (label isNil and: [asmLabel isNil and: [comment beginsWith: 'begin ']])) ifTrue:
 			[^true].
 		 aStream nextPutAll: '/* '; nextPutAll: comment; nextPutAll: ' */'.
-		 aCodeGen previousCommenter: self].
+		didOutputComment := true.
+		aCodeGen previousCommenter: self].
 	(asmLabel notNil "only output labels in the interpret function."
-	 and: [aCodeGen currentMethod selector == #interpret]) ifTrue:
-		[aStream crtab: level.
-		 aCodeGen outputAsmLabel: asmLabel on: aStream]
+	 and: [aCodeGen currentMethod selector == #interpret]) ifTrue: [
+		didOutputComment ifTrue: [ aStream cr ].
+		aStream tab: level.
+		aCodeGen outputAsmLabel: asmLabel on: aStream]
 ]
 
 { #category : #'C code generation' }
@@ -98,8 +155,8 @@ TLabeledCommentNode >> printOptionalLabelOn: aStream [
 		aStream
 			nextPutAll: label;
 			nextPut: $:;
-			nextPut: $;;
-			tab ]
+			cr;
+			nextPut: $; ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Added tests and translation on Labelled Comment nodes
 - label only
 - comment only
 - asm label only
 - and combinations

This shows that the `CLabeledStatementNode` is kind of overloaded for two different reasons: managing cases in switches, and adding labels to statements. I'll note a cleanup task to cut it in two later.