### PR TITLE
Fix/check integer value

### DIFF
--- a/smalltalksrc/VMMaker/CogObjectRepresentationFor32BitSpur.class.st
+++ b/smalltalksrc/VMMaker/CogObjectRepresentationFor32BitSpur.class.st
@@ -393,7 +393,7 @@ CogObjectRepresentationFor32BitSpur >> genJumpNotSmallIntegerValue: aRegister sc
 	<returnTypeC: #'AbstractInstruction *'>
 	^cogit
 		MoveR: aRegister R: scratchReg;
-		ArithmeticShiftRightCq: 1 R: scratchReg;
+		LogicalShiftLeftCq: 1 R: scratchReg;
 		XorR: aRegister R: scratchReg;
 		JumpLess: 0
 ]

--- a/smalltalksrc/VMMaker/CogObjectRepresentationFor64BitSpur.class.st
+++ b/smalltalksrc/VMMaker/CogObjectRepresentationFor64BitSpur.class.st
@@ -869,7 +869,7 @@ CogObjectRepresentationFor64BitSpur >> genJumpNotSmallIntegerValue: aRegister sc
 	<returnTypeC: #'AbstractInstruction *'>
 	^cogit
 		MoveR: aRegister R: scratchReg;
-		ArithmeticShiftRightCq: 64 - objectMemory numTagBits R: scratchReg;
+		ArithmeticShiftRightCq: 63 - objectMemory numTagBits R: scratchReg;
 		AddCq: 1 R: scratchReg;
 		AndCq: 1 << (objectMemory numTagBits + 1) - 1 R: scratchReg; "sign and top numTags bits must be the same"
 		CmpCq: 1 R: scratchReg;

