### PR TITLE
Improves PharoVMMaker constructors

### DIFF
--- a/smalltalksrc/VMMakerCompatibilityForPharo6/PharoVMMaker.class.st
+++ b/smalltalksrc/VMMakerCompatibilityForPharo6/PharoVMMaker.class.st
@@ -11,27 +11,81 @@ Class {
 	#category : #'VMMakerCompatibilityForPharo6-CommandLine'
 }
 
-{ #category : #generation }
-PharoVMMaker class >> generate: aClassName [
+{ #category : #defaults }
+PharoVMMaker class >> default32BitsMemoryManagerClass [
 
-	self generate: aClassName outputDirectory: FileSystem workingDirectory
+	^ Spur32BitCoMemoryManager
+]
+
+{ #category : #defaults }
+PharoVMMaker class >> default64BitsMemoryManagerClass [
+
+	^ Spur64BitCoMemoryManager
+]
+
+{ #category : #defaults }
+PharoVMMaker class >> defaultInterpreterClass [
+
+	^ CoInterpreter
+]
+
+{ #category : #defaults }
+PharoVMMaker class >> defaultMemoryManagerClass [
+
+	^ self default64BitsMemoryManagerClass 
 ]
 
 { #category : #generation }
-PharoVMMaker class >> generate: aClassName outputDirectory: aDirectory [
+PharoVMMaker class >> defaultOutputDirectory [
 
-	Transcript 
+	^ FileSystem workingDirectory
+]
+
+{ #category : #generation }
+PharoVMMaker class >> generate: anInterpreterClass [
+
+	self
+		generate: anInterpreterClass
+		outputDirectory: self defaultOutputDirectory
+]
+
+{ #category : #generation }
+PharoVMMaker class >> generate: anInterpreterClass outputDirectory: aDirectory [
+
+	Transcript
 		nextPutAll: 'Generating ';
-	 	nextPutAll: aClassName printString;
+		nextPutAll: anInterpreterClass printString;
 		nextPutAll: ' in ';
 		nextPutAll: aDirectory printString;
 		nextPutAll: '...';
 		newLine;
 		flush.
-	
+
 	self new
 		outputDirectory: aDirectory;
-		perform: #generate , aClassName asSymbol
+		perform: #generate , anInterpreterClass asSymbol
+]
+
+{ #category : #generation }
+PharoVMMaker class >> on: anInterpreterClass [
+
+	^ self
+		  on: anInterpreterClass
+		  outputDirectory: self defaultOutputDirectory
+]
+
+{ #category : #generation }
+PharoVMMaker class >> on: anInterpreterClass outputDirectory: aDirectory [
+
+	^ self new
+		  outputDirectory: aDirectory;
+		  vmMakerOn: anInterpreterClass
+]
+
+{ #category : #generation }
+PharoVMMaker class >> withCoInterpreter [
+
+	^ self on: CoInterpreter
 ]
 
 { #category : #generation }
@@ -82,15 +136,21 @@ PharoVMMaker >> generateStackVM [
 
 ]
 
-{ #category : #accessing }
+{ #category : #initialization }
 PharoVMMaker >> initialize [
 	super initialize.
 	stopOnErrors := false
 ]
 
+{ #category : #initialization }
+PharoVMMaker >> initializeOutputDirectory [
+
+	^ outputDirectory := self class defaultOutputDirectory
+]
+
 { #category : #accessing }
 PharoVMMaker >> outputDirectory [
-	^ outputDirectory
+	^ outputDirectory ifNil: [ self initializeOutputDirectory ]
 ]
 
 { #category : #accessing }
@@ -112,4 +172,42 @@ PharoVMMaker >> stopOnErrors [
 { #category : #accessing }
 PharoVMMaker >> stopOnErrors: anObject [
 	stopOnErrors := anObject
+]
+
+{ #category : #generation }
+PharoVMMaker >> vmMakerOn: anInterpreterClass [
+
+	^ self
+		  vmMakerWith: self class defaultInterpreterClass
+		  memoryManager: self class defaultMemoryManagerClass
+]
+
+{ #category : #generation }
+PharoVMMaker >> vmMakerWith: interpreterClass memoryManager: memoryManager [
+
+	| platformDirectory |
+	VMMakerConfiguration initializeForPharo.
+	(interpreterClass bindingOf: #COGMTVM) value: false.
+
+	platformDirectory := self platformDirectoryFor: memoryManager.
+
+
+	^ (VMMaker
+		   makerFor: interpreterClass
+		   and: StackToRegisterMappingCogit
+		   with: { 
+				   #COGMTVM.
+				   false.
+				   #ObjectMemory.
+				   memoryManager name.
+				   #MULTIPLEBYTECODESETS.
+				   true.
+				   #bytecodeTableInitializer.
+				   #initializeBytecodeTableForSqueakV3PlusClosuresSistaV1Hybrid }
+		   to: platformDirectory
+		   platformDir: platformDirectory
+		   including: #(  )
+		   configuration: VMMakerConfiguration)
+		  stopOnErrors: stopOnErrors;
+		  yourself
 ]


### PR DESCRIPTION
Adds to PharoVMMaker the constructors that would allow generating code for individual plugins.
Improves some parameter nammings.
Adds defaults.
Categorizes a couple of methods.

With this merge, you'll be able to do things like:

```smalltalk
generate := [ PharoVMMaker withCoInterpreter
  internal: #() external: #(HelloWorldPlugin);
  generateExternalPlugins ].

generate value.
```