### PR TITLE
Unicorn 2.0 and processor simulators cleanup

### DIFF
--- a/smalltalksrc/VMMaker-Tools/VMDebugger.class.st
+++ b/smalltalksrc/VMMaker-Tools/VMDebugger.class.st
@@ -76,7 +76,7 @@ VMDebugger >> connectPresenters [
 { #category : #actions }
 VMDebugger >> disassembleAtPC [
 
-	self initialInstructionToDisassemble:  machineSimulator instructionPointerValue.
+	self initialInstructionToDisassemble:  machineSimulator instructionPointerRegisterValue.
 	self refreshInstructions.
 ]
 
@@ -91,7 +91,7 @@ VMDebugger >> initialDisassembly [
 			copyFrom: self initialInstructionToDisassemble - cogit objectMemory memory initialAddress + 1
 			to: self initialInstructionToDisassemble - cogit objectMemory memory initialAddress + 600)
 		startAddress: self initialInstructionToDisassemble
-		pc: machineSimulator instructionPointerValue 
+		pc: machineSimulator instructionPointerRegisterValue 
 ]
 
 { #category : #showing }
@@ -104,7 +104,7 @@ VMDebugger >> initialExtent [
 VMDebugger >> initialInstructionToDisassemble [
 
 	^ initialInstructionToDisassemble
-		ifNil: [ machineSimulator instructionPointerValue ]
+		ifNil: [ machineSimulator instructionPointerRegisterValue ]
 ]
 
 { #category : #showing }
@@ -127,7 +127,7 @@ VMDebugger >> initializePresenters [
 		addColumn: (SpStringTableColumn evaluated: [ :item | item address hex ]);
 		addColumn:
 			((SpImageTableColumn evaluated: [ :item | 
-				item address = machineSimulator instructionPointerValue
+				item address = machineSimulator instructionPointerRegisterValue
 					ifTrue: [ self iconNamed: #forward ] ])
 				width: 50;
 				yourself);
@@ -196,7 +196,7 @@ VMDebugger >> runToSelectedInstruction [
 	selectedInstruction := self selectedInstruction.
 
 	machineSimulator
-		startAt: machineSimulator instructionPointerValue
+		startAt: machineSimulator instructionPointerRegisterValue
 		until: selectedInstruction address
 		timeout: 100000 "microseconds = 100ms"
 		count: 0.
@@ -218,7 +218,7 @@ VMDebugger >> selectedInstruction [
 { #category : #actions }
 VMDebugger >> setInstructionPointerToSelectedInstruction [
 	
-	machineSimulator instructionPointerValue: instructions selection selectedItem address
+	machineSimulator instructionPointerRegisterValue: instructions selection selectedItem address
 ]
 
 { #category : #actions }

--- a/smalltalksrc/VMMaker-Tools/VMMachineCodeDebugger.class.st
+++ b/smalltalksrc/VMMaker-Tools/VMMachineCodeDebugger.class.st
@@ -120,7 +120,7 @@ VMMachineCodeDebugger >> connectPresenters [
 { #category : #actions }
 VMMachineCodeDebugger >> disassembleAtPC [
 
-	self initialInstructionToDisassemble:  machineSimulator instructionPointerValue.
+	self initialInstructionToDisassemble:  machineSimulator instructionPointerRegisterValue.
 	self refreshInstructions.
 ]
 
@@ -135,7 +135,7 @@ VMMachineCodeDebugger >> doInitialDisassemble [
 			copyFrom: self initialInstructionToDisassemble
 			to: self initialInstructionToDisassemble + 600)
 		startAddress: self initialInstructionToDisassemble
-		pc: machineSimulator instructionPointerValue 
+		pc: machineSimulator instructionPointerRegisterValue 
 ]
 
 { #category : #showing }
@@ -160,7 +160,7 @@ VMMachineCodeDebugger >> initialExtent [
 VMMachineCodeDebugger >> initialInstructionToDisassemble [
 
 	^ initialInstructionToDisassemble
-		ifNil: [ machineSimulator instructionPointerValue ]
+		ifNil: [ machineSimulator instructionPointerRegisterValue ]
 ]
 
 { #category : #showing }
@@ -231,7 +231,7 @@ VMMachineCodeDebugger >> inspectSelectedInstruction [
 { #category : #actions }
 VMMachineCodeDebugger >> jump [
 
-	machineSimulator instructionPointerValue: (NumberParser parse: ipInput text).
+	machineSimulator instructionPointerRegisterValue: (NumberParser parse: ipInput text).
 	self refreshInstructions.
 	self refreshRegisters.
 ]
@@ -282,7 +282,7 @@ VMMachineCodeDebugger >> runToSelectedInstruction [
 	selectedInstruction := self selectedInstruction.
 
 	machineSimulator
-		startAt: machineSimulator instructionPointerValue
+		startAt: machineSimulator instructionPointerRegisterValue
 		until: selectedInstruction address
 		timeout: 100000 "microseconds = 100ms"
 		count: 0.
@@ -298,7 +298,7 @@ VMMachineCodeDebugger >> selectedInstruction [
 { #category : #actions }
 VMMachineCodeDebugger >> setInstructionPointerToSelectedInstruction [
 	
-	machineSimulator instructionPointerValue: instructions selection selectedItem address
+	machineSimulator instructionPointerRegisterValue: instructions selection selectedItem address
 ]
 
 { #category : #actions }

--- a/smalltalksrc/VMMaker-Tools/VMMachineCodeDebuggerInstruction.class.st
+++ b/smalltalksrc/VMMaker-Tools/VMMachineCodeDebuggerInstruction.class.st
@@ -54,7 +54,7 @@ VMMachineCodeDebuggerInstruction >> debugger: aVMMachineCodeDebugger [
 { #category : #showing }
 VMMachineCodeDebuggerInstruction >> icon [
 
-	self address = machineSimulator instructionPointerValue 
+	self address = machineSimulator instructionPointerRegisterValue 
 		ifTrue: [ ^ self iconNamed: #forward ].
 	
 	debugger selectedInstruction 

--- a/smalltalksrc/VMMakerTests/ProcessorSimulator.class.st
+++ b/smalltalksrc/VMMakerTests/ProcessorSimulator.class.st
@@ -4,6 +4,7 @@ Class {
 	#instVars : [
 		'simulator',
 		'registerAliases',
+		'registerSmalltalkAliases',
 		'memory'
 	],
 	#category : #VMMakerTests
@@ -43,11 +44,11 @@ ProcessorSimulator class >> aarch64 [
 ProcessorSimulator class >> riscv64 [
 
 	"TODO: Add riscv32 and possibly two subclasses for the RISCV simulator"
-	"^ UnicornRISCVSimulator new"
-	^ SpikeRISCVSimulator new
+	^ UnicornRISCVSimulator new
+	"^ SpikeRISCVSimulator new"
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 ProcessorSimulator class >> simulatorFor: isa [
 
 	^ (self subclasses detect: [ :each | each supportsISA: isa ]) perform: isa asSymbol
@@ -57,6 +58,12 @@ ProcessorSimulator class >> simulatorFor: isa [
 ProcessorSimulator >> aliasForRegister: aRegisterName [
 
 	^ registerAliases at: aRegisterName ifAbsent: [ '' ]
+]
+
+{ #category : #accessing }
+ProcessorSimulator >> aliasSmalltalkForRegister: aRegisterName [
+
+	^ registerSmalltalkAliases at: aRegisterName ifAbsent: [ '' ]
 ]
 
 { #category : #registers }
@@ -309,7 +316,7 @@ ProcessorSimulator >> doublePrecisionFloatingPointRegister2Value [
 { #category : #disassembling }
 ProcessorSimulator >> extractDestinationRegisterFromAssembly: aLLVMInstruction [
 
-	self subclassResponsibility
+	^  (aLLVMInstruction assemblyCodeString substrings: String tab, ',') second trimBoth
 ]
 
 { #category : #memory }
@@ -349,9 +356,11 @@ ProcessorSimulator >> framePointerRegisterValue: aValue [
 ]
 
 { #category : #accessing }
-ProcessorSimulator >> getLastAddress: abstractInstructions [
-
-	^ abstractInstructions last address + abstractInstructions last machineCodeSize
+ProcessorSimulator >> getLastAddress: abstractInstructions [ 
+	
+	| last |
+	last := (abstractInstructions reject: [ :e | e isLiteral ]) last.
+	^ last address + last machineCodeSize 
 ]
 
 { #category : #testing }
@@ -361,7 +370,23 @@ ProcessorSimulator >> hasLinkRegister [
 ]
 
 { #category : #initialization }
+ProcessorSimulator >> initialize [ 
+
+	super initialize.
+	registerAliases := Dictionary new.
+	registerSmalltalkAliases := Dictionary new.
+	self initializeRegisterAliases.
+	self initializeRegisterSmalltalkAliases.
+]
+
+{ #category : #initialization }
 ProcessorSimulator >> initializeRegisterAliases [
+
+	"Hook for subclasses"
+]
+
+{ #category : #initialization }
+ProcessorSimulator >> initializeRegisterSmalltalkAliases [
 
 	"Hook for subclasses"
 ]
@@ -624,11 +649,12 @@ ProcessorSimulator >> registerAliases [
 { #category : #registers }
 ProcessorSimulator >> registerDescriptors [
 
-	^ self registerList collect: [ :e |
-		UnicornRegisterDescriptor new
+	^ self registerList collect: [ :reg |
+		RegisterDescriptor new
 			simulator: self;
-			alias: (self aliasForRegister: e);
-			name: e;
+			alias: (self aliasForRegister: reg);
+			smalltalkAlias: (self aliasSmalltalkForRegister: reg);
+			name: reg;
 			yourself ]
 ]
 
@@ -653,7 +679,7 @@ ProcessorSimulator >> returnRegisterValue: aValue [
 { #category : #registers }
 ProcessorSimulator >> sendNumberOfArgumentsRegister [
 
-	self subclassResponsibility
+	^ SpikeRISCVRegisters x25
 ]
 
 { #category : #registers }

--- a/smalltalksrc/VMMakerTests/ProcessorSimulator.class.st
+++ b/smalltalksrc/VMMakerTests/ProcessorSimulator.class.st
@@ -97,6 +97,12 @@ ProcessorSimulator >> arg1RegisterValue [
 ]
 
 { #category : #registers }
+ProcessorSimulator >> arg1RegisterValue: aValue [
+
+	^ self writeRegister: self arg1Register value: aValue
+]
+
+{ #category : #registers }
 ProcessorSimulator >> baseRegister [
 
 	self subclassResponsibility
@@ -272,15 +278,15 @@ ProcessorSimulator >> doublePrecisionFloatingPointRegister0 [
 ]
 
 { #category : #registers }
-ProcessorSimulator >> doublePrecisionFloatingPointRegister0: aValue [
-
-	^ self writeFloat64Register: self doublePrecisionFloatingPointRegister0 value: aValue
-]
-
-{ #category : #registers }
 ProcessorSimulator >> doublePrecisionFloatingPointRegister0Value [
 
 	^ self readFloat64Register: self doublePrecisionFloatingPointRegister0
+]
+
+{ #category : #registers }
+ProcessorSimulator >> doublePrecisionFloatingPointRegister0Value: aValue [
+
+	^ self writeFloat64Register: self doublePrecisionFloatingPointRegister0 value: aValue
 ]
 
 { #category : #registers }
@@ -290,15 +296,15 @@ ProcessorSimulator >> doublePrecisionFloatingPointRegister1 [
 ]
 
 { #category : #registers }
-ProcessorSimulator >> doublePrecisionFloatingPointRegister1: aValue [
-
-	^ self writeFloat64Register: self doublePrecisionFloatingPointRegister1 value: aValue
-]
-
-{ #category : #registers }
 ProcessorSimulator >> doublePrecisionFloatingPointRegister1Value [
 
 	^ self readFloat64Register: self doublePrecisionFloatingPointRegister1
+]
+
+{ #category : #registers }
+ProcessorSimulator >> doublePrecisionFloatingPointRegister1Value: aValue [
+
+	^ self writeFloat64Register: self doublePrecisionFloatingPointRegister1 value: aValue
 ]
 
 { #category : #registers }
@@ -308,15 +314,15 @@ ProcessorSimulator >> doublePrecisionFloatingPointRegister2 [
 ]
 
 { #category : #registers }
-ProcessorSimulator >> doublePrecisionFloatingPointRegister2: aValue [
-
-	^ self writeFloat64Register: self doublePrecisionFloatingPointRegister2 value: aValue
-]
-
-{ #category : #registers }
 ProcessorSimulator >> doublePrecisionFloatingPointRegister2Value [
 
 	^ self readFloat64Register: self doublePrecisionFloatingPointRegister2
+]
+
+{ #category : #registers }
+ProcessorSimulator >> doublePrecisionFloatingPointRegister2Value: aValue [
+
+	^ self writeFloat64Register: self doublePrecisionFloatingPointRegister2 value: aValue
 ]
 
 { #category : #disassembling }
@@ -641,12 +647,6 @@ ProcessorSimulator >> register: anIndex readInto: aByteArray [
 ]
 
 { #category : #registers }
-ProcessorSimulator >> register: aRegisterIndex write: aByteArray [
-
-	simulator register: aRegisterIndex readInto: aByteArray
-]
-
-{ #category : #registers }
 ProcessorSimulator >> registerAliases [
 
 	^ registerAliases
@@ -673,11 +673,6 @@ ProcessorSimulator >> registerList [
 { #category : #registers }
 ProcessorSimulator >> sendNumberOfArgumentsRegister [
 
-	^ SpikeRISCVRegisters x25
-]
-
-{ #category : #registers }
-ProcessorSimulator >> sendNumberOfArgumentsRegister: anInteger [
 	self shouldBeImplemented.
 ]
 

--- a/smalltalksrc/VMMakerTests/ProcessorSimulator.class.st
+++ b/smalltalksrc/VMMakerTests/ProcessorSimulator.class.st
@@ -9,8 +9,46 @@ Class {
 	#category : #VMMakerTests
 }
 
+{ #category : #'instance creation' }
+ProcessorSimulator class >> ARMv5 [
+
+	^ UnicornARMv5Simulator new
+]
+
+{ #category : #'instance creation' }
+ProcessorSimulator class >> ARMv8 [
+
+	^ UnicornARMv8Simulator new
+]
+
+{ #category : #'instance creation' }
+ProcessorSimulator class >> IA32 [
+
+	^ UnicornI386Simulator new
+]
+
+{ #category : #'instance creation' }
+ProcessorSimulator class >> X64 [
+
+	^ UnicornX64Simulator new
+]
+
+{ #category : #'instance creation' }
+ProcessorSimulator class >> aarch64 [
+
+	^ UnicornARMv8Simulator new
+]
+
+{ #category : #'instance creation' }
+ProcessorSimulator class >> riscv64 [
+
+	"TODO: Add riscv32 and possibly two subclasses for the RISCV simulator"
+	"^ UnicornRISCVSimulator new"
+	^ SpikeRISCVSimulator new
+]
+
 { #category : #'as yet unclassified' }
-ProcessorSimulator class >> simulatorFor: isa [ 
+ProcessorSimulator class >> simulatorFor: isa [
 
 	^ (self subclasses detect: [ :each | each supportsISA: isa ]) perform: isa asSymbol
 ]
@@ -23,8 +61,8 @@ ProcessorSimulator >> aliasForRegister: aRegisterName [
 
 { #category : #registers }
 ProcessorSimulator >> arg0Register [
-	
-	^ self subclassResponsibility 
+
+	^ self subclassResponsibility
 ]
 
 { #category : #registers }
@@ -54,7 +92,7 @@ ProcessorSimulator >> arg1RegisterValue [
 { #category : #registers }
 ProcessorSimulator >> baseRegister [
 
-	self subclassResponsibility 
+	self subclassResponsibility
 ]
 
 { #category : #registers }
@@ -69,15 +107,15 @@ ProcessorSimulator >> baseRegisterValue: aValue [
 	^ self writeRegister: self baseRegister value: aValue
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'c calling convention' }
 ProcessorSimulator >> cResultRegister [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #'as yet unclassified' }
-ProcessorSimulator >> cReturnRegisterValue: aValue [ 
-	
+{ #category : #'c calling convention' }
+ProcessorSimulator >> cReturnRegisterValue: aValue [
+
 	self writeRegister: self cResultRegister value: aValue
 ]
 
@@ -183,7 +221,7 @@ ProcessorSimulator >> cogit [
 
 { #category : #disassembling }
 ProcessorSimulator >> disassembleCurrentInstruction [
-	
+
 	^ (self disassembleFrom: self instructionPointerRegisterValue opcodes: 1) first
 ]
 
@@ -199,7 +237,7 @@ ProcessorSimulator >> disassembleFrom: anIndex opcodes: numberOfInstructions [
 ]
 
 { #category : #disassembling }
-ProcessorSimulator >> disassembleFrom: start to: stop [ 
+ProcessorSimulator >> disassembleFrom: start to: stop [
 
 	^ self disassembler
 		printImmediatesInHexa;
@@ -214,70 +252,70 @@ ProcessorSimulator >> disassembler [
 	self subclassResponsibility
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #registers }
 ProcessorSimulator >> doublePrecisionFloatingPointRegister0 [
 
-	self subclassResponsibility 
+	self subclassResponsibility
 ]
 
 { #category : #registers }
 ProcessorSimulator >> doublePrecisionFloatingPointRegister0: aValue [
-	
+
 	^ self writeFloat64Register: self doublePrecisionFloatingPointRegister0 value: aValue
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #registers }
 ProcessorSimulator >> doublePrecisionFloatingPointRegister0Value [
 
 	^ self readFloat64Register: self doublePrecisionFloatingPointRegister0
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #registers }
 ProcessorSimulator >> doublePrecisionFloatingPointRegister1 [
 
-	self subclassResponsibility 
+	self subclassResponsibility
 ]
 
 { #category : #registers }
 ProcessorSimulator >> doublePrecisionFloatingPointRegister1: aValue [
-	
+
 	^ self writeFloat64Register: self doublePrecisionFloatingPointRegister1 value: aValue
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #registers }
 ProcessorSimulator >> doublePrecisionFloatingPointRegister1Value [
 
 	^ self readFloat64Register: self doublePrecisionFloatingPointRegister1
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #registers }
 ProcessorSimulator >> doublePrecisionFloatingPointRegister2 [
 
-	self subclassResponsibility 
+	self subclassResponsibility
 ]
 
 { #category : #registers }
 ProcessorSimulator >> doublePrecisionFloatingPointRegister2: aValue [
-	
+
 	^ self writeFloat64Register: self doublePrecisionFloatingPointRegister2 value: aValue
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #registers }
 ProcessorSimulator >> doublePrecisionFloatingPointRegister2Value [
 
 	^ self readFloat64Register: self doublePrecisionFloatingPointRegister2
 ]
 
 { #category : #disassembling }
-ProcessorSimulator >> extractDestinationRegisterFromAssembly: aLLVMInstruction [ 
-	
+ProcessorSimulator >> extractDestinationRegisterFromAssembly: aLLVMInstruction [
+
 	self subclassResponsibility
 ]
 
 { #category : #memory }
-ProcessorSimulator >> finishMappingMemory [ 
+ProcessorSimulator >> finishMappingMemory [
 
-	self subclassResponsibility 
+	self subclassResponsibility
 ]
 
 { #category : #shortcut }
@@ -294,7 +332,7 @@ ProcessorSimulator >> fp: aValue [
 
 { #category : #registers }
 ProcessorSimulator >> framePointerRegister [
-	
+
 	^ self subclassResponsibility
 ]
 
@@ -306,20 +344,20 @@ ProcessorSimulator >> framePointerRegisterValue [
 
 { #category : #registers }
 ProcessorSimulator >> framePointerRegisterValue: aValue [
-	
+
 	self writeRegister: self framePointerRegister value: aValue
 ]
 
 { #category : #accessing }
-ProcessorSimulator >> getLastAddress: abstractInstructions [ 
+ProcessorSimulator >> getLastAddress: abstractInstructions [
 
 	^ abstractInstructions last address + abstractInstructions last machineCodeSize
 ]
 
 { #category : #testing }
 ProcessorSimulator >> hasLinkRegister [
-	
-	self subclassResponsibility 
+
+	self subclassResponsibility
 ]
 
 { #category : #initialization }
@@ -336,54 +374,54 @@ ProcessorSimulator >> instructionPointerRegister [
 
 { #category : #registers }
 ProcessorSimulator >> instructionPointerRegisterValue [
-	
+
 	^ self readRegister: self instructionPointerRegister
 ]
 
 { #category : #registers }
 ProcessorSimulator >> instructionPointerRegisterValue: aValue [
-	
+
 	^ self writeRegister: self instructionPointerRegister value: aValue
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #registers }
 ProcessorSimulator >> integerRegisterState [
-	
+
 	^ {  }
 ]
 
 { #category : #accessing }
 ProcessorSimulator >> lastExecutedInstructionAddress [
 
-	^ simulator lastExecutedInstructionAddress 
+	^ simulator lastExecutedInstructionAddress
 ]
 
 { #category : #accessing }
 ProcessorSimulator >> lastExecutedInstructionSize [
 
-	^ simulator lastExecutedInstructionSize 
+	^ simulator lastExecutedInstructionSize
 ]
 
 { #category : #accessing }
 ProcessorSimulator >> lastInstructionCount [
-	
-	^ simulator lastInstructionCount 
+
+	^ simulator lastInstructionCount
 ]
 
 { #category : #registers }
-ProcessorSimulator >> linkRegister [ 
+ProcessorSimulator >> linkRegister [
 
 	self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : #registers }
 ProcessorSimulator >> linkRegisterValue [
 
-	^ self readRegister: self linkRegister 
+	^ self readRegister: self linkRegister
 ]
 
 { #category : #registers }
-ProcessorSimulator >> linkRegisterValue: aValue [ 
+ProcessorSimulator >> linkRegisterValue: aValue [
 
 	^ self writeRegister: self linkRegister value: aValue
 ]
@@ -391,7 +429,7 @@ ProcessorSimulator >> linkRegisterValue: aValue [
 { #category : #shortcut }
 ProcessorSimulator >> lr [
 
-	^ self linkRegisterValue 
+	^ self linkRegisterValue
 ]
 
 { #category : #shortcut }
@@ -425,13 +463,13 @@ ProcessorSimulator >> memory [
 
 { #category : #accessing }
 ProcessorSimulator >> memory: aSpur64BitMMLECoSimulator [
-	
-	memory := aSpur64BitMMLECoSimulator 
+
+	memory := aSpur64BitMMLECoSimulator
 ]
 
 { #category : #memory }
 ProcessorSimulator >> memoryAt: address readNext: byteSize [
-	
+
 	^ simulator memoryAt: address readNext: byteSize
 ]
 
@@ -463,17 +501,17 @@ ProcessorSimulator >> peek [
 
 	"Putting the value in the stack memory"
 	peekedByteArray := self memoryAt: stackAddressIntegerValue readNext: self wordSize.
-	
+
 	^ peekedByteArray
 ]
 
 { #category : #'helpers - stack' }
 ProcessorSimulator >> peekAddress [
-	
+
 	^ self peek integerAt: 1 size: self wordSize signed: false
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'helpers - stack' }
 ProcessorSimulator >> popBytes [
 
 	| stackAddressIntegerValue aByteArray |
@@ -482,15 +520,15 @@ ProcessorSimulator >> popBytes [
 	stackAddressIntegerValue := self stackPointerRegisterValue.
 	"Putting the value from the stack memory"
 	aByteArray := self memoryAt: stackAddressIntegerValue readNext: self wordSize.
-	
+
 	"Updating SP"
 	stackAddressIntegerValue := stackAddressIntegerValue + self wordSize.
 	self stackPointerRegisterValue: stackAddressIntegerValue.
-	
+
 	^ aByteArray
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'helpers - stack' }
 ProcessorSimulator >> popWord [
 
 	| aByteArray |
@@ -498,8 +536,8 @@ ProcessorSimulator >> popWord [
 	^ aByteArray integerAt: 1 size: self wordSize signed: false.
 ]
 
-{ #category : #'as yet unclassified' }
-ProcessorSimulator >> pushBytes: aByteArray [ 
+{ #category : #'helpers - stack' }
+ProcessorSimulator >> pushBytes: aByteArray [
 
 	| stackAddressIntegerValue |
 	self assert: aByteArray size = self wordSize.
@@ -510,7 +548,7 @@ ProcessorSimulator >> pushBytes: aByteArray [
 	"Updating SP"
 	stackAddressIntegerValue := stackAddressIntegerValue - self wordSize.
 	self stackPointerRegisterValue: stackAddressIntegerValue.
-	
+
 	"Putting the value in the stack memory"
 	self
 		memoryAt: stackAddressIntegerValue
@@ -519,8 +557,8 @@ ProcessorSimulator >> pushBytes: aByteArray [
 
 ]
 
-{ #category : #'as yet unclassified' }
-ProcessorSimulator >> pushWord: anInteger [ 
+{ #category : #'helpers - stack' }
+ProcessorSimulator >> pushWord: anInteger [
 
 	| aByteArray |
 	aByteArray := ByteArray new: self wordSize.
@@ -528,13 +566,13 @@ ProcessorSimulator >> pushWord: anInteger [
 	self pushBytes: aByteArray
 ]
 
-{ #category : #'as yet unclassified' }
-ProcessorSimulator >> readFloat64Register: aRegisterID [ 
+{ #category : #registers }
+ProcessorSimulator >> readFloat64Register: aRegisterID [
 
 	| registerValue |
 	registerValue := ByteArray new: 8.
 	simulator register: aRegisterID value readInto: registerValue.
-	
+
 	^ registerValue doubleAt: 1
 ]
 
@@ -549,8 +587,8 @@ ProcessorSimulator >> readRegister: aRegisterID [
 
 { #category : #registers }
 ProcessorSimulator >> receiverRegister [
-	
-	^ self subclassResponsibility 
+
+	^ self subclassResponsibility
 ]
 
 { #category : #registers }
@@ -560,26 +598,32 @@ ProcessorSimulator >> receiverRegisterValue [
 ]
 
 { #category : #registers }
-ProcessorSimulator >> receiverRegisterValue: anInteger [ 
+ProcessorSimulator >> receiverRegisterValue: anInteger [
 
 	self writeRegister: self receiverRegister value: anInteger
 ]
 
 { #category : #registers }
-ProcessorSimulator >> register: anIndex readInto: aByteArray [ 
+ProcessorSimulator >> register: anIndex readInto: aByteArray [
 
-	simulator register: anIndex readInto: aByteArray 
+	simulator register: anIndex readInto: aByteArray
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #registers }
 ProcessorSimulator >> register: aRegisterIndex write: aByteArray [
 
-	simulator register: aRegisterIndex readInto: aByteArray 
+	simulator register: aRegisterIndex readInto: aByteArray
 ]
 
-{ #category : #accessing }
+{ #category : #registers }
+ProcessorSimulator >> registerAliases [
+
+	^ registerAliases
+]
+
+{ #category : #registers }
 ProcessorSimulator >> registerDescriptors [
-	
+
 	^ self registerList collect: [ :e |
 		UnicornRegisterDescriptor new
 			simulator: self;
@@ -589,20 +633,20 @@ ProcessorSimulator >> registerDescriptors [
 ]
 
 { #category : #registers }
-ProcessorSimulator >> registerList [ 
+ProcessorSimulator >> registerList [
 
-	self subclassResponsibility 
+	self subclassResponsibility
 ]
 
 { #category : #registers }
 ProcessorSimulator >> returnRegisterValue [
-	
+
 	^ self receiverRegisterValue
 ]
 
 { #category : #registers }
 ProcessorSimulator >> returnRegisterValue: aValue [
-	
+
 	^ self receiverRegisterValue: aValue
 ]
 
@@ -613,7 +657,7 @@ ProcessorSimulator >> sendNumberOfArgumentsRegister [
 ]
 
 { #category : #registers }
-ProcessorSimulator >> sendNumberOfArgumentsRegister: anInteger [ 
+ProcessorSimulator >> sendNumberOfArgumentsRegister: anInteger [
 	self shouldBeImplemented.
 ]
 
@@ -629,13 +673,13 @@ ProcessorSimulator >> sendNumberOfArgumentsRegisterValue: aValue [
 	^ self writeRegister: self sendNumberOfArgumentsRegister value: aValue
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #actions }
 ProcessorSimulator >> simulateLeafCallOf: address nextpc: nextpc memory: aMemory [
 
 	self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : #registers }
 ProcessorSimulator >> smalltalkStackPointerRegister [
 	"By default they are the same"
 	^ self stackPointerRegister
@@ -649,19 +693,19 @@ ProcessorSimulator >> smalltalkStackPointerRegisterValue [
 
 { #category : #registers }
 ProcessorSimulator >> smalltalkStackPointerRegisterValue: aValue [
-	
+
 	self writeRegister: self smalltalkStackPointerRegister value: aValue
 ]
 
 { #category : #registers }
 ProcessorSimulator >> smashRegisterAccessors [
-	
-	^ self subclassResponsibility 
+
+	^ self subclassResponsibility
 ]
 
 { #category : #registers }
-ProcessorSimulator >> smashRegistersWithValuesFrom: base by: step [ 
-	
+ProcessorSimulator >> smashRegistersWithValuesFrom: base by: step [
+
 	self smashRegisterAccessors withIndexDo: [:accessor :index|
 		self perform: accessor with: index - 1 * step + base]
 ]
@@ -680,7 +724,7 @@ ProcessorSimulator >> sp: aValue [
 
 { #category : #registers }
 ProcessorSimulator >> stackPointerRegister [
-	
+
 	self subclassResponsibility
 ]
 
@@ -692,7 +736,7 @@ ProcessorSimulator >> stackPointerRegisterValue [
 
 { #category : #registers }
 ProcessorSimulator >> stackPointerRegisterValue: aValue [
-	
+
 	self writeRegister: self stackPointerRegister value: aValue
 ]
 
@@ -725,19 +769,19 @@ ProcessorSimulator >> stackValueBytesAt: position [
 
 { #category : #accessing }
 ProcessorSimulator >> stackValues [
-	
+
 	| initialValue |
 	initialValue := self smalltalkStackPointerRegisterValue.
-	
-	^ (1 to: 30) collect: [ :anIndex |  
-		VMMachineCodeDebuggerStackItem address: initialValue + (memory wordSize * (anIndex - 1)) on: self.	
-	] 
+
+	^ (1 to: 30) collect: [ :anIndex |
+		VMMachineCodeDebuggerStackItem address: initialValue + (memory wordSize * (anIndex - 1)) on: self.
+	]
 ]
 
 { #category : #actions }
 ProcessorSimulator >> startAt: begin until: until timeout: timeout count: count [
 
-	self subclassResponsibility 
+	self subclassResponsibility
 
 ]
 
@@ -757,7 +801,7 @@ ProcessorSimulator >> temporaryRegister [
 	^ self subclassResponsibility
 ]
 
-{ #category : #accessing }
+{ #category : #registers }
 ProcessorSimulator >> temporaryRegisterValue [
 
 	^ self readRegister: self temporaryRegister
@@ -770,8 +814,8 @@ ProcessorSimulator >> temporaryRegisterValue: anInteger [
 ]
 
 { #category : #accessing }
-ProcessorSimulator >> wordAt: anInteger [ 
-	
+ProcessorSimulator >> wordAt: anInteger [
+
 	^ memory longAt: anInteger
 ]
 
@@ -781,7 +825,7 @@ ProcessorSimulator >> wordSize [
 ]
 
 { #category : #registers }
-ProcessorSimulator >> writeFloat64Register: aRegister value: aDouble [ 
+ProcessorSimulator >> writeFloat64Register: aRegister value: aDouble [
 
 	| value |
 	value := ByteArray new: 8.
@@ -791,7 +835,7 @@ ProcessorSimulator >> writeFloat64Register: aRegister value: aDouble [
 ]
 
 { #category : #registers }
-ProcessorSimulator >> writeRegister: aRegister value: anInteger [ 
+ProcessorSimulator >> writeRegister: aRegister value: anInteger [
 
 	| value |
 	value := ByteArray new: self wordSize.

--- a/smalltalksrc/VMMakerTests/ProcessorSimulator.class.st
+++ b/smalltalksrc/VMMakerTests/ProcessorSimulator.class.st
@@ -120,8 +120,14 @@ ProcessorSimulator >> cResultRegister [
 	^ self subclassResponsibility
 ]
 
+{ #category : #registers }
+ProcessorSimulator >> cResultRegisterValue [
+
+	^ self readRegister: self cResultRegister
+]
+
 { #category : #'c calling convention' }
-ProcessorSimulator >> cReturnRegisterValue: aValue [
+ProcessorSimulator >> cResultRegisterValue: aValue [
 
 	self writeRegister: self cResultRegister value: aValue
 ]
@@ -366,7 +372,7 @@ ProcessorSimulator >> getLastAddress: abstractInstructions [
 { #category : #testing }
 ProcessorSimulator >> hasLinkRegister [
 
-	self subclassResponsibility
+	^ false
 ]
 
 { #category : #initialization }

--- a/smalltalksrc/VMMakerTests/ProcessorSimulator.class.st
+++ b/smalltalksrc/VMMakerTests/ProcessorSimulator.class.st
@@ -1,0 +1,801 @@
+Class {
+	#name : #ProcessorSimulator,
+	#superclass : #Object,
+	#instVars : [
+		'simulator',
+		'registerAliases',
+		'memory'
+	],
+	#category : #VMMakerTests
+}
+
+{ #category : #'as yet unclassified' }
+ProcessorSimulator class >> simulatorFor: isa [ 
+
+	^ (self subclasses detect: [ :each | each supportsISA: isa ]) perform: isa asSymbol
+]
+
+{ #category : #accessing }
+ProcessorSimulator >> aliasForRegister: aRegisterName [
+
+	^ registerAliases at: aRegisterName ifAbsent: [ '' ]
+]
+
+{ #category : #registers }
+ProcessorSimulator >> arg0Register [
+	
+	^ self subclassResponsibility 
+]
+
+{ #category : #registers }
+ProcessorSimulator >> arg0RegisterValue [
+
+	^ self readRegister: self arg0Register
+]
+
+{ #category : #registers }
+ProcessorSimulator >> arg0RegisterValue: aValue [
+
+	^ self writeRegister: self arg0Register value: aValue
+]
+
+{ #category : #registers }
+ProcessorSimulator >> arg1Register [
+
+	^ self subclassResponsibility
+]
+
+{ #category : #registers }
+ProcessorSimulator >> arg1RegisterValue [
+
+	^ self readRegister: self arg1Register
+]
+
+{ #category : #registers }
+ProcessorSimulator >> baseRegister [
+
+	self subclassResponsibility 
+]
+
+{ #category : #registers }
+ProcessorSimulator >> baseRegisterValue [
+
+	^ self readRegister: self baseRegister
+]
+
+{ #category : #registers }
+ProcessorSimulator >> baseRegisterValue: aValue [
+
+	^ self writeRegister: self baseRegister value: aValue
+]
+
+{ #category : #'as yet unclassified' }
+ProcessorSimulator >> cResultRegister [
+
+	^ self subclassResponsibility
+]
+
+{ #category : #'as yet unclassified' }
+ProcessorSimulator >> cReturnRegisterValue: aValue [ 
+	
+	self writeRegister: self cResultRegister value: aValue
+]
+
+{ #category : #'c calling convention' }
+ProcessorSimulator >> carg0 [
+
+	"By default fetch values from registers, override in platforms that don't (e.g. IA32)"
+	^ self carg0RegisterValue
+]
+
+{ #category : #'c calling convention' }
+ProcessorSimulator >> carg0Register [
+
+	^ self subclassResponsibility
+]
+
+{ #category : #'c calling convention' }
+ProcessorSimulator >> carg0RegisterValue [
+
+	^ self readRegister: self carg0Register
+]
+
+{ #category : #'c calling convention' }
+ProcessorSimulator >> carg1 [
+
+	"By default fetch values from registers, override in platforms that don't (e.g. IA32)"
+	^ self carg1RegisterValue
+]
+
+{ #category : #'c calling convention' }
+ProcessorSimulator >> carg1Register [
+
+	^ self subclassResponsibility
+]
+
+{ #category : #'c calling convention' }
+ProcessorSimulator >> carg1RegisterValue [
+
+	^ self readRegister: self carg1Register
+]
+
+{ #category : #'c calling convention' }
+ProcessorSimulator >> carg2 [
+
+	"By default fetch values from registers, override in platforms that don't (e.g. IA32)"
+	^ self carg2RegisterValue
+]
+
+{ #category : #'c calling convention' }
+ProcessorSimulator >> carg2Register [
+
+	^ self subclassResponsibility
+]
+
+{ #category : #'c calling convention' }
+ProcessorSimulator >> carg2RegisterValue [
+
+	^ self readRegister: self carg2Register
+]
+
+{ #category : #'c calling convention' }
+ProcessorSimulator >> carg3 [
+
+	"By default fetch values from registers, override in platforms that don't (e.g. IA32)"
+	^ self carg3RegisterValue
+]
+
+{ #category : #'c calling convention' }
+ProcessorSimulator >> carg3Register [
+
+	^ self subclassResponsibility
+]
+
+{ #category : #'c calling convention' }
+ProcessorSimulator >> carg3RegisterValue [
+
+	^ self readRegister: self carg3Register
+]
+
+{ #category : #registers }
+ProcessorSimulator >> classRegister [
+
+	^ self subclassResponsibility
+]
+
+{ #category : #registers }
+ProcessorSimulator >> classRegisterValue [
+
+	^ self readRegister: self classRegister
+]
+
+{ #category : #registers }
+ProcessorSimulator >> classRegisterValue: aValue [
+
+	^ self writeRegister: self classRegister value: aValue
+]
+
+{ #category : #accessing }
+ProcessorSimulator >> cogit [
+
+	^ memory interpreter cogit
+]
+
+{ #category : #disassembling }
+ProcessorSimulator >> disassembleCurrentInstruction [
+	
+	^ (self disassembleFrom: self instructionPointerRegisterValue opcodes: 1) first
+]
+
+{ #category : #disassembling }
+ProcessorSimulator >> disassembleFrom: anIndex opcodes: numberOfInstructions [
+
+	^ self disassembler
+		printImmediatesInHexa;
+		disassembleNext: numberOfInstructions
+		instructionsIn: (memory memoryManager copyFrom: anIndex to: anIndex + (numberOfInstructions * 50) "rough estimate")
+		startAddress: anIndex
+		pc: self instructionPointerRegisterValue
+]
+
+{ #category : #disassembling }
+ProcessorSimulator >> disassembleFrom: start to: stop [ 
+
+	^ self disassembler
+		printImmediatesInHexa;
+		disassembleNext: 1000
+		instructionsIn: (memory memory copyFrom: start to: stop)
+		startAddress: start
+		pc: self instructionPointerRegisterValue
+]
+
+{ #category : #disassembling }
+ProcessorSimulator >> disassembler [
+	self subclassResponsibility
+]
+
+{ #category : #'as yet unclassified' }
+ProcessorSimulator >> doublePrecisionFloatingPointRegister0 [
+
+	self subclassResponsibility 
+]
+
+{ #category : #registers }
+ProcessorSimulator >> doublePrecisionFloatingPointRegister0: aValue [
+	
+	^ self writeFloat64Register: self doublePrecisionFloatingPointRegister0 value: aValue
+]
+
+{ #category : #'as yet unclassified' }
+ProcessorSimulator >> doublePrecisionFloatingPointRegister0Value [
+
+	^ self readFloat64Register: self doublePrecisionFloatingPointRegister0
+]
+
+{ #category : #'as yet unclassified' }
+ProcessorSimulator >> doublePrecisionFloatingPointRegister1 [
+
+	self subclassResponsibility 
+]
+
+{ #category : #registers }
+ProcessorSimulator >> doublePrecisionFloatingPointRegister1: aValue [
+	
+	^ self writeFloat64Register: self doublePrecisionFloatingPointRegister1 value: aValue
+]
+
+{ #category : #'as yet unclassified' }
+ProcessorSimulator >> doublePrecisionFloatingPointRegister1Value [
+
+	^ self readFloat64Register: self doublePrecisionFloatingPointRegister1
+]
+
+{ #category : #'as yet unclassified' }
+ProcessorSimulator >> doublePrecisionFloatingPointRegister2 [
+
+	self subclassResponsibility 
+]
+
+{ #category : #registers }
+ProcessorSimulator >> doublePrecisionFloatingPointRegister2: aValue [
+	
+	^ self writeFloat64Register: self doublePrecisionFloatingPointRegister2 value: aValue
+]
+
+{ #category : #'as yet unclassified' }
+ProcessorSimulator >> doublePrecisionFloatingPointRegister2Value [
+
+	^ self readFloat64Register: self doublePrecisionFloatingPointRegister2
+]
+
+{ #category : #disassembling }
+ProcessorSimulator >> extractDestinationRegisterFromAssembly: aLLVMInstruction [ 
+	
+	self subclassResponsibility
+]
+
+{ #category : #memory }
+ProcessorSimulator >> finishMappingMemory [ 
+
+	self subclassResponsibility 
+]
+
+{ #category : #shortcut }
+ProcessorSimulator >> fp [
+
+	^ self framePointerRegisterValue
+]
+
+{ #category : #shortcut }
+ProcessorSimulator >> fp: aValue [
+
+	^ self framePointerRegisterValue: aValue
+]
+
+{ #category : #registers }
+ProcessorSimulator >> framePointerRegister [
+	
+	^ self subclassResponsibility
+]
+
+{ #category : #registers }
+ProcessorSimulator >> framePointerRegisterValue [
+
+	^ self readRegister: self framePointerRegister
+]
+
+{ #category : #registers }
+ProcessorSimulator >> framePointerRegisterValue: aValue [
+	
+	self writeRegister: self framePointerRegister value: aValue
+]
+
+{ #category : #accessing }
+ProcessorSimulator >> getLastAddress: abstractInstructions [ 
+
+	^ abstractInstructions last address + abstractInstructions last machineCodeSize
+]
+
+{ #category : #testing }
+ProcessorSimulator >> hasLinkRegister [
+	
+	self subclassResponsibility 
+]
+
+{ #category : #initialization }
+ProcessorSimulator >> initializeRegisterAliases [
+
+	"Hook for subclasses"
+]
+
+{ #category : #registers }
+ProcessorSimulator >> instructionPointerRegister [
+
+	^ self subclassResponsibility
+]
+
+{ #category : #registers }
+ProcessorSimulator >> instructionPointerRegisterValue [
+	
+	^ self readRegister: self instructionPointerRegister
+]
+
+{ #category : #registers }
+ProcessorSimulator >> instructionPointerRegisterValue: aValue [
+	
+	^ self writeRegister: self instructionPointerRegister value: aValue
+]
+
+{ #category : #'as yet unclassified' }
+ProcessorSimulator >> integerRegisterState [
+	
+	^ {  }
+]
+
+{ #category : #accessing }
+ProcessorSimulator >> lastExecutedInstructionAddress [
+
+	^ simulator lastExecutedInstructionAddress 
+]
+
+{ #category : #accessing }
+ProcessorSimulator >> lastExecutedInstructionSize [
+
+	^ simulator lastExecutedInstructionSize 
+]
+
+{ #category : #accessing }
+ProcessorSimulator >> lastInstructionCount [
+	
+	^ simulator lastInstructionCount 
+]
+
+{ #category : #registers }
+ProcessorSimulator >> linkRegister [ 
+
+	self subclassResponsibility
+]
+
+{ #category : #accessing }
+ProcessorSimulator >> linkRegisterValue [
+
+	^ self readRegister: self linkRegister 
+]
+
+{ #category : #registers }
+ProcessorSimulator >> linkRegisterValue: aValue [ 
+
+	^ self writeRegister: self linkRegister value: aValue
+]
+
+{ #category : #shortcut }
+ProcessorSimulator >> lr [
+
+	^ self linkRegisterValue 
+]
+
+{ #category : #shortcut }
+ProcessorSimulator >> lr: aValue [
+
+	^ self linkRegisterValue: aValue
+]
+
+{ #category : #memory }
+ProcessorSimulator >> mapMemory: aMemory at: anAddress [
+
+	simulator
+		mapHostMemory: aMemory
+		atAddress: anAddress
+		withPermissions: UnicornConstants permissionAll.
+]
+
+{ #category : #memory }
+ProcessorSimulator >> mapMemoryInManager: aSlangMemoryManager [
+
+	aSlangMemoryManager regionsDo: [ :startAddress :region |
+		self mapMemory: region at: startAddress
+	].
+	self finishMappingMemory.
+]
+
+{ #category : #accessing }
+ProcessorSimulator >> memory [
+	^ memory
+]
+
+{ #category : #accessing }
+ProcessorSimulator >> memory: aSpur64BitMMLECoSimulator [
+	
+	memory := aSpur64BitMMLECoSimulator 
+]
+
+{ #category : #memory }
+ProcessorSimulator >> memoryAt: address readNext: byteSize [
+	
+	^ simulator memoryAt: address readNext: byteSize
+]
+
+{ #category : #memory }
+ProcessorSimulator >> memoryAt: address write: bytes size: size [
+
+	simulator memoryAt: address write: bytes size: size
+]
+
+{ #category : #shortcut }
+ProcessorSimulator >> pc [
+
+	^ self instructionPointerRegisterValue
+]
+
+{ #category : #shortcut }
+ProcessorSimulator >> pc: aValue [
+
+	^ self instructionPointerRegisterValue: aValue
+]
+
+{ #category : #'helpers - stack' }
+ProcessorSimulator >> peek [
+
+	| stackAddressIntegerValue peekedByteArray |
+
+	"Getting address from stack register"
+	stackAddressIntegerValue := self stackPointerRegisterValue.
+
+	"Putting the value in the stack memory"
+	peekedByteArray := self memoryAt: stackAddressIntegerValue readNext: self wordSize.
+	
+	^ peekedByteArray
+]
+
+{ #category : #'helpers - stack' }
+ProcessorSimulator >> peekAddress [
+	
+	^ self peek integerAt: 1 size: self wordSize signed: false
+]
+
+{ #category : #'as yet unclassified' }
+ProcessorSimulator >> popBytes [
+
+	| stackAddressIntegerValue aByteArray |
+
+	"Getting address from stack register"
+	stackAddressIntegerValue := self stackPointerRegisterValue.
+	"Putting the value from the stack memory"
+	aByteArray := self memoryAt: stackAddressIntegerValue readNext: self wordSize.
+	
+	"Updating SP"
+	stackAddressIntegerValue := stackAddressIntegerValue + self wordSize.
+	self stackPointerRegisterValue: stackAddressIntegerValue.
+	
+	^ aByteArray
+]
+
+{ #category : #'as yet unclassified' }
+ProcessorSimulator >> popWord [
+
+	| aByteArray |
+	aByteArray := self popBytes.
+	^ aByteArray integerAt: 1 size: self wordSize signed: false.
+]
+
+{ #category : #'as yet unclassified' }
+ProcessorSimulator >> pushBytes: aByteArray [ 
+
+	| stackAddressIntegerValue |
+	self assert: aByteArray size = self wordSize.
+
+	"Getting address from stack register"
+	stackAddressIntegerValue := self stackPointerRegisterValue.
+
+	"Updating SP"
+	stackAddressIntegerValue := stackAddressIntegerValue - self wordSize.
+	self stackPointerRegisterValue: stackAddressIntegerValue.
+	
+	"Putting the value in the stack memory"
+	self
+		memoryAt: stackAddressIntegerValue
+		write: aByteArray
+		size: self wordSize
+
+]
+
+{ #category : #'as yet unclassified' }
+ProcessorSimulator >> pushWord: anInteger [ 
+
+	| aByteArray |
+	aByteArray := ByteArray new: self wordSize.
+	aByteArray integerAt: 1 put: anInteger size: self wordSize signed: false.
+	self pushBytes: aByteArray
+]
+
+{ #category : #'as yet unclassified' }
+ProcessorSimulator >> readFloat64Register: aRegisterID [ 
+
+	| registerValue |
+	registerValue := ByteArray new: 8.
+	simulator register: aRegisterID value readInto: registerValue.
+	
+	^ registerValue doubleAt: 1
+]
+
+{ #category : #registers }
+ProcessorSimulator >> readRegister: aRegisterID [
+
+	| registerValue |
+	registerValue := ByteArray new: self wordSize.
+	simulator register: aRegisterID value readInto: registerValue.
+	^ registerValue integerAt: 1 size: self wordSize signed: false
+]
+
+{ #category : #registers }
+ProcessorSimulator >> receiverRegister [
+	
+	^ self subclassResponsibility 
+]
+
+{ #category : #registers }
+ProcessorSimulator >> receiverRegisterValue [
+
+	^ self readRegister: self receiverRegister
+]
+
+{ #category : #registers }
+ProcessorSimulator >> receiverRegisterValue: anInteger [ 
+
+	self writeRegister: self receiverRegister value: anInteger
+]
+
+{ #category : #registers }
+ProcessorSimulator >> register: anIndex readInto: aByteArray [ 
+
+	simulator register: anIndex readInto: aByteArray 
+]
+
+{ #category : #'as yet unclassified' }
+ProcessorSimulator >> register: aRegisterIndex write: aByteArray [
+
+	simulator register: aRegisterIndex readInto: aByteArray 
+]
+
+{ #category : #accessing }
+ProcessorSimulator >> registerDescriptors [
+	
+	^ self registerList collect: [ :e |
+		UnicornRegisterDescriptor new
+			simulator: self;
+			alias: (self aliasForRegister: e);
+			name: e;
+			yourself ]
+]
+
+{ #category : #registers }
+ProcessorSimulator >> registerList [ 
+
+	self subclassResponsibility 
+]
+
+{ #category : #registers }
+ProcessorSimulator >> returnRegisterValue [
+	
+	^ self receiverRegisterValue
+]
+
+{ #category : #registers }
+ProcessorSimulator >> returnRegisterValue: aValue [
+	
+	^ self receiverRegisterValue: aValue
+]
+
+{ #category : #registers }
+ProcessorSimulator >> sendNumberOfArgumentsRegister [
+
+	self subclassResponsibility
+]
+
+{ #category : #registers }
+ProcessorSimulator >> sendNumberOfArgumentsRegister: anInteger [ 
+	self shouldBeImplemented.
+]
+
+{ #category : #registers }
+ProcessorSimulator >> sendNumberOfArgumentsRegisterValue [
+
+	^ self readRegister: self sendNumberOfArgumentsRegister
+]
+
+{ #category : #registers }
+ProcessorSimulator >> sendNumberOfArgumentsRegisterValue: aValue [
+
+	^ self writeRegister: self sendNumberOfArgumentsRegister value: aValue
+]
+
+{ #category : #'as yet unclassified' }
+ProcessorSimulator >> simulateLeafCallOf: address nextpc: nextpc memory: aMemory [
+
+	self subclassResponsibility
+]
+
+{ #category : #accessing }
+ProcessorSimulator >> smalltalkStackPointerRegister [
+	"By default they are the same"
+	^ self stackPointerRegister
+]
+
+{ #category : #registers }
+ProcessorSimulator >> smalltalkStackPointerRegisterValue [
+
+	^ self readRegister: self smalltalkStackPointerRegister
+]
+
+{ #category : #registers }
+ProcessorSimulator >> smalltalkStackPointerRegisterValue: aValue [
+	
+	self writeRegister: self smalltalkStackPointerRegister value: aValue
+]
+
+{ #category : #registers }
+ProcessorSimulator >> smashRegisterAccessors [
+	
+	^ self subclassResponsibility 
+]
+
+{ #category : #registers }
+ProcessorSimulator >> smashRegistersWithValuesFrom: base by: step [ 
+	
+	self smashRegisterAccessors withIndexDo: [:accessor :index|
+		self perform: accessor with: index - 1 * step + base]
+]
+
+{ #category : #shortcut }
+ProcessorSimulator >> sp [
+
+	^ self stackPointerRegisterValue
+]
+
+{ #category : #shortcut }
+ProcessorSimulator >> sp: aValue [
+
+	^ self stackPointerRegisterValue: aValue
+]
+
+{ #category : #registers }
+ProcessorSimulator >> stackPointerRegister [
+	
+	self subclassResponsibility
+]
+
+{ #category : #registers }
+ProcessorSimulator >> stackPointerRegisterValue [
+
+	^ self readRegister: self stackPointerRegister
+]
+
+{ #category : #registers }
+ProcessorSimulator >> stackPointerRegisterValue: aValue [
+	
+	self writeRegister: self stackPointerRegister value: aValue
+]
+
+{ #category : #'stack-access' }
+ProcessorSimulator >> stackValueAt: anInteger [
+
+	"Get a value from the stack at a 0-base position"
+	| aByteArray |
+	aByteArray := self stackValueBytesAt: anInteger.
+	^ aByteArray integerAt: 1 size: self wordSize signed: false
+]
+
+{ #category : #'stack-access' }
+ProcessorSimulator >> stackValueBytesAt: position [
+
+	"Get the bytes from the stack at a 0-base position"
+	| stackAddressIntegerValue aByteArray |
+
+	"Getting address from stack register"
+	stackAddressIntegerValue := self stackPointerRegisterValue.
+
+	"Putting the value from the stack memory.
+	Remember, stack grows down, so we add the offset"
+	aByteArray := self
+		memoryAt: stackAddressIntegerValue + (position * self wordSize)
+		readNext: self wordSize.
+
+	^ aByteArray
+]
+
+{ #category : #accessing }
+ProcessorSimulator >> stackValues [
+	
+	| initialValue |
+	initialValue := self smalltalkStackPointerRegisterValue.
+	
+	^ (1 to: 30) collect: [ :anIndex |  
+		VMMachineCodeDebuggerStackItem address: initialValue + (memory wordSize * (anIndex - 1)) on: self.	
+	] 
+]
+
+{ #category : #actions }
+ProcessorSimulator >> startAt: begin until: until timeout: timeout count: count [
+
+	self subclassResponsibility 
+
+]
+
+{ #category : #actions }
+ProcessorSimulator >> step [
+
+	self
+		startAt: self instructionPointerRegisterValue
+		until: 0
+		timeout: 0
+		count: 1
+]
+
+{ #category : #registers }
+ProcessorSimulator >> temporaryRegister [
+
+	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+ProcessorSimulator >> temporaryRegisterValue [
+
+	^ self readRegister: self temporaryRegister
+]
+
+{ #category : #registers }
+ProcessorSimulator >> temporaryRegisterValue: anInteger [
+
+	^ self writeRegister: self temporaryRegister value: anInteger
+]
+
+{ #category : #accessing }
+ProcessorSimulator >> wordAt: anInteger [ 
+	
+	^ memory longAt: anInteger
+]
+
+{ #category : #accessing }
+ProcessorSimulator >> wordSize [
+	self subclassResponsibility
+]
+
+{ #category : #registers }
+ProcessorSimulator >> writeFloat64Register: aRegister value: aDouble [ 
+
+	| value |
+	value := ByteArray new: 8.
+	value integerAt: 1 put: aDouble size: 8 signed: false.
+	simulator register: aRegister value write: value.
+
+]
+
+{ #category : #registers }
+ProcessorSimulator >> writeRegister: aRegister value: anInteger [ 
+
+	| value |
+	value := ByteArray new: self wordSize.
+	value integerAt: 1 put: anInteger size: self wordSize signed: false.
+	simulator register: aRegister value write: value.
+
+]

--- a/smalltalksrc/VMMakerTests/ProcessorSimulator.class.st
+++ b/smalltalksrc/VMMakerTests/ProcessorSimulator.class.st
@@ -7,7 +7,7 @@ Class {
 		'registerSmalltalkAliases',
 		'memory'
 	],
-	#category : #VMMakerTests
+	#category : #'VMMakerTests-Unicorn'
 }
 
 { #category : #'instance creation' }
@@ -668,18 +668,6 @@ ProcessorSimulator >> registerDescriptors [
 ProcessorSimulator >> registerList [
 
 	self subclassResponsibility
-]
-
-{ #category : #registers }
-ProcessorSimulator >> returnRegisterValue [
-
-	^ self receiverRegisterValue
-]
-
-{ #category : #registers }
-ProcessorSimulator >> returnRegisterValue: aValue [
-
-	^ self receiverRegisterValue: aValue
 ]
 
 { #category : #registers }

--- a/smalltalksrc/VMMakerTests/RegisterDescriptor.class.st
+++ b/smalltalksrc/VMMakerTests/RegisterDescriptor.class.st
@@ -1,0 +1,88 @@
+Class {
+	#name : #RegisterDescriptor,
+	#superclass : #Object,
+	#instVars : [
+		'simulator',
+		'name',
+		'alias',
+		'smalltalkAlias'
+	],
+	#category : #VMMakerTests
+}
+
+{ #category : #accessing }
+RegisterDescriptor >> alias [
+	^ alias
+]
+
+{ #category : #accessing }
+RegisterDescriptor >> alias: aString [ 
+	
+	alias := aString
+]
+
+{ #category : #actions }
+RegisterDescriptor >> copyValueToClipboard [
+	
+	Clipboard clipboardText: self value hex
+]
+
+{ #category : #actions }
+RegisterDescriptor >> inspectValue [
+
+	self value inspect
+]
+
+{ #category : #accessing }
+RegisterDescriptor >> name [
+	^ name
+]
+
+{ #category : #accessing }
+RegisterDescriptor >> name: anObject [
+	name := anObject
+]
+
+{ #category : #accessing }
+RegisterDescriptor >> printOn: aStream [
+
+	(self value isKindOf: Boolean )
+		ifTrue: [ ^ aStream print: self value ].
+		
+	aStream print: self value hex	
+
+]
+
+{ #category : #actions }
+RegisterDescriptor >> printValue [
+
+	simulator memory interpreter longPrintOop: self value
+]
+
+{ #category : #accessing }
+RegisterDescriptor >> simulator [
+	^ simulator
+]
+
+{ #category : #accessing }
+RegisterDescriptor >> simulator: anObject [
+	simulator := anObject
+]
+
+{ #category : #accessing }
+RegisterDescriptor >> smalltalkAlias [
+	
+	^ smalltalkAlias
+]
+
+{ #category : #accessing }
+RegisterDescriptor >> smalltalkAlias: aString [ 
+	
+	smalltalkAlias := aString
+]
+
+{ #category : #accessing }
+RegisterDescriptor >> value [
+
+	^ simulator perform: name
+]

--- a/smalltalksrc/VMMakerTests/UnicornARMv5Simulator.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornARMv5Simulator.class.st
@@ -204,17 +204,6 @@ UnicornARMv5Simulator >> extractDestinationRegisterFromAssembly: aLLVMInstructio
 ]
 
 { #category : #registers }
-UnicornARMv5Simulator >> fp [
-	^ self readRegister: UcARMRegisters fp
-]
-
-{ #category : #registers }
-UnicornARMv5Simulator >> fp: anInteger [
-
-	self writeRegister: UcARMRegisters fp value: anInteger
-]
-
-{ #category : #registers }
 UnicornARMv5Simulator >> framePointerRegister [
 
 	^ UcARMRegisters fp
@@ -255,28 +244,6 @@ UnicornARMv5Simulator >> integerRegisterState [
 UnicornARMv5Simulator >> linkRegister [
 
 	^ UcARMRegisters lr
-]
-
-{ #category : #registers }
-UnicornARMv5Simulator >> lr [
-	^ self readRegister: UcARMRegisters lr
-]
-
-{ #category : #registers }
-UnicornARMv5Simulator >> lr: anInteger [
-
-	self writeRegister: UcARMRegisters lr value: anInteger
-]
-
-{ #category : #registers }
-UnicornARMv5Simulator >> pc [
-	^ self readRegister: UcARMRegisters pc
-]
-
-{ #category : #registers }
-UnicornARMv5Simulator >> pc: anInteger [
-
-	self writeRegister: UcARMRegisters pc value: anInteger
 ]
 
 { #category : #'as yet unclassified' }
@@ -504,11 +471,6 @@ UnicornARMv5Simulator >> smashCallerSavedRegistersWithValuesFrom: base by: step 
 UnicornARMv5Simulator >> smashRegisterAccessors [
 
 	^ #(r0: r1: r2: r3:)
-]
-
-{ #category : #registers }
-UnicornARMv5Simulator >> sp [
-	^ self readRegister: UcARMRegisters sp
 ]
 
 { #category : #registers }

--- a/smalltalksrc/VMMakerTests/UnicornARMv5Simulator.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornARMv5Simulator.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #registers }
 UnicornARMv5Simulator >> arg0Register [
-
+	
 	^ UcARMRegisters r3
 ]
 
@@ -24,54 +24,54 @@ UnicornARMv5Simulator >> baseRegister [
 
 { #category : #'c calling convention' }
 UnicornARMv5Simulator >> cResultRegister [
-
-	^ self r0
+	
+	^ UcARMRegisters r0
 ]
 
 { #category : #'c calling convention' }
 UnicornARMv5Simulator >> carg0Register [
-
+	
 	^ UcARMRegisters r0
 ]
 
 { #category : #'c calling convention' }
 UnicornARMv5Simulator >> carg1Register [
-
+	
 	^ UcARMRegisters r1
 ]
 
 { #category : #'c calling convention' }
 UnicornARMv5Simulator >> carg2Register [
-
+	
 	^ UcARMRegisters r2
 ]
 
 { #category : #'c calling convention' }
 UnicornARMv5Simulator >> carg3Register [
-
+	
 	^ UcARMRegisters r3
 ]
 
 { #category : #registers }
 UnicornARMv5Simulator >> classRegister [
-
+	
 	^ UcARMRegisters r8
 ]
 
 { #category : #'as yet unclassified' }
-UnicornARMv5Simulator >> convertIntegerToInternal: anInteger [
+UnicornARMv5Simulator >> convertIntegerToInternal: anInteger [ 
 
 	anInteger < 0 ifFalse: [ ^ anInteger ].
-
+	
 	^ 16rFFFFFFFF - anInteger abs + 1
 ]
 
 { #category : #'as yet unclassified' }
 UnicornARMv5Simulator >> convertInternalToInteger: aTwoComplementNumber [
 
-	(aTwoComplementNumber bitAnd: 1 << 31) = 0 ifTrue: [
+	(aTwoComplementNumber bitAnd: 1 << 31) = 0 ifTrue: [ 
 		^ aTwoComplementNumber ].
-
+	
 	^ aTwoComplementNumber - 16rFFFFFFFF - 1
 ]
 
@@ -90,7 +90,7 @@ UnicornARMv5Simulator >> createUnicorn [
 "
 
 	| bytes mappedMemory |
-	bytes := #[
+	bytes := #[ 
 	16r0f 16r36 16ra0 16re3
 	16r50 16r3f 16r01 16ree
 	16r6f 16rf0 16r7f 16rf5
@@ -102,19 +102,19 @@ UnicornARMv5Simulator >> createUnicorn [
 	Create a region of 4KB and map it also at a multiple of 4KB."
 	mappedMemory := ByteArray new: 4096.
 	mappedMemory replaceFrom: 1 to: bytes size with: bytes.
-	unicorn := Unicorn arm.
-	unicorn mapHostMemory: mappedMemory atAddress: 4096 withPermissions: UnicornConstants permissionAll.
+	simulator := Unicorn arm.
+	simulator mapHostMemory: mappedMemory atAddress: 4096 withPermissions: UnicornConstants permissionAll.
 
-	unicorn doStartAt: 4096 until: 0 timeout: 0 count: 5 "instructions".
+	simulator doStartAt: 4096 until: 0 timeout: 0 count: 5 "instructions".
 
 	"Cleanup: unmap the memory so the ByteArray can be safely get garbage collected and that memory region can be reused"
-	unicorn unmapMemoryAt: 4096 size: 4096.
-	^ unicorn
+	simulator unmapMemoryAt: 4096 size: 4096.
+	^ simulator
 ]
 
 { #category : #disassembling }
 UnicornARMv5Simulator >> disassembler [
-
+	
 	^ LLVMARMDisassembler armv7
 ]
 
@@ -123,7 +123,7 @@ UnicornARMv5Simulator >> doStartAt: startAddress until: until timeout: timeout c
 
 	| actualCount result error startTime remainingTimeout currentTime |
 
-	"This implementation is almost the same, because ARMv5 does not accept correctly to run
+	"This implementation is almost the same, because ARMv5 does not accept correctly to run 
 	more than one instruction. It has the problem that it misses the count or the current address"
 
 	actualCount := 0.
@@ -132,41 +132,41 @@ UnicornARMv5Simulator >> doStartAt: startAddress until: until timeout: timeout c
 	remainingTimeout := timeout.
 
 	[ true ]
-		whileTrue: [
+		whileTrue: [ 
 			[result :=  simulator
 				startAt: self instructionPointerRegisterValue
 				until: 0
 				timeout: 0
 				count: 1.
-
-				stopReason ifNotNil: [
+					
+				stopReason ifNotNil: [ 
 						error := stopReason.
 						stopReason := nil.
 						error signal ].
-
+		
 			"If execution did not stop because of a stop reason, verify the error code"
-			unicorn verifyErrorCode: result.
+			simulator verifyErrorCode: result.
 
-
-					actualCount := actualCount + 1]
+			
+					actualCount := actualCount + 1] 
 				on: UnicornInvalidMemoryAccess do: [ :invalidAccess |
 					self instructionPointerRegisterValue = until ifTrue: [ ^ 0 ].
-
+					
 					(self handleInvalidAccess: invalidAccess)
 						ifFalse: [ ^ result ].
-
+						
 					actualCount := actualCount + 1 ].
-
+			
 			stopReason ifNotNil: [ ^ result ].
 			count = actualCount ifTrue: [ ^ result ].
 
 
-			timeout ~= 0 ifTrue: [
+			timeout ~= 0 ifTrue: [  
 				currentTime := Time millisecondClockValue.
 				remainingTimeout := remainingTimeout - (currentTime - startTime).
-
+				
 				remainingTimeout <= 0
-					ifTrue: [
+					ifTrue: [ 	
 						UnicornTimeout new
 								target: until;
 								signal ]].
@@ -193,33 +193,25 @@ UnicornARMv5Simulator >> doublePrecisionFloatingPointRegister2 [
 ]
 
 { #category : #'as yet unclassified' }
-UnicornARMv5Simulator >> extractDestinationRegisterFromAssembly: aLLVMInstruction [
-
-	"In ARM, instructions are usually encoded asSpotterCandidateLink
-
+UnicornARMv5Simulator >> extractDestinationRegisterFromAssembly: aLLVMInstruction [ 
+	
+	"In ARM, instructions are usually encoded asSpotterCandidateLink 
+	
 	INST Destination, Source
 	"
-
+	
 	^ (aLLVMInstruction assemblyCodeString substrings: String tab, ',') second trimBoth.
 ]
 
 { #category : #registers }
 UnicornARMv5Simulator >> framePointerRegister [
-
+	
 	^ UcARMRegisters fp
 ]
 
 { #category : #accessing }
-UnicornARMv5Simulator >> getLastAddress: abstractInstructions [
-
-	| last |
-	last := (abstractInstructions reject: [ :e | e isLiteral ]) last.
-	^ last address + last machineCodeSize
-]
-
-{ #category : #accessing }
 UnicornARMv5Simulator >> getReturnAddress [
-
+	
 	^ self linkRegisterValue
 ]
 
@@ -236,29 +228,29 @@ UnicornARMv5Simulator >> instructionPointerRegister [
 
 { #category : #'as yet unclassified' }
 UnicornARMv5Simulator >> integerRegisterState [
-
+	
 	^ #()
 ]
 
 { #category : #registers }
 UnicornARMv5Simulator >> linkRegister [
-
+	
 	^ UcARMRegisters lr
 ]
 
 { #category : #'as yet unclassified' }
-UnicornARMv5Simulator >> postCallArgumentsNumArgs: numArgs in: aMemory [
+UnicornARMv5Simulator >> postCallArgumentsNumArgs: numArgs in: aMemory [ 
 	"Answer an argument vector of the requested size after a vanilla
 	 ABI call. For ARM the Procedure Calling Specification can be found in IHI0042D_aapcs.pdf.
 	On ARM this typically means accessing r0 through r3 and fetching additional arguments from the stack, acording to pages 20f. aapcs.
 	We assume that all arguments are single word arguments, which can not be supplied on co-processor-registers.
 	 For compatibility with Cog/Slang we answer unsigned values."
-
+	
 	^(1 to: numArgs) collect: [:i |
-		i < 5
+		i < 5 
 			ifTrue: [self perform: (self registerStateGetters at: i)]
 			"ARM uses a full descending stack. Directly after calling a procedure, nothing but the arguments are pushed."
-			ifFalse: [memory unsignedLongAt: self sp + (i-5)*4 bigEndian: false]].
+			ifFalse: [memory unsignedLongAt: self sp + (i-5)*4 bigEndian: false]].	
 ]
 
 { #category : #registers }
@@ -267,8 +259,8 @@ UnicornARMv5Simulator >> r0 [
 ]
 
 { #category : #registers }
-UnicornARMv5Simulator >> r0: anInteger [
-
+UnicornARMv5Simulator >> r0: anInteger [ 
+	
 	^ self writeRegister: UcARMRegisters r0 value: anInteger
 ]
 
@@ -283,32 +275,32 @@ UnicornARMv5Simulator >> r10 [
 ]
 
 { #category : #registers }
-UnicornARMv5Simulator >> r10: anInteger [
-
+UnicornARMv5Simulator >> r10: anInteger [ 
+	
 	^ self writeRegister: UcARMRegisters r10 value: anInteger
 ]
 
 { #category : #registers }
-UnicornARMv5Simulator >> r11: anInteger [
-
+UnicornARMv5Simulator >> r11: anInteger [ 
+	
 	^ self writeRegister: UcARMRegisters r11 value: anInteger
 ]
 
 { #category : #accessing }
 UnicornARMv5Simulator >> r12 [
-
+	
 	^ self readRegister: UcARMRegisters r12
 ]
 
 { #category : #registers }
-UnicornARMv5Simulator >> r12: anInteger [
+UnicornARMv5Simulator >> r12: anInteger [ 
 
 	self writeRegister: UcARMRegisters r12 value: anInteger
 ]
 
 { #category : #registers }
-UnicornARMv5Simulator >> r1: anInteger [
-
+UnicornARMv5Simulator >> r1: anInteger [ 
+	
 	^ self writeRegister: UcARMRegisters r1 value: anInteger
 ]
 
@@ -318,8 +310,8 @@ UnicornARMv5Simulator >> r2 [
 ]
 
 { #category : #registers }
-UnicornARMv5Simulator >> r2: anInteger [
-
+UnicornARMv5Simulator >> r2: anInteger [ 
+	
 	^ self writeRegister: UcARMRegisters r2 value: anInteger
 ]
 
@@ -329,8 +321,8 @@ UnicornARMv5Simulator >> r3 [
 ]
 
 { #category : #registers }
-UnicornARMv5Simulator >> r3: anInteger [
-
+UnicornARMv5Simulator >> r3: anInteger [ 
+	
 	^ self writeRegister: UcARMRegisters r3 value: anInteger
 ]
 
@@ -340,8 +332,8 @@ UnicornARMv5Simulator >> r4 [
 ]
 
 { #category : #registers }
-UnicornARMv5Simulator >> r4: anInteger [
-
+UnicornARMv5Simulator >> r4: anInteger [ 
+	
 	^ self writeRegister: UcARMRegisters r4 value: anInteger
 ]
 
@@ -351,8 +343,8 @@ UnicornARMv5Simulator >> r5 [
 ]
 
 { #category : #registers }
-UnicornARMv5Simulator >> r5: anInteger [
-
+UnicornARMv5Simulator >> r5: anInteger [ 
+	
 	^ self writeRegister: UcARMRegisters r5 value: anInteger
 ]
 
@@ -362,8 +354,8 @@ UnicornARMv5Simulator >> r6 [
 ]
 
 { #category : #registers }
-UnicornARMv5Simulator >> r6: anInteger [
-
+UnicornARMv5Simulator >> r6: anInteger [ 
+	
 	^ self writeRegister: UcARMRegisters r6 value: anInteger
 ]
 
@@ -373,8 +365,8 @@ UnicornARMv5Simulator >> r7 [
 ]
 
 { #category : #registers }
-UnicornARMv5Simulator >> r7: anInteger [
-
+UnicornARMv5Simulator >> r7: anInteger [ 
+	
 	^ self writeRegister: UcARMRegisters r7 value: anInteger
 ]
 
@@ -384,8 +376,8 @@ UnicornARMv5Simulator >> r8 [
 ]
 
 { #category : #registers }
-UnicornARMv5Simulator >> r8: anInteger [
-
+UnicornARMv5Simulator >> r8: anInteger [ 
+	
 	^ self writeRegister: UcARMRegisters r8 value: anInteger
 ]
 
@@ -395,14 +387,14 @@ UnicornARMv5Simulator >> r9 [
 ]
 
 { #category : #registers }
-UnicornARMv5Simulator >> r9: anInteger [
-
+UnicornARMv5Simulator >> r9: anInteger [ 
+	
 	^ self writeRegister: UcARMRegisters r9 value: anInteger
 ]
 
 { #category : #registers }
 UnicornARMv5Simulator >> receiverRegister [
-
+	
 	^ UcARMRegisters r5
 ]
 
@@ -414,12 +406,12 @@ UnicornARMv5Simulator >> registerList [
 
 { #category : #'as yet unclassified' }
 UnicornARMv5Simulator >> registerStateGetters [
-
+	
 	^#(r0 r1 r2 r3 r4)
 ]
 
 { #category : #'as yet unclassified' }
-UnicornARMv5Simulator >> retpcIn: aMemory [
+UnicornARMv5Simulator >> retpcIn: aMemory [ 
 	"The return address is on the stack, having been pushed by either
 	 simulateCallOf:nextpc:memory: or simulateJumpCallOf:memory:"
 	^memory longAt: self fp + 4
@@ -427,7 +419,7 @@ UnicornARMv5Simulator >> retpcIn: aMemory [
 
 { #category : #registers }
 UnicornARMv5Simulator >> sendNumberOfArgumentsRegister [
-
+	
 	^ UcARMRegisters r6
 ]
 
@@ -436,7 +428,7 @@ UnicornARMv5Simulator >> simulateJumpCallOf: address memory: aMemory [
 	"Simulate a frame-building jump of address.  Build a frame since
 	a) this is used for calls into the run-time which are unlikely to be leaf-calls"
 	"This method builds a stack frame as expected by the simulator, not as defined by ARM aapcs-abi.
-	In ARM aapcs, every method can define for itself, wether it wants to push lr (nextpc), and wether it
+	In ARM aapcs, every method can define for itself, wether it wants to push lr (nextpc), and wether it 
 	uses a frame pointer. The standard never mentions a fp. It merely defines r4-r11 to be callee-saved."
 
 	self assert: self sp \\ 8 = 0. "This check ensures, that we conform with ARM abi. Before doing anything to the stack, we ensure 2-word alignment."
@@ -475,13 +467,13 @@ UnicornARMv5Simulator >> smashRegisterAccessors [
 
 { #category : #registers }
 UnicornARMv5Simulator >> stackPointerRegister [
-
+	
 	^ UcARMRegisters sp
 ]
 
 { #category : #registers }
 UnicornARMv5Simulator >> temporaryRegister [
-
+	
 	^ UcARMRegisters r2
 ]
 

--- a/smalltalksrc/VMMakerTests/UnicornARMv5Simulator.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornARMv5Simulator.class.st
@@ -6,20 +6,14 @@ Class {
 
 { #category : #registers }
 UnicornARMv5Simulator >> arg0Register [
-	
+
 	^ UcARMRegisters r3
 ]
 
 { #category : #registers }
-UnicornARMv5Simulator >> argument0RegisterValue [
-	
-	^ self r3
-]
+UnicornARMv5Simulator >> arg1Register [
 
-{ #category : #accessing }
-UnicornARMv5Simulator >> argument0RegisterValue: anInteger [ 
-
-	self writeRegister: UcARMRegisters r3 value: anInteger
+	^ UcARMRegisters r4
 ]
 
 { #category : #registers }
@@ -30,60 +24,54 @@ UnicornARMv5Simulator >> baseRegister [
 
 { #category : #'c calling convention' }
 UnicornARMv5Simulator >> cResultRegister [
-	
+
 	^ self r0
 ]
 
 { #category : #'c calling convention' }
-UnicornARMv5Simulator >> cReturnRegisterValue: anInteger [ 
-
-	self r0: anInteger 
-]
-
-{ #category : #'c calling convention' }
 UnicornARMv5Simulator >> carg0Register [
-	
+
 	^ UcARMRegisters r0
 ]
 
 { #category : #'c calling convention' }
 UnicornARMv5Simulator >> carg1Register [
-	
+
 	^ UcARMRegisters r1
 ]
 
 { #category : #'c calling convention' }
 UnicornARMv5Simulator >> carg2Register [
-	
+
 	^ UcARMRegisters r2
 ]
 
 { #category : #'c calling convention' }
 UnicornARMv5Simulator >> carg3Register [
-	
+
 	^ UcARMRegisters r3
 ]
 
 { #category : #registers }
 UnicornARMv5Simulator >> classRegister [
-	
+
 	^ UcARMRegisters r8
 ]
 
 { #category : #'as yet unclassified' }
-UnicornARMv5Simulator >> convertIntegerToInternal: anInteger [ 
+UnicornARMv5Simulator >> convertIntegerToInternal: anInteger [
 
 	anInteger < 0 ifFalse: [ ^ anInteger ].
-	
+
 	^ 16rFFFFFFFF - anInteger abs + 1
 ]
 
 { #category : #'as yet unclassified' }
 UnicornARMv5Simulator >> convertInternalToInteger: aTwoComplementNumber [
 
-	(aTwoComplementNumber bitAnd: 1 << 31) = 0 ifTrue: [ 
+	(aTwoComplementNumber bitAnd: 1 << 31) = 0 ifTrue: [
 		^ aTwoComplementNumber ].
-	
+
 	^ aTwoComplementNumber - 16rFFFFFFFF - 1
 ]
 
@@ -102,7 +90,7 @@ UnicornARMv5Simulator >> createUnicorn [
 "
 
 	| bytes mappedMemory |
-	bytes := #[ 
+	bytes := #[
 	16r0f 16r36 16ra0 16re3
 	16r50 16r3f 16r01 16ree
 	16r6f 16rf0 16r7f 16rf5
@@ -126,7 +114,7 @@ UnicornARMv5Simulator >> createUnicorn [
 
 { #category : #disassembling }
 UnicornARMv5Simulator >> disassembler [
-	
+
 	^ LLVMARMDisassembler armv7
 ]
 
@@ -135,71 +123,83 @@ UnicornARMv5Simulator >> doStartAt: startAddress until: until timeout: timeout c
 
 	| actualCount result error startTime remainingTimeout currentTime |
 
-	"This implementation is almost the same, because ARMv5 does not accept correctly to run 
+	"This implementation is almost the same, because ARMv5 does not accept correctly to run
 	more than one instruction. It has the problem that it misses the count or the current address"
 
 	actualCount := 0.
-	self instructionPointerValue: startAddress.
+	self instructionPointerRegisterValue: startAddress.
 	startTime := Time millisecondClockValue.
 	remainingTimeout := timeout.
 
 	[ true ]
-		whileTrue: [ 
-			[result :=  unicorn
-				startAt: self instructionPointerValue
+		whileTrue: [
+			[result :=  simulator
+				startAt: self instructionPointerRegisterValue
 				until: 0
 				timeout: 0
 				count: 1.
-					
-				stopReason ifNotNil: [ 
+
+				stopReason ifNotNil: [
 						error := stopReason.
 						stopReason := nil.
 						error signal ].
-		
+
 			"If execution did not stop because of a stop reason, verify the error code"
 			unicorn verifyErrorCode: result.
 
-			
-					actualCount := actualCount + 1] 
+
+					actualCount := actualCount + 1]
 				on: UnicornInvalidMemoryAccess do: [ :invalidAccess |
-					self instructionPointerValue = until ifTrue: [ ^ 0 ].
-					
+					self instructionPointerRegisterValue = until ifTrue: [ ^ 0 ].
+
 					(self handleInvalidAccess: invalidAccess)
 						ifFalse: [ ^ result ].
-						
+
 					actualCount := actualCount + 1 ].
-			
+
 			stopReason ifNotNil: [ ^ result ].
 			count = actualCount ifTrue: [ ^ result ].
 
 
-			timeout ~= 0 ifTrue: [  
+			timeout ~= 0 ifTrue: [
 				currentTime := Time millisecondClockValue.
 				remainingTimeout := remainingTimeout - (currentTime - startTime).
-				
+
 				remainingTimeout <= 0
-					ifTrue: [ 	
+					ifTrue: [
 						UnicornTimeout new
 								target: until;
 								signal ]].
 
-			self instructionPointerValue = until ifTrue: [ ^ result ]]
+			self instructionPointerRegisterValue = until ifTrue: [ ^ result ]]
 ]
 
 { #category : #'as yet unclassified' }
-UnicornARMv5Simulator >> doublePrecisionFloatingPointRegister0Value [
+UnicornARMv5Simulator >> doublePrecisionFloatingPointRegister0 [
 
-	^ self readFloat64Register: UcARMRegisters d0
+	^ UcARMRegisters d0
 ]
 
 { #category : #'as yet unclassified' }
-UnicornARMv5Simulator >> extractDestinationRegisterFromAssembly: aLLVMInstruction [ 
-	
-	"In ARM, instructions are usually encoded asSpotterCandidateLink 
-	
+UnicornARMv5Simulator >> doublePrecisionFloatingPointRegister1 [
+
+	^ UcARMRegisters d1
+]
+
+{ #category : #'as yet unclassified' }
+UnicornARMv5Simulator >> doublePrecisionFloatingPointRegister2 [
+
+	^ UcARMRegisters d2
+]
+
+{ #category : #'as yet unclassified' }
+UnicornARMv5Simulator >> extractDestinationRegisterFromAssembly: aLLVMInstruction [
+
+	"In ARM, instructions are usually encoded asSpotterCandidateLink
+
 	INST Destination, Source
 	"
-	
+
 	^ (aLLVMInstruction assemblyCodeString substrings: String tab, ',') second trimBoth.
 ]
 
@@ -209,28 +209,28 @@ UnicornARMv5Simulator >> fp [
 ]
 
 { #category : #registers }
-UnicornARMv5Simulator >> fp: anInteger [ 
-	
+UnicornARMv5Simulator >> fp: anInteger [
+
 	self writeRegister: UcARMRegisters fp value: anInteger
 ]
 
 { #category : #registers }
 UnicornARMv5Simulator >> framePointerRegister [
-	
+
 	^ UcARMRegisters fp
 ]
 
 { #category : #accessing }
-UnicornARMv5Simulator >> getLastAddress: abstractInstructions [ 
-	
+UnicornARMv5Simulator >> getLastAddress: abstractInstructions [
+
 	| last |
 	last := (abstractInstructions reject: [ :e | e isLiteral ]) last.
-	^ last address + last machineCodeSize 
+	^ last address + last machineCodeSize
 ]
 
 { #category : #accessing }
 UnicornARMv5Simulator >> getReturnAddress [
-	
+
 	^ self linkRegisterValue
 ]
 
@@ -247,36 +247,24 @@ UnicornARMv5Simulator >> instructionPointerRegister [
 
 { #category : #'as yet unclassified' }
 UnicornARMv5Simulator >> integerRegisterState [
-	
+
 	^ #()
 ]
 
 { #category : #registers }
 UnicornARMv5Simulator >> linkRegister [
-	
+
 	^ UcARMRegisters lr
-]
-
-{ #category : #accessing }
-UnicornARMv5Simulator >> linkRegisterValue [
-
-	^ self readRegister: self linkRegister 
-]
-
-{ #category : #registers }
-UnicornARMv5Simulator >> linkRegisterValue: aValue [ 
-
-	^ self writeRegister: self linkRegister value: aValue
 ]
 
 { #category : #registers }
 UnicornARMv5Simulator >> lr [
-	^ self readRegister: UcARMRegisters lr	
+	^ self readRegister: UcARMRegisters lr
 ]
 
 { #category : #registers }
-UnicornARMv5Simulator >> lr: anInteger [ 
-	
+UnicornARMv5Simulator >> lr: anInteger [
+
 	self writeRegister: UcARMRegisters lr value: anInteger
 ]
 
@@ -286,24 +274,24 @@ UnicornARMv5Simulator >> pc [
 ]
 
 { #category : #registers }
-UnicornARMv5Simulator >> pc: anInteger [ 
-	
+UnicornARMv5Simulator >> pc: anInteger [
+
 	self writeRegister: UcARMRegisters pc value: anInteger
 ]
 
 { #category : #'as yet unclassified' }
-UnicornARMv5Simulator >> postCallArgumentsNumArgs: numArgs in: aMemory [ 
+UnicornARMv5Simulator >> postCallArgumentsNumArgs: numArgs in: aMemory [
 	"Answer an argument vector of the requested size after a vanilla
 	 ABI call. For ARM the Procedure Calling Specification can be found in IHI0042D_aapcs.pdf.
 	On ARM this typically means accessing r0 through r3 and fetching additional arguments from the stack, acording to pages 20f. aapcs.
 	We assume that all arguments are single word arguments, which can not be supplied on co-processor-registers.
 	 For compatibility with Cog/Slang we answer unsigned values."
-	
+
 	^(1 to: numArgs) collect: [:i |
-		i < 5 
+		i < 5
 			ifTrue: [self perform: (self registerStateGetters at: i)]
 			"ARM uses a full descending stack. Directly after calling a procedure, nothing but the arguments are pushed."
-			ifFalse: [memory unsignedLongAt: self sp + (i-5)*4 bigEndian: false]].	
+			ifFalse: [memory unsignedLongAt: self sp + (i-5)*4 bigEndian: false]].
 ]
 
 { #category : #registers }
@@ -312,8 +300,8 @@ UnicornARMv5Simulator >> r0 [
 ]
 
 { #category : #registers }
-UnicornARMv5Simulator >> r0: anInteger [ 
-	
+UnicornARMv5Simulator >> r0: anInteger [
+
 	^ self writeRegister: UcARMRegisters r0 value: anInteger
 ]
 
@@ -328,32 +316,32 @@ UnicornARMv5Simulator >> r10 [
 ]
 
 { #category : #registers }
-UnicornARMv5Simulator >> r10: anInteger [ 
-	
+UnicornARMv5Simulator >> r10: anInteger [
+
 	^ self writeRegister: UcARMRegisters r10 value: anInteger
 ]
 
 { #category : #registers }
-UnicornARMv5Simulator >> r11: anInteger [ 
-	
+UnicornARMv5Simulator >> r11: anInteger [
+
 	^ self writeRegister: UcARMRegisters r11 value: anInteger
 ]
 
 { #category : #accessing }
 UnicornARMv5Simulator >> r12 [
-	
+
 	^ self readRegister: UcARMRegisters r12
 ]
 
 { #category : #registers }
-UnicornARMv5Simulator >> r12: anInteger [ 
+UnicornARMv5Simulator >> r12: anInteger [
 
 	self writeRegister: UcARMRegisters r12 value: anInteger
 ]
 
 { #category : #registers }
-UnicornARMv5Simulator >> r1: anInteger [ 
-	
+UnicornARMv5Simulator >> r1: anInteger [
+
 	^ self writeRegister: UcARMRegisters r1 value: anInteger
 ]
 
@@ -363,8 +351,8 @@ UnicornARMv5Simulator >> r2 [
 ]
 
 { #category : #registers }
-UnicornARMv5Simulator >> r2: anInteger [ 
-	
+UnicornARMv5Simulator >> r2: anInteger [
+
 	^ self writeRegister: UcARMRegisters r2 value: anInteger
 ]
 
@@ -374,8 +362,8 @@ UnicornARMv5Simulator >> r3 [
 ]
 
 { #category : #registers }
-UnicornARMv5Simulator >> r3: anInteger [ 
-	
+UnicornARMv5Simulator >> r3: anInteger [
+
 	^ self writeRegister: UcARMRegisters r3 value: anInteger
 ]
 
@@ -385,8 +373,8 @@ UnicornARMv5Simulator >> r4 [
 ]
 
 { #category : #registers }
-UnicornARMv5Simulator >> r4: anInteger [ 
-	
+UnicornARMv5Simulator >> r4: anInteger [
+
 	^ self writeRegister: UcARMRegisters r4 value: anInteger
 ]
 
@@ -396,8 +384,8 @@ UnicornARMv5Simulator >> r5 [
 ]
 
 { #category : #registers }
-UnicornARMv5Simulator >> r5: anInteger [ 
-	
+UnicornARMv5Simulator >> r5: anInteger [
+
 	^ self writeRegister: UcARMRegisters r5 value: anInteger
 ]
 
@@ -407,8 +395,8 @@ UnicornARMv5Simulator >> r6 [
 ]
 
 { #category : #registers }
-UnicornARMv5Simulator >> r6: anInteger [ 
-	
+UnicornARMv5Simulator >> r6: anInteger [
+
 	^ self writeRegister: UcARMRegisters r6 value: anInteger
 ]
 
@@ -418,8 +406,8 @@ UnicornARMv5Simulator >> r7 [
 ]
 
 { #category : #registers }
-UnicornARMv5Simulator >> r7: anInteger [ 
-	
+UnicornARMv5Simulator >> r7: anInteger [
+
 	^ self writeRegister: UcARMRegisters r7 value: anInteger
 ]
 
@@ -429,8 +417,8 @@ UnicornARMv5Simulator >> r8 [
 ]
 
 { #category : #registers }
-UnicornARMv5Simulator >> r8: anInteger [ 
-	
+UnicornARMv5Simulator >> r8: anInteger [
+
 	^ self writeRegister: UcARMRegisters r8 value: anInteger
 ]
 
@@ -440,14 +428,14 @@ UnicornARMv5Simulator >> r9 [
 ]
 
 { #category : #registers }
-UnicornARMv5Simulator >> r9: anInteger [ 
-	
+UnicornARMv5Simulator >> r9: anInteger [
+
 	^ self writeRegister: UcARMRegisters r9 value: anInteger
 ]
 
 { #category : #registers }
 UnicornARMv5Simulator >> receiverRegister [
-	
+
 	^ UcARMRegisters r5
 ]
 
@@ -459,12 +447,12 @@ UnicornARMv5Simulator >> registerList [
 
 { #category : #'as yet unclassified' }
 UnicornARMv5Simulator >> registerStateGetters [
-	
+
 	^#(r0 r1 r2 r3 r4)
 ]
 
 { #category : #'as yet unclassified' }
-UnicornARMv5Simulator >> retpcIn: aMemory [ 
+UnicornARMv5Simulator >> retpcIn: aMemory [
 	"The return address is on the stack, having been pushed by either
 	 simulateCallOf:nextpc:memory: or simulateJumpCallOf:memory:"
 	^memory longAt: self fp + 4
@@ -472,7 +460,7 @@ UnicornARMv5Simulator >> retpcIn: aMemory [
 
 { #category : #registers }
 UnicornARMv5Simulator >> sendNumberOfArgumentsRegister [
-	
+
 	^ UcARMRegisters r6
 ]
 
@@ -481,7 +469,7 @@ UnicornARMv5Simulator >> simulateJumpCallOf: address memory: aMemory [
 	"Simulate a frame-building jump of address.  Build a frame since
 	a) this is used for calls into the run-time which are unlikely to be leaf-calls"
 	"This method builds a stack frame as expected by the simulator, not as defined by ARM aapcs-abi.
-	In ARM aapcs, every method can define for itself, wether it wants to push lr (nextpc), and wether it 
+	In ARM aapcs, every method can define for itself, wether it wants to push lr (nextpc), and wether it
 	uses a frame pointer. The standard never mentions a fp. It merely defines r4-r11 to be callee-saved."
 
 	self assert: self sp \\ 8 = 0. "This check ensures, that we conform with ARM abi. Before doing anything to the stack, we ensure 2-word alignment."
@@ -525,13 +513,13 @@ UnicornARMv5Simulator >> sp [
 
 { #category : #registers }
 UnicornARMv5Simulator >> stackPointerRegister [
-	
+
 	^ UcARMRegisters sp
 ]
 
 { #category : #registers }
 UnicornARMv5Simulator >> temporaryRegister [
-	
+
 	^ UcARMRegisters r2
 ]
 

--- a/smalltalksrc/VMMakerTests/UnicornARMv8Simulator.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornARMv8Simulator.class.st
@@ -37,7 +37,7 @@ UnicornARMv8Simulator >> baseRegister [
 { #category : #accessing }
 UnicornARMv8Simulator >> cResultRegister [
 	
-	^ self x0
+	^ UcARM64Registers x0
 ]
 
 { #category : #registers }
@@ -91,10 +91,10 @@ UnicornARMv8Simulator >> cpacr_el1: anInteger [
 { #category : #'as yet unclassified' }
 UnicornARMv8Simulator >> createUnicorn [
 
-	unicorn := Unicorn arm64.
+	simulator := Unicorn arm64.
 	"Enable floating point..."
 	self cpacr_el1: (self cpacr_el1 bitOr: 2r11 << 20).
-	^ unicorn
+	^ simulator
 ]
 
 { #category : #disassembling }
@@ -136,14 +136,6 @@ UnicornARMv8Simulator >> extractDestinationRegisterFromAssembly: aLLVMInstructio
 UnicornARMv8Simulator >> framePointerRegister [
 	
 	^ UcARM64Registers fp
-]
-
-{ #category : #accessing }
-UnicornARMv8Simulator >> getLastAddress: abstractInstructions [ 
-	
-	| last |
-	last := (abstractInstructions reject: [ :e | e isLiteral ]) last.
-	^ last address + last machineCodeSize 
 ]
 
 { #category : #accessing }

--- a/smalltalksrc/VMMakerTests/UnicornARMv8Simulator.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornARMv8Simulator.class.st
@@ -28,18 +28,6 @@ UnicornARMv8Simulator >> arg3Register [
 	^ UcARM64Registers x3
 ]
 
-{ #category : #'as yet unclassified' }
-UnicornARMv8Simulator >> argument0RegisterValue [
-	
-	^ self x3
-]
-
-{ #category : #accessing }
-UnicornARMv8Simulator >> argument0RegisterValue: anInteger [ 
-
-	self writeRegister: UcARM64Registers x3 value: anInteger
-]
-
 { #category : #registers }
 UnicornARMv8Simulator >> baseRegister [
 
@@ -50,12 +38,6 @@ UnicornARMv8Simulator >> baseRegister [
 UnicornARMv8Simulator >> cResultRegister [
 	
 	^ self x0
-]
-
-{ #category : #'as yet unclassified' }
-UnicornARMv8Simulator >> cReturnRegisterValue: anInteger [ 
-	
-	self x0: anInteger
 ]
 
 { #category : #registers }
@@ -122,15 +104,21 @@ UnicornARMv8Simulator >> disassembler [
 ]
 
 { #category : #'as yet unclassified' }
-UnicornARMv8Simulator >> doublePrecisionFloatingPointRegister0Value [
+UnicornARMv8Simulator >> doublePrecisionFloatingPointRegister0 [
 
-	^ self readFloat64Register: UcARM64Registers d0 
+	^ UcARM64Registers d0
 ]
 
 { #category : #'as yet unclassified' }
-UnicornARMv8Simulator >> doublePrecisionFloatingPointRegister1Value [
+UnicornARMv8Simulator >> doublePrecisionFloatingPointRegister1 [
 
-	^ self readFloat64Register: UcARM64Registers d1
+	^ UcARM64Registers d1
+]
+
+{ #category : #'as yet unclassified' }
+UnicornARMv8Simulator >> doublePrecisionFloatingPointRegister2 [
+
+	^ UcARM64Registers d2
 ]
 
 { #category : #'as yet unclassified' }
@@ -142,11 +130,6 @@ UnicornARMv8Simulator >> extractDestinationRegisterFromAssembly: aLLVMInstructio
 	"
 	
 	^ (aLLVMInstruction assemblyCodeString substrings: String tab, ',') second trimBoth.
-]
-
-{ #category : #registers }
-UnicornARMv8Simulator >> fp [
-	^ self readRegister: UcARM64Registers x29
 ]
 
 { #category : #registers }
@@ -193,38 +176,10 @@ UnicornARMv8Simulator >> instructionPointerRegister [
 	^ UcARM64Registers pc
 ]
 
-{ #category : #'as yet unclassified' }
-UnicornARMv8Simulator >> integerRegisterState [
-
-	^{	 }
-]
-
 { #category : #registers }
 UnicornARMv8Simulator >> linkRegister [
 	
 	^ UcARM64Registers x30
-]
-
-{ #category : #accessing }
-UnicornARMv8Simulator >> linkRegisterValue [
-
-	^ self readRegister: self linkRegister 
-]
-
-{ #category : #registers }
-UnicornARMv8Simulator >> linkRegisterValue: aValue [ 
-
-	^ self writeRegister: self linkRegister value: aValue
-]
-
-{ #category : #registers }
-UnicornARMv8Simulator >> lr [
-	^ self readRegister: self linkRegister
-]
-
-{ #category : #registers }
-UnicornARMv8Simulator >> lr: aValue [
-	^ self writeRegister: self linkRegister value: aValue
 ]
 
 { #category : #'as yet unclassified' }
@@ -243,16 +198,6 @@ UnicornARMv8Simulator >> nzcv [
 UnicornARMv8Simulator >> overflow [
 
 	^ (self nzcv bitAnd: (1<<28)) ~= 0
-]
-
-{ #category : #registers }
-UnicornARMv8Simulator >> pc [
-	^ self readRegister: self instructionPointerRegister
-]
-
-{ #category : #registers }
-UnicornARMv8Simulator >> pc: aValue [
-	^ self writeRegister: self instructionPointerRegister value: aValue
 ]
 
 { #category : #'as yet unclassified' }
@@ -313,7 +258,7 @@ UnicornARMv8Simulator >> simulateJumpCallOf: address memory: aMemory [
 	self pushWord: self fp.
 	self framePointerRegisterValue: self stackPointerRegisterValue.
 
-	self instructionPointerValue: address
+	self instructionPointerRegisterValue: address
 ]
 
 { #category : #'as yet unclassified' }
@@ -329,7 +274,7 @@ UnicornARMv8Simulator >> simulateReturnIn: aSpurSimulatedMemory [
 	self framePointerRegisterValue: self popWord.
 	self linkRegisterValue: self popWord.
 
-	self instructionPointerValue: self linkRegisterValue
+	self instructionPointerRegisterValue: self linkRegisterValue
 
 ]
 
@@ -355,11 +300,6 @@ UnicornARMv8Simulator >> smashRegisterAccessors [
 ]
 
 { #category : #registers }
-UnicornARMv8Simulator >> sp [
-	^ self readRegister: UcARM64Registers sp
-]
-
-{ #category : #registers }
 UnicornARMv8Simulator >> stackPointerRegister [
 	
 	^ UcARM64Registers sp
@@ -369,12 +309,6 @@ UnicornARMv8Simulator >> stackPointerRegister [
 UnicornARMv8Simulator >> temporaryRegister [
 
 	^ UcARM64Registers x1
-]
-
-{ #category : #accessing }
-UnicornARMv8Simulator >> temporaryRegisterValue [
-	
-	^ self x1
 ]
 
 { #category : #accessing }

--- a/smalltalksrc/VMMakerTests/UnicornI386Simulator.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornI386Simulator.class.st
@@ -10,18 +10,6 @@ UnicornI386Simulator >> arg0Register [
 	^ UcX86Registers esi
 ]
 
-{ #category : #'as yet unclassified' }
-UnicornI386Simulator >> argument0RegisterValue [
-	
-	^ self esi
-]
-
-{ #category : #accessing }
-UnicornI386Simulator >> argument0RegisterValue: anInteger [ 
-
-	self writeRegister: UcX86Registers esi value: anInteger
-]
-
 { #category : #registers }
 UnicornI386Simulator >> baseRegister [
 
@@ -212,11 +200,6 @@ UnicornI386Simulator >> extractDestinationRegisterFromAssembly: aLLVMInstruction
 	^ registerName
 ]
 
-{ #category : #'as yet unclassified' }
-UnicornI386Simulator >> fp [
-	^ self readRegister: UcX86Registers ebp
-]
-
 { #category : #registers }
 UnicornI386Simulator >> framePointerRegister [
 	
@@ -240,11 +223,6 @@ UnicornI386Simulator >> integerRegisterState [
 
 	^{	self eax. self ebx. self ecx. self edx. self esp. self ebp. self esi. self edi.
 		self eip. self eflags }
-]
-
-{ #category : #'as yet unclassified' }
-UnicornI386Simulator >> pc [
-	^ self readRegister: UcX86Registers eip
 ]
 
 { #category : #'as yet unclassified' }
@@ -320,11 +298,6 @@ UnicornI386Simulator >> smashCallerSavedRegistersWithValuesFrom: base by: step i
 UnicornI386Simulator >> smashRegisterAccessors [
 
 	^#(eax: ebx: ecx: edx: esi: edi:)
-]
-
-{ #category : #'as yet unclassified' }
-UnicornI386Simulator >> sp [
-	^ self readRegister: UcX86Registers esp
 ]
 
 { #category : #registers }

--- a/smalltalksrc/VMMakerTests/UnicornI386Simulator.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornI386Simulator.class.st
@@ -29,11 +29,6 @@ UnicornI386Simulator >> carg0 [
 	^ self stackValueAt: 1
 ]
 
-{ #category : #registers }
-UnicornI386Simulator >> carg0Register [
-	self shouldBeImplemented.
-]
-
 { #category : #'c calling convention' }
 UnicornI386Simulator >> carg1 [
 
@@ -74,9 +69,9 @@ UnicornI386Simulator >> disassembler [
 ]
 
 { #category : #'as yet unclassified' }
-UnicornI386Simulator >> doublePrecisionFloatingPointRegister0Value [
+UnicornI386Simulator >> doublePrecisionFloatingPointRegister0 [
 
-	^ self readFloat64Register: UcX86Registers xmm0
+	^ UcX86Registers xmm0
 ]
 
 { #category : #accessing }
@@ -212,6 +207,12 @@ UnicornI386Simulator >> getReturnAddress [
 	^ self peekAddress
 ]
 
+{ #category : #'as yet unclassified' }
+UnicornI386Simulator >> hasLinkRegister [ 
+
+	^ false
+]
+
 { #category : #registers }
 UnicornI386Simulator >> instructionPointerRegister [
 	
@@ -311,12 +312,6 @@ UnicornI386Simulator >> temporaryRegister [
 	
 	"Assume SysV"
 	^ UcX86Registers eax
-]
-
-{ #category : #accessing }
-UnicornI386Simulator >> temporaryRegisterValue [
-	
-	^ self eax
 ]
 
 { #category : #accessing }

--- a/smalltalksrc/VMMakerTests/UnicornI386Simulator.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornI386Simulator.class.st
@@ -19,7 +19,7 @@ UnicornI386Simulator >> baseRegister [
 { #category : #'as yet unclassified' }
 UnicornI386Simulator >> cResultRegister [
 
-	^ self eax
+	^ UcX86Registers eax
 ]
 
 { #category : #'c calling convention' }

--- a/smalltalksrc/VMMakerTests/UnicornProcessor.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornProcessor.class.st
@@ -134,13 +134,13 @@ UnicornProcessor >> machineSimulator: aMachineSimulator [
 { #category : #registers }
 UnicornProcessor >> pc [
 	
-	^ machineSimulator instructionPointerValue
+	^ machineSimulator instructionPointerRegisterValue
 ]
 
 { #category : #registers }
 UnicornProcessor >> pc: anInteger [ 
 	
-	^ machineSimulator instructionPointerValue: anInteger
+	^ machineSimulator instructionPointerRegisterValue: anInteger
 ]
 
 { #category : #'stack-management' }
@@ -279,7 +279,7 @@ UnicornProcessor >> rsp: anInteger [
 UnicornProcessor >> runInMemory: aMemory minimumAddress: minimumAddress readOnlyBelow: minimumWritableAddress [
 
 
-	^ machineSimulator startAt: machineSimulator instructionPointerValue
+	^ machineSimulator startAt: machineSimulator instructionPointerRegisterValue
 		until: 0
 		timeout: 0
 		count: 0
@@ -288,7 +288,7 @@ UnicornProcessor >> runInMemory: aMemory minimumAddress: minimumAddress readOnly
 { #category : #'as yet unclassified' }
 UnicornProcessor >> runUntil: anAddress [
 
-	^ machineSimulator startAt: machineSimulator instructionPointerValue
+	^ machineSimulator startAt: machineSimulator instructionPointerRegisterValue
 		until: anAddress
 		timeout: 100000 "microseconds = 100ms"
 		count: 0

--- a/smalltalksrc/VMMakerTests/UnicornProcessor.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornProcessor.class.st
@@ -16,7 +16,7 @@ UnicornProcessor >> cResultRegister [
 { #category : #'as yet unclassified' }
 UnicornProcessor >> cResultRegister: anInteger [ 
 	
-	machineSimulator cReturnRegisterValue: anInteger
+	machineSimulator cResultRegisterValue: anInteger
 ]
 
 { #category : #'as yet unclassified' }

--- a/smalltalksrc/VMMakerTests/UnicornProcessor.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornProcessor.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #'as yet unclassified' }
 UnicornProcessor >> cResultRegister [
 	
-	^ machineSimulator cResultRegister
+	^ machineSimulator cResultRegisterValue
 ]
 
 { #category : #'as yet unclassified' }

--- a/smalltalksrc/VMMakerTests/UnicornRISCVSimulator.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornRISCVSimulator.class.st
@@ -60,8 +60,11 @@ UnicornRISCVSimulator >> classRegister [
 
 { #category : #initialization }
 UnicornRISCVSimulator >> createUnicorn [
-
-	^ Unicorn riscv64
+	
+	simulator := Unicorn riscv64.
+	"Enable floating point"
+	self mstatusRegisterValue: 16r6000.
+	^ simulator
 ]
 
 { #category : #disassembling }
@@ -280,6 +283,54 @@ UnicornRISCVSimulator >> f9 [
 	^ self readRegister: UcRISCVRegisters f9
 ]
 
+{ #category : #'c calling convention' }
+UnicornRISCVSimulator >> flagCarryRegister [
+
+	^ UcRISCVRegisters x31
+]
+
+{ #category : #'c calling convention' }
+UnicornRISCVSimulator >> flagCarryRegisterValue [
+
+	^ self readRegister: self flagCarryRegister
+]
+
+{ #category : #'c calling convention' }
+UnicornRISCVSimulator >> flagOverflowRegister [
+
+	^ UcRISCVRegisters x30
+]
+
+{ #category : #'c calling convention' }
+UnicornRISCVSimulator >> flagOverflowRegisterValue [
+
+	^ self readRegister: self flagOverflowRegister
+]
+
+{ #category : #'c calling convention' }
+UnicornRISCVSimulator >> flagSignRegister [
+
+	^ UcRISCVRegisters x29
+]
+
+{ #category : #'c calling convention' }
+UnicornRISCVSimulator >> flagSignRegisterValue [
+
+	^ self readRegister: self flagSignRegister
+]
+
+{ #category : #'c calling convention' }
+UnicornRISCVSimulator >> flagZeroRegister [
+
+	^ UcRISCVRegisters x28
+]
+
+{ #category : #'c calling convention' }
+UnicornRISCVSimulator >> flagZeroRegisterValue [
+
+	^ self readRegister: self flagZeroRegister
+]
+
 { #category : #registers }
 UnicornRISCVSimulator >> framePointerRegister [
 	
@@ -287,10 +338,91 @@ UnicornRISCVSimulator >> framePointerRegister [
 	^ UcRISCVRegisters x8
 ]
 
+{ #category : #'c calling convention' }
+UnicornRISCVSimulator >> getReturnAddress [
+	
+	^ self linkRegisterValue
+]
+
 { #category : #testing }
 UnicornRISCVSimulator >> hasLinkRegister [
 	
 	^ true
+]
+
+{ #category : #disassembling }
+UnicornRISCVSimulator >> initializeRegisterAliases [ 
+
+	registerAliases
+		at: #x0  put: #zero;
+		at: #x1  put: #ra;
+		at: #x2  put: #sp; "Smalltalk sp" 
+		at: #x3  put: #gp;
+		at: #x4  put: #tp;
+		at: #x5  put: #t0; "Smalltalk ip1"
+		at: #x6  put: #t1;	 "Smalltalk ip2"
+		at: #x7  put: #t2;
+		at: #x8  put: #fp; "Smalltalk fp"		
+		at: #x9  put: #s1;
+		at: #x10 put: #a0; "Smalltalk arg0"		
+		at: #x11 put: #a1; "Smalltalk arg1"
+		at: #x12 put: #a2; "Smalltalk carg0"	
+		at: #x13 put: #a3; "Smalltalk carg1"
+		at: #x14 put: #a4; "Smalltalk carg2"
+		at: #x15 put: #a5; "Smalltalk carg3"
+		at: #x16 put: #a6;
+		at: #x17 put: #a7;
+		at: #x18 put: #s2;  "Smalltalk extra0"
+		at: #x19 put: #s3;  "Smalltalk extra1"
+		at: #x20 put: #s4;  "Smalltalk extra2"
+		at: #x21 put: #s5;
+		at: #x22 put: #s6;  "Smalltalk temp"
+		at: #x23 put: #s7;  "Smalltalk classreg"
+		at: #x24 put: #s8;  "Smalltalk receiver"
+		at: #x25 put: #s9;  "Smalltalk argnum"
+		at: #x26 put: #s10; "Smalltalk varbase"
+		at: #x27 put: #s11; "Smalltalk flag"
+		at: #x28 put: #t3; 
+		at: #x29 put: #t4;
+		at: #x30 put: #t5;
+		at: #x31 put: #t6;
+		at: #f0  put: #ft0;
+		at: #f1  put: #ft1;
+		at: #f2  put: #ft2;
+		at: #f3  put: #ft3;
+		at: #f4  put: #ft4;
+		at: #f5  put: #ft5;
+		at: #f6  put: #ft6;
+		at: #f7  put: #ft7
+]
+
+{ #category : #disassembling }
+UnicornRISCVSimulator >> initializeRegisterSmalltalkAliases [ 
+
+	registerSmalltalkAliases
+		at: #x2  put: #sp;
+		at: #x5  put: #ip1;
+		at: #x6  put: #ip2;
+		at: #x7  put: #ip3;
+		at: #x8  put: #fp;
+		at: #x10 put: #arg0;
+		at: #x11 put: #arg1;
+		at: #x12 put: #carg0;
+		at: #x13 put: #carg1;
+		at: #x14 put: #carg2;
+		at: #x15 put: #carg3;
+		at: #x18 put: #extra0;
+		at: #x19 put: #extra1;
+		at: #x20 put: #extra2;
+		at: #x22 put: #temp;
+		at: #x23 put: #class;
+		at: #x24 put: #receiver;
+		at: #x25 put: #argnum;
+		at: #x26 put: #varbase;
+		at: #x28 put: #zero;
+		at: #x29 put: #sign;
+		at: #x30 put: #overflow;
+		at: #x31 put: #carry
 ]
 
 { #category : #registers }
@@ -305,6 +437,24 @@ UnicornRISCVSimulator >> linkRegister [
 	^ UcRISCVRegisters x1
 ]
 
+{ #category : #'c calling convention' }
+UnicornRISCVSimulator >> mstatus [
+
+	^ UcRISCVRegisters mstatus
+]
+
+{ #category : #'c calling convention' }
+UnicornRISCVSimulator >> mstatusRegisterValue [
+
+	^ self readRegister: self mstatus
+]
+
+{ #category : #'c calling convention' }
+UnicornRISCVSimulator >> mstatusRegisterValue: aValue [
+
+	^ self writeRegister: self mstatus value: aValue
+]
+
 { #category : #registers }
 UnicornRISCVSimulator >> receiverRegister [
 	
@@ -316,7 +466,68 @@ UnicornRISCVSimulator >> registerList [
 
 	^ #(lr pc sp fp 
 		 x0 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 
-		 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 x31)
+		 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 x31
+		 f0 f1 f2 f3 f4 f5 f6 f7)
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> s0 [
+
+	^ self readRegister: UcRISCVRegisters s0
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> s0: aValue [
+
+	^ self writeRegister: UcRISCVRegisters s0 value: aValue
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> s2 [
+
+	^ self readRegister: UcRISCVRegisters s2
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> s2: aValue [
+
+	^ self writeRegister: UcRISCVRegisters s2 value: aValue
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> s7 [
+
+	^ self readRegister: UcRISCVRegisters s7
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> s7: aValue [
+
+	^ self writeRegister: UcRISCVRegisters s7 value: aValue
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> s8 [
+
+	^ self readRegister: UcRISCVRegisters s8
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> s8: aValue [
+
+	^ self writeRegister: UcRISCVRegisters s8 value: aValue
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> s9 [
+
+	^ self readRegister: UcRISCVRegisters s9
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> s9: aValue [
+
+	^ self writeRegister: UcRISCVRegisters s9 value: aValue
 ]
 
 { #category : #registers }
@@ -345,10 +556,94 @@ UnicornRISCVSimulator >> stackPointerRegister [
 	^ UcRISCVRegisters x2
 ]
 
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> t0 [
+
+	^ self readRegister: UcRISCVRegisters t0
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> t0: aValue [
+
+	^ self writeRegister: UcRISCVRegisters t0 value: aValue
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> t1 [
+
+	^ self readRegister: UcRISCVRegisters t1
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> t1: aValue [
+
+	^ self writeRegister: UcRISCVRegisters t1 value: aValue
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> t2 [
+
+	^ self readRegister: UcRISCVRegisters t2
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> t2: aValue [
+
+	^ self writeRegister: UcRISCVRegisters t2 value: aValue
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> t3 [
+
+	^ self readRegister: UcRISCVRegisters t3
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> t3: aValue [
+
+	^ self writeRegister: UcRISCVRegisters t3 value: aValue
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> t4 [
+
+	^ self readRegister: UcRISCVRegisters t4
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> t4: aValue [
+
+	^ self writeRegister: UcRISCVRegisters t4 value: aValue
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> t5 [
+
+	^ self readRegister: UcRISCVRegisters t5
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> t5: aValue [
+
+	^ self writeRegister: UcRISCVRegisters t5 value: aValue
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> t6 [
+
+	^ self readRegister: UcRISCVRegisters t6
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> t6: aValue [
+
+	^ self writeRegister: UcRISCVRegisters t6 value: aValue
+]
+
 { #category : #registers }
 UnicornRISCVSimulator >> temporaryRegister [
 
-	^ self x22
+	^ UcRISCVRegisters x22
 ]
 
 { #category : #accessing }

--- a/smalltalksrc/VMMakerTests/UnicornRISCVSimulator.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornRISCVSimulator.class.st
@@ -64,6 +64,12 @@ UnicornRISCVSimulator >> createUnicorn [
 	^ Unicorn riscv64
 ]
 
+{ #category : #disassembling }
+UnicornRISCVSimulator >> disassembler [ 
+
+	^ LLVMRV64Disassembler riscv64
+]
+
 { #category : #'as yet unclassified' }
 UnicornRISCVSimulator >> doublePrecisionFloatingPointRegister0 [
 

--- a/smalltalksrc/VMMakerTests/UnicornRISCVSimulator.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornRISCVSimulator.class.st
@@ -1,0 +1,544 @@
+Class {
+	#name : #UnicornRISCVSimulator,
+	#superclass : #UnicornSimulator,
+	#category : #'VMMakerTests-Unicorn'
+}
+
+{ #category : #registers }
+UnicornRISCVSimulator >> arg0Register [
+
+	^ UcRISCVRegisters x10
+]
+
+{ #category : #registers }
+UnicornRISCVSimulator >> arg1Register [
+
+	^ UcRISCVRegisters x11
+]
+
+{ #category : #registers }
+UnicornRISCVSimulator >> baseRegister [
+
+	^ UcRISCVRegisters x26
+]
+
+{ #category : #'c calling convention' }
+UnicornRISCVSimulator >> cResultRegister [
+
+	^ UcRISCVRegisters x12
+]
+
+{ #category : #'c calling convention' }
+UnicornRISCVSimulator >> carg0Register [
+
+	^ UcRISCVRegisters x12
+]
+
+{ #category : #'c calling convention' }
+UnicornRISCVSimulator >> carg1Register [
+
+	^ UcRISCVRegisters x13
+]
+
+{ #category : #'c calling convention' }
+UnicornRISCVSimulator >> carg2Register [
+
+	^ UcRISCVRegisters x14
+]
+
+{ #category : #'c calling convention' }
+UnicornRISCVSimulator >> carg3Register [
+
+	^ UcRISCVRegisters x15
+]
+
+{ #category : #registers }
+UnicornRISCVSimulator >> classRegister [
+
+	^ UcRISCVRegisters x23
+]
+
+{ #category : #initialization }
+UnicornRISCVSimulator >> createUnicorn [
+
+	^ Unicorn riscv64
+]
+
+{ #category : #'as yet unclassified' }
+UnicornRISCVSimulator >> doublePrecisionFloatingPointRegister0 [
+
+	^ UcRISCVRegisters f0
+]
+
+{ #category : #'as yet unclassified' }
+UnicornRISCVSimulator >> doublePrecisionFloatingPointRegister1 [
+
+	^ UcRISCVRegisters f1
+]
+
+{ #category : #'as yet unclassified' }
+UnicornRISCVSimulator >> doublePrecisionFloatingPointRegister2 [
+
+	^ UcRISCVRegisters f2
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> f0 [
+
+	^ self readRegister: UcRISCVRegisters f0
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> f1 [
+
+	^ self readRegister: UcRISCVRegisters f1
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> f10 [
+
+	^ self readRegister: UcRISCVRegisters f10
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> f11 [
+
+	^ self readRegister: UcRISCVRegisters f11
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> f12 [
+
+	^ self readRegister: UcRISCVRegisters f12
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> f13 [
+
+	^ self readRegister: UcRISCVRegisters f13
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> f14 [
+
+	^ self readRegister: UcRISCVRegisters f14
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> f15 [
+
+	^ self readRegister: UcRISCVRegisters f15
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> f16 [
+
+	^ self readRegister: UcRISCVRegisters f16
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> f17 [
+
+	^ self readRegister: UcRISCVRegisters f17
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> f18 [
+
+	^ self readRegister: UcRISCVRegisters f18
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> f19 [
+
+	^ self readRegister: UcRISCVRegisters f19
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> f2 [
+
+	^ self readRegister: UcRISCVRegisters f2
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> f20 [
+
+	^ self readRegister: UcRISCVRegisters f20
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> f21 [
+
+	^ self readRegister: UcRISCVRegisters f21
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> f22 [
+
+	^ self readRegister: UcRISCVRegisters f22
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> f23 [
+
+	^ self readRegister: UcRISCVRegisters f23
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> f24 [
+
+	^ self readRegister: UcRISCVRegisters f24
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> f25 [
+
+	^ self readRegister: UcRISCVRegisters f25
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> f26 [
+
+	^ self readRegister: UcRISCVRegisters f26
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> f27 [
+
+	^ self readRegister: UcRISCVRegisters f27
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> f28 [
+
+	^ self readRegister: UcRISCVRegisters f28
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> f29 [
+
+	^ self readRegister: UcRISCVRegisters f29
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> f3 [
+
+	^ self readRegister: UcRISCVRegisters f3
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> f30 [
+
+	^ self readRegister: UcRISCVRegisters f30
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> f31 [
+
+	^ self readRegister: UcRISCVRegisters f31
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> f4 [
+
+	^ self readRegister: UcRISCVRegisters f4
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> f5 [
+
+	^ self readRegister: UcRISCVRegisters f5
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> f6 [
+
+	^ self readRegister: UcRISCVRegisters f6
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> f7 [
+
+	^ self readRegister: UcRISCVRegisters f7
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> f8 [
+
+	^ self readRegister: UcRISCVRegisters f8
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> f9 [
+
+	^ self readRegister: UcRISCVRegisters f9
+]
+
+{ #category : #registers }
+UnicornRISCVSimulator >> framePointerRegister [
+	
+	"Frame Pointer"
+	^ UcRISCVRegisters x8
+]
+
+{ #category : #testing }
+UnicornRISCVSimulator >> hasLinkRegister [
+	
+	^ true
+]
+
+{ #category : #registers }
+UnicornRISCVSimulator >> instructionPointerRegister [
+
+	^ UcRISCVRegisters pc
+]
+
+{ #category : #disassembling }
+UnicornRISCVSimulator >> linkRegister [ 
+
+	^ UcRISCVRegisters x1
+]
+
+{ #category : #registers }
+UnicornRISCVSimulator >> receiverRegister [
+	
+	^ UcRISCVRegisters x24
+]
+
+{ #category : #accessing }
+UnicornRISCVSimulator >> registerList [
+
+	^ #(lr pc sp fp 
+		 x0 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 
+		 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 x31)
+]
+
+{ #category : #registers }
+UnicornRISCVSimulator >> sendNumberOfArgumentsRegister [
+
+	^ UcRISCVRegisters x25
+]
+
+{ #category : #'as yet unclassified' }
+UnicornRISCVSimulator >> simulateLeafCallOf: destinationAddress nextpc: returnAddress memory: anUndefinedObject [ 
+
+	self linkRegisterValue: returnAddress.
+	self instructionPointerRegisterValue: destinationAddress
+]
+
+{ #category : #registers }
+UnicornRISCVSimulator >> smashRegisterAccessors [
+	
+	"Caller saved registers to smash"
+	^#( x1: x5: x6: x7: x10: x11: x12: x13: x14: x15: x16: x17: x28: x29: x30: x31:)
+]
+
+{ #category : #registers }
+UnicornRISCVSimulator >> stackPointerRegister [
+	
+	^ UcRISCVRegisters x2
+]
+
+{ #category : #registers }
+UnicornRISCVSimulator >> temporaryRegister [
+
+	^ self x22
+]
+
+{ #category : #accessing }
+UnicornRISCVSimulator >> wordSize [
+	
+	^ 8
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> x0 [
+
+	^ self readRegister: UcRISCVRegisters x0
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> x1 [
+
+	^ self readRegister: UcRISCVRegisters x1
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> x10 [
+
+	^ self readRegister: UcRISCVRegisters x10
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> x11 [
+
+	^ self readRegister: UcRISCVRegisters x11
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> x12 [
+
+	^ self readRegister: UcRISCVRegisters x12
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> x13 [
+
+	^ self readRegister: UcRISCVRegisters x13
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> x14 [
+
+	^ self readRegister: UcRISCVRegisters x14
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> x15 [
+
+	^ self readRegister: UcRISCVRegisters x15
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> x16 [
+
+	^ self readRegister: UcRISCVRegisters x16
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> x17 [
+
+	^ self readRegister: UcRISCVRegisters x17
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> x18 [
+
+	^ self readRegister: UcRISCVRegisters x18
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> x19 [
+
+	^ self readRegister: UcRISCVRegisters x19
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> x2 [
+
+	^ self readRegister: UcRISCVRegisters x2
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> x20 [
+
+	^ self readRegister: UcRISCVRegisters x20
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> x21 [
+
+	^ self readRegister: UcRISCVRegisters x21
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> x22 [
+
+	^ self readRegister: UcRISCVRegisters x22
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> x23 [
+
+	^ self readRegister: UcRISCVRegisters x23
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> x24 [
+
+	^ self readRegister: UcRISCVRegisters x24
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> x25 [
+
+	^ self readRegister: UcRISCVRegisters x25
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> x26 [
+
+	^ self readRegister: UcRISCVRegisters x26
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> x27 [
+
+	^ self readRegister: UcRISCVRegisters x27
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> x28 [
+
+	^ self readRegister: UcRISCVRegisters x28
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> x29 [
+
+	^ self readRegister: UcRISCVRegisters x29
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> x3 [
+
+	^ self readRegister: UcRISCVRegisters x3
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> x30 [
+
+	^ self readRegister: UcRISCVRegisters x30
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> x31 [
+
+	^ self readRegister: UcRISCVRegisters x31
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> x4 [
+
+	^ self readRegister: UcRISCVRegisters x4
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> x5 [
+
+	^ self readRegister: UcRISCVRegisters x5
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> x6 [
+
+	^ self readRegister: UcRISCVRegisters x6
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> x7 [
+
+	^ self readRegister: UcRISCVRegisters x7
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> x8 [
+
+	^ self readRegister: UcRISCVRegisters x8
+]
+
+{ #category : #'machine registers' }
+UnicornRISCVSimulator >> x9 [
+
+	^ self readRegister: UcRISCVRegisters x9
+]

--- a/smalltalksrc/VMMakerTests/UnicornSimulationTrap.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornSimulationTrap.class.st
@@ -28,7 +28,7 @@ UnicornSimulationTrap >> nextpc [
 	
 	| instruction |
 	instruction := self simulator disassembleCurrentInstruction.
-	^ self simulator instructionPointerValue + instruction size
+	^ self simulator instructionPointerRegisterValue + instruction size
 ]
 
 { #category : #accessing }

--- a/smalltalksrc/VMMakerTests/UnicornSimulator.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornSimulator.class.st
@@ -13,13 +13,13 @@ Class {
 
 { #category : #'instance creation' }
 UnicornSimulator class >> ARMv5 [
-	
+
 	^ UnicornARMv5Simulator new
 ]
 
 { #category : #'instance creation' }
 UnicornSimulator class >> ARMv8 [
-	
+
 	^ UnicornARMv8Simulator new
 ]
 
@@ -31,192 +31,27 @@ UnicornSimulator class >> IA32 [
 
 { #category : #'instance creation' }
 UnicornSimulator class >> X64 [
-	
+
 	^ UnicornX64Simulator new
 ]
 
 { #category : #'instance creation' }
 UnicornSimulator class >> aarch64 [
-	
+
 	^ UnicornARMv8Simulator new
 ]
 
-{ #category : #accessing }
-UnicornSimulator >> aliasForRegister: aRegisterName [
+{ #category : #'instance creation' }
+UnicornSimulator class >> riscv64 [
 
-	^ registerAliases at: aRegisterName ifAbsent: [ '' ]
+	"TODO: Add riscv32 and possibly two subclasses for the RISCV simulator"
+	^ UnicornRISCVSimulator new
 ]
 
-{ #category : #registers }
-UnicornSimulator >> arg0Register [
-	
-	^ self subclassResponsibility 
-]
+{ #category : #'instance creation' }
+UnicornSimulator class >> supportsISA: isa [
 
-{ #category : #registers }
-UnicornSimulator >> arg0RegisterValue [
-	
-	^ self readRegister: self arg0Register 
-]
-
-{ #category : #registers }
-UnicornSimulator >> arg0RegisterValue: aValue [
-
-	^ self writeRegister: self arg0Register value: aValue
-]
-
-{ #category : #registers }
-UnicornSimulator >> arg1Register [
-	
-	^ self subclassResponsibility 
-]
-
-{ #category : #registers }
-UnicornSimulator >> arg1RegisterValue [
-	
-	^ self readRegister: self arg1Register 
-]
-
-{ #category : #'as yet unclassified' }
-UnicornSimulator >> argument0RegisterValue [
-	
-	^ self subclassResponsibility
-]
-
-{ #category : #accessing }
-UnicornSimulator >> argument0RegisterValue: anInteger [ 
-	
-	self subclassResponsibility
-]
-
-{ #category : #registers }
-UnicornSimulator >> baseRegister [
-
-	^ self subclassResponsibility
-]
-
-{ #category : #registers }
-UnicornSimulator >> baseRegisterValue [
-	
-	^ self readRegister: self baseRegister
-]
-
-{ #category : #registers }
-UnicornSimulator >> baseRegisterValue: aValue [
-	
-	^ self writeRegister: self baseRegister value: aValue
-]
-
-{ #category : #'c calling convention' }
-UnicornSimulator >> cResultRegister [
-
-	^ self subclassResponsibility
-]
-
-{ #category : #'c calling convention' }
-UnicornSimulator >> cReturnRegisterValue: anInteger [ 
-	
-	self eax: anInteger
-]
-
-{ #category : #'c calling convention' }
-UnicornSimulator >> carg0 [
-	
-	"By default fetch values from registers, override in platforms that don't (e.g. IA32)"
-	^ self carg0RegisterValue
-]
-
-{ #category : #'c calling convention' }
-UnicornSimulator >> carg0Register [
-	
-	^ self subclassResponsibility
-]
-
-{ #category : #'c calling convention' }
-UnicornSimulator >> carg0RegisterValue [
-	
-	^ self readRegister: self carg0Register
-]
-
-{ #category : #'c calling convention' }
-UnicornSimulator >> carg1 [
-	
-	"By default fetch values from registers, override in platforms that don't (e.g. IA32)"
-	^ self carg1RegisterValue
-]
-
-{ #category : #'c calling convention' }
-UnicornSimulator >> carg1Register [
-	
-	^ self subclassResponsibility
-]
-
-{ #category : #'c calling convention' }
-UnicornSimulator >> carg1RegisterValue [
-	
-	^ self readRegister: self carg1Register
-]
-
-{ #category : #'c calling convention' }
-UnicornSimulator >> carg2 [
-	
-	"By default fetch values from registers, override in platforms that don't (e.g. IA32)"
-	^ self carg2RegisterValue
-]
-
-{ #category : #'c calling convention' }
-UnicornSimulator >> carg2Register [
-	
-	^ self subclassResponsibility
-]
-
-{ #category : #'c calling convention' }
-UnicornSimulator >> carg2RegisterValue [
-	
-	^ self readRegister: self carg2Register
-]
-
-{ #category : #'c calling convention' }
-UnicornSimulator >> carg3 [
-	
-	"By default fetch values from registers, override in platforms that don't (e.g. IA32)"
-	^ self carg3RegisterValue
-]
-
-{ #category : #'c calling convention' }
-UnicornSimulator >> carg3Register [
-	
-	^ self subclassResponsibility
-]
-
-{ #category : #'c calling convention' }
-UnicornSimulator >> carg3RegisterValue [
-	
-	^ self readRegister: self carg3Register
-]
-
-{ #category : #registers }
-UnicornSimulator >> classRegister [
-	
-	^ self subclassResponsibility
-]
-
-{ #category : #registers }
-UnicornSimulator >> classRegisterValue [
-	
-	^ self readRegister: self classRegister
-]
-
-{ #category : #registers }
-UnicornSimulator >> classRegisterValue: aValue [
-	
-	^ self writeRegister: self classRegister value: aValue
-]
-
-{ #category : #accessing }
-UnicornSimulator >> cogit [
-
-	^ memory interpreter cogit
+	^ #( #ARMv5 #ARMv8 #IA32 #X64 #aarch64 #riscv64 ) includes: isa
 ]
 
 { #category : #initialization }
@@ -227,7 +62,7 @@ UnicornSimulator >> createUnicorn [
 
 { #category : #disassembling }
 UnicornSimulator >> disassembleCurrentInstruction [
-	
+
 	^ (self disassembleFrom: self instructionPointerValue opcodes: 1) first
 ]
 
@@ -243,7 +78,7 @@ UnicornSimulator >> disassembleFrom: anIndex opcodes: numberOfInstructions [
 ]
 
 { #category : #disassembling }
-UnicornSimulator >> disassembleFrom: start to: stop [ 
+UnicornSimulator >> disassembleFrom: start to: stop [
 
 	^ self disassembler
 		printImmediatesInHexa;
@@ -263,105 +98,75 @@ UnicornSimulator >> doStartAt: startAddress until: until timeout: timeout count:
 
 	| result error startTime currentTime remainingTimeout remainingCount |
 
-	self instructionPointerValue: startAddress.
+	self instructionPointerRegisterValue: startAddress.
 	startTime := Time millisecondClockValue.
 	remainingTimeout := timeout.
 	remainingCount := count.
 
 	[ true ]
-		whileTrue: [ 
-			[result :=  unicorn
-				startAt: self instructionPointerValue
+		whileTrue: [
+			[result :=  simulator
+				startAt: self instructionPointerRegisterValue
 				until: until
 				timeout: remainingTimeout
 				count: remainingCount.
-					
-				stopReason ifNotNil: [ 
+
+				stopReason ifNotNil: [
 						error := stopReason.
 						stopReason := nil.
 						error signal ].
-		
+
 			"If execution did not stop because of a stop reason, verify the error code"
-			unicorn verifyErrorCode: result] 
+			unicorn verifyErrorCode: result]
 				on: UnicornInvalidMemoryAccess do: [ :invalidAccess |
-					
-					self instructionPointerValue = until ifTrue: [ ^ 0 ].
-					
+
+					self instructionPointerRegisterValue = until ifTrue: [ ^ 0 ].
+
 					(self handleInvalidAccess: invalidAccess)
 						ifFalse: [ ^ result ]].
-			
+
 			stopReason ifNotNil: [ ^ result ].
-		
+
 			count ~= 0 ifTrue: [ | lastCount |
 				lastCount := unicorn lastInstructionCount.
 				remainingCount := remainingCount - lastCount.
 				remainingCount <= 0 ifTrue: [ ^ result ]].
-			
-			timeout ~= 0 ifTrue: [  
+
+			timeout ~= 0 ifTrue: [
 				currentTime := Time millisecondClockValue.
 				remainingTimeout := remainingTimeout - (currentTime - startTime).
-				
+
 				remainingTimeout <= 0
-					ifTrue: [ 	
+					ifTrue: [
 						UnicornTimeout new
 								target: until;
 								signal ]].
-			
-			self instructionPointerValue = until 
+
+			self instructionPointerRegisterValue = until
 				ifTrue: [ ^ result ]]
 ]
 
-{ #category : #'as yet unclassified' }
-UnicornSimulator >> doublePrecisionFloatingPointRegister1Value [
-	
-	self subclassResponsibility
-]
+{ #category : #'stack-access' }
+UnicornSimulator >> finishMappingMemory [
 
-{ #category : #disassembling }
-UnicornSimulator >> extractDestinationRegisterFromAssembly: aLLVMInstruction [ 
-	
-	self subclassResponsibility
-]
-
-{ #category : #registers }
-UnicornSimulator >> framePointerRegister [
-	
-	^ self subclassResponsibility
-]
-
-{ #category : #registers }
-UnicornSimulator >> framePointerRegisterValue [
-
-	^ self readRegister: self framePointerRegister
-]
-
-{ #category : #registers }
-UnicornSimulator >> framePointerRegisterValue: aValue [
-	
-	self writeRegister: self framePointerRegister value: aValue
-]
-
-{ #category : #accessing }
-UnicornSimulator >> getLastAddress: abstractInstructions [ 
-
-	^ abstractInstructions last address + abstractInstructions last machineCodeSize
+	"Do nothing in the case of Unicorn, is useful if the simulator used has to map memory by hand"
 ]
 
 { #category : #'handling invalid accesses' }
-UnicornSimulator >> handleInvalidAccess: invalidAccess [ 
+UnicornSimulator >> handleInvalidAccess: invalidAccess [
 
 	| previousInstructionPointer hasToContinue |
-	previousInstructionPointer := self instructionPointerValue.
-	
+	previousInstructionPointer := self instructionPointerRegisterValue.
+
 	"If the called handler want to resume execution but it has not set a next instruction pointer to execute I will calculate it"
-	
+
 	(hasToContinue := invalidAccessHandler value: invalidAccess)
-		ifTrue: [ previousInstructionPointer = self instructionPointerValue 
-			ifTrue: [  
-					self instructionPointerValue: 
-						self lastExecutedInstructionAddress + self lastExecutedInstructionSize 
-				] ].	
-		
+		ifTrue: [ previousInstructionPointer = self instructionPointerRegisterValue
+			ifTrue: [
+					self instructionPointerRegisterValue:
+						self lastExecutedInstructionAddress + self lastExecutedInstructionSize
+				] ].
+
 	^ hasToContinue
 ]
 
@@ -376,11 +181,11 @@ UnicornSimulator >> initialize [
 	super initialize.
 	unicorn := self createUnicorn.
 	self initializeUnicorn.
-	
+
 	registerAliases := Dictionary new.
 	self initializeRegisterAliases.
-	
-	invalidAccessHandler := [ :invalidAccess | 
+
+	invalidAccessHandler := [ :invalidAccess |
 		self cogit handleSimulationTrap: (UnicornSimulationTrap simulator: self error: invalidAccess).
 		true]
 ]
@@ -395,8 +200,8 @@ UnicornSimulator >> initializeRegisterAliases [
 UnicornSimulator >> initializeUnicorn [
 
 	unicorn
-		registerInvalidMemoryAccessHook: UcHookType invalidMemoryAccess value 
-		doing: [ :type :address :size :value | 
+		registerInvalidMemoryAccessHook: UcHookType invalidMemoryAccess value
+		doing: [ :type :address :size :value |
 			unicorn stop.
 			stopReason := UnicornInvalidMemoryAccess new
 				type: type;
@@ -415,409 +220,38 @@ UnicornSimulator >> instructionPointerRegister [
 
 { #category : #registers }
 UnicornSimulator >> instructionPointerValue [
-	
+
 	^ self readRegister: self instructionPointerRegister
 ]
 
 { #category : #registers }
 UnicornSimulator >> instructionPointerValue: aValue [
-	
+
 	^ self writeRegister: self instructionPointerRegister value: aValue
 ]
 
 { #category : #'as yet unclassified' }
 UnicornSimulator >> integerRegisterState [
-	
-	self subclassResponsibility 
+
+	self subclassResponsibility
 ]
 
 { #category : #'handling invalid accesses' }
-UnicornSimulator >> invalidAccessHandler: aFullBlockClosure [ 
+UnicornSimulator >> invalidAccessHandler: aFullBlockClosure [
 	invalidAccessHandler := aFullBlockClosure
-]
-
-{ #category : #accessing }
-UnicornSimulator >> lastExecutedInstructionAddress [
-
-	^ unicorn lastExecutedInstructionAddress 
-]
-
-{ #category : #accessing }
-UnicornSimulator >> lastExecutedInstructionSize [
-
-	^ unicorn lastExecutedInstructionSize 
-]
-
-{ #category : #accessing }
-UnicornSimulator >> lastInstructionCount [
-	
-	^ unicorn lastInstructionCount 
-]
-
-{ #category : #memory }
-UnicornSimulator >> mapMemory: aMemory at: anAddress [
-
-	unicorn
-		mapHostMemory: aMemory
-		atAddress: anAddress
-		withPermissions: UnicornConstants permissionAll.
-]
-
-{ #category : #'memory-mapping' }
-UnicornSimulator >> mapMemoryInManager: aSlangMemoryManager [
-
-	aSlangMemoryManager regionsDo: [ :startAddress :region |
-		self mapMemory: region at: startAddress
-	]
-]
-
-{ #category : #accessing }
-UnicornSimulator >> memory [
-	^ memory
-]
-
-{ #category : #accessing }
-UnicornSimulator >> memory: aSpur64BitMMLECoSimulator [
-	
-	memory := aSpur64BitMMLECoSimulator 
-]
-
-{ #category : #memory }
-UnicornSimulator >> memoryAt: address readNext: byteSize [
-	
-	^ unicorn memoryAt: address readNext: byteSize
-]
-
-{ #category : #memory }
-UnicornSimulator >> memoryAt: address write: bytes size: size [
-
-	unicorn memoryAt: address write: bytes size: size
-]
-
-{ #category : #'helpers - stack' }
-UnicornSimulator >> peek [
-
-	| stackAddressIntegerValue peekedByteArray |
-
-	"Getting address from stack register"
-	stackAddressIntegerValue := self stackPointerRegisterValue.
-
-	"Putting the value in the stack memory"
-	peekedByteArray := self memoryAt: stackAddressIntegerValue readNext: self wordSize.
-	
-	^ peekedByteArray
-]
-
-{ #category : #'helpers - stack' }
-UnicornSimulator >> peekAddress [
-	
-	^ self peek integerAt: 1 size: self wordSize signed: false
-]
-
-{ #category : #'stack-access' }
-UnicornSimulator >> popBytes [
-
-	| stackAddressIntegerValue aByteArray |
-
-	"Getting address from stack register"
-	stackAddressIntegerValue := self stackPointerRegisterValue.
-	"Putting the value from the stack memory"
-	aByteArray := self memoryAt: stackAddressIntegerValue readNext: self wordSize.
-	
-	"Updating SP"
-	stackAddressIntegerValue := stackAddressIntegerValue + self wordSize.
-	self stackPointerRegisterValue: stackAddressIntegerValue.
-	
-	^ aByteArray
-]
-
-{ #category : #'stack-access' }
-UnicornSimulator >> popWord [
-
-	| aByteArray |
-	aByteArray := self popBytes.
-	^ aByteArray integerAt: 1 size: self wordSize signed: false.
-]
-
-{ #category : #'stack-access' }
-UnicornSimulator >> pushBytes: aByteArray [ 
-
-	| stackAddressIntegerValue |
-	self assert: aByteArray size = self wordSize.
-
-	"Getting address from stack register"
-	stackAddressIntegerValue := self stackPointerRegisterValue.
-
-	"Updating SP"
-	stackAddressIntegerValue := stackAddressIntegerValue - self wordSize.
-	self stackPointerRegisterValue: stackAddressIntegerValue.
-	
-	"Putting the value in the stack memory"
-	self
-		memoryAt: stackAddressIntegerValue
-		write: aByteArray
-		size: self wordSize
-
-]
-
-{ #category : #'stack-access' }
-UnicornSimulator >> pushWord: anInteger [ 
-
-	| aByteArray |
-	aByteArray := ByteArray new: self wordSize.
-	aByteArray integerAt: 1 put: anInteger size: self wordSize signed: false.
-	self pushBytes: aByteArray
-]
-
-{ #category : #'as yet unclassified' }
-UnicornSimulator >> readFloat64Register: aRegisterID [ 
-
-	| registerValue |
-	registerValue := ByteArray new: 8.
-	unicorn register: aRegisterID value readInto: registerValue.
-	
-	^ registerValue doubleAt: 1
-]
-
-{ #category : #registers }
-UnicornSimulator >> readRegister: aRegisterID [
-
-	| registerValue |
-	registerValue := ByteArray new: self wordSize.
-	unicorn register: aRegisterID value readInto: registerValue.
-	^ registerValue integerAt: 1 size: self wordSize signed: false
-]
-
-{ #category : #registers }
-UnicornSimulator >> receiverRegister [
-	
-	^ self subclassResponsibility
-]
-
-{ #category : #registers }
-UnicornSimulator >> receiverRegisterValue [
-
-	^ self readRegister: self receiverRegister
-]
-
-{ #category : #registers }
-UnicornSimulator >> receiverRegisterValue: anInteger [ 
-
-	self writeRegister: self receiverRegister value: anInteger
-]
-
-{ #category : #'reading memory' }
-UnicornSimulator >> register: anIndex readInto: aByteArray [ 
-
-	unicorn register: anIndex readInto: aByteArray 
-]
-
-{ #category : #'as yet unclassified' }
-UnicornSimulator >> register: aRegisterIndex write: aByteArray [
-
-	unicorn register: aRegisterIndex readInto: aByteArray 
-]
-
-{ #category : #accessing }
-UnicornSimulator >> registerDescriptors [
-	
-	^ self registerList collect: [ :e |
-		UnicornRegisterDescriptor new
-			simulator: self;
-			alias: (self aliasForRegister: e);
-			name: e;
-			yourself ]
 ]
 
 { #category : #initialization }
 UnicornSimulator >> registerHook: aBlock atAddress: anAddress [
 
 	unicorn
-		registerInvalidMemoryAccessHook: UcHookType fetchingAccess value 
+		registerInvalidMemoryAccessHook: UcHookType fetchingAccess value
 		doing: [ :type :address :size :value | address = anAddress ifTrue: aBlock ]
 ]
 
-{ #category : #registers }
-UnicornSimulator >> returnRegisterValue [
-	
-	^ self receiverRegisterValue
-]
-
-{ #category : #registers }
-UnicornSimulator >> returnRegisterValue: aValue [
-	
-	^ self receiverRegisterValue: aValue
-]
-
-{ #category : #registers }
-UnicornSimulator >> sendNumberOfArgumentsRegister [
-
-	self subclassResponsibility
-]
-
-{ #category : #registers }
-UnicornSimulator >> sendNumberOfArgumentsRegister: anInteger [ 
-	self shouldBeImplemented.
-]
-
-{ #category : #registers }
-UnicornSimulator >> sendNumberOfArgumentsRegisterValue [
-	
-	^ self readRegister: self sendNumberOfArgumentsRegister
-]
-
-{ #category : #registers }
-UnicornSimulator >> sendNumberOfArgumentsRegisterValue: aValue [
-
-	^ self writeRegister: self sendNumberOfArgumentsRegister value: aValue
-]
-
-{ #category : #'as yet unclassified' }
-UnicornSimulator >> simulateLeafCallOf: address nextpc: nextpc memory: aMemory [
-
-	self pushWord: nextpc.
-	self rip: address
-]
-
-{ #category : #accessing }
-UnicornSimulator >> smalltalkStackPointerRegister [
-	"By default they are the same"
-	^ self stackPointerRegister
-]
-
-{ #category : #registers }
-UnicornSimulator >> smalltalkStackPointerRegisterValue [
-
-	^ self readRegister: self smalltalkStackPointerRegister
-]
-
-{ #category : #registers }
-UnicornSimulator >> smalltalkStackPointerRegisterValue: aValue [
-	
-	self writeRegister: self smalltalkStackPointerRegister value: aValue
-]
-
-{ #category : #registers }
-UnicornSimulator >> smashRegisterAccessors [
-	
-	^ self subclassResponsibility 
-]
-
-{ #category : #registers }
-UnicornSimulator >> smashRegistersWithValuesFrom: base by: step [ 
-	
-	self smashRegisterAccessors withIndexDo: [:accessor :index|
-		self perform: accessor with: index - 1 * step + base]
-]
-
-{ #category : #registers }
-UnicornSimulator >> stackPointerRegister [
-	
-	self subclassResponsibility
-]
-
-{ #category : #registers }
-UnicornSimulator >> stackPointerRegisterValue [
-
-	^ self readRegister: self stackPointerRegister
-]
-
-{ #category : #registers }
-UnicornSimulator >> stackPointerRegisterValue: aValue [
-	
-	self writeRegister: self stackPointerRegister value: aValue
-]
-
-{ #category : #'stack-access' }
-UnicornSimulator >> stackValueAt: anInteger [ 
-
-	"Get a value from the stack at a 0-base position"
-	| aByteArray |
-	aByteArray := self stackValueBytesAt: anInteger.
-	^ aByteArray integerAt: 1 size: self wordSize signed: false
-]
-
-{ #category : #'stack-access' }
-UnicornSimulator >> stackValueBytesAt: position [
-
-	"Get the bytes from the stack at a 0-base position"
-	| stackAddressIntegerValue aByteArray |
-
-	"Getting address from stack register"
-	stackAddressIntegerValue := self stackPointerRegisterValue.
-
-	"Putting the value from the stack memory.
-	Remember, stack grows down, so we add the offset"
-	aByteArray := self
-		memoryAt: stackAddressIntegerValue + (position * self wordSize)
-		readNext: self wordSize.
-
-	^ aByteArray
-]
-
-{ #category : #'stack-access' }
-UnicornSimulator >> stackValues [
-	
-	| initialValue |
-	initialValue := self smalltalkStackPointerRegisterValue.
-	
-	^ (1 to: 30) collect: [ :anIndex |  
-		VMMachineCodeDebuggerStackItem address: initialValue + (memory wordSize * (anIndex - 1)) on: self.	
-	] 
-]
-
 { #category : #executing }
-UnicornSimulator >> startAt: begin until: until timeout: timeout count: count [ 
+UnicornSimulator >> startAt: begin until: until timeout: timeout count: count [
 
 	^ self doStartAt: begin until: until timeout: timeout count: count.
-	
-]
-
-{ #category : #actions }
-UnicornSimulator >> step [
-	
-	self
-		startAt: self instructionPointerValue
-		until: 0
-		timeout: 0
-		count: 1
-]
-
-{ #category : #registers }
-UnicornSimulator >> temporaryRegister [
-	
-	^ self subclassResponsibility
-]
-
-{ #category : #accessing }
-UnicornSimulator >> temporaryRegisterValue [
-	
-	^ self readRegister: self temporaryRegister
-]
-
-{ #category : #registers }
-UnicornSimulator >> temporaryRegisterValue: anInteger [ 
-	
-	^ self writeRegister: self temporaryRegister value: anInteger
-]
-
-{ #category : #accessing }
-UnicornSimulator >> wordAt: anInteger [ 
-	
-	^ memory longAt: anInteger
-]
-
-{ #category : #accessing }
-UnicornSimulator >> wordSize [
-	self subclassResponsibility
-]
-
-{ #category : #registers }
-UnicornSimulator >> writeRegister: aRegister value: anInteger [ 
-
-	| value |
-	value := ByteArray new: self wordSize.
-	value integerAt: 1 put: anInteger size: self wordSize signed: false.
-	unicorn register: aRegister value write: value.
 
 ]

--- a/smalltalksrc/VMMakerTests/UnicornSimulator.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornSimulator.class.st
@@ -12,43 +12,6 @@ Class {
 }
 
 { #category : #'instance creation' }
-UnicornSimulator class >> ARMv5 [
-
-	^ UnicornARMv5Simulator new
-]
-
-{ #category : #'instance creation' }
-UnicornSimulator class >> ARMv8 [
-
-	^ UnicornARMv8Simulator new
-]
-
-{ #category : #'instance creation' }
-UnicornSimulator class >> IA32 [
-
-	^ UnicornI386Simulator new
-]
-
-{ #category : #'instance creation' }
-UnicornSimulator class >> X64 [
-
-	^ UnicornX64Simulator new
-]
-
-{ #category : #'instance creation' }
-UnicornSimulator class >> aarch64 [
-
-	^ UnicornARMv8Simulator new
-]
-
-{ #category : #'instance creation' }
-UnicornSimulator class >> riscv64 [
-
-	"TODO: Add riscv32 and possibly two subclasses for the RISCV simulator"
-	^ UnicornRISCVSimulator new
-]
-
-{ #category : #'instance creation' }
 UnicornSimulator class >> supportsISA: isa [
 
 	^ #( #ARMv5 #ARMv8 #IA32 #X64 #aarch64 #riscv64 ) includes: isa
@@ -102,7 +65,7 @@ UnicornSimulator >> doStartAt: startAddress until: until timeout: timeout count:
 	startTime := Time millisecondClockValue.
 	remainingTimeout := timeout.
 	remainingCount := count.
-
+	
 	[ true ]
 		whileTrue: [
 			[result :=  simulator

--- a/smalltalksrc/VMMakerTests/UnicornSimulator.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornSimulator.class.st
@@ -1,11 +1,8 @@
 Class {
 	#name : #UnicornSimulator,
-	#superclass : #Object,
+	#superclass : #ProcessorSimulator,
 	#instVars : [
-		'unicorn',
 		'stopReason',
-		'memory',
-		'registerAliases',
 		'invalidAccessHandler'
 	],
 	#category : #'VMMakerTests-Unicorn'
@@ -23,39 +20,6 @@ UnicornSimulator >> createUnicorn [
 	self subclassResponsibility
 ]
 
-{ #category : #disassembling }
-UnicornSimulator >> disassembleCurrentInstruction [
-
-	^ (self disassembleFrom: self instructionPointerValue opcodes: 1) first
-]
-
-{ #category : #disassembling }
-UnicornSimulator >> disassembleFrom: anIndex opcodes: numberOfInstructions [
-
-	^ self disassembler
-		printImmediatesInHexa;
-		disassembleNext: numberOfInstructions
-		instructionsIn: (memory memoryManager copyFrom: anIndex to: anIndex + (numberOfInstructions * 50) "rough estimate")
-		startAddress: anIndex
-		pc: self instructionPointerValue
-]
-
-{ #category : #disassembling }
-UnicornSimulator >> disassembleFrom: start to: stop [
-
-	^ self disassembler
-		printImmediatesInHexa;
-		disassembleNext: 1000
-		instructionsIn: (memory memory copyFrom: start to: stop)
-		startAddress: start
-		pc: self instructionPointerValue
-]
-
-{ #category : #disassembling }
-UnicornSimulator >> disassembler [
-	self subclassResponsibility
-]
-
 { #category : #executing }
 UnicornSimulator >> doStartAt: startAddress until: until timeout: timeout count: count [
 
@@ -65,7 +29,6 @@ UnicornSimulator >> doStartAt: startAddress until: until timeout: timeout count:
 	startTime := Time millisecondClockValue.
 	remainingTimeout := timeout.
 	remainingCount := count.
-	
 	[ true ]
 		whileTrue: [
 			[result :=  simulator
@@ -80,7 +43,7 @@ UnicornSimulator >> doStartAt: startAddress until: until timeout: timeout count:
 						error signal ].
 
 			"If execution did not stop because of a stop reason, verify the error code"
-			unicorn verifyErrorCode: result]
+			simulator verifyErrorCode: result]
 				on: UnicornInvalidMemoryAccess do: [ :invalidAccess |
 
 					self instructionPointerRegisterValue = until ifTrue: [ ^ 0 ].
@@ -91,7 +54,7 @@ UnicornSimulator >> doStartAt: startAddress until: until timeout: timeout count:
 			stopReason ifNotNil: [ ^ result ].
 
 			count ~= 0 ifTrue: [ | lastCount |
-				lastCount := unicorn lastInstructionCount.
+				lastCount := simulator lastInstructionCount.
 				remainingCount := remainingCount - lastCount.
 				remainingCount <= 0 ifTrue: [ ^ result ]].
 
@@ -104,7 +67,6 @@ UnicornSimulator >> doStartAt: startAddress until: until timeout: timeout count:
 						UnicornTimeout new
 								target: until;
 								signal ]].
-
 			self instructionPointerRegisterValue = until
 				ifTrue: [ ^ result ]]
 ]
@@ -133,16 +95,11 @@ UnicornSimulator >> handleInvalidAccess: invalidAccess [
 	^ hasToContinue
 ]
 
-{ #category : #testing }
-UnicornSimulator >> hasLinkRegister [
-	^ false
-]
-
 { #category : #initialization }
 UnicornSimulator >> initialize [
 
 	super initialize.
-	unicorn := self createUnicorn.
+	simulator := self createUnicorn.
 	self initializeUnicorn.
 
 	registerAliases := Dictionary new.
@@ -154,18 +111,12 @@ UnicornSimulator >> initialize [
 ]
 
 { #category : #initialization }
-UnicornSimulator >> initializeRegisterAliases [
-
-	"Hook for subclasses"
-]
-
-{ #category : #initialization }
 UnicornSimulator >> initializeUnicorn [
 
-	unicorn
+	simulator
 		registerInvalidMemoryAccessHook: UcHookType invalidMemoryAccess value
 		doing: [ :type :address :size :value |
-			unicorn stop.
+			simulator stop.
 			stopReason := UnicornInvalidMemoryAccess new
 				type: type;
 				address: address;
@@ -173,30 +124,6 @@ UnicornSimulator >> initializeUnicorn [
 				value: value;
 				yourself.
 			false ]
-]
-
-{ #category : #registers }
-UnicornSimulator >> instructionPointerRegister [
-
-	^ self subclassResponsibility
-]
-
-{ #category : #registers }
-UnicornSimulator >> instructionPointerValue [
-
-	^ self readRegister: self instructionPointerRegister
-]
-
-{ #category : #registers }
-UnicornSimulator >> instructionPointerValue: aValue [
-
-	^ self writeRegister: self instructionPointerRegister value: aValue
-]
-
-{ #category : #'as yet unclassified' }
-UnicornSimulator >> integerRegisterState [
-
-	self subclassResponsibility
 ]
 
 { #category : #'handling invalid accesses' }
@@ -207,7 +134,7 @@ UnicornSimulator >> invalidAccessHandler: aFullBlockClosure [
 { #category : #initialization }
 UnicornSimulator >> registerHook: aBlock atAddress: anAddress [
 
-	unicorn
+	simulator
 		registerInvalidMemoryAccessHook: UcHookType fetchingAccess value
 		doing: [ :type :address :size :value | address = anAddress ifTrue: aBlock ]
 ]

--- a/smalltalksrc/VMMakerTests/UnicornX64Simulator.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornX64Simulator.class.st
@@ -10,22 +10,6 @@ UnicornX64Simulator >> arg0Register [
 	^ UcX86Registers rdi
 ]
 
-{ #category : #'as yet unclassified' }
-UnicornX64Simulator >> argument0RegisterValue [
-	
-	"System V value.
-	
-	This does not (yet) handle Win64 ABI which uses RCX"
-	
-	^ self rdi
-]
-
-{ #category : #accessing }
-UnicornX64Simulator >> argument0RegisterValue: anInteger [ 
-
-	self writeRegister: UcX86Registers rdi value: anInteger
-]
-
 { #category : #'phisical-registers' }
 UnicornX64Simulator >> baseRegister [
 
@@ -36,12 +20,6 @@ UnicornX64Simulator >> baseRegister [
 UnicornX64Simulator >> cResultRegister [
 	
 	^ self rax
-]
-
-{ #category : #'as yet unclassified' }
-UnicornX64Simulator >> cReturnRegisterValue: anInteger [ 
-	
-	self rax: anInteger
 ]
 
 { #category : #registers }

--- a/smalltalksrc/VMMakerTests/UnicornX64Simulator.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornX64Simulator.class.st
@@ -80,12 +80,6 @@ UnicornX64Simulator >> doublePrecisionFloatingPointRegister0 [
 	^ UcX86Registers xmm0
 ]
 
-{ #category : #'as yet unclassified' }
-UnicornX64Simulator >> doublePrecisionFloatingPointRegister0Value [
-
-	^ self readFloat64Register: UcX86Registers xmm0
-]
-
 { #category : #registers }
 UnicornX64Simulator >> doublePrecisionFloatingPointRegister1 [
 
@@ -106,12 +100,6 @@ UnicornX64Simulator >> extractDestinationRegisterFromAssembly: aLLVMInstruction 
 	(registerName beginsWith: '%')
 		ifTrue: [ registerName := registerName allButFirst ].
 	^ registerName
-]
-
-{ #category : #'phisical-registers' }
-UnicornX64Simulator >> fp [
-
-	^ self rbp
 ]
 
 { #category : #'virtual-registers' }
@@ -153,11 +141,6 @@ UnicornX64Simulator >> instructionPointerRegister [
 UnicornX64Simulator >> integerRegisterState [
 	
 	^ #()
-]
-
-{ #category : #'as yet unclassified' }
-UnicornX64Simulator >> pc [
-	^ self rip
 ]
 
 { #category : #'as yet unclassified' }
@@ -495,7 +478,7 @@ UnicornX64Simulator >> smashRegisterAccessors [
 { #category : #'virtual-registers' }
 UnicornX64Simulator >> stackPointerRegister [
 
-	^ UcX86Registers rsp
+	^ UcX86Registers esp
 ]
 
 { #category : #registers }

--- a/smalltalksrc/VMMakerTests/UnicornX64Simulator.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornX64Simulator.class.st
@@ -10,6 +10,12 @@ UnicornX64Simulator >> arg0Register [
 	^ UcX86Registers rdi
 ]
 
+{ #category : #registers }
+UnicornX64Simulator >> arg1Register [
+	
+	^ UcX86Registers rsi
+]
+
 { #category : #'phisical-registers' }
 UnicornX64Simulator >> baseRegister [
 
@@ -68,10 +74,28 @@ UnicornX64Simulator >> disassembler [
 	^ LLVMDisassembler amd64
 ]
 
+{ #category : #registers }
+UnicornX64Simulator >> doublePrecisionFloatingPointRegister0 [
+
+	^ UcX86Registers xmm0
+]
+
 { #category : #'as yet unclassified' }
 UnicornX64Simulator >> doublePrecisionFloatingPointRegister0Value [
 
 	^ self readFloat64Register: UcX86Registers xmm0
+]
+
+{ #category : #registers }
+UnicornX64Simulator >> doublePrecisionFloatingPointRegister1 [
+
+	^ UcX86Registers xmm1
+]
+
+{ #category : #registers }
+UnicornX64Simulator >> doublePrecisionFloatingPointRegister2 [
+
+	^ UcX86Registers xmm2
 ]
 
 { #category : #'as yet unclassified' }
@@ -100,6 +124,12 @@ UnicornX64Simulator >> framePointerRegister [
 UnicornX64Simulator >> getReturnAddress [
 	
 	^ self peekAddress 
+]
+
+{ #category : #testing }
+UnicornX64Simulator >> hasLinkRegister [
+
+	^ false
 ]
 
 { #category : #initialization }
@@ -455,12 +485,6 @@ UnicornX64Simulator >> smashRegisterAccessors [
 	^#(rax: rbx: rcx: rdx: rsi: rdi: r8: r9: r10: r11: r12: r13: r14: r15:)
 ]
 
-{ #category : #'phisical-registers' }
-UnicornX64Simulator >> sp [
-
-	^ self rsp
-]
-
 { #category : #'virtual-registers' }
 UnicornX64Simulator >> stackPointerRegister [
 
@@ -472,12 +496,6 @@ UnicornX64Simulator >> temporaryRegister [
 	
 	"Both in System V and Windows"
 	^ UcX86Registers rax
-]
-
-{ #category : #accessing }
-UnicornX64Simulator >> temporaryRegisterValue [
-
-	^ self rax
 ]
 
 { #category : #accessing }

--- a/smalltalksrc/VMMakerTests/UnicornX64Simulator.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornX64Simulator.class.st
@@ -25,7 +25,7 @@ UnicornX64Simulator >> baseRegister [
 { #category : #'as yet unclassified' }
 UnicornX64Simulator >> cResultRegister [
 	
-	^ self rax
+	^ UcX86Registers rax
 ]
 
 { #category : #registers }
@@ -451,6 +451,13 @@ UnicornX64Simulator >> simulateJumpCallOf: address memory: aMemory [
 	self pushWord: self rbp.
 	self rbp: self rsp.
 
+	self rip: address
+]
+
+{ #category : #'as yet unclassified' }
+UnicornX64Simulator >> simulateLeafCallOf: address nextpc: nextpc memory: aMemory [
+
+	self pushWord: nextpc.
 	self rip: address
 ]
 

--- a/smalltalksrc/VMMakerTests/UnicornX64Simulator.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornX64Simulator.class.st
@@ -478,7 +478,7 @@ UnicornX64Simulator >> smashRegisterAccessors [
 { #category : #'virtual-registers' }
 UnicornX64Simulator >> stackPointerRegister [
 
-	^ UcX86Registers esp
+	^ UcX86Registers rsp
 ]
 
 { #category : #registers }

--- a/smalltalksrc/VMMakerTests/VMARMV8SpecificEncodingTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMARMV8SpecificEncodingTest.class.st
@@ -35,13 +35,13 @@ VMARMV8SpecificEncodingTest >> doTestEncodeMoveMbrR: constant [
 	
 	memory byteAt: expectedAddress put: expectedValue.
 	
-	machineSimulator argument0RegisterValue: 0.
+	machineSimulator arg0RegisterValue: 0.
 	machineSimulator receiverRegisterValue: expectedAddress + constant negated.
 
 	self runGeneratedCode.
 	
 	self 
-		assert: machineSimulator argument0RegisterValue 
+		assert: machineSimulator arg0RegisterValue 
 		equals: expectedValue.
 
 ]
@@ -59,13 +59,13 @@ VMARMV8SpecificEncodingTest >> doTestEncodeMoveMwrR: constant [
 	
 	memory long32At: expectedAddress put: expectedValue.
 	
-	machineSimulator argument0RegisterValue: 0.
+	machineSimulator arg0RegisterValue: 0.
 	machineSimulator receiverRegisterValue: expectedAddress + constant negated.
 
 	self runGeneratedCode.
 	
 	self 
-		assert: machineSimulator argument0RegisterValue 
+		assert: machineSimulator arg0RegisterValue 
 		equals: expectedValue.
 
 ]
@@ -82,7 +82,7 @@ VMARMV8SpecificEncodingTest >> doTestEncodeMoveRMwr: constant [
 		cogit MoveR: ReceiverResultReg Mw: constant r: Arg0Reg].
 	
 	machineSimulator receiverRegisterValue: 16r100.
-	machineSimulator argument0RegisterValue: expectedAddress + constant negated.
+	machineSimulator arg0RegisterValue: expectedAddress + constant negated.
 
 	self runGeneratedCode.
 	

--- a/smalltalksrc/VMMakerTests/VMCodeCompactionTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMCodeCompactionTest.class.st
@@ -94,7 +94,7 @@ VMCodeCompactionTest >> testCompactDuringInterpreterPrimitiveThatMovesCurrentMet
 	cogit setCFramePointer: interpreter rumpCStackAddress.
 	
 	self prepareStackForSendReceiver: memory nilObject arguments: {memory falseObject}.
-	machineSimulator instructionPointerValue: compactMethod address + cogit noCheckEntryOffset. 
+	machineSimulator instructionPointerRegisterValue: compactMethod address + cogit noCheckEntryOffset. 
 	
 	self runFrom: compactMethod address + cogit noCheckEntryOffset until: callerAddress.
 
@@ -133,7 +133,7 @@ VMCodeCompactionTest >> testCompactDuringInterpreterPrimitiveThatMovesCurrentMet
 	cogit setCFramePointer: interpreter rumpCStackAddress.
 	
 	self prepareStackForSendReceiver: memory nilObject arguments: {memory falseObject}.
-	machineSimulator instructionPointerValue: compactMethod address + cogit noCheckEntryOffset. 
+	machineSimulator instructionPointerRegisterValue: compactMethod address + cogit noCheckEntryOffset. 
 	
 	self runFrom: compactMethod address + cogit noCheckEntryOffset until: callerAddress.
 
@@ -195,7 +195,7 @@ VMCodeCompactionTest >> testCompactingShouldRelocateInSendsLiterals [
 
 	"In StackToRegisterMappingCogit the argument came in the registerArg0"
 	self
-		assert: machineSimulator argument0RegisterValue
+		assert: machineSimulator arg0RegisterValue
 		equals: memory nilObject
 ]
 
@@ -311,7 +311,7 @@ VMCodeCompactionTest >> testCompactingShouldRelocateMonomorphicCallsite [
 		until: (interpreter cogMethodOf: calleeMethodOop) asInteger + cogit entryOffset.
 
 	self
-		assert: machineSimulator instructionPointerValue
+		assert: machineSimulator instructionPointerRegisterValue
 		equals: (interpreter cogMethodOf: calleeMethodOop) asInteger + cogit entryOffset
 ]
 
@@ -384,7 +384,7 @@ VMCodeCompactionTest >> testCompactingShouldRelocatePolymorphicPICCallsite [
 		until: (interpreter cogMethodOf: calleeMethodOop) asInteger + cogit noCheckEntryOffset.
 
 	self
-		assert: machineSimulator instructionPointerValue
+		assert: machineSimulator instructionPointerRegisterValue
 		equals: (interpreter cogMethodOf: calleeMethodOop) asInteger + cogit noCheckEntryOffset.
 	
 	"Check case 2"
@@ -395,7 +395,7 @@ VMCodeCompactionTest >> testCompactingShouldRelocatePolymorphicPICCallsite [
 		until: (interpreter cogMethodOf: calleeMethodOop2) asInteger + cogit noCheckEntryOffset.
 
 	self
-		assert: machineSimulator instructionPointerValue
+		assert: machineSimulator instructionPointerRegisterValue
 		equals: (interpreter cogMethodOf: calleeMethodOop2) asInteger + cogit noCheckEntryOffset.
 	
 	"Check PIC MISS trampoline"
@@ -408,7 +408,7 @@ VMCodeCompactionTest >> testCompactingShouldRelocatePolymorphicPICCallsite [
 		until: cogit ceCPICMissTrampoline.
 
 	self
-		assert: machineSimulator instructionPointerValue
+		assert: machineSimulator instructionPointerRegisterValue
 		equals: cogit ceCPICMissTrampoline
 ]
 
@@ -480,7 +480,7 @@ VMCodeCompactionTest >> testCompactingShouldRelocatePolymorphicPICInterpreterAbo
 		until: cogit cePICAbortTrampoline.
 
 	self
-		assert: machineSimulator instructionPointerValue
+		assert: machineSimulator instructionPointerRegisterValue
 		equals: cogit cePICAbortTrampoline
 ]
 
@@ -554,7 +554,7 @@ VMCodeCompactionTest >> testCompactingShouldRelocatePolymorphicPICMNUAbortCallsi
 		until: cogit cePICAbortTrampoline.
 
 	self
-		assert: machineSimulator instructionPointerValue
+		assert: machineSimulator instructionPointerRegisterValue
 		equals: cogit cePICAbortTrampoline
 ]
 

--- a/smalltalksrc/VMMakerTests/VMJittedBoxFloatPrimitivesTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJittedBoxFloatPrimitivesTest.class.st
@@ -55,6 +55,6 @@ VMJittedBoxFloatPrimitivesTest >> testAsFloatWhenThereIsNotSpaceFailsPrimitive [
 	self prepareStackForSendReceiver: (self memory integerObjectOf: 27) arguments: #().
 
 	self runFrom: initialAddress until: stop address.
-	self assert: machineSimulator instructionPointerValue equals: stop address
+	self assert: machineSimulator instructionPointerRegisterValue equals: stop address
 
 ]

--- a/smalltalksrc/VMMakerTests/VMJittedGeneralPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJittedGeneralPrimitiveTest.class.st
@@ -345,7 +345,7 @@ VMJittedGeneralPrimitiveTest >> testGetClassObjectOfClassIndex [
 	machineSimulator receiverRegisterValue: ClassFloatCompactIndex.
 	self runGeneratedCode.
 	
-	self assert: machineSimulator argument0RegisterValue equals: classFloat
+	self assert: machineSimulator arg0RegisterValue equals: classFloat
 ]
 
 { #category : #'tests - support' }
@@ -359,7 +359,7 @@ VMJittedGeneralPrimitiveTest >> testGetNumberOfSlotsOf16BitIndexable [
 	machineSimulator receiverRegisterValue: (self new16BitIndexableOfSize: 8).
 	self runGeneratedCode.
 
-	self assert: machineSimulator argument0RegisterValue equals: 8 * 2 "bytes" / self wordSize
+	self assert: machineSimulator arg0RegisterValue equals: 8 * 2 "bytes" / self wordSize
 ]
 
 { #category : #'tests - support' }
@@ -373,7 +373,7 @@ VMJittedGeneralPrimitiveTest >> testGetNumberOfSlotsOf16BitIndexableWithPadding 
 	machineSimulator receiverRegisterValue: (self new16BitIndexableOfSize: 7).
 	self runGeneratedCode.
 
-	self assert: machineSimulator argument0RegisterValue equals: 8 * 2 "bytes" / self wordSize
+	self assert: machineSimulator arg0RegisterValue equals: 8 * 2 "bytes" / self wordSize
 ]
 
 { #category : #'tests - support' }
@@ -387,7 +387,7 @@ VMJittedGeneralPrimitiveTest >> testGetNumberOfSlotsOf32BitIndexable [
 	machineSimulator receiverRegisterValue: (self new32BitIndexableOfSize: 8).
 	self runGeneratedCode.
 
-	self assert: machineSimulator argument0RegisterValue equals: 8 * 4 "bytes" / self wordSize
+	self assert: machineSimulator arg0RegisterValue equals: 8 * 4 "bytes" / self wordSize
 ]
 
 { #category : #'tests - support' }
@@ -401,7 +401,7 @@ VMJittedGeneralPrimitiveTest >> testGetNumberOfSlotsOf32BitIndexableWithPadding 
 	machineSimulator receiverRegisterValue: (self new32BitIndexableOfSize: 7).
 	self runGeneratedCode.
 
-	self assert: machineSimulator argument0RegisterValue equals: (7 * 4 roundUpTo: self wordSize) "bytes" / self wordSize
+	self assert: machineSimulator arg0RegisterValue equals: (7 * 4 roundUpTo: self wordSize) "bytes" / self wordSize
 ]
 
 { #category : #'tests - support' }
@@ -419,7 +419,7 @@ VMJittedGeneralPrimitiveTest >> testGetNumberOfSlotsOf64BitIndexable [
 	machineSimulator receiverRegisterValue: (self new64BitIndexableOfSize: desiredSlots).
 	self runGeneratedCode.
 
-	self assert: machineSimulator argument0RegisterValue equals: (desiredSlots * 8 / self wordSize)
+	self assert: machineSimulator arg0RegisterValue equals: (desiredSlots * 8 / self wordSize)
 ]
 
 { #category : #'tests - support' }
@@ -433,7 +433,7 @@ VMJittedGeneralPrimitiveTest >> testGetNumberOfSlotsOf8BitIndexable [
 	machineSimulator receiverRegisterValue: (self new8BitIndexableOfSize: 8).
 	self runGeneratedCode.
 
-	self assert: machineSimulator argument0RegisterValue equals: 8 "bytes" / self wordSize
+	self assert: machineSimulator arg0RegisterValue equals: 8 "bytes" / self wordSize
 ]
 
 { #category : #'tests - support' }
@@ -447,7 +447,7 @@ VMJittedGeneralPrimitiveTest >> testGetNumberOfSlotsOf8BitIndexableWithPadding [
 	machineSimulator receiverRegisterValue: (self new8BitIndexableOfSize: 7).
 	self runGeneratedCode.
 
-	self assert: machineSimulator argument0RegisterValue equals: 8 "bytes" / self wordSize
+	self assert: machineSimulator arg0RegisterValue equals: 8 "bytes" / self wordSize
 ]
 
 { #category : #'tests - support' }
@@ -1073,7 +1073,7 @@ VMJittedGeneralPrimitiveTest >> testSmallIntegerLessThanNonSmallIntegerArgumentD
 	
 	"Receiver and argument should stay untouched"
 	self assert: machineSimulator receiverRegisterValue equals: (self memory integerObjectOf: 42).
-	self assert: machineSimulator argument0RegisterValue equals: self memory falseObject.
+	self assert: machineSimulator arg0RegisterValue equals: self memory falseObject.
 ]
 
 { #category : #'tests - support' }

--- a/smalltalksrc/VMMakerTests/VMJittedPrimitiveAtTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJittedPrimitiveAtTest.class.st
@@ -11,7 +11,7 @@ Class {
 VMJittedPrimitiveAtTest >> assertFallsThrough [
 
 	self runFrom: initialAddress until: stop address.
-	self assert: machineSimulator instructionPointerValue equals: stop address
+	self assert: machineSimulator instructionPointerRegisterValue equals: stop address
 ]
 
 { #category : #running }
@@ -543,7 +543,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAtFixedObjectWithNoInstanceVariablesShou
 		arguments: { memory integerObjectOf: 1 }.
 	self runFrom: initialAddress until: stop address.
 
-	self assert: machineSimulator instructionPointerValue equals: stop address
+	self assert: machineSimulator instructionPointerRegisterValue equals: stop address
 ]
 
 { #category : #'tests - immediate' }
@@ -552,7 +552,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAtImmediateCharacterShouldFallThrough [
 	machineSimulator receiverRegisterValue: (memory characterObjectOf: $a codePoint).
 	self runFrom: initialAddress until: stop address.
 
-	self assert: machineSimulator instructionPointerValue equals: stop address
+	self assert: machineSimulator instructionPointerRegisterValue equals: stop address
 ]
 
 { #category : #'tests - immediate' }
@@ -564,7 +564,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAtImmediateFloatShouldFallThrough [
 	machineSimulator receiverRegisterValue: (memory smallFloatObjectOf: 1.0).
 	self runFrom: initialAddress until: stop address.
 
-	self assert: machineSimulator instructionPointerValue equals: stop address
+	self assert: machineSimulator instructionPointerRegisterValue equals: stop address
 ]
 
 { #category : #'tests - immediate' }
@@ -573,5 +573,5 @@ VMJittedPrimitiveAtTest >> testPrimitiveAtSmallIntegerShouldFallThrough [
 	machineSimulator receiverRegisterValue: (memory integerObjectOf: 17).
 	self runFrom: initialAddress until: stop address.
 
-	self assert: machineSimulator instructionPointerValue equals: stop address
+	self assert: machineSimulator instructionPointerRegisterValue equals: stop address
 ]

--- a/smalltalksrc/VMMakerTests/VMJittedPrimitiveSizeTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJittedPrimitiveSizeTest.class.st
@@ -11,7 +11,7 @@ Class {
 VMJittedPrimitiveSizeTest >> assertFallsThrough [
 
 	self runFrom: initialAddress until: stop address.
-	self assert: machineSimulator instructionPointerValue equals: stop address
+	self assert: machineSimulator instructionPointerRegisterValue equals: stop address
 ]
 
 { #category : #running }

--- a/smalltalksrc/VMMakerTests/VMMachineSimulatorTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMMachineSimulatorTest.class.st
@@ -133,7 +133,7 @@ VMMachineSimulatorTest >> testMemoryAccessExceptionHandledCountIsRespected [
 	
 	
 	self 
-		assert: self machineSimulator instructionPointerValue 
+		assert: self machineSimulator instructionPointerRegisterValue 
 		equals: expectedAddress
 ]
 
@@ -243,7 +243,7 @@ VMMachineSimulatorTest >> testMemoryAccessExceptionHandledUntilAddressIsRespecte
 		timeout: 100000 "microseconds = 100ms"
 		count: 0.
 	
-	self assert: self machineSimulator instructionPointerValue equals: jumpInstruction address
+	self assert: self machineSimulator instructionPointerRegisterValue equals: jumpInstruction address
 ]
 
 { #category : #'tests - memory access exception' }
@@ -260,7 +260,7 @@ VMMachineSimulatorTest >> testMemoryAccessExceptionInCallContinuesToCorrectPC [
 	
 	self machineSimulator invalidAccessHandler: [:invalidAccess | 
 		invalidAddressHandled := true.
-		self machineSimulator instructionPointerValue: returningPoint address.
+		self machineSimulator instructionPointerRegisterValue: returningPoint address.
 		true].
 
 	self
@@ -285,7 +285,7 @@ VMMachineSimulatorTest >> testMemoryAccessExceptionInCallHasUpdatedPC [
 	
 	self machineSimulator invalidAccessHandler: [:invalidAccess | 
 		self 
-			assert: self machineSimulator instructionPointerValue 
+			assert: self machineSimulator instructionPointerRegisterValue 
 			equals: 16r7FFF0000.
 		invalidAddressHandled := true.
 		false].
@@ -313,7 +313,7 @@ VMMachineSimulatorTest >> testMemoryAccessExceptionInJumpContinuesToCorrectPC [
 	
 	self machineSimulator invalidAccessHandler: [:invalidAccess | 
 		invalidAddressHandled := true.
-		self machineSimulator instructionPointerValue: returningPoint address.
+		self machineSimulator instructionPointerRegisterValue: returningPoint address.
 		true].
 	
 	self
@@ -338,7 +338,7 @@ VMMachineSimulatorTest >> testMemoryAccessExceptionInJumpHasUpdatedPC [
 	
 	self machineSimulator invalidAccessHandler: [:invalidAccess | 
 		self 
-			assert: self machineSimulator instructionPointerValue 
+			assert: self machineSimulator instructionPointerRegisterValue 
 			equals: 16r7FFF0000.
 		invalidAddressHandled := true.
 		false].
@@ -435,7 +435,7 @@ VMMachineSimulatorTest >> testNormalExecutionCountIsRespectedAndHasCorrectInstru
 		timeout: 0
 		count: 10.
 
-	self assert: self machineSimulator instructionPointerValue equals: jumpInstruction address.
+	self assert: self machineSimulator instructionPointerRegisterValue equals: jumpInstruction address.
 
 ]
 
@@ -479,7 +479,7 @@ VMMachineSimulatorTest >> testNormalExecutionRespectTimeoutUpdatesInstructionPoi
 		timeout: 100000 "microseconds = 100ms" ]
 			on: UnicornTimeout
 			do: [ :e | 
-				self deny: self machineSimulator instructionPointerValue equals: initialAddress.
+				self deny: self machineSimulator instructionPointerRegisterValue equals: initialAddress.
 				self assert: e messageText equals: ''. ^ self ].
 			
 	self fail.

--- a/smalltalksrc/VMMakerTests/VMPrimitiveCallAbstractTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveCallAbstractTest.class.st
@@ -18,12 +18,12 @@ VMPrimitiveCallAbstractTest >> callCogMethod: callingMethod receiver: receiver a
 	arguments do: [ :e | self pushAddress: e ].
 
 	arguments size = 1 
-		ifTrue: [ machineSimulator argument0RegisterValue: (arguments at: 1) ].
+		ifTrue: [ machineSimulator arg0RegisterValue: (arguments at: 1) ].
 
 	arguments size > 1 ifTrue: [ self halt ].
 	
 	self prepareCall.
-	machineSimulator instructionPointerValue: callingMethod address + cogit noCheckEntryOffset. 
+	machineSimulator instructionPointerRegisterValue: callingMethod address + cogit noCheckEntryOffset. 
 
 	self runFrom: callingMethod address + cogit noCheckEntryOffset until: returnAddress.
 

--- a/smalltalksrc/VMMakerTests/VMPrimitiveCallingTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveCallingTest.class.st
@@ -794,7 +794,7 @@ VMPrimitiveCallingTest >> testPrimitiveWithProfileSemaphoreAndNextTickTakesSampl
 		arguments: {memory nilObject}
 		returnAddress: cogit ceMethodAbortTrampoline.
 
-	self assert: machineSimulator instructionPointerValue equals: cogit ceMethodAbortTrampoline.
+	self assert: machineSimulator instructionPointerRegisterValue equals: cogit ceMethodAbortTrampoline.
 	self assert: interpreter nextProfileTick equals: 0
 ]
 

--- a/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitAbstractTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitAbstractTest.class.st
@@ -568,7 +568,7 @@ VMSimpleStackBasedCogitAbstractTest >> prepareStackForSendReceiver: aReceiver ar
 
 	"If the cogit is the StackToRegisterMapping the arguments should go in the registers also"
 	(cogit isKindOf: StackToRegisterMappingCogit) ifTrue: [
-		arguments size >= 1 ifTrue: [ self machineSimulator argument0RegisterValue: (arguments at: 1) ].
+		arguments size >= 1 ifTrue: [ self machineSimulator arg0RegisterValue: (arguments at: 1) ].
 		arguments size > 1 ifTrue: [ self halt ]].
 	
 	self prepareCall

--- a/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitBytecodeTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitBytecodeTest.class.st
@@ -94,7 +94,7 @@ VMSimpleStackBasedCogitBytecodeTest >> doTestReturnReturnsObjectInReturnRegister
 	self compile: compilationBlock.
 	self runUntilReturn.
 
-	self assert: machineSimulator returnRegisterValue equals: anAddress
+	self assert: machineSimulator receiverRegisterValue equals: anAddress
 ]
 
 { #category : #'tests - single bytecode - return' }
@@ -1436,7 +1436,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testSendLiteralZeroWithZeroArgsPushesRetu
 	self runFrom: sendAddress until: sendTrampolineAddress.
 		
 	"Now return from called function/method and execute until the end of the send instruction"
-	machineSimulator returnRegisterValue: (memory integerObjectOf: 42).
+	machineSimulator receiverRegisterValue: (memory integerObjectOf: 42).
 	self runFrom: machineSimulator instructionPointerRegisterValue until: self getLastAddress.
 	
 	self assert: self popAddress equals: (memory integerObjectOf: 42).
@@ -1564,7 +1564,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testSendOneArgSpecialMessagePushesReturnV
 	self runFrom: sendAddress until: sendTrampolineAddress.
 	
 	"Now return from called function/method and execute until the end of the send instruction"
-	machineSimulator returnRegisterValue: (memory integerObjectOf: 42).
+	machineSimulator receiverRegisterValue: (memory integerObjectOf: 42).
 	self runFrom: machineSimulator instructionPointerRegisterValue until: self getLastAddress.
 	
 	self assert: self popAddress equals: (memory integerObjectOf: 42).
@@ -1673,7 +1673,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testSendTwoArgSpecialMessagePushesReturnV
 	self runFrom: sendAddress until: sendTrampolineAddress.
 	
 	"Now return from called function/method and execute until the end of the send instruction"
-	machineSimulator returnRegisterValue: (memory integerObjectOf: 42).
+	machineSimulator receiverRegisterValue: (memory integerObjectOf: 42).
 	self runFrom: machineSimulator instructionPointerRegisterValue until: self getLastAddress.
 	
 	self assert: self popAddress equals: (memory integerObjectOf: 42).
@@ -1766,7 +1766,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testSendZeroArgSpecialMessagePushesReturn
 	self runFrom: sendAddress until: sendTrampolineAddress.
 	
 	"Now return from called function/method and execute until the end of the send instruction"
-	machineSimulator returnRegisterValue: (memory integerObjectOf: 42).
+	machineSimulator receiverRegisterValue: (memory integerObjectOf: 42).
 	self runFrom: machineSimulator instructionPointerRegisterValue until: self getLastAddress.
 	
 	self assert: self popAddress equals: (memory integerObjectOf: 42).

--- a/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitBytecodeTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitBytecodeTest.class.st
@@ -986,7 +986,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testPushThisContextForFullBlockWithFullFr
 	
 	self runFrom: method until: cogit ceLargeActiveContextInFullBlockTrampoline.
 	
-	self assert: machineSimulator instructionPointerValue equals: cogit ceLargeActiveContextInFullBlockTrampoline.
+	self assert: machineSimulator instructionPointerRegisterValue equals: cogit ceLargeActiveContextInFullBlockTrampoline.
 	self assert: machineSimulator sendNumberOfArgumentsRegisterValue equals: numberOfArguments.
 ]
 
@@ -1015,7 +1015,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testPushThisContextForFullBlockWithSmallF
 	
 	self runFrom: method until: cogit ceSmallActiveContextInFullBlockTrampoline.
 	
-	self assert: machineSimulator instructionPointerValue equals: cogit ceSmallActiveContextInFullBlockTrampoline.
+	self assert: machineSimulator instructionPointerRegisterValue equals: cogit ceSmallActiveContextInFullBlockTrampoline.
 	self assert: machineSimulator sendNumberOfArgumentsRegisterValue equals: numberOfArguments.
 ]
 
@@ -1043,7 +1043,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testPushThisContextForMethodWithLargeFram
 	
 	self runFrom: method until: cogit ceLargeActiveContextInMethodTrampoline.
 	
-	self assert: machineSimulator instructionPointerValue equals: cogit ceLargeActiveContextInMethodTrampoline.
+	self assert: machineSimulator instructionPointerRegisterValue equals: cogit ceLargeActiveContextInMethodTrampoline.
 	self assert: machineSimulator sendNumberOfArgumentsRegisterValue equals: numberOfArguments.
 ]
 
@@ -1071,7 +1071,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testPushThisContextForMethodWithSmallFram
 	
 	self runFrom: method until: cogit ceSmallActiveContextInMethodTrampoline.
 	
-	self assert: machineSimulator instructionPointerValue equals: cogit ceSmallActiveContextInMethodTrampoline.
+	self assert: machineSimulator instructionPointerRegisterValue equals: cogit ceSmallActiveContextInMethodTrampoline.
 	self assert: machineSimulator sendNumberOfArgumentsRegisterValue equals: numberOfArguments.
 ]
 
@@ -1100,7 +1100,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testPushThisContextForVanillaBlockWithLar
 	
 	self runFrom: method until: cogit ceLargeActiveContextInBlockTrampoline.
 	
-	self assert: machineSimulator instructionPointerValue equals: cogit ceLargeActiveContextInBlockTrampoline.
+	self assert: machineSimulator instructionPointerRegisterValue equals: cogit ceLargeActiveContextInBlockTrampoline.
 	self assert: machineSimulator sendNumberOfArgumentsRegisterValue equals: numberOfArguments.
 ]
 
@@ -1129,7 +1129,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testPushThisContextForVanillaBlockWithSma
 	
 	self runFrom: method until: cogit ceSmallActiveContextInBlockTrampoline.
 	
-	self assert: machineSimulator instructionPointerValue equals: cogit ceSmallActiveContextInBlockTrampoline.
+	self assert: machineSimulator instructionPointerRegisterValue equals: cogit ceSmallActiveContextInBlockTrampoline.
 	self assert: machineSimulator sendNumberOfArgumentsRegisterValue equals: numberOfArguments.
 ]
 
@@ -1437,7 +1437,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testSendLiteralZeroWithZeroArgsPushesRetu
 		
 	"Now return from called function/method and execute until the end of the send instruction"
 	machineSimulator returnRegisterValue: (memory integerObjectOf: 42).
-	self runFrom: machineSimulator instructionPointerValue until: self getLastAddress.
+	self runFrom: machineSimulator instructionPointerRegisterValue until: self getLastAddress.
 	
 	self assert: self popAddress equals: (memory integerObjectOf: 42).
 ]
@@ -1565,7 +1565,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testSendOneArgSpecialMessagePushesReturnV
 	
 	"Now return from called function/method and execute until the end of the send instruction"
 	machineSimulator returnRegisterValue: (memory integerObjectOf: 42).
-	self runFrom: machineSimulator instructionPointerValue until: self getLastAddress.
+	self runFrom: machineSimulator instructionPointerRegisterValue until: self getLastAddress.
 	
 	self assert: self popAddress equals: (memory integerObjectOf: 42).
 ]
@@ -1674,7 +1674,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testSendTwoArgSpecialMessagePushesReturnV
 	
 	"Now return from called function/method and execute until the end of the send instruction"
 	machineSimulator returnRegisterValue: (memory integerObjectOf: 42).
-	self runFrom: machineSimulator instructionPointerValue until: self getLastAddress.
+	self runFrom: machineSimulator instructionPointerRegisterValue until: self getLastAddress.
 	
 	self assert: self popAddress equals: (memory integerObjectOf: 42).
 ]
@@ -1767,7 +1767,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testSendZeroArgSpecialMessagePushesReturn
 	
 	"Now return from called function/method and execute until the end of the send instruction"
 	machineSimulator returnRegisterValue: (memory integerObjectOf: 42).
-	self runFrom: machineSimulator instructionPointerValue until: self getLastAddress.
+	self runFrom: machineSimulator instructionPointerRegisterValue until: self getLastAddress.
 	
 	self assert: self popAddress equals: (memory integerObjectOf: 42).
 ]

--- a/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitCoggedMethods.class.st
+++ b/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitCoggedMethods.class.st
@@ -25,7 +25,7 @@ VMSimpleStackBasedCogitCoggedMethods >> testUsingEntryOffsetChecksClassRegisterA
 	
 	self runFrom: cogMethod address + cogit entryOffset until: otherBlock.
 
-	self assert: machineSimulator instructionPointerValue equals: otherBlock 
+	self assert: machineSimulator instructionPointerRegisterValue equals: otherBlock 
 ]
 
 { #category : #tests }
@@ -40,7 +40,7 @@ VMSimpleStackBasedCogitCoggedMethods >> testUsingEntryOffsetChecksClassRegisterA
 	
 	self runFrom: cogMethod address + cogit entryOffset until: cogit ceMethodAbortTrampoline.
 
-	self assert: machineSimulator instructionPointerValue equals: cogit ceMethodAbortTrampoline 
+	self assert: machineSimulator instructionPointerRegisterValue equals: cogit ceMethodAbortTrampoline 
 ]
 
 { #category : #tests }
@@ -55,5 +55,5 @@ VMSimpleStackBasedCogitCoggedMethods >> testUsingNoCheckEntryDoesNotCheckClassTa
 	
 	self runFrom: cogMethod address + cogit noCheckEntryOffset until: otherBlock.
 
-	self assert: machineSimulator instructionPointerValue equals: otherBlock 
+	self assert: machineSimulator instructionPointerRegisterValue equals: otherBlock 
 ]

--- a/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitMegamorphicPICTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitMegamorphicPICTest.class.st
@@ -205,5 +205,5 @@ VMSimpleStackBasedCogitMegamorphicPICTest >> testRelinkCallSiteToMegamorphicPICC
 		runFrom: patchedCogMethod address + cogit noCheckEntryOffset 
 		until: createdPic asInteger + cogit entryOffset. 
 	
-	self assert: machineSimulator instructionPointerValue equals: createdPic asInteger + cogit entryOffset
+	self assert: machineSimulator instructionPointerRegisterValue equals: createdPic asInteger + cogit entryOffset
 ]

--- a/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitPolymorphicPICTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitPolymorphicPICTest.class.st
@@ -54,7 +54,7 @@ VMSimpleStackBasedCogitPolymorphicPICTest >> assertPIC: pic hits: hitMethod [
 	 - The instruction pointer is at no check entry offset of the hitted method
 	 - The class register value case 0 tag regardless of the hit
 	 - the receiver register value contains the receiver"
-	self assert: machineSimulator instructionPointerValue equals: hitMethod address + cogit noCheckEntryOffset.
+	self assert: machineSimulator instructionPointerRegisterValue equals: hitMethod address + cogit noCheckEntryOffset.
 	self assert: machineSimulator classRegisterValue equals: (picTypeTags at: 0).
 	self assert: machineSimulator receiverRegisterValue equals: receiver
 ]
@@ -75,7 +75,7 @@ VMSimpleStackBasedCogitPolymorphicPICTest >> assertPICMiss: pic [
 	 - The instruction pointer is at the trampoline
 	 - The class register value contains the pic
 	 - the receiver register value contains the receiver"	
-	self assert: machineSimulator instructionPointerValue equals: cogit ceCPICMissTrampoline.
+	self assert: machineSimulator instructionPointerRegisterValue equals: cogit ceCPICMissTrampoline.
 	self assert: machineSimulator classRegisterValue equals: pic address.
 	self assert: machineSimulator receiverRegisterValue equals: receiver
 ]

--- a/smalltalksrc/VMMakerTests/VMSpecialSendArithmethicTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpecialSendArithmethicTest.class.st
@@ -16,7 +16,7 @@ VMSpecialSendArithmethicTest class >> testParameters [
 { #category : #running }
 VMSpecialSendArithmethicTest >> assertSpecialSendTo: receiverOop withArg: argOop [ 
 
-	self assert: machineSimulator instructionPointerValue equals: sendTrampolineAddress.
+	self assert: machineSimulator instructionPointerRegisterValue equals: sendTrampolineAddress.
 	self assert: machineSimulator receiverRegisterValue equals: receiverOop.
 	self assert: machineSimulator arg0RegisterValue equals: argOop.
 ]


### PR DESCRIPTION
Hello, this is the cleanup I made of the different Unicorn simulators. I tried to get as much as possible in the `ProcessorSimulator` class to remove redundant methods. Now, a simulator only has to define the different registers it uses and the access API is already handled in the superclass. A layer of inheritance is added on top of the `UnicornSimulator` class because it might be useful in the case of other simulators (I had to use Spike and reusing the API was handy!).

I tried to clean things up for the `headless` branch but I can try it again for pharoX if needed!