### PR TITLE
Pharo x

### DIFF
--- a/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
@@ -3365,6 +3365,58 @@ VMPrimitiveTest >> testPrimitiveSmallFloatDivide [
 ]
 
 { #category : #'tests - primitiveDivide - SmallFloat' }
+VMPrimitiveTest >> testPrimitiveSmallFloatDivideFailsOnFirstOperandWithTypeErrorPreservesStack [
+
+	self wordSize = 8 ifFalse: [ ^ self skip].
+	"This line skips the test for 32 bits machines since smallFloat do not exist in 32 bits."
+	
+	interpreter push: memory trueObject. 
+	interpreter push: (memory smallFloatObjectOf: 2.0). 
+	
+	interpreter primitiveSmallFloatDivide. 
+	
+	self assert: interpreter failed. 
+	
+	self assert: (interpreter stackValue: 1) equals:  (memory trueObject). 
+	self assert: interpreter stackTop equals: (memory smallFloatObjectOf: 2.0).
+]
+
+{ #category : #'tests - primitiveDivide - SmallFloat' }
+VMPrimitiveTest >> testPrimitiveSmallFloatDivideFailsOnSecondOperandWithTypeErrorPreservesStack [
+
+	self wordSize = 8 ifFalse: [ ^ self skip].
+	"This line skips the test for 32 bits machines since smallFloat do not exist in 32 bits."
+	
+	interpreter push: (memory smallFloatObjectOf: 2.0). 
+	interpreter push: memory trueObject. 
+	
+	interpreter primitiveSmallFloatDivide. 
+	
+	self assert: interpreter failed. 
+	
+	self assert: interpreter stackTop equals: memory trueObject.
+	self assert: (interpreter stackValue: 1) equals:  (memory smallFloatObjectOf: 2.0).
+]
+
+{ #category : #'tests - primitiveDivide - SmallFloat' }
+VMPrimitiveTest >> testPrimitiveSmallFloatDivideFailsOnZeroDivisionPreservesStack [
+
+	self wordSize = 8 ifFalse: [ ^ self skip].
+	"This line skips the test for 32 bits machines since smallFloat do not exist in 32 bits."
+	
+	interpreter push: (memory smallFloatObjectOf: 2.0). 
+	interpreter push: (memory smallFloatObjectOf: 0.0). 
+	
+	
+	interpreter primitiveSmallFloatDivide. 
+	
+	self assert: interpreter failed. 
+	
+	self assert: (interpreter stackValue: 1) equals:  (memory smallFloatObjectOf: 2.0). 
+	self assert: interpreter stackTop equals: (memory smallFloatObjectOf: 0.0).
+]
+
+{ #category : #'tests - primitiveDivide - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatDivideFailsWithTypeErrorOnFirstOperand [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3376,8 +3428,6 @@ VMPrimitiveTest >> testPrimitiveSmallFloatDivideFailsWithTypeErrorOnFirstOperand
 	interpreter primitiveSmallFloatDivide. 
 
 	self assert: interpreter failed.
-	
-	
 ]
 
 { #category : #'tests - primitiveDivide - SmallFloat' }
@@ -3392,27 +3442,6 @@ VMPrimitiveTest >> testPrimitiveSmallFloatDivideFailsWithTypeErrorOnSecondOperan
 	interpreter primitiveSmallFloatDivide. 
 
 	self assert: interpreter failed.
-	
-	
-]
-
-{ #category : #'tests - primitiveDivide - SmallFloat' }
-VMPrimitiveTest >> testPrimitiveSmallFloatDivideFailsWithTypeErrorPreservesStack [
-
-	self wordSize = 8 ifFalse: [ ^ self skip].
-	"This line skips the test for 32 bits machines since smallFloat do not exist in 32 bits."
-	
-	interpreter push: (memory smallFloatObjectOf: 2.0). 
-	interpreter push: memory trueObject. 
-	
-	interpreter primitiveSmallFloatDivide. 
-	
-	self assert: interpreter failed. 
-	
-	self assert: interpreter stackTop equals: memory trueObject.
-	self assert: (interpreter stackValue: 1) equals:  (memory smallFloatObjectOf: 2.0). 
-	
-	
 ]
 
 { #category : #'tests - primitiveDivide - SmallFloat' }
@@ -3443,10 +3472,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatDividePopsOperands [
 	"The previous lines pop the result of primiviteDivide (1 2) for us to check that 1 and 2 were popped from the stack by checking that the next value is our marker, for instance 42"
 	
 	self deny: interpreter failed. 
-	"self assert: (interpreter stackValue: 1) equals: (memory integerObjectOf: 42)."
-	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 42). 
-	
-	
+	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 42).
 ]
 
 { #category : #'tests - primitiveEqual - SmallFloat' }

--- a/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
@@ -4303,9 +4303,24 @@ VMPrimitiveTest >> testPrimitiveSmallFloatSubtract [
 	interpreter primitiveSmallFloatSubtract.  
 
 	self deny: interpreter failed.
-	self assert: interpreter stackTop equals: (memory smallFloatObjectOf: 2.0). 
+	self assert: interpreter stackTop equals: (memory smallFloatObjectOf: 2.0).
+]
+
+{ #category : #'tests - primitiveSubtract - SmallFloat' }
+VMPrimitiveTest >> testPrimitiveSmallFloatSubtractFailsOnSecondOperandWithTypeErrorPreservesStack [
+
+	self wordSize = 8 ifFalse: [ ^ self skip].
+	"This line skips the test for 32 bits machines since smallFloat do not exist in 32 bits."
 	
+	interpreter push: (memory smallFloatObjectOf: 2.0). 
+	interpreter push: memory trueObject. 
 	
+	interpreter primitiveSmallFloatSubtract. 
+	
+	self assert: interpreter failed. 
+	
+	self assert: interpreter stackTop equals: memory trueObject.
+	self assert: (interpreter stackValue: 1) equals:  (memory smallFloatObjectOf: 2.0).
 ]
 
 { #category : #'tests - primitiveSubtract - SmallFloat' }
@@ -4320,8 +4335,6 @@ VMPrimitiveTest >> testPrimitiveSmallFloatSubtractFailsWithTypeErrorOnFirstOpera
 	interpreter primitiveSmallFloatSubtract. 
 
 	self assert: interpreter failed.
-	
-	
 ]
 
 { #category : #'tests - primitiveSubtract - SmallFloat' }
@@ -4336,27 +4349,6 @@ VMPrimitiveTest >> testPrimitiveSmallFloatSubtractFailsWithTypeErrorOnSecondOper
 	interpreter primitiveSmallFloatSubtract.  
 
 	self assert: interpreter failed.
-	
-	
-]
-
-{ #category : #'tests - primitiveSubtract - SmallFloat' }
-VMPrimitiveTest >> testPrimitiveSmallFloatSubtractFailsWithTypeErrorPreservesStack [
-
-	self wordSize = 8 ifFalse: [ ^ self skip].
-	"This line skips the test for 32 bits machines since smallFloat do not exist in 32 bits."
-	
-	interpreter push: (memory smallFloatObjectOf: 2.0). 
-	interpreter push: memory trueObject. 
-	
-	interpreter primitiveSmallFloatSubtract. 
-	
-	self assert: interpreter failed. 
-	
-	self assert: interpreter stackTop equals: memory trueObject.
-	self assert: (interpreter stackValue: 1) equals:  (memory smallFloatObjectOf: 2.0). 
-	
-	
 ]
 
 { #category : #'tests - primitiveSubtract - SmallFloat' }
@@ -4374,11 +4366,8 @@ VMPrimitiveTest >> testPrimitiveSmallFloatSubtractPopsOperands [
 	interpreter popStack. 
 	"The previous lines pop the result of primiviteSmallFloatSubtract (1 2) for us to check that 1 and 2 were popped from the stack by checking that the next value is our marker, for instance 42"
 	
-	self deny: interpreter failed. 
-	"self assert: (interpreter stackValue: 1) equals: (memory integerObjectOf: 42)."
-	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 42). 
-	
-	
+	self deny: interpreter failed.
+	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 42).
 ]
 
 { #category : #'tests - snapshot' }

--- a/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
@@ -3276,6 +3276,40 @@ VMPrimitiveTest >> testPrimitiveSmallFloatAdd [
 ]
 
 { #category : #'tests - primitiveAdd - SmallFloat' }
+VMPrimitiveTest >> testPrimitiveSmallFloatAddFailsOnFirstOperandWithTypeErrorPreservesStack [
+
+	self wordSize = 8 ifFalse: [ ^ self skip].
+	"This line skips the test for 32 bits machines since smallFloat do not exist in 32 bits."
+	
+	interpreter push: memory trueObject. 
+	interpreter push: (memory smallFloatObjectOf: 2.0).
+	
+	interpreter primitiveSmallFloatAdd. 
+	
+	self assert: interpreter failed. 
+	
+	self assert: interpreter stackTop equals: (memory smallFloatObjectOf: 2.0).
+	self assert: (interpreter stackValue: 1) equals: memory trueObject.
+]
+
+{ #category : #'tests - primitiveAdd - SmallFloat' }
+VMPrimitiveTest >> testPrimitiveSmallFloatAddFailsOnSecondOperandWithTypeErrorPreservesStack [
+
+	self wordSize = 8 ifFalse: [ ^ self skip].
+	"This line skips the test for 32 bits machines since smallFloat do not exist in 32 bits."
+	
+	interpreter push: (memory smallFloatObjectOf: 2.0). 
+	interpreter push: memory trueObject. 
+	
+	interpreter primitiveSmallFloatAdd. 
+	
+	self assert: interpreter failed. 
+	
+	self assert: interpreter stackTop equals: memory trueObject.
+	self assert: (interpreter stackValue: 1) equals:  (memory smallFloatObjectOf: 2.0).
+]
+
+{ #category : #'tests - primitiveAdd - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatAddFailsWithTypeErrorOnFirstOperand [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3287,8 +3321,6 @@ VMPrimitiveTest >> testPrimitiveSmallFloatAddFailsWithTypeErrorOnFirstOperand [
 	interpreter primitiveSmallFloatAdd. 
 
 	self assert: interpreter failed.
-	
-	
 ]
 
 { #category : #'tests - primitiveAdd - SmallFloat' }
@@ -3303,27 +3335,6 @@ VMPrimitiveTest >> testPrimitiveSmallFloatAddFailsWithTypeErrorOnSecondOperand [
 	interpreter primitiveSmallFloatAdd. 
 
 	self assert: interpreter failed.
-	
-	
-]
-
-{ #category : #'tests - primitiveAdd - SmallFloat' }
-VMPrimitiveTest >> testPrimitiveSmallFloatAddFailsWithTypeErrorPreservesStack [
-
-	self wordSize = 8 ifFalse: [ ^ self skip].
-	"This line skips the test for 32 bits machines since smallFloat do not exist in 32 bits."
-	
-	interpreter push: (memory smallFloatObjectOf: 2.0). 
-	interpreter push: memory trueObject. 
-	
-	interpreter primitiveSmallFloatAdd. 
-	
-	self assert: interpreter failed. 
-	
-	self assert: interpreter stackTop equals: memory trueObject.
-	self assert: (interpreter stackValue: 1) equals:  (memory smallFloatObjectOf: 2.0). 
-	
-	
 ]
 
 { #category : #'tests - primitiveAdd - SmallFloat' }
@@ -3340,11 +3351,8 @@ VMPrimitiveTest >> testPrimitiveSmallFloatAddPopsOperands [
 	interpreter popStack. 
 	"The previous lines pop the result of primiviteAdd (1 2) for us to check that 1 and 2 were popped from the stack by checking that the next value is our marker, for instance 42"
 	
-	self deny: interpreter failed. 
-	"self assert: (interpreter stackValue: 1) equals: (memory integerObjectOf: 42)."
-	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 42). 
-	
-	
+	self deny: interpreter failed.
+	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 42).
 ]
 
 { #category : #'tests - primitiveDivide - SmallFloat' }

--- a/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
@@ -3712,7 +3712,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatGreaterThan [
 ]
 
 { #category : #'tests - primitiveGreaterThan - SmallFloat' }
-VMPrimitiveTest >> testPrimitiveSmallFloatGreaterThanFailsOnSecondOperandWithTypeErrorPreservesStack [
+VMPrimitiveTest >> testPrimitiveSmallFloatGreaterThanFailsOnFirstOperandWithTypeErrorPreservesStack [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
 	"This line skips the test for 32 bits machines since smallFloat do not exist in 32 bits."
@@ -3726,6 +3726,23 @@ VMPrimitiveTest >> testPrimitiveSmallFloatGreaterThanFailsOnSecondOperandWithTyp
 	
 	self assert: interpreter stackTop equals: (memory smallFloatObjectOf: 2.0).
 	self assert: (interpreter stackValue: 1) equals: memory trueObject.
+]
+
+{ #category : #'tests - primitiveGreaterThan - SmallFloat' }
+VMPrimitiveTest >> testPrimitiveSmallFloatGreaterThanFailsOnSecondOperandWithTypeErrorPreservesStack [
+
+	self wordSize = 8 ifFalse: [ ^ self skip].
+	"This line skips the test for 32 bits machines since smallFloat do not exist in 32 bits."
+	
+	interpreter push: (memory smallFloatObjectOf: 2.0). 
+	interpreter push: memory trueObject. 
+	
+	interpreter primitiveSmallFloatGreaterThan. 
+	
+	self assert: interpreter failed. 
+	
+	self assert: interpreter stackTop equals: memory trueObject.
+	self assert: (interpreter stackValue: 1) equals: (memory smallFloatObjectOf: 2.0).
 ]
 
 { #category : #'tests - primitiveGreaterThan - SmallFloat' }

--- a/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
@@ -3821,6 +3821,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatGreaterThantWithNegativeNumbers [
 	interpreter primitiveSmallFloatGreaterThan.
 
 	self deny: interpreter failed.
+	self assert: interpreter stackTop equals: memory trueObject. 
 ]
 
 { #category : #'tests - primitiveLessOrEqual - SmallFloat' }
@@ -3835,9 +3836,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatLessOrEqual [
 	interpreter primitiveSmallFloatLessOrEqual.  
 
 	self deny: interpreter failed.
-	self assert: interpreter stackTop equals: (memory falseObject). 
-	
-	
+	self assert: interpreter stackTop equals: memory falseObject.
 ]
 
 { #category : #'tests - primitiveLessOrEqual - SmallFloat' }
@@ -3852,9 +3851,41 @@ VMPrimitiveTest >> testPrimitiveSmallFloatLessOrEqualEquality [
 	interpreter primitiveSmallFloatLessOrEqual.  
 
 	self deny: interpreter failed.
-	self assert: interpreter stackTop equals: (memory trueObject). 
+	self assert: interpreter stackTop equals: memory trueObject.
+]
+
+{ #category : #'tests - primitiveLessOrEqual - SmallFloat' }
+VMPrimitiveTest >> testPrimitiveSmallFloatLessOrEqualFailsOnFirstOperandWithTypeErrorPreservesStackk [
+
+	self wordSize = 8 ifFalse: [ ^ self skip].
+	"This line skips the test for 32 bits machines since smallFloat do not exist in 32 bits."
 	
+	interpreter push: memory trueObject. 
+	interpreter push: (memory smallFloatObjectOf: 2.0). 
 	
+	interpreter primitiveSmallFloatLessOrEqual. 
+	
+	self assert: interpreter failed. 
+	
+	self assert: interpreter stackTop equals: (memory smallFloatObjectOf: 2.0).
+	self assert: (interpreter stackValue: 1) equals: memory trueObject.
+]
+
+{ #category : #'tests - primitiveLessOrEqual - SmallFloat' }
+VMPrimitiveTest >> testPrimitiveSmallFloatLessOrEqualFailsOnSecondOperandWithTypeErrorPreservesStackk [
+
+	self wordSize = 8 ifFalse: [ ^ self skip].
+	"This line skips the test for 32 bits machines since smallFloat do not exist in 32 bits."
+	
+	interpreter push: (memory smallFloatObjectOf: 2.0). 
+	interpreter push: memory trueObject. 
+	
+	interpreter primitiveSmallFloatLessOrEqual. 
+	
+	self assert: interpreter failed. 
+	
+	self assert: interpreter stackTop equals: memory trueObject.
+	self assert: (interpreter stackValue: 1) equals:  (memory smallFloatObjectOf: 2.0).
 ]
 
 { #category : #'tests - primitiveLessOrEqual - SmallFloat' }
@@ -3869,8 +3900,6 @@ VMPrimitiveTest >> testPrimitiveSmallFloatLessOrEqualFailsWithTypeErrorOnFirstOp
 	interpreter primitiveSmallFloatLessOrEqual. 
 
 	self assert: interpreter failed.
-	
-	
 ]
 
 { #category : #'tests - primitiveLessOrEqual - SmallFloat' }
@@ -3885,27 +3914,6 @@ VMPrimitiveTest >> testPrimitiveSmallFloatLessOrEqualFailsWithTypeErrorOnSecondO
 	interpreter primitiveSmallFloatLessOrEqual. 
 
 	self assert: interpreter failed.
-	
-	
-]
-
-{ #category : #'tests - primitiveLessOrEqual - SmallFloat' }
-VMPrimitiveTest >> testPrimitiveSmallFloatLessOrEqualFailsWithTypeErrorPreservesStack [
-
-	self wordSize = 8 ifFalse: [ ^ self skip].
-	"This line skips the test for 32 bits machines since smallFloat do not exist in 32 bits."
-	
-	interpreter push: (memory smallFloatObjectOf: 2.0). 
-	interpreter push: memory trueObject. 
-	
-	interpreter primitiveSmallFloatLessOrEqual. 
-	
-	self assert: interpreter failed. 
-	
-	self assert: interpreter stackTop equals: memory trueObject.
-	self assert: (interpreter stackValue: 1) equals:  (memory smallFloatObjectOf: 2.0). 
-	
-	
 ]
 
 { #category : #'tests - primitiveLessOrEqual - SmallFloat' }
@@ -3924,10 +3932,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatLessOrEqualPopsOperands [
 	"The previous lines pop the result of primiviteSmallFloatLessOrEqual (1 2) for us to check that 1 and 2 were popped from the stack by checking that the next value is our marker, for instance 42"
 	
 	self deny: interpreter failed. 
-	"self assert: (interpreter stackValue: 1) equals: (memory integerObjectOf: 42)."
-	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 42). 
-	
-	
+	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 42).
 ]
 
 { #category : #'tests - primitiveLessOrEqual - SmallFloat' }
@@ -3942,9 +3947,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatLessOrEqualtWithNegativeNumbers [
 	interpreter primitiveSmallFloatLessOrEqual.
 
 	self deny: interpreter failed. 
-	self assert: interpreter stackTop equals: memory falseObject. 
-	
-	
+	self assert: interpreter stackTop equals: memory falseObject.
 ]
 
 { #category : #'tests - primitiveLessThan - SmallFloat' }

--- a/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
@@ -3708,9 +3708,24 @@ VMPrimitiveTest >> testPrimitiveSmallFloatGreaterThan [
 	interpreter primitiveSmallFloatGreaterThan.  
 
 	self deny: interpreter failed.
-	self assert: interpreter stackTop equals: (memory trueObject). 
+	self assert: interpreter stackTop equals: memory trueObject.
+]
+
+{ #category : #'tests - primitiveGreaterThan - SmallFloat' }
+VMPrimitiveTest >> testPrimitiveSmallFloatGreaterThanFailsOnSecondOperandWithTypeErrorPreservesStack [
+
+	self wordSize = 8 ifFalse: [ ^ self skip].
+	"This line skips the test for 32 bits machines since smallFloat do not exist in 32 bits."
 	
+	interpreter push: memory trueObject. 
+	interpreter push: (memory smallFloatObjectOf: 2.0). 
 	
+	interpreter primitiveSmallFloatGreaterThan. 
+	
+	self assert: interpreter failed. 
+	
+	self assert: interpreter stackTop equals: (memory smallFloatObjectOf: 2.0).
+	self assert: (interpreter stackValue: 1) equals: memory trueObject.
 ]
 
 { #category : #'tests - primitiveGreaterThan - SmallFloat' }
@@ -3725,8 +3740,6 @@ VMPrimitiveTest >> testPrimitiveSmallFloatGreaterThanFailsWithTypeErrorOnFirstOp
 	interpreter primitiveSmallFloatGreaterThan. 
 
 	self assert: interpreter failed.
-	
-	
 ]
 
 { #category : #'tests - primitiveGreaterThan - SmallFloat' }
@@ -3741,27 +3754,6 @@ VMPrimitiveTest >> testPrimitiveSmallFloatGreaterThanFailsWithTypeErrorOnSecondO
 	interpreter primitiveSmallFloatGreaterThan. 
 
 	self assert: interpreter failed.
-	
-	
-]
-
-{ #category : #'tests - primitiveGreaterThan - SmallFloat' }
-VMPrimitiveTest >> testPrimitiveSmallFloatGreaterThanFailsWithTypeErrorPreservesStack [
-
-	self wordSize = 8 ifFalse: [ ^ self skip].
-	"This line skips the test for 32 bits machines since smallFloat do not exist in 32 bits."
-	
-	interpreter push: (memory smallFloatObjectOf: 2.0). 
-	interpreter push: memory trueObject. 
-	
-	interpreter primitiveSmallFloatGreaterThan. 
-	
-	self assert: interpreter failed. 
-	
-	self assert: interpreter stackTop equals: memory trueObject.
-	self assert: (interpreter stackValue: 1) equals:  (memory smallFloatObjectOf: 2.0). 
-	
-	
 ]
 
 { #category : #'tests - primitiveGreaterThan - SmallFloat' }
@@ -3779,11 +3771,8 @@ VMPrimitiveTest >> testPrimitiveSmallFloatGreaterThanPopsOperands [
 	interpreter popStack. 
 	"The previous lines pop the result of primiviteGreaterThan (1 2) for us to check that 1 and 2 were popped from the stack by checking that the next value is our marker, for instance 42"
 	
-	self deny: interpreter failed. 
-	"self assert: (interpreter stackValue: 1) equals: (memory integerObjectOf: 42)."
-	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 42). 
-	
-	
+	self deny: interpreter failed.
+	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 42).
 ]
 
 { #category : #'tests - primitiveGreaterThan - SmallFloat' }
@@ -3797,9 +3786,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatGreaterThantWithNegativeNumbers [
 	
 	interpreter primitiveSmallFloatGreaterThan.
 
-	self deny: interpreter failed. 
-	
-	
+	self deny: interpreter failed.
 ]
 
 { #category : #'tests - primitiveLessOrEqual - SmallFloat' }

--- a/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
@@ -3487,9 +3487,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatEqual [
 	interpreter primitiveSmallFloatEqual.  
 
 	self deny: interpreter failed.
-	self assert: interpreter stackTop equals: (memory falseObject). 
-	
-	
+	self assert: interpreter stackTop equals: memory falseObject.
 ]
 
 { #category : #'tests - primitiveEqual - SmallFloat' }
@@ -3504,9 +3502,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatEqualEqualEquality [
 	interpreter primitiveSmallFloatEqual.  
 
 	self deny: interpreter failed.
-	self assert: interpreter stackTop equals: (memory trueObject). 
-	
-	
+	self assert: interpreter stackTop equals: memory trueObject.
 ]
 
 { #category : #'tests - primitiveEqual - SmallFloat' }
@@ -3521,8 +3517,6 @@ VMPrimitiveTest >> testPrimitiveSmallFloatEqualFailsWithTypeErrorOnFirstOperand 
 	interpreter primitiveSmallFloatEqual. 
 
 	self assert: interpreter failed.
-	
-	
 ]
 
 { #category : #'tests - primitiveEqual - SmallFloat' }
@@ -3537,8 +3531,6 @@ VMPrimitiveTest >> testPrimitiveSmallFloatEqualFailsWithTypeErrorOnSecondOperand
 	interpreter primitiveSmallFloatEqual. 
 
 	self assert: interpreter failed.
-	
-	
 ]
 
 { #category : #'tests - primitiveEqual - SmallFloat' }
@@ -3555,9 +3547,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatEqualFailsWithTypeErrorPreservesStack 
 	self assert: interpreter failed. 
 	
 	self assert: interpreter stackTop equals: memory trueObject.
-	self assert: (interpreter stackValue: 1) equals:  (memory smallFloatObjectOf: 2.0). 
-	
-	
+	self assert: (interpreter stackValue: 1) equals:  (memory smallFloatObjectOf: 2.0).
 ]
 
 { #category : #'tests - primitiveEqual - SmallFloat' }
@@ -3576,10 +3566,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatEqualPopsOperands [
 	"The previous lines pop the result of primiviteSmallFloatEqual (1 2) for us to check that 1 and 2 were popped from the stack by checking that the next value is our marker, for instance 42"
 	
 	self deny: interpreter failed. 
-	"self assert: (interpreter stackValue: 1) equals: (memory integerObjectOf: 42)."
-	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 42). 
-	
-	
+	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 42).
 ]
 
 { #category : #'tests - primitiveEqual - SmallFloat' }
@@ -3594,9 +3581,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatEqualtWithNegativeNumbers [
 	interpreter primitiveSmallFloatEqual.
 
 	self deny: interpreter failed. 
-	self assert: interpreter stackTop equals: memory falseObject. 
-	
-	
+	self assert: interpreter stackTop equals: memory falseObject.
 ]
 
 { #category : #'tests - primitiveGreaterOrEqual - SmallFloat' }

--- a/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
@@ -4082,39 +4082,26 @@ VMPrimitiveTest >> testPrimitiveSmallFloatMultiply [
 ]
 
 { #category : #'tests - primitiveMultiply - SmallFloat' }
-VMPrimitiveTest >> testPrimitiveSmallFloatMultiplyFailsWithTypeErrorOnFirstOperand [
+VMPrimitiveTest >> testPrimitiveSmallFloatMultiplyFailsOnFirstOperandWithTypeErrorPreservesStack [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
 	"This line skips the test for 32 bits machines since smallFloat do not exist in 32 bits."
-
-	interpreter push: memory trueObject.
-	interpreter push: (memory smallFloatObjectOf: 2.0).
+	
+	interpreter push: memory trueObject. 
+	interpreter push: (memory smallFloatObjectOf: 2.0). 
 	
 	interpreter primitiveSmallFloatMultiply. 
-
-	self assert: interpreter failed.
+	
+	self assert: interpreter failed. 
+	
+	self assert: interpreter stackTop equals: (memory smallFloatObjectOf: 2.0).
+	self assert: (interpreter stackValue: 1) equals: memory trueObject. 
 	
 	
 ]
 
 { #category : #'tests - primitiveMultiply - SmallFloat' }
-VMPrimitiveTest >> testPrimitiveSmallFloatMultiplyFailsWithTypeErrorOnSecondOperand [
-
-	self wordSize = 8 ifFalse: [ ^ self skip].
-	"This line skips the test for 32 bits machines since smallFloat do not exist in 32 bits."
-	
-	interpreter push: (memory smallFloatObjectOf: 2.0).
-	interpreter push: memory trueObject.
-	
-	interpreter primitiveSmallFloatMultiply. 
-
-	self assert: interpreter failed.
-	
-	
-]
-
-{ #category : #'tests - primitiveMultiply - SmallFloat' }
-VMPrimitiveTest >> testPrimitiveSmallFloatMultiplyFailsWithTypeErrorPreservesStack [
+VMPrimitiveTest >> testPrimitiveSmallFloatMultiplyFailsOnSecondOperandWithTypeErrorPreservesStack [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
 	"This line skips the test for 32 bits machines since smallFloat do not exist in 32 bits."
@@ -4133,6 +4120,34 @@ VMPrimitiveTest >> testPrimitiveSmallFloatMultiplyFailsWithTypeErrorPreservesSta
 ]
 
 { #category : #'tests - primitiveMultiply - SmallFloat' }
+VMPrimitiveTest >> testPrimitiveSmallFloatMultiplyFailsWithTypeErrorOnFirstOperand [
+
+	self wordSize = 8 ifFalse: [ ^ self skip].
+	"This line skips the test for 32 bits machines since smallFloat do not exist in 32 bits."
+
+	interpreter push: memory trueObject.
+	interpreter push: (memory smallFloatObjectOf: 2.0).
+	
+	interpreter primitiveSmallFloatMultiply. 
+
+	self assert: interpreter failed.
+]
+
+{ #category : #'tests - primitiveMultiply - SmallFloat' }
+VMPrimitiveTest >> testPrimitiveSmallFloatMultiplyFailsWithTypeErrorOnSecondOperand [
+
+	self wordSize = 8 ifFalse: [ ^ self skip].
+	"This line skips the test for 32 bits machines since smallFloat do not exist in 32 bits."
+	
+	interpreter push: (memory smallFloatObjectOf: 2.0).
+	interpreter push: memory trueObject.
+	
+	interpreter primitiveSmallFloatMultiply. 
+
+	self assert: interpreter failed.
+]
+
+{ #category : #'tests - primitiveMultiply - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatMultiplyPopsOperands [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4147,10 +4162,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatMultiplyPopsOperands [
 	"The previous lines pop the result of primiviteMultiply (1 2) for us to check that 1 and 2 were popped from the stack by checking that the next value is our marker, for instance 42"
 	
 	self deny: interpreter failed. 
-	"self assert: (interpreter stackValue: 1) equals: (memory integerObjectOf: 42)."
-	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 42). 
-	
-	
+	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 42).
 ]
 
 { #category : #'tests - primitiveNotEqual - SmallFloat' }

--- a/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
@@ -3617,6 +3617,40 @@ VMPrimitiveTest >> testPrimitiveSmallFloatGreaterOrEqualEquality [
 ]
 
 { #category : #'tests - primitiveGreaterOrEqual - SmallFloat' }
+VMPrimitiveTest >> testPrimitiveSmallFloatGreaterOrEqualFailsOnFirstOperandWithTypeErrorPreservesStack [
+
+	self wordSize = 8 ifFalse: [ ^ self skip].
+	"This line skips the test for 32 bits machines since smallFloat do not exist in 32 bits."
+	
+	interpreter push: memory trueObject. 
+	interpreter push: (memory smallFloatObjectOf: 2.0). 
+	
+	interpreter primitiveSmallFloatGreaterOrEqual. 
+	
+	self assert: interpreter failed. 
+	
+	self assert: interpreter stackTop equals: (memory smallFloatObjectOf: 2.0).
+	self assert: (interpreter stackValue: 1) equals:  memory trueObject.
+]
+
+{ #category : #'tests - primitiveGreaterOrEqual - SmallFloat' }
+VMPrimitiveTest >> testPrimitiveSmallFloatGreaterOrEqualFailsOnSecondOperandWithTypeErrorPreservesStack [
+
+	self wordSize = 8 ifFalse: [ ^ self skip].
+	"This line skips the test for 32 bits machines since smallFloat do not exist in 32 bits."
+	
+	interpreter push: (memory smallFloatObjectOf: 2.0). 
+	interpreter push: memory trueObject. 
+	
+	interpreter primitiveSmallFloatGreaterOrEqual. 
+	
+	self assert: interpreter failed. 
+	
+	self assert: interpreter stackTop equals: memory trueObject.
+	self assert: (interpreter stackValue: 1) equals:  (memory smallFloatObjectOf: 2.0).
+]
+
+{ #category : #'tests - primitiveGreaterOrEqual - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatGreaterOrEqualFailsWithTypeErrorOnFirstOperand [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3642,23 +3676,6 @@ VMPrimitiveTest >> testPrimitiveSmallFloatGreaterOrEqualFailsWithTypeErrorOnSeco
 	interpreter primitiveSmallFloatGreaterOrEqual. 
 
 	self assert: interpreter failed.
-]
-
-{ #category : #'tests - primitiveGreaterOrEqual - SmallFloat' }
-VMPrimitiveTest >> testPrimitiveSmallFloatGreaterOrEqualFailsWithTypeErrorPreservesStack [
-
-	self wordSize = 8 ifFalse: [ ^ self skip].
-	"This line skips the test for 32 bits machines since smallFloat do not exist in 32 bits."
-	
-	interpreter push: (memory smallFloatObjectOf: 2.0). 
-	interpreter push: memory trueObject. 
-	
-	interpreter primitiveSmallFloatGreaterOrEqual. 
-	
-	self assert: interpreter failed. 
-	
-	self assert: interpreter stackTop equals: memory trueObject.
-	self assert: (interpreter stackValue: 1) equals:  (memory smallFloatObjectOf: 2.0).
 ]
 
 { #category : #'tests - primitiveGreaterOrEqual - SmallFloat' }

--- a/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
@@ -4177,9 +4177,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatNotEqual [
 	interpreter primitiveSmallFloatNotEqual.  
 
 	self deny: interpreter failed.
-	self assert: interpreter stackTop equals: (memory trueObject). 
-	
-	
+	self assert: interpreter stackTop equals: memory trueObject.
 ]
 
 { #category : #'tests - primitiveNotEqual - SmallFloat' }
@@ -4194,9 +4192,41 @@ VMPrimitiveTest >> testPrimitiveSmallFloatNotEqualEqual [
 	interpreter primitiveSmallFloatNotEqual.  
 
 	self deny: interpreter failed.
-	self assert: interpreter stackTop equals: (memory falseObject). 
+	self assert: interpreter stackTop equals: memory falseObject.
+]
+
+{ #category : #'tests - primitiveNotEqual - SmallFloat' }
+VMPrimitiveTest >> testPrimitiveSmallFloatNotEqualFailsOnFirstOperandWithTypeErrorPreservesStack [
+
+	self wordSize = 8 ifFalse: [ ^ self skip].
+	"This line skips the test for 32 bits machines since smallFloat do not exist in 32 bits."
 	
+	interpreter push: memory trueObject. 
+	interpreter push: (memory smallFloatObjectOf: 2.0).
 	
+	interpreter primitiveSmallFloatNotEqual. 
+	
+	self assert: interpreter failed. 
+	
+	self assert: interpreter stackTop equals: (memory smallFloatObjectOf: 2.0).
+	self assert: (interpreter stackValue: 1) equals: memory trueObject.
+]
+
+{ #category : #'tests - primitiveNotEqual - SmallFloat' }
+VMPrimitiveTest >> testPrimitiveSmallFloatNotEqualFailsOnSecondOperandWithTypeErrorPreservesStack [
+
+	self wordSize = 8 ifFalse: [ ^ self skip].
+	"This line skips the test for 32 bits machines since smallFloat do not exist in 32 bits."
+	
+	interpreter push: (memory smallFloatObjectOf: 2.0). 
+	interpreter push: memory trueObject. 
+	
+	interpreter primitiveSmallFloatNotEqual. 
+	
+	self assert: interpreter failed. 
+	
+	self assert: interpreter stackTop equals: memory trueObject.
+	self assert: (interpreter stackValue: 1) equals:  (memory smallFloatObjectOf: 2.0).
 ]
 
 { #category : #'tests - primitiveNotEqual - SmallFloat' }
@@ -4211,8 +4241,6 @@ VMPrimitiveTest >> testPrimitiveSmallFloatNotEqualFailsWithTypeErrorOnFirstOpera
 	interpreter primitiveSmallFloatNotEqual. 
 
 	self assert: interpreter failed.
-	
-	
 ]
 
 { #category : #'tests - primitiveNotEqual - SmallFloat' }
@@ -4227,27 +4255,6 @@ VMPrimitiveTest >> testPrimitiveSmallFloatNotEqualFailsWithTypeErrorOnSecondOper
 	interpreter primitiveSmallFloatNotEqual. 
 
 	self assert: interpreter failed.
-	
-	
-]
-
-{ #category : #'tests - primitiveNotEqual - SmallFloat' }
-VMPrimitiveTest >> testPrimitiveSmallFloatNotEqualFailsWithTypeErrorPreservesStack [
-
-	self wordSize = 8 ifFalse: [ ^ self skip].
-	"This line skips the test for 32 bits machines since smallFloat do not exist in 32 bits."
-	
-	interpreter push: (memory smallFloatObjectOf: 2.0). 
-	interpreter push: memory trueObject. 
-	
-	interpreter primitiveSmallFloatNotEqual. 
-	
-	self assert: interpreter failed. 
-	
-	self assert: interpreter stackTop equals: memory trueObject.
-	self assert: (interpreter stackValue: 1) equals:  (memory smallFloatObjectOf: 2.0). 
-	
-	
 ]
 
 { #category : #'tests - primitiveNotEqual - SmallFloat' }
@@ -4266,10 +4273,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatNotEqualPopsOperands [
 	"The previous lines pop the result of primiviteSmallFloatNotEqual (1 2) for us to check that 1 and 2 were popped from the stack by checking that the next value is our marker, for instance 42"
 	
 	self deny: interpreter failed. 
-	"self assert: (interpreter stackValue: 1) equals: (memory integerObjectOf: 42)."
-	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 42). 
-	
-	
+	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 42).
 ]
 
 { #category : #'tests - primitiveNotEqual - SmallFloat' }
@@ -4284,9 +4288,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatNotEqualtWithNegativeNumbers [
 	interpreter primitiveSmallFloatNotEqual.
 
 	self deny: interpreter failed. 
-	self assert: interpreter stackTop equals: memory trueObject. 
-	
-	
+	self assert: interpreter stackTop equals: memory trueObject.
 ]
 
 { #category : #'tests - primitiveSubtract - SmallFloat' }

--- a/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
@@ -3596,9 +3596,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatGreaterOrEqual [
 	interpreter primitiveSmallFloatGreaterOrEqual.  
 
 	self deny: interpreter failed.
-	self assert: interpreter stackTop equals: (memory trueObject). 
-	
-	
+	self assert: interpreter stackTop equals: memory trueObject.
 ]
 
 { #category : #'tests - primitiveGreaterOrEqual - SmallFloat' }
@@ -3613,7 +3611,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatGreaterOrEqualEquality [
 	interpreter primitiveSmallFloatGreaterOrEqual.  
 
 	self deny: interpreter failed.
-	self assert: interpreter stackTop equals: (memory trueObject). 
+	self assert: interpreter stackTop equals: memory trueObject. 
 	
 	
 ]
@@ -3630,8 +3628,6 @@ VMPrimitiveTest >> testPrimitiveSmallFloatGreaterOrEqualFailsWithTypeErrorOnFirs
 	interpreter primitiveSmallFloatGreaterOrEqual. 
 
 	self assert: interpreter failed.
-	
-	
 ]
 
 { #category : #'tests - primitiveGreaterOrEqual - SmallFloat' }
@@ -3646,8 +3642,6 @@ VMPrimitiveTest >> testPrimitiveSmallFloatGreaterOrEqualFailsWithTypeErrorOnSeco
 	interpreter primitiveSmallFloatGreaterOrEqual. 
 
 	self assert: interpreter failed.
-	
-	
 ]
 
 { #category : #'tests - primitiveGreaterOrEqual - SmallFloat' }
@@ -3664,9 +3658,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatGreaterOrEqualFailsWithTypeErrorPreser
 	self assert: interpreter failed. 
 	
 	self assert: interpreter stackTop equals: memory trueObject.
-	self assert: (interpreter stackValue: 1) equals:  (memory smallFloatObjectOf: 2.0). 
-	
-	
+	self assert: (interpreter stackValue: 1) equals:  (memory smallFloatObjectOf: 2.0).
 ]
 
 { #category : #'tests - primitiveGreaterOrEqual - SmallFloat' }
@@ -3686,9 +3678,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatGreaterOrEqualPopsOperands [
 	
 	self deny: interpreter failed. 
 	"self assert: (interpreter stackValue: 1) equals: (memory integerObjectOf: 42)."
-	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 42). 
-	
-	
+	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 42).
 ]
 
 { #category : #'tests - primitiveGreaterOrEqual - SmallFloat' }
@@ -3703,9 +3693,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatGreaterOrEqualtWithNegativeNumbers [
 	interpreter primitiveSmallFloatGreaterOrEqual.
 
 	self deny: interpreter failed. 
-	self assert: interpreter stackTop equals: memory trueObject. 
-	
-	
+	self assert: interpreter stackTop equals: memory trueObject.
 ]
 
 { #category : #'tests - primitiveGreaterThan - SmallFloat' }

--- a/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
@@ -3863,7 +3863,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatLessOrEqualEquality [
 ]
 
 { #category : #'tests - primitiveLessOrEqual - SmallFloat' }
-VMPrimitiveTest >> testPrimitiveSmallFloatLessOrEqualFailsOnFirstOperandWithTypeErrorPreservesStackk [
+VMPrimitiveTest >> testPrimitiveSmallFloatLessOrEqualFailsOnFirstOperandWithTypeErrorPreservesStack [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
 	"This line skips the test for 32 bits machines since smallFloat do not exist in 32 bits."
@@ -3880,7 +3880,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatLessOrEqualFailsOnFirstOperandWithType
 ]
 
 { #category : #'tests - primitiveLessOrEqual - SmallFloat' }
-VMPrimitiveTest >> testPrimitiveSmallFloatLessOrEqualFailsOnSecondOperandWithTypeErrorPreservesStackk [
+VMPrimitiveTest >> testPrimitiveSmallFloatLessOrEqualFailsOnSecondOperandWithTypeErrorPreservesStack [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
 	"This line skips the test for 32 bits machines since smallFloat do not exist in 32 bits."


### PR DESCRIPTION
Tests correction for primitives on small floats. 
(Spaces, parenthesis, commented dead code, and add tests to assert the stack stays untouched if the primitive fails). 