### PR TITLE
Speed up object initialization in AArch64 using SIMD instructions

### DIFF
--- a/smalltalksrc/VMMaker/CogARMv8Compiler.class.st
+++ b/smalltalksrc/VMMaker/CogARMv8Compiler.class.st
@@ -312,6 +312,15 @@ CogARMv8Compiler class >> initializeAbstractRegisters [
 	DPFPReg5			:= D5.
 	DPFPReg6			:= D6.
 	DPFPReg7			:= D7.
+	
+	VReg0 := V0.
+	VReg1 := V1.
+	VReg2 := V2.
+	VReg3 := V3.
+	VReg4 := V4.
+	VReg5 := V5.
+	VReg6 := V6.
+	VReg7 := V7.
 
 	NumFloatRegisters := 8
 ]

--- a/smalltalksrc/VMMaker/CogARMv8Compiler.class.st
+++ b/smalltalksrc/VMMaker/CogARMv8Compiler.class.st
@@ -3777,6 +3777,8 @@ CogARMv8Compiler >> fillFrom: startMemoryAddr until: endMemoryAddr with: fillReg
 	cogit St1S: 64 Vr: vectorRegister R: startMemoryAddr Mw: 16.
 	cogit CmpR: startMemoryAddr R: endMemoryAddr.
 	cogit JumpAbove: fillLoop.
