### PR TITLE
Blocking signals while signaling semaphores

### DIFF
--- a/extracted/vm/src/common/sqExternalSemaphores.c
+++ b/extracted/vm/src/common/sqExternalSemaphores.c
@@ -190,6 +190,9 @@ doSignalExternalSemaphores(sqInt externalSemaphoreTableSize)
     sigset_t blockedSignalSet;
     sigemptyset(&blockedSignalSet);
     sigaddset(&blockedSignalSet, SIGCHLD);
+    sigaddset(&blockedSignalSet, SIGINT);
+    sigaddset(&blockedSignalSet, SIGSTOP);
+    sigaddset(&blockedSignalSet, SIGTSTP);
 
     sigprocmask(SIG_BLOCK, &blockedSignalSet, NULL);
 	requestMutex->wait(requestMutex);


### PR DESCRIPTION
Avoid deadlocks caused by signal handlers. Workaround for #392 .
This is a workaround because plugins could add new signal handlers, so this is a bit brittle.