### PR TITLE
Make the error code to work in the internal version too

### DIFF
--- a/smalltalksrc/VMMaker/CoInterpreter.class.st
+++ b/smalltalksrc/VMMaker/CoInterpreter.class.st
@@ -508,7 +508,7 @@ CoInterpreter >> activateCoggedNewMethod: inInterpreter [
 
 	((self methodHeaderHasPrimitive: methodHeader)
 	 and: [primFailCode ~= 0]) ifTrue:
-		[self reapAndResetErrorCodeTo: stackPointer header: methodHeader].
+		[self reapAndResetErrorCodeTo: framePointer header: methodHeader].
 
 	"Now check for stack overflow or an event (interrupt, must scavenge, etc)."
 	stackPointer >= stackLimit ifTrue:
@@ -654,7 +654,7 @@ CoInterpreter >> activateNewMethod [
 		  with a long store temp.  Strictly no need to skip the store because it's effectively a noop."
 		 instructionPointer := instructionPointer + (self sizeOfCallPrimitiveBytecode: methodHeader).
 		 primFailCode ~= 0 ifTrue:
-			[self reapAndResetErrorCodeTo: stackPointer header: methodHeader]].
+			[self reapAndResetErrorCodeTo: framePointer header: methodHeader]].
 
 	"Now check for stack overflow or an event (interrupt, must scavenge, etc)."
 	switched := true.
@@ -1654,7 +1654,7 @@ CoInterpreter >> ceReapAndResetErrorCodeFor: cogMethod [
 	<var: #cogMethod type: #'CogMethod *'>
 	self assert: primFailCode ~= 0.
 	newMethod := cogMethod methodObject.
-	self reapAndResetErrorCodeTo: stackPointer + objectMemory wordSize
+	self reapAndResetErrorCodeTo: framePointer
 		header: cogMethod methodHeader
 ]
 
@@ -3948,7 +3948,7 @@ CoInterpreter >> internalActivateNewMethod [
 		  with a long store temp.  Strictly no need to skip the store because it's effectively a noop."
 		 localIP := localIP + (self sizeOfCallPrimitiveBytecode: methodHeader).
 		 primFailCode ~= 0 ifTrue:
-			[self reapAndResetErrorCodeTo: localSP header: methodHeader]].
+			[self reapAndResetErrorCodeTo: framePointer header: methodHeader]].
 
 	self assert: (self frameNumArgs: localFP) = argumentCount.
 	self assert: (self frameIsBlockActivation: localFP) not.
@@ -4234,7 +4234,7 @@ CoInterpreter >> justActivateNewMethod: mustBeInterpreterFrame [
 		 cogMethod ifNil:
 			[instructionPointer := instructionPointer + (self sizeOfCallPrimitiveBytecode: methodHeader) + (self sizeOfLongStoreTempBytecode: methodHeader)].
 		 primFailCode ~= 0 ifTrue:
-			[self reapAndResetErrorCodeTo: stackPointer header: methodHeader]].
+			[self reapAndResetErrorCodeTo: framePointer header: methodHeader]].
 
 	^methodHeader
 ]

