### PR TITLE
Make MAXHOSTNAMELEN at least 256

### DIFF
--- a/extracted/plugins/SocketPlugin/src/common/SocketPluginImpl.c
+++ b/extracted/plugins/SocketPlugin/src/common/SocketPluginImpl.c
@@ -129,9 +129,10 @@ struct sockaddr_un
 #endif
 #endif /* !ACORN */
 
-/* Solaris sometimes fails to define this in netdb.h */
-#ifndef  MAXHOSTNAMELEN
-# define MAXHOSTNAMELEN	256
+/* Standardize this to a minimum of 256 characters */
+#if !defined(MAXHOSTNAMELEN) || MAXHOSTNAMELEN < 256
+# undef MAXHOSTNAMELEN
+# define MAXHOSTNAMELEN 256
 #endif
 
 #ifdef HAVE_SD_DAEMON


### PR DESCRIPTION
In Linux is defined as 64, which is correct, since it representes the
max length of a hostname. On other platforms is defined as 256 or not
defined at all.

The Socket plugin uses this value as a limit for the FQDN (Fully
Qualified Domain Name) length. This is very restrictive on Linux, as 64
characters are not enough to resolve some domain names. Making it 256 if
it's not defined as greater fixes this issue on Linux (and any other
platform where this could happen).

Fixes issue #220 - Unable to resolve a host name to an IP address.

Thanks a lot @ezeaguerre