### PR TITLE
upgrades users of declarationAt:

### DIFF
--- a/smalltalksrc/Slang/TMethod.class.st
+++ b/smalltalksrc/Slang/TMethod.class.st
@@ -675,7 +675,7 @@ TMethod >> emitProxyFunctionPrototype: aStream generator: aCodeGen [
 		ifTrue: [aStream nextPutAll: #void]
 		ifFalse:
 			[args
-				do: [:arg| aStream nextPutAll: (self declarationAt: arg)]
+				do: [:arg| aStream nextPutAll: (self declarationAt: arg ifAbsent: [ aCodeGen defaultType, ' ', arg ])]
 				separatedBy: [ aStream nextPutAll: ', ' ]].
 	aStream nextPut: $)
 ]

--- a/smalltalksrc/VMMaker/CogStackPageSurrogate32.class.st
+++ b/smalltalksrc/VMMaker/CogStackPageSurrogate32.class.st
@@ -85,13 +85,13 @@ CogStackPageSurrogate32 >> lastAddress: aValue [
 
 { #category : #accessing }
 CogStackPageSurrogate32 >> nextPage [
-	^stackPages surrogateAtAddress: (memory unsignedLong32At: address + 36)
+	^stackPages surrogateAtAddress: (memory unsignedLong32At: address + 32)
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate32 >> nextPage: aValue [
-	self assert: (address + 36 >= zoneBase and: [address + 39 < zoneLimit]).
-	memory unsignedLong32At: address + 36 put: aValue asInteger.
+	self assert: (address + 32 >= zoneBase and: [address + 35 < zoneLimit]).
+	memory unsignedLong32At: address + 32 put: aValue asInteger.
 	^aValue
 ]
 
@@ -108,13 +108,13 @@ CogStackPageSurrogate32 >> padToWord: aValue [
 
 { #category : #accessing }
 CogStackPageSurrogate32 >> prevPage [
-	^stackPages surrogateAtAddress: (memory unsignedLong32At: address + 40)
+	^stackPages surrogateAtAddress: (memory unsignedLong32At: address + 36)
 ]
 
 { #category : #accessing }
 CogStackPageSurrogate32 >> prevPage: aValue [
-	self assert: (address + 40 >= zoneBase and: [address + 43 < zoneLimit]).
-	memory unsignedLong32At: address + 40 put: aValue asInteger.
+	self assert: (address + 36 >= zoneBase and: [address + 39 < zoneLimit]).
+	memory unsignedLong32At: address + 36 put: aValue asInteger.
 	^aValue
 ]
 

--- a/smalltalksrc/VMMaker/SmartSyntaxPluginTMethod.class.st
+++ b/smalltalksrc/VMMaker/SmartSyntaxPluginTMethod.class.st
@@ -43,7 +43,7 @@ SmartSyntaxPluginTMethod >> emitCLocalsOn: aStream generator: aCodeGen [
 			[ :var |
 		aStream 
 			tab; 
-			nextPutAll: (self declarationAt: var);
+			nextPutAll: (self declarationAt: var ifAbsent: [ aCodeGen defaultType, ' ', var ]);
 			nextPut: $;; 
 			newLine].
 		 aStream newLine]


### PR DESCRIPTION
Makes deprecated `declarationAt:` have no senders anymore.