### PR TITLE
Fix issue on local vars renaming with inline

### DIFF
--- a/smalltalksrc/Slang/TMethod.class.st
+++ b/smalltalksrc/Slang/TMethod.class.st
@@ -2462,7 +2462,7 @@ TMethod >> renameVariablesUsing: aDictionary [
 			(aDictionary at: oldName ifAbsent: nil)
 				ifNotNil: [ :newName | 
 					| index |
-					index := decl indexOfWord: oldName.
+					index := decl findLastOccurrenceOfString: oldName startingAt: 1.
 					newDecls
 						at: newName
 						put:

--- a/smalltalksrc/VMMakerTests/VMMASTTranslationTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMMASTTranslationTest.class.st
@@ -41,6 +41,16 @@ VMMASTTranslationTest >> inlineTwiceSecondLevelMethodWithLoop [
 ]
 
 { #category : #'generation-targets' }
+VMMASTTranslationTest >> inlinedMethodWithLocalWithSameName [
+
+	<inline:true>
+	<var: 'cond' type: 'pthread_cond_t'>
+	| cond |
+	cond := 50
+
+]
+
+{ #category : #'generation-targets' }
 VMMASTTranslationTest >> methodWithArgument: anArgument [
 ]
 
@@ -96,6 +106,15 @@ VMMASTTranslationTest >> methodWithIfNotNilWithArgument [
 
 	self something ifNotNil: [ :soSomething |
 		self lala: soSomething ]
+]
+
+{ #category : #'generation-targets' }
+VMMASTTranslationTest >> methodWithLocalVarAndAndInlinedMethod [
+
+	<var: 'cond' type: 'pthread_cond_t'>
+	| cond |
+	cond := 42.
+	self inlinedMethodWithLocalWithSameName.
 ]
 
 { #category : #'generation-targets' }
@@ -316,6 +335,26 @@ VMMASTTranslationTest >> testInlineTwiceSecondLevelMethodWithLoopDeclaresLoopInd
 	codeGenerator doInlining: true.
 
 	self assert: translation locals size equals: 2
+]
+
+{ #category : #tests }
+VMMASTTranslationTest >> testInlinedLocalVariableWithSameNameIsProperlyRenamed [
+
+	|  method codeGenerator  methodTranslation inlinedMethod inlinedMethodTranslation |
+	method := (self class >> #methodWithLocalVarAndAndInlinedMethod).
+	methodTranslation := method asTranslationMethodOfClass: TMethod.
+	methodTranslation declarations at: #cond put: 'pthread_cond_t cond'. 
+
+	inlinedMethod := (self class >> #inlinedMethodWithLocalWithSameName).
+	inlinedMethodTranslation := inlinedMethod asTranslationMethodOfClass: TMethod.
+	inlinedMethodTranslation declarations at: #cond put: 'pthread_cond_t cond'. 
+	
+	codeGenerator := CCodeGeneratorGlobalStructure new.
+	codeGenerator addMethod: methodTranslation.
+	codeGenerator addMethod: inlinedMethodTranslation.
+	codeGenerator doInlining: true.
+
+	self assert: (methodTranslation declarations at: #cond1) equals: 'pthread_cond_t cond1'
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Correct the renaming of declaration of inlined locals with the same name.