--- a/smalltalksrc/VMMaker/CoInterpreter.class.st
+++ b/smalltalksrc/VMMaker/CoInterpreter.class.st
@@ -652,7 +652,7 @@ CoInterpreter >> activateNewMethod [
 	(self methodHeaderHasPrimitive: methodHeader) ifTrue:
 		["Skip the CallPrimitive bytecode, if it's there, and store the error code if the method starts
 		  with a long store temp.  Strictly no need to skip the store because it's effectively a noop."
-		 instructionPointer := instructionPointer + (self sizeOfCallPrimitiveBytecode: methodHeader).
+		 instructionPointer := instructionPointer + (self sizeOfCallPrimitiveBytecode: methodHeader) + (self sizeOfLongStoreTempBytecode: methodHeader).
 		 primFailCode ~= 0 ifTrue:
 			[self reapAndResetErrorCodeTo: framePointer header: methodHeader]].
 
@@ -3946,7 +3946,7 @@ CoInterpreter >> internalActivateNewMethod [
 	(self methodHeaderHasPrimitive: methodHeader) ifTrue:
 		["Skip the CallPrimitive bytecode, if it's there, and store the error code if the method starts
 		  with a long store temp.  Strictly no need to skip the store because it's effectively a noop."
-		 localIP := localIP + (self sizeOfCallPrimitiveBytecode: methodHeader).
+		 localIP := localIP + (self sizeOfCallPrimitiveBytecode: methodHeader) + (self sizeOfLongStoreTempBytecode: methodHeader).
 		 primFailCode ~= 0 ifTrue:
 			[self reapAndResetErrorCodeTo: framePointer header: methodHeader]].
 

--- a/smalltalksrc/VMMaker/CoInterpreter.class.st
+++ b/smalltalksrc/VMMaker/CoInterpreter.class.st
@@ -652,9 +652,11 @@ CoInterpreter >> activateNewMethod [
 	(self methodHeaderHasPrimitive: methodHeader) ifTrue:
 		["Skip the CallPrimitive bytecode, if it's there, and store the error code if the method starts
 		  with a long store temp.  Strictly no need to skip the store because it's effectively a noop."
-		 instructionPointer := instructionPointer + (self sizeOfCallPrimitiveBytecode: methodHeader) + (self sizeOfLongStoreTempBytecode: methodHeader).
-		 primFailCode ~= 0 ifTrue:
-			[self reapAndResetErrorCodeTo: framePointer header: methodHeader]].
+		 instructionPointer := instructionPointer + (self sizeOfCallPrimitiveBytecode: methodHeader).
+		 primFailCode ~= 0 ifTrue: [ | shouldSkipStoreBytecode |
+			shouldSkipStoreBytecode := self reapAndResetErrorCodeTo: framePointer header: methodHeader.
+			shouldSkipStoreBytecode ifTrue: [ 
+				instructionPointer := instructionPointer + (self sizeOfLongStoreTempBytecode: methodHeader)  ] ] ].
 
 	"Now check for stack overflow or an event (interrupt, must scavenge, etc)."
 	switched := true.
@@ -3946,9 +3948,11 @@ CoInterpreter >> internalActivateNewMethod [
 	(self methodHeaderHasPrimitive: methodHeader) ifTrue:
 		["Skip the CallPrimitive bytecode, if it's there, and store the error code if the method starts
 		  with a long store temp.  Strictly no need to skip the store because it's effectively a noop."
-		 localIP := localIP + (self sizeOfCallPrimitiveBytecode: methodHeader) + (self sizeOfLongStoreTempBytecode: methodHeader).
-		 primFailCode ~= 0 ifTrue:
-			[self reapAndResetErrorCodeTo: framePointer header: methodHeader]].
+		 localIP := localIP + (self sizeOfCallPrimitiveBytecode: methodHeader).
+		 primFailCode ~= 0 ifTrue: [ | shouldSkipStoreBytecode |
+			shouldSkipStoreBytecode := self reapAndResetErrorCodeTo: localFP header: methodHeader.
+			shouldSkipStoreBytecode ifTrue: [ 
+				localIP := localIP + (self sizeOfLongStoreTempBytecode: methodHeader)  ] ] ].
 
 	self assert: (self frameNumArgs: localFP) = argumentCount.
 	self assert: (self frameIsBlockActivation: localFP) not.
@@ -4232,9 +4236,11 @@ CoInterpreter >> justActivateNewMethod: mustBeInterpreterFrame [
 		["Skip the CallPrimitive bytecode, if it's there, and store the error code if the method starts
 		  with a long store temp.  Strictly no need to skip the store because it's effectively a noop."
 		 cogMethod ifNil:
-			[instructionPointer := instructionPointer + (self sizeOfCallPrimitiveBytecode: methodHeader) + (self sizeOfLongStoreTempBytecode: methodHeader)].
-		 primFailCode ~= 0 ifTrue:
-			[self reapAndResetErrorCodeTo: framePointer header: methodHeader]].
+			[instructionPointer := instructionPointer + (self sizeOfCallPrimitiveBytecode: methodHeader)].
+		 primFailCode ~= 0 ifTrue: [ | shouldSkipStoreBytecode |
+			shouldSkipStoreBytecode := self reapAndResetErrorCodeTo: framePointer header: methodHeader.
+			(cogMethod isNil and: [shouldSkipStoreBytecode]) ifTrue: [ 
+				instructionPointer := instructionPointer + (self sizeOfLongStoreTempBytecode: methodHeader)  ] ] ]..
 
 	^methodHeader
 ]

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -8023,9 +8023,11 @@ StackInterpreter >> internalActivateNewMethod [
 	(self methodHeaderHasPrimitive: methodHeader) ifTrue:
 		["Skip the CallPrimitive bytecode, if it's there, and store the error code if the method starts
 		  with a long store temp.  Strictly no need to skip the store because it's effectively a noop."
-		 localIP := localIP + (self sizeOfCallPrimitiveBytecode: methodHeader) + (self sizeOfLongStoreTempBytecode: methodHeader).
-		 primFailCode ~= 0 ifTrue:
-			[self reapAndResetErrorCodeTo: localFP header: methodHeader]].
+		 localIP := localIP + (self sizeOfCallPrimitiveBytecode: methodHeader).
+		 primFailCode ~= 0 ifTrue: [ | shouldSkipStoreBytecode |
+			shouldSkipStoreBytecode := self reapAndResetErrorCodeTo: localFP header: methodHeader.
+			shouldSkipStoreBytecode ifTrue: [ 
+				localIP := localIP + (self sizeOfLongStoreTempBytecode: methodHeader)  ] ] ].
 
 	self assert: (self frameNumArgs: localFP) = argumentCount.
 	self assert: (self frameIsBlockActivation: localFP) not.
@@ -8847,9 +8849,11 @@ StackInterpreter >> justActivateNewMethod: mustBeInterpreterFrame [
 	(self methodHeaderHasPrimitive: methodHeader) ifTrue:
 		["Skip the CallPrimitive bytecode, if it's there, and store the error code if the method starts
 		  with a long store temp.  Strictly no need to skip the store because it's effectively a noop."
-		 instructionPointer := instructionPointer + (self sizeOfCallPrimitiveBytecode: methodHeader) + (self sizeOfLongStoreTempBytecode: methodHeader).
-		 primFailCode ~= 0 ifTrue:
-			[self reapAndResetErrorCodeTo: framePointer header: methodHeader]].
+		 instructionPointer := instructionPointer + (self sizeOfCallPrimitiveBytecode: methodHeader).
+		 primFailCode ~= 0 ifTrue: [ | shouldSkipStoreBytecode |
+			shouldSkipStoreBytecode := self reapAndResetErrorCodeTo: framePointer header: methodHeader.
+			shouldSkipStoreBytecode ifTrue: [ 
+				instructionPointer := instructionPointer + (self sizeOfLongStoreTempBytecode: methodHeader)  ] ] ].
 
 	^methodHeader
 ]
