### PR TITLE
Correctly converting the command line arguments of the VM

### DIFF
--- a/cmake/Windows.cmake
+++ b/cmake/Windows.cmake
@@ -63,7 +63,7 @@ set(VM_FRONTEND_SOURCES
     ${Win32Resource})
 
 set(VM_CONSOLE_FRONTEND_SOURCES
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/unixMain.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/win32Main.c
     ${Win32ConsoleResource})
 
 set(VM_FRONTEND_APPLICATION_TYPE WIN32)

--- a/src/win32Main.c
+++ b/src/win32Main.c
@@ -1,9 +1,51 @@
 #include "pharovm/pharoClient.h"
 
 #include <windows.h>
+#include <shellapi.h>
 
 int CALLBACK
 WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow)
 {
-    return vm_main(__argc, (const char **)__argv, (const char**)environ);
+	
+	char  **argsInUtf8 = NULL;
+	LPWSTR *wideArgs;
+	int numberOfArgs;
+	int totalSize = 0;
+	char *currentString;
+	int *sizes;
+	int i;
+
+	/*
+		Converting the arguments from wide char strings to UTF8 strings.
+	*/
+
+	wideArgs = CommandLineToArgvW(GetCommandLineW(), &numberOfArgs);
+	if( NULL == wideArgs )
+	{
+		logErrorFromGetLastError("CommandLineToArgvW failed");
+		return 0;
+	}
+
+	sizes = (int*)malloc(sizeof(int)*numberOfArgs);
+   
+	for( i=0; i<numberOfArgs; i++){
+		sizes[i] = WideCharToMultiByte(CP_UTF8, 0, wideArgs[i], -1, NULL, 0, NULL, FALSE);
+		totalSize += sizes[i];
+	}
+
+	totalSize += sizeof(char*) * numberOfArgs;
+	argsInUtf8 = malloc(totalSize);
+	
+	currentString = &argsInUtf8[numberOfArgs];
+	
+	for( i=0; i<numberOfArgs; i++){
+		argsInUtf8[i] = currentString;
+		WideCharToMultiByte(CP_UTF8, 0, wideArgs[i], -1, currentString, sizes[i], NULL, FALSE);
+		currentString = currentString + sizes[i];
+	}
+
+	LocalFree(wideArgs);
+	free((void*)sizes);
+
+    return vm_main(numberOfArgs, (const char **)argsInUtf8, (const char**)environ);
 }


### PR DESCRIPTION
In Windows, the arguments to the VM are not well encoded in UTF8 when they are passed in Unix style.
The wide char API should be used to access the arguments

Fix https://github.com/pharo-project/pharo-launcher/issues/572#issuecomment-1235238236
@demarey 