### PR TITLE
fix/marshalling-largeIntegers-in-32bits

### DIFF
--- a/smalltalksrc/VMMaker/StackInterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreterPrimitives.class.st
@@ -576,9 +576,6 @@ StackInterpreterPrimitives >> marshallSInt32From: argumentArrayOop at: index int
 
 	self failed ifTrue: [ ^self primitiveFailFor: PrimErrBadArgument ].
 
-	value > INT32_MAX ifTrue: [ ^ self primitiveFailFor: PrimErrBadArgument ].
-	value < INT32_MIN ifTrue: [ ^ self primitiveFailFor: PrimErrBadArgument ].
-
 	intHolder := self cCoerce: holder to: #'int32_t *'.
 	intHolder at: 0 put: value.
 		
@@ -661,10 +658,7 @@ StackInterpreterPrimitives >> marshallUInt32From: argumentArrayOop at: index int
 	value := self positive32BitValueOf: (objectMemory fetchPointer: index ofObject: argumentArrayOop).
 	
 	self failed ifTrue: [ ^self primitiveFailFor: PrimErrBadArgument ].
-	
-	value < 0 ifTrue: [ ^ self primitiveFailFor: PrimErrBadArgument ].
-	value > UINT32_MAX ifTrue: [ ^ self primitiveFailFor: PrimErrBadArgument ].
-		
+			
 	intHolder := self cCoerce: holder to: #'uint32_t *'.
 	intHolder at: 0 put: value.
 		

--- a/smalltalksrc/VMMaker/StackInterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreterPrimitives.class.st
@@ -572,12 +572,15 @@ StackInterpreterPrimitives >> marshallSInt32From: argumentArrayOop at: index int
 
 	| intHolder value |
 
-	value := self fetchInteger: index ofObject: argumentArrayOop.	
+	value := self signed32BitValueOf: (objectMemory fetchPointer: index ofObject: argumentArrayOop).
+
+	self failed ifTrue: [ ^self primitiveFailFor: PrimErrBadArgument ].
+
 	value > INT32_MAX ifTrue: [ ^ self primitiveFailFor: PrimErrBadArgument ].
 	value < INT32_MIN ifTrue: [ ^ self primitiveFailFor: PrimErrBadArgument ].
 
 	intHolder := self cCoerce: holder to: #'int32_t *'.
-	intHolder at: 0 put: (self fetchInteger: index ofObject: argumentArrayOop ).
+	intHolder at: 0 put: value.
 		
 ]
 
@@ -655,7 +658,10 @@ StackInterpreterPrimitives >> marshallUInt32From: argumentArrayOop at: index int
 
 	| intHolder value |
 	
-	value := self fetchInteger: index ofObject: argumentArrayOop.
+	value := self positive32BitValueOf: (objectMemory fetchPointer: index ofObject: argumentArrayOop).
+	
+	self failed ifTrue: [ ^self primitiveFailFor: PrimErrBadArgument ].
+	
 	value < 0 ifTrue: [ ^ self primitiveFailFor: PrimErrBadArgument ].
 	value > UINT32_MAX ifTrue: [ ^ self primitiveFailFor: PrimErrBadArgument ].
 		