@@ -12888,19 +12892,28 @@ StackInterpreter >> quinaryInlinePrimitive: primIndex [
 
 { #category : #'primitive support' }
 StackInterpreter >> reapAndResetErrorCodeTo: theFP header: methodHeader [
+
 	"Assuming the primFailCode is non-zero, check if the method consumes the error code
 	 and if so, assign it through theFP into the correct temporary variable.
 	Then zero the primFailCode.  This is infrequent code, so keep it out of the common path."
+
 	<var: 'theSP' type: #'char *'>
 	<inline: #never>
 	| initialPC |
 	self assert: primFailCode ~= 0.
-	initialPC := (self initialIPForHeader: methodHeader method: newMethod) + (self sizeOfCallPrimitiveBytecode: methodHeader).
-	(objectMemory byteAt: initialPC) = (self longStoreBytecodeForHeader: methodHeader) ifTrue: [
+	initialPC := (self initialIPForHeader: methodHeader method: newMethod)
+	             + (self sizeOfCallPrimitiveBytecode: methodHeader).
+	(objectMemory byteAt: initialPC)
+	= (self longStoreBytecodeForHeader: methodHeader) ifTrue: [ 
 		| temporaryIndex |
-		temporaryIndex := (objectMemory byteAt: initialPC + 1).
-		self temporary: temporaryIndex in: theFP put: self getErrorObjectFromPrimFailCode].
-	 primFailCode := 0
+		temporaryIndex := objectMemory byteAt: initialPC + 1.
+		self
+			temporary: temporaryIndex
+			in: theFP
+			put: self getErrorObjectFromPrimFailCode.
+		^ true].
+	primFailCode := 0.
+	^ false
 ]
 
 { #category : #'internal interpreter access' }

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -8023,7 +8023,7 @@ StackInterpreter >> internalActivateNewMethod [
 	(self methodHeaderHasPrimitive: methodHeader) ifTrue:
 		["Skip the CallPrimitive bytecode, if it's there, and store the error code if the method starts
 		  with a long store temp.  Strictly no need to skip the store because it's effectively a noop."
-		 localIP := localIP + (self sizeOfCallPrimitiveBytecode: methodHeader).
+		 localIP := localIP + (self sizeOfCallPrimitiveBytecode: methodHeader) + (self sizeOfLongStoreTempBytecode: methodHeader).
 		 primFailCode ~= 0 ifTrue:
 			[self reapAndResetErrorCodeTo: localFP header: methodHeader]].
 

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -8025,7 +8025,7 @@ StackInterpreter >> internalActivateNewMethod [
 		  with a long store temp.  Strictly no need to skip the store because it's effectively a noop."
 		 localIP := localIP + (self sizeOfCallPrimitiveBytecode: methodHeader).
 		 primFailCode ~= 0 ifTrue:
-			[self reapAndResetErrorCodeTo: localSP header: methodHeader]].
+			[self reapAndResetErrorCodeTo: localFP header: methodHeader]].
 
 	self assert: (self frameNumArgs: localFP) = argumentCount.
 	self assert: (self frameIsBlockActivation: localFP) not.
@@ -8849,7 +8849,7 @@ StackInterpreter >> justActivateNewMethod: mustBeInterpreterFrame [
 		  with a long store temp.  Strictly no need to skip the store because it's effectively a noop."
 		 instructionPointer := instructionPointer + (self sizeOfCallPrimitiveBytecode: methodHeader) + (self sizeOfLongStoreTempBytecode: methodHeader).
 		 primFailCode ~= 0 ifTrue:
-			[self reapAndResetErrorCodeTo: stackPointer header: methodHeader]].
+			[self reapAndResetErrorCodeTo: framePointer header: methodHeader]].
 
 	^methodHeader
 ]
@@ -12887,10 +12887,10 @@ StackInterpreter >> quinaryInlinePrimitive: primIndex [
 ]
 
 { #category : #'primitive support' }
-StackInterpreter >> reapAndResetErrorCodeTo: theSP header: methodHeader [
+StackInterpreter >> reapAndResetErrorCodeTo: theFP header: methodHeader [
 	"Assuming the primFailCode is non-zero, check if the method consumes the error code
-	 and if so, assign it through theSP.  Then zero the primFailCode.  This is infrequent code,
-	 so keep it out of the common path."
+	 and if so, assign it through theFP into the correct temporary variable.
+	Then zero the primFailCode.  This is infrequent code, so keep it out of the common path."
 	<var: 'theSP' type: #'char *'>
 	<inline: #never>
 	| initialPC |
@@ -12899,7 +12899,7 @@ StackInterpreter >> reapAndResetErrorCodeTo: theSP header: methodHeader [
 	(objectMemory byteAt: initialPC) = (self longStoreBytecodeForHeader: methodHeader) ifTrue: [
 		| temporaryIndex |
 		temporaryIndex := (objectMemory byteAt: initialPC + 1).
-		self temporary: temporaryIndex in: framePointer put: self getErrorObjectFromPrimFailCode].
+		self temporary: temporaryIndex in: theFP put: self getErrorObjectFromPrimFailCode].
 	 primFailCode := 0
 ]
 

--- a/smalltalksrc/VMMaker/StackInterpreterSimulator.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreterSimulator.class.st
@@ -1187,6 +1187,12 @@ StackInterpreterSimulator >> localFP [
 ]
 
 { #category : #'spur bootstrap' }
+StackInterpreterSimulator >> localFP: anFP [
+	
+	^ localFP := anFP
+]
+
+{ #category : #'spur bootstrap' }
 StackInterpreterSimulator >> localIP [
 	^localIP
 ]

--- a/smalltalksrc/VMMakerTests/VMPrimitiveCallingTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveCallingTest.class.st
@@ -47,3 +47,32 @@ VMPrimitiveCallingTest >> testPrimitiveFailingSetsErrorCodeInCorrectTemp [
 
 	self assert: (interpreter temporary: 0 in: interpreter framePointer) equals: (memory integerObjectOf: -1)
 ]
+
+{ #category : #tests }
+VMPrimitiveCallingTest >> testPrimitiveFailingSetsErrorCodeInCorrectTempWithInternalActivation [
+
+	"The method has two temporaries. The first one is the error code, the second one is a user defined temp."
+	| method |
+	method := methodBuilder newMethod
+		bytecodes:
+			#[ "call primitive" 		16rF8 16rB8 16r00
+				"store into temp 0" 	16rF5 16r00 ];
+		numberOfTemporaries: 2;
+		isPrimitive: true;
+		buildMethod.
+	
+	stackBuilder addNewFrame; addNewFrame; buildStack.
+	interpreter newMethod: method.
+	interpreter primFailCode: -1.
+
+	"Move the frame pointer to its caller but keep the correct one in the local FP".
+	interpreter internalizeIPandSP.
+	interpreter framePointer: (interpreter frameCallerFP: interpreter framePointer).
+
+	"Use the internal version using the localFP"
+	interpreter internalActivateNewMethod.
+	
+	"Then externalize and assert"
+	interpreter externalizeFPandSP.
+	self assert: (interpreter temporary: 0 in: interpreter framePointer) equals: (memory integerObjectOf: -1)
+]

--- a/smalltalksrc/VMMakerTests/VMPrimitiveCallingTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveCallingTest.class.st
@@ -27,6 +27,29 @@ VMPrimitiveCallingTest >> testPrimitiveFailingDoesNotSetErrorCodeInOtherTemp [
 ]
 
 { #category : #tests }
+VMPrimitiveCallingTest >> testPrimitiveFailingDoesNotSkipSecondBytecodeIfNotLongStore [
+
+	"The method has two temporaries. The first one is the error code, the second one is a user defined temp."
+	| method |
+	method := methodBuilder newMethod
+		bytecodes:
+			#[ "call primitive" 		16rF8 16rB8 16r00
+				"not store into temp 0" 	16rF4 ];
+		numberOfTemporaries: 2;
+		isPrimitive: true;
+		buildMethod.
+	
+	stackBuilder addNewFrame; buildStack.
+	interpreter newMethod: method.
+	interpreter primFailCode: -1.
+
+	interpreter activateNewMethod.
+	
+	interpreter internalizeIPandSP.
+	self assert: interpreter fetchByte equals: 16rF4
+]
+
+{ #category : #tests }
 VMPrimitiveCallingTest >> testPrimitiveFailingSetsErrorCodeInCorrectTemp [
 
 	"The method has two temporaries. The first one is the error code, the second one is a user defined temp."


### PR DESCRIPTION
Test internal version too.
Pass the FP instead of the SP, to be able to access temporaries.