+	
+	^0 "Necessary to keep Slang happy"
 ]
 
 { #category : #'ARM convenience instructions' }

--- a/smalltalksrc/VMMaker/CogARMv8Compiler.class.st
+++ b/smalltalksrc/VMMaker/CogARMv8Compiler.class.st
@@ -3767,6 +3767,7 @@ CogARMv8Compiler >> fcmpFType: ftype leftRegister: firstRegister rightRegister: 
 
 { #category : #concretize }
 CogARMv8Compiler >> fillFrom: startMemoryAddr until: endMemoryAddr with: fillReg usingVr: vectorRegister [
+	<inline: true>
 	| fillLoop |
 	fillLoop := cogit DupS: 64 R: fillReg Vr: vectorRegister.
 	"St1 copies data in 128-bit chunks. This may exceed the size of an object (that only needs to be a multiple of 64 bits).

--- a/smalltalksrc/VMMaker/CogARMv8Compiler.class.st
+++ b/smalltalksrc/VMMaker/CogARMv8Compiler.class.st
@@ -187,7 +187,17 @@ CogARMv8Compiler class >> initialize [
 	D5 := 5.
 	D6 := 6.
 	D7 := 7.
-
+	
+	"ARM 128-bit SIMD registers"
+	V0 := 0.
+	V1 := 1.
+	V2 := 2.
+	V3 := 3.
+	V4 := 4.
+	V5 := 5.
+	V6 := 6.
+	V7 := 7.
+	
 	CArg0Reg := 0.
 	CArg1Reg := 1.
 	CArg2Reg := 2.

--- a/smalltalksrc/VMMaker/CogARMv8Compiler.class.st
+++ b/smalltalksrc/VMMaker/CogARMv8Compiler.class.st
@@ -1231,8 +1231,8 @@ CogARMv8Compiler >> computeMaximumSize [
 		[MovePatcheableC32R] -> [ ^ 4 ].
 		
 		"SIMD Ops"
-		[DupRVR] -> [ ^ 4 ].
-		[St1VRMwO] -> [ ^ 4 ]
+		[DupRVr] -> [ ^ 4 ].
+		[St1VrRMw] -> [ ^ 4 ]
 		}.
 	^0 "to keep C compiler quiet"
 
@@ -1795,7 +1795,7 @@ CogARMv8Compiler >> concretizeDivRdRd [
 ]
 
 { #category : #concretizing }
-CogARMv8Compiler >> concretizeDupRVR [
+CogARMv8Compiler >> concretizeDupRVr [
 
 	"Will get inlined into concretizeAt: switch."
 
@@ -3392,8 +3392,8 @@ CogARMv8Compiler >> dispatchConcretize [
 		[ MovePatcheableC32R ] -> [ ^ self concretizeMovePatcheableC32R ].
 	
 		"SIMD Ops"
-		[ DupRVR ] -> [ ^ self concretizeDupRVR ].
-		[ St1VRMwO ] -> [ ^ self concretizeSt1VRMRO ].
+		[ DupRVr ] -> [ ^ self concretizeDupRVr ].
+		[ St1VrRMw ] -> [ ^ self concretizeSt1VRMRO ].
 		}
 ]
 

--- a/smalltalksrc/VMMaker/CogARMv8Compiler.class.st
+++ b/smalltalksrc/VMMaker/CogARMv8Compiler.class.st
@@ -84,6 +84,14 @@ Class {
 		'STMFD',
 		'SubOpcode',
 		'TstOpcode',
+		'V0',
+		'V1',
+		'V2',
+		'V3',
+		'V4',
+		'V5',
+		'V6',
+		'V7',
 		'VC',
 		'VS',
 		'XorOpcode'
@@ -1214,7 +1222,7 @@ CogARMv8Compiler >> computeMaximumSize [
 		
 		"SIMD Ops"
 		[DupRVR] -> [ ^ 4 ].
-		[St1VRMRO] -> [ ^ 4 ]
+		[St1VRMwO] -> [ ^ 4 ]
 		}.
 	^0 "to keep C compiler quiet"
 
@@ -3375,7 +3383,7 @@ CogARMv8Compiler >> dispatchConcretize [
 	
 		"SIMD Ops"
 		[ DupRVR ] -> [ ^ self concretizeDupRVR ].
-		[ St1VRMRO ] -> [ ^ self concretizeSt1VRMRO ].
+		[ St1VRMwO ] -> [ ^ self concretizeSt1VRMRO ].
 		}
 ]
 

--- a/smalltalksrc/VMMaker/CogARMv8Compiler.class.st
+++ b/smalltalksrc/VMMaker/CogARMv8Compiler.class.st
@@ -1210,7 +1210,10 @@ CogARMv8Compiler >> computeMaximumSize [
 		[MoveRRd]				-> [^4].
 				
 		"This is a fixed size instruction using a literal. We need exactly 1 instructions to move a literal from a PC relative position, so this takes ALWAYS 1 instruction of 4 bytes"
-		[MovePatcheableC32R] -> [ ^ 4 ]
+		[MovePatcheableC32R] -> [ ^ 4 ].
+		
+		"SIMD Ops"
+		[DupRVR] -> [ ^ 4 ]
 		}.
 	^0 "to keep C compiler quiet"
 
@@ -1769,6 +1772,30 @@ CogARMv8Compiler >> concretizeDivRdRd [
 		fDivFirstRegister: registerB
 		secondRegister: registerA
 		destinationRegister: destinationRegister).
+	^ machineCodeSize := 4
+]
+
+{ #category : #concretizing }
+CogARMv8Compiler >> concretizeDupRVR [
+
+	"Will get inlined into concretizeAt: switch."
+
+	<inline: true>
+
+	| srcReg destReg instruction t q size |
+
+	size := operands at: 0.
+	srcReg := operands at: 1.
+	destReg := operands at: 2.
+
+	size = 64 
+		ifTrue: [ t := 2r1000. q := 1 ]
+		ifFalse: [ self notYetImplemented ].
+
+	instruction := self dupT: t q: q source: srcReg dest: destReg.
+
+	self machineCodeAt: 0 put: instruction.
+
 	^ machineCodeSize := 4
 ]
 
@@ -3310,8 +3337,32 @@ CogARMv8Compiler >> dispatchConcretize [
 		[MoveRRd]			-> [^self concretizeMoveRRd].
 		
 		"Patcheable literal instruction"
-		[ MovePatcheableC32R ] -> [ ^ self concretizeMovePatcheableC32R ]
+		[ MovePatcheableC32R ] -> [ ^ self concretizeMovePatcheableC32R ].
+	
+		"SIMD Ops"
+		[ DupRVR ] -> [ ^ self concretizeDupRVR ]
 		}
+]
+
+{ #category : #assembler }
+CogARMv8Compiler >> dupT: t q: q source: src dest: dest [ 
+
+	"
+		C7.2.40 DUP (general)
+
+	DUP <Vd>.<T>, <R><n>
+
+	Duplicate general-purpose register to vector. This instruction duplicates the contents of the source general-purpose
+	register into a scalar or each element in a vector, and writes the result to the SIMD&FP destination register.
+	Depending on the settings in the CPACR_EL1, CPTR_EL2, and CPTR_EL3 registers, and the current Security state
+	and Exception level, an attempt to execute the instruction might be trapped"
+	
+	^ q << 30
+		bitOr: (2r111 << 25
+		bitOr: ((t bitAnd: 2r11111) << 16 
+		bitOr: (2r11 << 10
+		bitOr: ((src bitAnd: 2r11111) << 5
+		bitOr: (dest bitAnd: 2r11111)))))
 ]
 
 { #category : #'immediate-encodings' }

--- a/smalltalksrc/VMMaker/CogARMv8Compiler.class.st
+++ b/smalltalksrc/VMMaker/CogARMv8Compiler.class.st
@@ -3756,6 +3756,19 @@ CogARMv8Compiler >> fcmpFType: ftype leftRegister: firstRegister rightRegister: 
 		bitOr: ((firstRegister bitAnd: 16r1f) << 5)))))
 ]
 
+{ #category : #concretize }
+CogARMv8Compiler >> fillFrom: startMemoryAddr until: endMemoryAddr with: fillReg usingVr: vectorRegister [
+	| fillLoop |
+	fillLoop := cogit DupS: 64 R: fillReg Vr: vectorRegister.
+	"St1 copies data in 128-bit chunks. This may exceed the size of an object (that only needs to be a multiple of 64 bits).
+	This overflow is not an issue, however. The reason for that is that objects are allocated sequentially in the Eden space
+	using a bumpAllocator, which means that the overflowing bits won't overwrite another object. This is true even when reaching
+	the end of the Eden space, as after it we reserve additional headroom."
+	cogit St1S: 64 Vr: vectorRegister R: startMemoryAddr Mw: 16.
+	cogit CmpR: startMemoryAddr R: endMemoryAddr.
+	cogit JumpAbove: fillLoop.
+]
+
 { #category : #'ARM convenience instructions' }
 CogARMv8Compiler >> fldd: destReg rn: srcReg plus: u imm: immediate8bitValue [
 "FLDD or VLDR instruction to move a value from address in an ARM srcReg +/- offset<<2 to an fpu double destReg

--- a/smalltalksrc/VMMaker/CogARMv8Compiler.class.st
+++ b/smalltalksrc/VMMaker/CogARMv8Compiler.class.st
@@ -1213,7 +1213,8 @@ CogARMv8Compiler >> computeMaximumSize [
 		[MovePatcheableC32R] -> [ ^ 4 ].
 		
 		"SIMD Ops"
-		[DupRVR] -> [ ^ 4 ]
+		[DupRVR] -> [ ^ 4 ].
+		[St1VRMRO] -> [ ^ 4 ]
 		}.
 	^0 "to keep C compiler quiet"
 
@@ -2955,6 +2956,39 @@ CogARMv8Compiler >> concretizeSqrtRd [
 	^ machineCodeSize := 4
 ]
 
+{ #category : #concretizing }
+CogARMv8Compiler >> concretizeSt1VRMRO [
+
+	"Will get inlined into concretizeAt: switch."
+
+	<inline: true>
+	| opCode instruction q t size vectorR memoryR offset rm |
+	opCode := 2r0111. "TODO support multiple-register variants"
+	rm := 2r11111. "TODO support register offset variant"
+	size := operands at: 0.
+	vectorR := operands at: 1.
+	memoryR := operands at: 2.
+	offset := operands at: 3.
+
+	((size = 64) & (offset = 16))
+		ifTrue: [ 
+			q := 1.
+			t := 11 ]
+		ifFalse: [ self notYetImplemented ].
+
+	instruction := self
+		               st1Q: q
+		               Rm: rm
+		               OpCode: opCode
+		               S: t
+		               Rn: memoryR
+		               Rt: vectorR.
+
+	self machineCodeAt: 0 put: instruction.
+
+	^ machineCodeSize := 4
+]
+
 { #category : #'generate machine code - concretize' }
 CogARMv8Compiler >> concretizeStop [
 	<inline: true>
@@ -3340,7 +3374,8 @@ CogARMv8Compiler >> dispatchConcretize [
 		[ MovePatcheableC32R ] -> [ ^ self concretizeMovePatcheableC32R ].
 	
 		"SIMD Ops"
-		[ DupRVR ] -> [ ^ self concretizeDupRVR ]
+		[ DupRVR ] -> [ ^ self concretizeDupRVR ].
+		[ St1VRMRO ] -> [ ^ self concretizeSt1VRMRO ].
 		}
 ]
 
@@ -5641,6 +5676,25 @@ CogARMv8Compiler >> smulhSize: is64bits firstRegister: registerA secondRegister:
 		bitOr: (16r1f << 10
 		bitOr: (((registerA bitAnd: 16r1f) << 5)
 		bitOr: (destinationRegister bitAnd: 16r1f))))
+]
+
+{ #category : #concretizing }
+CogARMv8Compiler >> st1Q: q Rm: rm OpCode: opCode S: size Rn: rn Rt: rt [
+
+	"
+	C7.2.321 ST1 (multiple structures)
+
+	ST1 { <Vt>.<T> }, [<Xn|SP>], <Xm>
+
+	Store multiple single-element structures from one, two, three, or four registers. This instruction 	stores elements to memory from one, two, three, or four SIMD&FP registers, without interleaving. 	Every element of each register is stored."
+	
+	^ q << 30
+		bitOr: (2r11001 << 23
+		bitOr: ((rm bitAnd: 2r11111) << 16
+		bitOr: ((opCode bitAnd: 2r1111) << 12
+		bitOr: ((size bitAnd: 2r11) << 10
+		bitOr: ((rn bitAnd: 2r11111) << 5
+		bitOr: (rt bitAnd: 2r11111))))))
 ]
 
 { #category : #accessing }

--- a/smalltalksrc/VMMaker/CogAbstractInstruction.class.st
+++ b/smalltalksrc/VMMaker/CogAbstractInstruction.class.st
@@ -716,6 +716,7 @@ CogAbstractInstruction >> disassembleOn: aStream [
 
 { #category : #accessing }
 CogAbstractInstruction >> fillFrom: startMemoryAddr until: endMemoryAddr with: fillReg usingVr: vectorRegister [
+	<inline: true>
 	| fillLoop |
 	fillLoop := cogit MoveR: fillReg Mw: 0 r: startMemoryAddr.
 	cogit AddCq: 8 R: startMemoryAddr.

--- a/smalltalksrc/VMMaker/CogAbstractInstruction.class.st
+++ b/smalltalksrc/VMMaker/CogAbstractInstruction.class.st
@@ -722,6 +722,8 @@ CogAbstractInstruction >> fillFrom: startMemoryAddr until: endMemoryAddr with: f
 	cogit AddCq: 8 R: startMemoryAddr.
 	cogit CmpR: startMemoryAddr R: endMemoryAddr.
 	cogit JumpAbove: fillLoop.
+	
+	^0 "Necessary to keep Slang happy"
 ]
 
 { #category : #abi }

--- a/smalltalksrc/VMMaker/CogAbstractInstruction.class.st
+++ b/smalltalksrc/VMMaker/CogAbstractInstruction.class.st
@@ -718,8 +718,9 @@ CogAbstractInstruction >> disassembleOn: aStream [
 CogAbstractInstruction >> fillFrom: startMemoryAddr until: endMemoryAddr with: fillReg usingVr: vectorRegister [
 	| fillLoop |
 	fillLoop := cogit MoveR: fillReg Mw: 0 r: startMemoryAddr.
-	cogit AddCq: 8 R: Arg1Reg.
-	cogit CmpR: Arg1Reg R: startMemoryAddr.
+	cogit AddCq: 8 R: startMemoryAddr.
+	cogit CmpR: startMemoryAddr R: endMemoryAddr.
+	cogit JumpAbove: fillLoop.
 ]
 
 { #category : #abi }

--- a/smalltalksrc/VMMaker/CogAbstractInstruction.class.st
+++ b/smalltalksrc/VMMaker/CogAbstractInstruction.class.st
@@ -714,6 +714,14 @@ CogAbstractInstruction >> disassembleOn: aStream [
 		on: aStream
 ]
 
+{ #category : #accessing }
+CogAbstractInstruction >> fillFrom: startMemoryAddr until: endMemoryAddr with: fillReg usingVr: vectorRegister [
+	| fillLoop |
+	fillLoop := cogit MoveR: fillReg Mw: 0 r: startMemoryAddr.
+	cogit AddCq: 8 R: Arg1Reg.
+	cogit CmpR: Arg1Reg R: startMemoryAddr.
+]
+
 { #category : #abi }
 CogAbstractInstruction >> fullCallsAreRelative [
 	"Answer if CallFull and/or JumpFull are relative and hence need relocating on method

--- a/smalltalksrc/VMMaker/CogAbstractRegisters.class.st
+++ b/smalltalksrc/VMMaker/CogAbstractRegisters.class.st
@@ -44,6 +44,14 @@ Class {
 		'SPReg',
 		'SendNumArgsReg',
 		'TempReg',
+		'VReg0',
+		'VReg1',
+		'VReg2',
+		'VReg3',
+		'VReg4',
+		'VReg5',
+		'VReg6',
+		'VReg7',
 		'VarBaseReg'
 	],
 	#category : #'VMMaker-JIT'
@@ -65,7 +73,7 @@ CogAbstractRegisters class >> initialize [
 	NoReg := -1.
 
 	"The core set of abstract registers that define the Cogit's model of Smalltalk code
-	 provide for a register-based calling convention oriented towards inline cacheing and
+	 provide for a register-based calling convention oriented towards inline caching and
 	 executing a core set of machine code primitives in registers.  The set is composed of
 	 8 registers, dictated by the available registers on IA32."
 	"Smalltalk machine code executes on stack pages in the stack zone, requiring frame and stack pointers."
@@ -113,7 +121,17 @@ CogAbstractRegisters class >> initialize [
 	DPFPReg13	:= #undefined.
 	DPFPReg14	:= #undefined.
 	DPFPReg15	:= #undefined.
-
+		
+	"Up to 8 floating-point registers. e.g. IA32+SSE2 can use 8, x64 can use 16."
+	VReg0 := #undefined.
+	VReg1 := #undefined.
+	VReg2 := #undefined.
+	VReg3 := #undefined.
+	VReg4 := #undefined.
+	VReg5 := #undefined.
+	VReg6 := #undefined.
+	VReg7 := #undefined.
+		
 	NumFloatRegisters	:= #undefined.	"Number of floating-point registers (we don;t do single-precision; we don't do xmm high (yet)."
 ]
 

--- a/smalltalksrc/VMMaker/CogAbstractRegisters.class.st
+++ b/smalltalksrc/VMMaker/CogAbstractRegisters.class.st
@@ -122,7 +122,7 @@ CogAbstractRegisters class >> initialize [
 	DPFPReg14	:= #undefined.
 	DPFPReg15	:= #undefined.
 		
-	"Up to 8 floating-point registers. e.g. IA32+SSE2 can use 8, x64 can use 16."
+	"Up to 8 SIMD registers. e.g. IA32+SSE can use 8, Armv8 can use 32."
 	VReg0 := #undefined.
 	VReg1 := #undefined.
 	VReg2 := #undefined.

--- a/smalltalksrc/VMMaker/CogObjectRepresentationFor64BitSpur.class.st
+++ b/smalltalksrc/VMMaker/CogObjectRepresentationFor64BitSpur.class.st
@@ -1583,7 +1583,7 @@ CogObjectRepresentationFor64BitSpur >> genPrimitiveNew [
 	"now fill"
 	cogit LoadEffectiveAddressMw: objectMemory baseHeaderSize r: ReceiverResultReg R: Arg1Reg.
 	cogit MoveCq: objectMemory nilObject R: fillReg.
-	cogit backend fillFrom: Arg1Reg until: byteSizeReg with: fillReg usingVr: 1 "V1"."TODO add constants for vector registers"
+	cogit backend fillFrom: Arg1Reg until: byteSizeReg with: fillReg usingVr: VReg1.
 	cogit genPrimReturn.
 
 	jumpUnhashed jmpTarget:
@@ -1731,7 +1731,7 @@ CogObjectRepresentationFor64BitSpur >> genPrimitiveNewWithArg [
 	cogit MoveR: headerReg Mw: 0 r: ReceiverResultReg.
 	"now fill"
 	cogit LoadEffectiveAddressMw: objectMemory baseHeaderSize r: ReceiverResultReg R: Arg1Reg.
-	cogit backend fillFrom: Arg1Reg until: byteSizeReg with: fillReg usingVr: 1 "V1"."TODO add constants for vector registers"
+	cogit backend fillFrom: Arg1Reg until: byteSizeReg with: fillReg usingVr: VReg1.
 	cogit genPrimReturn.
 	
 	jumpNoSpace jmpTarget:

--- a/smalltalksrc/VMMaker/CogObjectRepresentationFor64BitSpur.class.st
+++ b/smalltalksrc/VMMaker/CogObjectRepresentationFor64BitSpur.class.st
@@ -1583,10 +1583,14 @@ CogObjectRepresentationFor64BitSpur >> genPrimitiveNew [
 	"now fill"
 	cogit LoadEffectiveAddressMw: objectMemory baseHeaderSize r: ReceiverResultReg R: Arg1Reg.
 	cogit MoveCq: objectMemory nilObject R: fillReg.
-	fillLoop := 
-	cogit MoveR: fillReg Mw: 0 r: Arg1Reg.
+	"fillLoop := 
+		cogit MoveR: fillReg Mw: 0 r: Arg1Reg.
 	cogit AddCq: 8 R: Arg1Reg.
-	cogit CmpR: Arg1Reg R: byteSizeReg.
+	cogit CmpR: Arg1Reg R: byteSizeReg."
+	fillLoop :=
+		cogit DupS: 64 R: fillReg VR: "Vr" 1 "V1"."TODO use vector reg as last argument"
+	cogit St1S: 64 VR:"Vr" 1 Mw:"rename" Arg1Reg O:"Mw" 16.
+	cogit CmpR: Arg1Reg R: byteSizeReg."TODO explain why this works!!! Overflow works because Eden is empty, bumpAllocator, and head room"
 	cogit JumpAbove: fillLoop.
 	cogit genPrimReturn.
 

--- a/smalltalksrc/VMMaker/CogObjectRepresentationFor64BitSpur.class.st
+++ b/smalltalksrc/VMMaker/CogObjectRepresentationFor64BitSpur.class.st
@@ -1741,9 +1741,12 @@ CogObjectRepresentationFor64BitSpur >> genPrimitiveNewWithArg [
 	cogit MoveR: headerReg Mw: 0 r: ReceiverResultReg.
 	"now fill"
 	cogit LoadEffectiveAddressMw: objectMemory baseHeaderSize r: ReceiverResultReg R: Arg1Reg.
-	fillLoop := 
+	"fillLoop := 
 	cogit MoveR: fillReg Mw: 0 r: Arg1Reg.
 	cogit AddCq: 8 R: Arg1Reg.
+	cogit CmpR: Arg1Reg R: byteSizeReg."
+	fillLoop := cogit DupS: 64 R: fillReg Vr: 1 "V1"."TODO add constants for vector registers"
+	cogit St1S: 64 Vr: 1 R: Arg1Reg Mw: 16.
 	cogit CmpR: Arg1Reg R: byteSizeReg.
 	cogit JumpAbove: fillLoop.
 	cogit genPrimReturn.

--- a/smalltalksrc/VMMaker/CogObjectRepresentationFor64BitSpur.class.st
+++ b/smalltalksrc/VMMaker/CogObjectRepresentationFor64BitSpur.class.st
@@ -1583,17 +1583,7 @@ CogObjectRepresentationFor64BitSpur >> genPrimitiveNew [
 	"now fill"
 	cogit LoadEffectiveAddressMw: objectMemory baseHeaderSize r: ReceiverResultReg R: Arg1Reg.
 	cogit MoveCq: objectMemory nilObject R: fillReg.
-	"fillLoop := cogit MoveR: fillReg Mw: 0 r: Arg1Reg.
-	cogit AddCq: 8 R: Arg1Reg.
-	cogit CmpR: Arg1Reg R: byteSizeReg."
-	fillLoop := cogit DupS: 64 R: fillReg Vr: 1 "V1"."TODO add constants for vector registers"
-	"St1 copies data in 128-bit chunks. This may exceed the size of an object (that only needs to be a multiple of 64 bits).
-	This overflow is not an issue, however. The reason for that is that objects are allocated sequentially in the Eden space
-	using a bumpAllocator, which means that the overflowing bits won't overwrite another object. This is true even when reaching
-	the end of the Eden space, as after it we reserve additional headroom."
-	cogit St1S: 64 Vr: 1 R: Arg1Reg Mw: 16.
-	cogit CmpR: Arg1Reg R: byteSizeReg.
-	cogit JumpAbove: fillLoop.
+	cogit backend fillFrom: Arg1Reg until: byteSizeReg with: fillReg usingVr: 1 "V1"."TODO add constants for vector registers"
 	cogit genPrimReturn.
 
 	jumpUnhashed jmpTarget:
@@ -1741,14 +1731,7 @@ CogObjectRepresentationFor64BitSpur >> genPrimitiveNewWithArg [
 	cogit MoveR: headerReg Mw: 0 r: ReceiverResultReg.
 	"now fill"
 	cogit LoadEffectiveAddressMw: objectMemory baseHeaderSize r: ReceiverResultReg R: Arg1Reg.
-	"fillLoop := 
-	cogit MoveR: fillReg Mw: 0 r: Arg1Reg.
-	cogit AddCq: 8 R: Arg1Reg.
-	cogit CmpR: Arg1Reg R: byteSizeReg."
-	fillLoop := cogit DupS: 64 R: fillReg Vr: 1 "V1"."TODO add constants for vector registers"
-	cogit St1S: 64 Vr: 1 R: Arg1Reg Mw: 16.
-	cogit CmpR: Arg1Reg R: byteSizeReg.
-	cogit JumpAbove: fillLoop.
+	cogit backend fillFrom: Arg1Reg until: byteSizeReg with: fillReg usingVr: 1 "V1"."TODO add constants for vector registers"
 	cogit genPrimReturn.
 	
 	jumpNoSpace jmpTarget:

--- a/smalltalksrc/VMMaker/CogObjectRepresentationFor64BitSpur.class.st
+++ b/smalltalksrc/VMMaker/CogObjectRepresentationFor64BitSpur.class.st
@@ -1583,14 +1583,16 @@ CogObjectRepresentationFor64BitSpur >> genPrimitiveNew [
 	"now fill"
 	cogit LoadEffectiveAddressMw: objectMemory baseHeaderSize r: ReceiverResultReg R: Arg1Reg.
 	cogit MoveCq: objectMemory nilObject R: fillReg.
-	"fillLoop := 
-		cogit MoveR: fillReg Mw: 0 r: Arg1Reg.
+	"fillLoop := cogit MoveR: fillReg Mw: 0 r: Arg1Reg.
 	cogit AddCq: 8 R: Arg1Reg.
 	cogit CmpR: Arg1Reg R: byteSizeReg."
-	fillLoop :=
-		cogit DupS: 64 R: fillReg VR: "Vr" 1 "V1"."TODO use vector reg as last argument"
-	cogit St1S: 64 VR:"Vr" 1 Mw:"rename" Arg1Reg O:"Mw" 16.
-	cogit CmpR: Arg1Reg R: byteSizeReg."TODO explain why this works!!! Overflow works because Eden is empty, bumpAllocator, and head room"
+	fillLoop := cogit DupS: 64 R: fillReg Vr: 1 "V1"."TODO add constants for vector registers"
+	"St1 copies data in 128-bit chunks. This may exceed the size of an object (that only needs to be a multiple of 64 bits).
+	This overflow is not an issue, however. The reason for that is that objects are allocated sequentially in the Eden space
+	using a bumpAllocator, which means that the overflowing bits won't overwrite another object. This is true even when reaching
+	the end of the Eden space, as after it we reserve additional headroom."
+	cogit St1S: 64 Vr: 1 R: Arg1Reg Mw: 16.
+	cogit CmpR: Arg1Reg R: byteSizeReg.
 	cogit JumpAbove: fillLoop.
 	cogit genPrimReturn.
 

--- a/smalltalksrc/VMMaker/CogObjectRepresentationFor64BitSpur.class.st
+++ b/smalltalksrc/VMMaker/CogObjectRepresentationFor64BitSpur.class.st
@@ -1520,10 +1520,8 @@ CogObjectRepresentationFor64BitSpur >> genPrimitiveNew [
 	- the result fits in eden (actually below scavengeThreshold)"
 
 	| headerReg fillReg instSpecReg byteSizeReg
-	  jumpUnhashed jumpVariableOrEphemeron jumpNoSpace jumpTooBig jumpHasSlots
-	  fillLoop skip |
+	  jumpUnhashed jumpVariableOrEphemeron jumpNoSpace jumpTooBig jumpHasSlots skip |
 	<var: 'skip' type: #'AbstractInstruction *'>
-	<var: 'fillLoop' type: #'AbstractInstruction *'>
 	<var: 'jumpTooBig' type: #'AbstractInstruction *'>
 	<var: 'jumpHasSlots' type: #'AbstractInstruction *'>
 	<var: 'jumpNoSpace' type: #'AbstractInstruction *'>
@@ -1583,7 +1581,7 @@ CogObjectRepresentationFor64BitSpur >> genPrimitiveNew [
 	"now fill"
 	cogit LoadEffectiveAddressMw: objectMemory baseHeaderSize r: ReceiverResultReg R: Arg1Reg.
 	cogit MoveCq: objectMemory nilObject R: fillReg.
-	cogit backend fillFrom: Arg1Reg until: byteSizeReg with: fillReg usingVr: VReg1.
+	cogit fillFrom: Arg1Reg until: byteSizeReg with: fillReg usingVr: VReg1.
 	cogit genPrimReturn.
 
 	jumpUnhashed jmpTarget:
@@ -1731,7 +1729,7 @@ CogObjectRepresentationFor64BitSpur >> genPrimitiveNewWithArg [
 	cogit MoveR: headerReg Mw: 0 r: ReceiverResultReg.
 	"now fill"
 	cogit LoadEffectiveAddressMw: objectMemory baseHeaderSize r: ReceiverResultReg R: Arg1Reg.
-	cogit backend fillFrom: Arg1Reg until: byteSizeReg with: fillReg usingVr: VReg1.
+	cogit fillFrom: Arg1Reg until: byteSizeReg with: fillReg usingVr: VReg1.
 	cogit genPrimReturn.
 	
 	jumpNoSpace jmpTarget:

--- a/smalltalksrc/VMMaker/CogRTLOpcodes.class.st
+++ b/smalltalksrc/VMMaker/CogRTLOpcodes.class.st
@@ -138,7 +138,7 @@ Class {
 		'SignExtend8RR',
 		'SqrtRd',
 		'SqrtRs',
-		'St1VRMRO',
+		'St1VRMwO',
 		'Stop',
 		'SubCqR',
 		'SubCwR',

--- a/smalltalksrc/VMMaker/CogRTLOpcodes.class.st
+++ b/smalltalksrc/VMMaker/CogRTLOpcodes.class.st
@@ -36,6 +36,7 @@ Class {
 		'ConvertRsRd',
 		'DivRdRd',
 		'DivRsRs',
+		'DupRVR',
 		'Fill32',
 		'FirstJump',
 		'FirstShortJump',
@@ -317,6 +318,9 @@ CogRTLOpcodes class >> initialize [
 
 						SignExtend8RR SignExtend16RR SignExtend32RR
 						ZeroExtend8RR ZeroExtend16RR ZeroExtend32RR
+
+						"SIMD ops"
+						DupRVR
 
 						LastRTLCode).
 

--- a/smalltalksrc/VMMaker/CogRTLOpcodes.class.st
+++ b/smalltalksrc/VMMaker/CogRTLOpcodes.class.st
@@ -36,7 +36,7 @@ Class {
 		'ConvertRsRd',
 		'DivRdRd',
 		'DivRsRs',
-		'DupRVR',
+		'DupRVr',
 		'Fill32',
 		'FirstJump',
 		'FirstShortJump',
@@ -138,7 +138,7 @@ Class {
 		'SignExtend8RR',
 		'SqrtRd',
 		'SqrtRs',
-		'St1VRMwO',
+		'St1VrRMw',
 		'Stop',
 		'SubCqR',
 		'SubCwR',
@@ -321,8 +321,8 @@ CogRTLOpcodes class >> initialize [
 						ZeroExtend8RR ZeroExtend16RR ZeroExtend32RR
 
 						"SIMD ops"
-						DupRVR
-						St1VRMRO
+						DupRVr
+						St1VrRMw
 
 						LastRTLCode).
 

--- a/smalltalksrc/VMMaker/CogRTLOpcodes.class.st
+++ b/smalltalksrc/VMMaker/CogRTLOpcodes.class.st
@@ -138,6 +138,7 @@ Class {
 		'SignExtend8RR',
 		'SqrtRd',
 		'SqrtRs',
+		'St1VRMRO',
 		'Stop',
 		'SubCqR',
 		'SubCwR',
@@ -321,6 +322,7 @@ CogRTLOpcodes class >> initialize [
 
 						"SIMD ops"
 						DupRVR
+						St1VRMRO
 
 						LastRTLCode).
 

--- a/smalltalksrc/VMMaker/Cogit.class.st
+++ b/smalltalksrc/VMMaker/Cogit.class.st
@@ -6601,7 +6601,7 @@ Cogit >> fakeVarBaseAddress [
 { #category : #concretize }
 Cogit >> fillFrom: startMemoryAddr until: endMemoryAddr with: fillReg usingVr: vectorRegister [
 
-	<inline: true>
+	<doNotGenerate>
 	backEnd fillFrom: startMemoryAddr until: endMemoryAddr with: fillReg usingVr: vectorRegister
 ]
 

--- a/smalltalksrc/VMMaker/Cogit.class.st
+++ b/smalltalksrc/VMMaker/Cogit.class.st
@@ -2921,6 +2921,16 @@ Cogit >> SqrtRs: dpreg [
 ]
 
 { #category : #'abstract instructions' }
+Cogit >> St1S: aSize VR: aVectorRegister MR: aMemoryRegister O: anOffset [ 
+	^ self
+		  gen: St1VRMRO
+		  operand: aSize 
+		  operand: aVectorRegister
+		  operand: aMemoryRegister 
+		  operand: anOffset 
+]
+
+{ #category : #'abstract instructions' }
 Cogit >> Stop [
 	<inline: true>
 	<returnTypeC: #'AbstractInstruction *'>

--- a/smalltalksrc/VMMaker/Cogit.class.st
+++ b/smalltalksrc/VMMaker/Cogit.class.st
@@ -2921,9 +2921,9 @@ Cogit >> SqrtRs: dpreg [
 ]
 
 { #category : #'abstract instructions' }
-Cogit >> St1S: aSize VR: aVectorRegister MR: aMemoryRegister O: anOffset [ 
+Cogit >> St1S: aSize VR: aVectorRegister Mw: aMemoryRegister O: anOffset [ 
 	^ self
-		  gen: St1VRMRO
+		  gen: St1VRMwO
 		  operand: aSize 
 		  operand: aVectorRegister
 		  operand: aMemoryRegister 

--- a/smalltalksrc/VMMaker/Cogit.class.st
+++ b/smalltalksrc/VMMaker/Cogit.class.st
@@ -6598,6 +6598,13 @@ Cogit >> fakeVarBaseAddress [
 	^self fakeAddressFor: nil index: 48
 ]
 
+{ #category : #concretize }
+Cogit >> fillFrom: startMemoryAddr until: endMemoryAddr with: fillReg usingVr: vectorRegister [
+
+	<inline: true>
+	backEnd fillFrom: startMemoryAddr until: endMemoryAddr with: fillReg usingVr: vectorRegister
+]
+
 { #category : #'generate machine code' }
 Cogit >> fillInCPICHeader: pic numArgs: numArgs numCases: numCases hasMNUCase: hasMNUCase selector: selector [
 	<returnTypeC: #'CogMethod *'>

--- a/smalltalksrc/VMMaker/Cogit.class.st
+++ b/smalltalksrc/VMMaker/Cogit.class.st
@@ -2058,10 +2058,10 @@ Cogit >> DivRs: dpreg1 Rs: dpreg2 [
 ]
 
 { #category : #'abstract instructions' }
-Cogit >> DupS: aSize R: aGeneralRegister VR: aVectorRegister [
+Cogit >> DupS: aSize R: aGeneralRegister Vr: aVectorRegister [
 
 	^ self
-		  gen: DupRVR
+		  gen: DupRVr
 		  operand: aSize
 		  operand: aGeneralRegister
 		  operand: aVectorRegister
@@ -2921,9 +2921,9 @@ Cogit >> SqrtRs: dpreg [
 ]
 
 { #category : #'abstract instructions' }
-Cogit >> St1S: aSize VR: aVectorRegister Mw: aMemoryRegister O: anOffset [ 
+Cogit >> St1S: aSize Vr: aVectorRegister R: aMemoryRegister Mw: anOffset [ 
 	^ self
-		  gen: St1VRMwO
+		  gen: St1VrRMw
 		  operand: aSize 
 		  operand: aVectorRegister
 		  operand: aMemoryRegister 

--- a/smalltalksrc/VMMaker/Cogit.class.st
+++ b/smalltalksrc/VMMaker/Cogit.class.st
@@ -2058,6 +2058,16 @@ Cogit >> DivRs: dpreg1 Rs: dpreg2 [
 ]
 
 { #category : #'abstract instructions' }
+Cogit >> DupS: aSize R: aGeneralRegister VR: aVectorRegister [
+
+	^ self
+		  gen: DupRVR
+		  operand: aSize
+		  operand: aGeneralRegister
+		  operand: aVectorRegister
+]
+
+{ #category : #'abstract instructions' }
 Cogit >> Fill32: value [
 	<inline: true>
 	<returnTypeC: #'AbstractInstruction *'>

--- a/smalltalksrc/VMMakerTests/DummyProcessor.class.st
+++ b/smalltalksrc/VMMakerTests/DummyProcessor.class.st
@@ -1,0 +1,159 @@
+Class {
+	#name : #DummyProcessor,
+	#superclass : #Object,
+	#instVars : [
+		'stackPointer',
+		'framePointer',
+		'baseRegisterValue',
+		'programCounter',
+		'smalltalkStackPointerRegisterValue',
+		'linkRegisterValue',
+		'receiverRegisterValue'
+	],
+	#category : #'VMMakerTests-JitTests'
+}
+
+{ #category : #accessing }
+DummyProcessor >> baseRegisterValue: anInteger [ 
+	
+	baseRegisterValue := anInteger
+]
+
+{ #category : #accessing }
+DummyProcessor >> cResultRegister [
+	
+	^ nil
+]
+
+{ #category : #accessing }
+DummyProcessor >> disassembler [
+	
+	^ LLVMDisassembler aarch64
+]
+
+{ #category : #operations }
+DummyProcessor >> flushICacheFrom: anInteger to: anInteger2 [ 
+	
+	
+]
+
+{ #category : #accessing }
+DummyProcessor >> fp [
+	
+	^ framePointer 
+]
+
+{ #category : #accessing }
+DummyProcessor >> fp: anInteger [ 
+	
+	framePointer := anInteger 
+]
+
+{ #category : #accessing }
+DummyProcessor >> framePointerRegisterValue: anInteger [ 
+
+	framePointer := anInteger 
+]
+
+{ #category : #accessing }
+DummyProcessor >> hasLinkRegister [
+	
+	^ true
+]
+
+{ #category : #initialization }
+DummyProcessor >> initializeStackFor: aSimpleStackBasedCogit [ 
+
+	"We are dummy...."
+]
+
+{ #category : #accessing }
+DummyProcessor >> instructionPointerRegisterValue [
+	
+	^ programCounter 
+]
+
+{ #category : #accessing }
+DummyProcessor >> integerRegisterState [
+	
+	^ #()
+]
+
+{ #category : #accessing }
+DummyProcessor >> linkRegisterValue: anInteger [ 
+
+	linkRegisterValue := anInteger 
+]
+
+{ #category : #accessing }
+DummyProcessor >> machineSimulator [
+	
+	^ self
+]
+
+{ #category : #accessing }
+DummyProcessor >> memoryAt: anInteger write: aCollection size: anInteger3 [ 
+
+	
+]
+
+{ #category : #accessing }
+DummyProcessor >> pc [
+	
+	^ programCounter
+]
+
+{ #category : #accessing }
+DummyProcessor >> pc: anInteger [ 
+	
+	programCounter := anInteger
+]
+
+{ #category : #operations }
+DummyProcessor >> pushWord: anInteger [ 
+
+	stackPointer := stackPointer - 8
+]
+
+{ #category : #accessing }
+DummyProcessor >> receiverRegisterValue: anInteger [ 
+
+	receiverRegisterValue := anInteger 
+]
+
+{ #category : #accessing }
+DummyProcessor >> runUntil: anInteger [ 
+	
+	programCounter := anInteger
+	
+]
+
+{ #category : #accessing }
+DummyProcessor >> setFramePointer: aFPValue stackPointer: aSPValue [
+ 
+	stackPointer := aSPValue.
+	framePointer := aFPValue 
+]
+
+{ #category : #accessing }
+DummyProcessor >> simulateLeafCallOf: anInteger nextpc: anInteger2 memory: anUndefinedObject [ 
+
+	
+]
+
+{ #category : #accessing }
+DummyProcessor >> smalltalkStackPointerRegisterValue [
+	^ smalltalkStackPointerRegisterValue
+]
+
+{ #category : #accessing }
+DummyProcessor >> smalltalkStackPointerRegisterValue: anInteger [ 
+
+	smalltalkStackPointerRegisterValue := anInteger 	
+]
+
+{ #category : #accessing }
+DummyProcessor >> sp [
+	
+	^ stackPointer 
+]

--- a/smalltalksrc/VMMakerTests/UnicornProcessor.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornProcessor.class.st
@@ -55,6 +55,12 @@ UnicornProcessor >> ecx: anInteger [
 	machineSimulator ecx: anInteger
 ]
 
+{ #category : #'as yet unclassified' }
+UnicornProcessor >> edi: anInteger [ 
+	
+	machineSimulator edi: anInteger
+]
+
 { #category : #registers }
 UnicornProcessor >> edx: anInteger [ 
 	
@@ -268,6 +274,12 @@ UnicornProcessor >> rdx: anInteger [
 UnicornProcessor >> retpcIn: aSpurSimulatedMemory [ 
 
 	^ machineSimulator retpcIn: aSpurSimulatedMemory 
+]
+
+{ #category : #'as yet unclassified' }
+UnicornProcessor >> rsi: anInteger [ 
+	
+	machineSimulator rsi: anInteger
 ]
 
 { #category : #registers }

--- a/smalltalksrc/VMMakerTests/VMARMV8SIMDEncodingTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMARMV8SIMDEncodingTest.class.st
@@ -43,3 +43,13 @@ VMARMV8SIMDEncodingTest >> jitOptions [
 		  put: DummyProcessor;
 		  yourself
 ]
+
+{ #category : #'tests - MoveRMwr' }
+VMARMV8SIMDEncodingTest >> testEncodeDupRVRWith64BitLanes [
+
+	self compile: [ cogit DupS: 64 R: 3 VR: 0 ].
+	
+	self
+		assert: (self armInstructionAt: 1) assemblyCodeString
+		equals: 'dup	v0.2d, x3'
+]

--- a/smalltalksrc/VMMakerTests/VMARMV8SIMDEncodingTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMARMV8SIMDEncodingTest.class.st
@@ -1,0 +1,45 @@
+Class {
+	#name : #VMARMV8SIMDEncodingTest,
+	#superclass : #VMSimpleStackBasedCogitAbstractTest,
+	#category : #'VMMakerTests-JitTests'
+}
+
+{ #category : #'building suites' }
+VMARMV8SIMDEncodingTest class >> testParameters [
+
+	^ ParametrizedTestMatrix new
+		addCase: { #ISA -> #'aarch64'. #wordSize -> 8};
+		yourself
+]
+
+{ #category : #'tests - MoveRMwr' }
+VMARMV8SIMDEncodingTest >> armInstructionAt: index [
+
+	| addr inst |
+	addr := initialAddress + ((index - 1) * 8).
+	inst := memory long32At: addr.
+	
+	^ inst aarch64Disassembled
+]
+
+{ #category : #configuration }
+VMARMV8SIMDEncodingTest >> generateCaptureCStackPointers [
+	
+	^ false
+]
+
+{ #category : #accessing }
+VMARMV8SIMDEncodingTest >> initializationOptions [
+
+	^ super initializationOptions , { 
+		#ProcessorClass . DummyProcessor }
+]
+
+{ #category : #accessing }
+VMARMV8SIMDEncodingTest >> jitOptions [
+
+	^ super jitOptions
+		  at: #ProcessorClass
+		  put: DummyProcessor;
+		  yourself
+]

--- a/smalltalksrc/VMMakerTests/VMARMV8SIMDEncodingTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMARMV8SIMDEncodingTest.class.st
@@ -45,9 +45,9 @@ VMARMV8SIMDEncodingTest >> jitOptions [
 ]
 
 { #category : #tests }
-VMARMV8SIMDEncodingTest >> testEncodeDupRVRWith64BitLanes [
+VMARMV8SIMDEncodingTest >> testEncodeDupWith64BitLanes [
 
-	self compile: [ cogit DupS: 64 R: 3 VR: 0 ].
+	self compile: [ cogit DupS: 64 R: 3 Vr: 0 ].
 	
 	self
 		assert: (self armInstructionAt: 1) assemblyCodeString
@@ -57,7 +57,7 @@ VMARMV8SIMDEncodingTest >> testEncodeDupRVRWith64BitLanes [
 { #category : #tests }
 VMARMV8SIMDEncodingTest >> testEncodeSt1WithOne64BitLaneRegisterAndImmediateOffset [
 
-	self compile: [ cogit St1S: 64 VR: 0 Mw: 1 O: 16 ].
+	self compile: [ cogit St1S: 64 Vr: 0 R: 1 Mw: 16 ].
 	
 	self
 		assert: (self armInstructionAt: 1) assemblyCodeString

--- a/smalltalksrc/VMMakerTests/VMARMV8SIMDEncodingTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMARMV8SIMDEncodingTest.class.st
@@ -57,7 +57,7 @@ VMARMV8SIMDEncodingTest >> testEncodeDupRVRWith64BitLanes [
 { #category : #tests }
 VMARMV8SIMDEncodingTest >> testEncodeSt1WithOne64BitLaneRegisterAndImmediateOffset [
 
-	self compile: [ cogit St1S: 64 VR: 0 MR: 1 O: 16 ].
+	self compile: [ cogit St1S: 64 VR: 0 Mw: 1 O: 16 ].
 	
 	self
 		assert: (self armInstructionAt: 1) assemblyCodeString

--- a/smalltalksrc/VMMakerTests/VMARMV8SIMDEncodingTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMARMV8SIMDEncodingTest.class.st
@@ -12,7 +12,7 @@ VMARMV8SIMDEncodingTest class >> testParameters [
 		yourself
 ]
 
-{ #category : #'tests - MoveRMwr' }
+{ #category : #tests }
 VMARMV8SIMDEncodingTest >> armInstructionAt: index [
 
 	| addr inst |
@@ -44,7 +44,7 @@ VMARMV8SIMDEncodingTest >> jitOptions [
 		  yourself
 ]
 
-{ #category : #'tests - MoveRMwr' }
+{ #category : #tests }
 VMARMV8SIMDEncodingTest >> testEncodeDupRVRWith64BitLanes [
 
 	self compile: [ cogit DupS: 64 R: 3 VR: 0 ].
@@ -52,4 +52,14 @@ VMARMV8SIMDEncodingTest >> testEncodeDupRVRWith64BitLanes [
 	self
 		assert: (self armInstructionAt: 1) assemblyCodeString
 		equals: 'dup	v0.2d, x3'
+]
+
+{ #category : #tests }
+VMARMV8SIMDEncodingTest >> testEncodeSt1WithOne64BitLaneRegisterAndImmediateOffset [
+
+	self compile: [ cogit St1S: 64 VR: 0 MR: 1 O: 16 ].
+	
+	self
+		assert: (self armInstructionAt: 1) assemblyCodeString
+		equals: 'st1	{ v0.2d }, [x1], #16'
 ]

--- a/smalltalksrc/VMMakerTests/VMJittedGeneralPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJittedGeneralPrimitiveTest.class.st
@@ -7,6 +7,14 @@ Class {
 	#category : #'VMMakerTests-JitTests'
 }
 
+{ #category : #accessing }
+VMJittedGeneralPrimitiveTest >> lastObjectInNewSpace [
+
+	| lastOop |
+	memory allNewSpaceObjectsDo: [ :oop | lastOop := oop ].
+	^ lastOop
+]
+
 { #category : #'tests - support' }
 VMJittedGeneralPrimitiveTest >> testCheckImmediateWhenImmediateFloat [
 
@@ -1836,6 +1844,32 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveMultiplyReturnsZeroWithZeroOperand 
 	
 	self runFrom: primitiveAddress until: callerAddress.
 	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 0).
+]
+
+{ #category : #'tests - primitiveNew' }
+VMJittedGeneralPrimitiveTest >> testPrimitiveNewInitializesObjectCorrectly [
+
+	| endInstruction primitiveAddress class classHash newOop instanceVariableCount |
+	instanceVariableCount := 4.
+	class := self
+		         newClassInOldSpaceWithSlots: instanceVariableCount
+		         instSpec: memory nonIndexablePointerFormat.
+	memory ensureBehaviorHash: class.
+
+	primitiveAddress := self compile: [ 
+		                    cogit objectRepresentation genPrimitiveNew.
+		                    "If the primitive fails it continues, so we need to have an instruction to detect the end"
+		                    endInstruction := cogit Stop ].
+
+	self prepareStackForSendReceiver: class.
+	self runFrom: primitiveAddress until: callerAddress.
+
+	newOop := self lastObjectInNewSpace.
+
+	0 to: (instanceVariableCount - 1) do: [ :slotIndex | 
+		self
+			assert: (memory fetchPointer: slotIndex ofObject: newOop)
+			equals: memory nilObject ]
 ]
 
 { #category : #'tests - primitiveNotEqual' }

--- a/smalltalksrc/VMMakerTests/VMJittedGeneralPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJittedGeneralPrimitiveTest.class.st
@@ -1872,6 +1872,33 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveNewInitializesObjectCorrectly [
 			equals: memory nilObject ]
 ]
 
+{ #category : #'tests - primitiveNew' }
+VMJittedGeneralPrimitiveTest >> testPrimitiveNewWithArgInitializesObjectCorrectly [
+
+	| endInstruction primitiveAddress class classHash newOop arraySize |
+	arraySize := 4.
+	class := self
+		newClassInOldSpaceWithSlots: 0
+		instSpec: Array instSpec.
+	memory ensureBehaviorHash: class.
+	
+	cogit methodOrBlockNumArgs: 1.
+	primitiveAddress := self compile: [ 
+		                    cogit objectRepresentation genPrimitiveNewWithArg.
+		                    "If the primitive fails it continues, so we need to have an instruction to detect the end"
+		                    endInstruction := cogit Stop ].
+
+	self prepareStackForSendReceiver: class arguments: { memory integerObjectOf: arraySize }.
+	self runFrom: primitiveAddress until: callerAddress.
+
+	newOop := self lastObjectInNewSpace.
+
+	0 to: (arraySize - 1) do: [ :slotIndex | 
+		self
+			assert: (memory fetchPointer: slotIndex ofObject: newOop)
+			equals: memory nilObject ]
+]
+
 { #category : #'tests - primitiveNotEqual' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveNotEqualDoesNotCompileIfReceiverTagIsNotSmallInteger [
 	

--- a/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitAbstractTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitAbstractTest.class.st
@@ -357,6 +357,12 @@ VMSimpleStackBasedCogitAbstractTest >> framePointerRegisterValue: aValue [
 	machineSimulator framePointerRegisterValue: aValue
 ]
 
+{ #category : #configuration }
+VMSimpleStackBasedCogitAbstractTest >> generateCaptureCStackPointers [
+	
+	^ true
+]
+
 { #category : #'helpers - cog methods' }
 VMSimpleStackBasedCogitAbstractTest >> generateCogMethod: aBlockClosure selector: anSelectorOop [ 
 
@@ -741,7 +747,7 @@ VMSimpleStackBasedCogitAbstractTest >> setUp [
 	
 	machineSimulator := cogit processor machineSimulator.
 	
-	cogit generateStackPointerCapture.
+	self generateCaptureCStackPointers ifTrue: [cogit generateStackPointerCapture].
 	cogit methodZone manageFrom: cogit cogCodeBase to: initialAddress + self initialCodeSize.
 
 	memory coInterpreter numStackPages: 8.


### PR DESCRIPTION
This PR adds initial support for SIMD instructions targeting the AArch64 architecture, and uses them to speed up object initialization (on JIT-ed `new` primitives) by ~2x, while still supporting the previous scalar implementation on other platforms.