--- a/smalltalksrc/VMMakerTests/VMCogitHelpersTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMCogitHelpersTest.class.st
@@ -1,0 +1,128 @@
+Class {
+	#name : #VMCogitHelpersTest,
+	#superclass : #VMSimpleStackBasedCogitAbstractTest,
+	#instVars : [
+		'checkIsSmallInteger',
+		'checkNotSmallInteger'
+	],
+	#pools : [
+		'CogAbstractRegisters',
+		'CogRTLOpcodes'
+	],
+	#category : #'VMMakerTests-JitTests'
+}
+
+{ #category : #'as yet unclassified' }
+VMCogitHelpersTest >> assertIsInSmallIntegerRange: anInteger [
+
+	machineSimulator classRegisterValue: anInteger.
+
+	self runUntilReturnFrom: checkIsSmallInteger.
+	
+	self assert: machineSimulator classRegisterValue equals: 0
+]
+
+{ #category : #'as yet unclassified' }
+VMCogitHelpersTest >> assertNotInSmallIntegerRange: anInteger [
+
+	machineSimulator classRegisterValue: anInteger.
+
+	self prepareCall.
+	self runUntilReturnFrom: checkNotSmallInteger.
+	
+	self assert: machineSimulator classRegisterValue equals: 0
+]
+
+{ #category : #'as yet unclassified' }
+VMCogitHelpersTest >> denyIsInSmallIntegerRange: anInteger [
+
+	machineSimulator classRegisterValue: anInteger.
+
+	self runUntilReturnFrom: checkIsSmallInteger.
+	
+	self assert: machineSimulator classRegisterValue equals: 1
+]
+
+{ #category : #'as yet unclassified' }
+VMCogitHelpersTest >> denyIsNotInSmallIntegerRange: anInteger [
+
+	machineSimulator classRegisterValue: anInteger.
+
+	self runUntilReturnFrom: checkNotSmallInteger.
+	
+	self assert: machineSimulator classRegisterValue equals: 1
+]
+
+{ #category : #'as yet unclassified' }
+VMCogitHelpersTest >> runUntilReturnFrom: anAddress [
+	
+	self prepareCall.
+	super runUntilReturnFrom: anAddress
+]
+
+{ #category : #'as yet unclassified' }
+VMCogitHelpersTest >> setUp [
+
+	super setUp.
+	"Compile a simple routine that checks if the Class register has a small integer or not.
+	Puts 0 in the class register if ok, puts 1 if not"
+	checkIsSmallInteger := self compile: [ | jump |
+		jump := cogit objectRepresentation genJumpIsSmallIntegerValue: ClassReg scratch: ReceiverResultReg.
+		"If not integer"
+		cogit MoveCq: 1 R: ClassReg.
+		cogit RetN: 0.
+		"if integer"
+		jump jmpTarget: cogit Label.
+		cogit MoveCq: 0 R: ClassReg.
+		cogit RetN: 0
+	].
+
+	"Compile a simple routine that checks if the Class register has not small integer.
+	Puts 0 in the class register if ok, puts 1 if not"
+	checkNotSmallInteger := self compile: [ | jump |
+		jump := cogit objectRepresentation genJumpNotSmallIntegerValue: ClassReg scratch: ReceiverResultReg.
+		"If not integer"
+		cogit MoveCq: 1 R: ClassReg.
+		cogit RetN: 0.
+		"if integer"
+		jump jmpTarget: cogit Label.
+		cogit MoveCq: 0 R: ClassReg.
+		cogit RetN: 0
+	].
+]
+
+{ #category : #'as yet unclassified' }
+VMCogitHelpersTest >> testCheckNotSmallIntegerWithNonValidSmallIntegers [
+
+	self assertNotInSmallIntegerRange: memory maxSmallInteger + 1.
+
+	"In 32 bits check shifting only by one, in 64 bits by 1, 2 and 3"
+	1 to: memory numSmallIntegerTagBits do: [ :i |
+		self assertNotInSmallIntegerRange: memory maxSmallInteger << i.
+	]
+]
+
+{ #category : #'as yet unclassified' }
+VMCogitHelpersTest >> testCheckNotSmallIntegerWithValidSmallIntegers [
+
+	self denyIsNotInSmallIntegerRange: 0.
+	self denyIsNotInSmallIntegerRange: memory maxSmallInteger.
+]
+
+{ #category : #'as yet unclassified' }
+VMCogitHelpersTest >> testCheckSmallIntegerWithNonValidSmallIntegers [
+
+	self denyIsInSmallIntegerRange: memory maxSmallInteger + 1.
+
+	"In 32 bits check shifting only by one, in 64 bits by 1, 2 and 3"
+	1 to: memory numSmallIntegerTagBits do: [ :i |
+		self denyIsInSmallIntegerRange: memory maxSmallInteger << i.
+	]
+]
+
+{ #category : #'as yet unclassified' }
+VMCogitHelpersTest >> testCheckSmallIntegerWithValidSmallIntegers [
+
+	self assertIsInSmallIntegerRange: 0.
+	self assertIsInSmallIntegerRange: memory maxSmallInteger
+]

--- a/smalltalksrc/VMMakerTests/VMCogitHelpersTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMCogitHelpersTest.class.st
@@ -27,7 +27,6 @@ VMCogitHelpersTest >> assertNotInSmallIntegerRange: anInteger [
 
 	machineSimulator classRegisterValue: anInteger.
 
-	self prepareCall.
 	self runUntilReturnFrom: checkNotSmallInteger.
 	
 	self assert: machineSimulator classRegisterValue equals: 0


### PR DESCRIPTION
We found that integer value checking was not properly defined both in 64 and 32 bits.
The bug is not hit because the buggy functions are only used in 2 places and in really special cases (division) that almost never generates overflows (and thus always generates numbers within range).

The only problematic case was `SmallInteger minVal / -1` that produces integers outside of the integer range.
Think for example that a `int8` has 2^8=256 different values with zero included, giving the range [-128, 127).
So, -128/-1 => 128 which is outside the range.
However, for this case, the buggy code detected correctly the out of range anyways.