--- a/smalltalksrc/VMMakerTests/VMFFIArgumentMarshallingTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMFFIArgumentMarshallingTest.class.st
@@ -23,6 +23,27 @@ VMFFIArgumentMarshallingTest >> doTestFuntionWithArgumentType: argumentType smal
 ]
 
 { #category : #'tests - parameters marshalling' }
+VMFFIArgumentMarshallingTest >> newLargeIntegerForValue: aValue [
+
+	| newLargeInteger byteSize class |
+	byteSize := ((aValue abs log: 2) + 1 roundUpTo: 8) / 8.
+	class := aValue > 0 ifTrue: [ ClassLargePositiveIntegerCompactIndex ] ifFalse: [ ClassLargeNegativeIntegerCompactIndex ].
+	
+	newLargeInteger := memory
+		                   eeInstantiateSmallClassIndex: class
+		                   format: (memory byteFormatForNumBytes: byteSize)
+		                   numSlots:
+		                   (byteSize / memory bytesPerOop) ceiling asInteger.
+
+	0 to: byteSize do: [ :i | 
+		memory
+			storeByte: i
+			ofObject: newLargeInteger
+			withValue: (aValue byteAt: i + 1) ].
+	^ newLargeInteger
+]
+
+{ #category : #'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithCharacterArgumentIsMarshalledCorrectly [
 
 	self
@@ -94,6 +115,38 @@ VMFFIArgumentMarshallingTest >> testCalloutWithSINT16PositiveOutOfRangeProducesB
 		smalltalkValue: (memory integerObjectOf: INT16_MAX + 1)
 		failsWith: PrimErrBadArgument
 
+]
+
+{ #category : #'tests - parameters marshalling' }
+VMFFIArgumentMarshallingTest >> testCalloutWithSINT32ArgumentWithLargeNegativeValueIsMarshalledCorrectly [
+
+	| aValue aValueToStore |
+
+	aValue := -16r40000000 - 2.
+
+	aValueToStore := self wordSize = 8
+		                ifTrue: [ memory integerObjectOf: aValue ]
+		                ifFalse: [ self newLargeIntegerForValue: aValue ].
+
+	self
+		doTestFuntionWithArgumentType: interpreter libFFI sint32
+		smalltalkValue: aValueToStore
+		expectedValue: aValue
+]
+
+{ #category : #'tests - parameters marshalling' }
+VMFFIArgumentMarshallingTest >> testCalloutWithSINT32ArgumentWithLargePositiveHigherThan4BytesFails [
+
+	| aValue |
+
+	aValue := self wordSize = 8
+		                ifTrue: [ memory integerObjectOf: UINT32_MAX * 2 ]
+		                ifFalse: [ self newLargeIntegerForValue: UINT32_MAX * 2 ].
+
+	self
+		doTestFuntionWithArgumentType: interpreter libFFI sint32
+		smalltalkValue: aValue
+		failsWith: PrimErrBadArgument
 ]
 
 { #category : #'tests - parameters marshalling' }
@@ -302,6 +355,36 @@ VMFFIArgumentMarshallingTest >> testCalloutWithUINT16WithPositiveOutOfRangeFails
 ]
 
 { #category : #'tests - parameters marshalling' }
+VMFFIArgumentMarshallingTest >> testCalloutWithUINT32ArgumentWithLargePositiveHigherThan4BytesFails [
+
+	| aValue |
+
+	aValue := self wordSize = 8
+		                ifTrue: [ memory integerObjectOf: UINT32_MAX * 2 ]
+		                ifFalse: [ self newLargeIntegerForValue: UINT32_MAX * 2 ].
+
+	self
+		doTestFuntionWithArgumentType: interpreter libFFI uint32
+		smalltalkValue: aValue
+		failsWith: PrimErrBadArgument
+]
+
+{ #category : #'tests - parameters marshalling' }
+VMFFIArgumentMarshallingTest >> testCalloutWithUINT32ArgumentWithLargePositiveValueIsMarshalledCorrectly [
+
+	| aValue |
+
+	aValue := self wordSize = 8
+		                ifTrue: [ memory integerObjectOf: 16r3FFFFFFF + 2 ]
+		                ifFalse: [ self newLargeIntegerForValue: 16r3FFFFFFF + 2 ].
+
+	self
+		doTestFuntionWithArgumentType: interpreter libFFI uint32
+		smalltalkValue: aValue
+		expectedValue: 16r3FFFFFFF + 2
+]
+
+{ #category : #'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithUINT32ArgumentWithNegatieValueFails [
 
 	self
@@ -323,9 +406,10 @@ VMFFIArgumentMarshallingTest >> testCalloutWithUINT32ArgumentWithPositiveValueIs
 VMFFIArgumentMarshallingTest >> testCalloutWithUINT32WithPositiveOutOfRangeFailsWithPrimErrBadArgument [
 
 	| valueToStore |
-	valueToStore := self wordSize = 8 
-		ifTrue: [ memory integerObjectOf: UINT32_MAX + 1 ]
-		ifFalse: [ memory signed32BitIntegerFor: UINT32_MAX + 1 ].
+
+	valueToStore := self wordSize = 8
+		                ifTrue: [ memory integerObjectOf: UINT32_MAX + 1 ]
+		                ifFalse: [ self newLargeIntegerForValue: UINT32_MAX + 1 ].
 
 	self
 		doTestFuntionWithArgumentType: interpreter libFFI uint32


### PR DESCRIPTION
- Fixing issues in the marshalling of 32bits numbers when they are LargeIntegers (in 32 bits machines)

- Adding tests