### PR TITLE
Fix/simulation

### DIFF
--- a/smalltalksrc/Slang/SlangMemoryManager.class.st
+++ b/smalltalksrc/Slang/SlangMemoryManager.class.st
@@ -157,7 +157,7 @@ SlangMemoryManager >> long32At: address [
 { #category : #'memory-access' }
 SlangMemoryManager >> long32At: address put: a32BitValue [
 	
-	^ self writeSignedInteger: a32BitValue at: address size: 4
+	^ self writeUnsignedInteger: a32BitValue at: address size: 4
 ]
 
 { #category : #'memory-access' }

--- a/smalltalksrc/VMMaker/SmartSyntaxPluginTMethod.class.st
+++ b/smalltalksrc/VMMaker/SmartSyntaxPluginTMethod.class.st
@@ -476,13 +476,13 @@ SmartSyntaxPluginTMethod >> setSelector: sel definingClass: class args: argList 
 	selector := sel.
 	definingClass := class.
 	returnType := #sqInt. 	 "assume return type is sqInt for now"
-	args := argList asOrderedCollection collect: [:arg | arg key].
-	self locals: (localList collect: [:arg | arg key]) asSet.
+	args := argList asOrderedCollection collect: [:arg | arg name].
 	declarations := Dictionary new.
 	primitive := aNumber.
 	properties := methodProperties.
 	comment := aComment.
 	self parseTree: (aBlockNode asTranslatorNodeIn: self).
+	self locals: (localList collect: [:arg | arg key]) asSet.
 	labels := Set new.
 	complete := false.  "set to true when all possible inlining has been done"
 	export := self extractExportDirective.

--- a/smalltalksrc/VMMaker/SmartSyntaxPluginTMethod.class.st
+++ b/smalltalksrc/VMMaker/SmartSyntaxPluginTMethod.class.st
@@ -51,6 +51,7 @@ SmartSyntaxPluginTMethod >> emitCLocalsOn: aStream generator: aCodeGen [
 
 { #category : #'specifying primitives' }
 SmartSyntaxPluginTMethod >> extractPrimitiveDirectives [
+
 	"Save selector in fullSelector and args in fullArgs.  Scan top-level statements for a directive of the form:
 
 		self	
@@ -67,23 +68,20 @@ or
 
 or an assignment of that expression to a local, and manipulate the state and parse tree accordingly."
 
-	parseTree setStatements: (Array streamContents:
-		[:sStream |
-			parseTree statements do:
-				[:stmt |
-				 (self primitiveDirectiveWasHandled: stmt on: sStream)
-					ifFalse: [sStream nextPut: stmt]]]).
-	isPrimitive 
-		ifTrue:
-			[export := true.
-			 parseTree 
-				setStatements: self namedPrimitiveProlog, 
-								parseTree statements.
-			 self fixUpReturns.
-			 self replaceSizeMessages.
-			 ^true]
-		ifFalse: [self removeFinalSelfReturnIn: nil].
-	^false
+	parseTree statements: (Array streamContents: [ :sStream | 
+			 parseTree statements do: [ :stmt | 
+				 (self primitiveDirectiveWasHandled: stmt on: sStream) ifFalse: [ 
+					 sStream nextPut: stmt ] ] ]).
+	isPrimitive
+		ifTrue: [ 
+			export := true.
+			parseTree statements:
+				self namedPrimitiveProlog , parseTree statements.
+			self fixUpReturns.
+			self replaceSizeMessages.
+			^ true ]
+		ifFalse: [ self removeFinalSelfReturnIn: nil ].
+	^ false
 ]
 
 { #category : #transforming }
@@ -145,14 +143,14 @@ SmartSyntaxPluginTMethod >> fixUpReturnOneStmt: stmt on: sStream [
 
 { #category : #transforming }
 SmartSyntaxPluginTMethod >> fixUpReturns [
+
 	"Replace each return statement in this method with (a) the given postlog, (b) code to pop the receiver and the given number of arguments, and (c) code to push the integer result and return."
 
-	parseTree nodesDo: [:node |
-		node isStatementList ifTrue: [
-			node setStatements: (Array streamContents:
-				[:sStream |
-				 node statements do: 
-					[:stmt | self fixUpReturnOneStmt: stmt on: sStream]])]]
+	parseTree nodesDo: [ :node | 
+		node isStatementList ifTrue: [ 
+			node statements: (Array streamContents: [ :sStream | 
+					 node statements do: [ :stmt | 
+						 self fixUpReturnOneStmt: stmt on: sStream ] ]) ] ]
 ]
 
 { #category : #initialization }
@@ -200,23 +198,25 @@ SmartSyntaxPluginTMethod >> handlePrimitiveDirective: aStmt on: sStream [
 
 { #category : #'specifying primitives' }
 SmartSyntaxPluginTMethod >> isPrimitiveDirectiveSend: stmt [
-	
-	stmt isSend ifTrue:
-		[stmt selector = #primitive: ifTrue:
-			[^self primitive: 	stmt args first value
-				   parameters:	(Array new: args size withAll: #Oop)
-				   receiver:		#Oop].
-		 stmt selector = #primitive:parameters: ifTrue:
-			[^self primitive: 	stmt args first value
-				   parameters: 	stmt args second value
-				   receiver:		#Oop].
-		 stmt selector = #primitive:parameters:receiver: ifTrue:
-			[^self primitive:		stmt args first value
-				   parameters:	stmt args second value
-				   receiver:		stmt args third value].
-		^false].
-	^false.
 
+	stmt isSend ifTrue: [ 
+		stmt selector = #primitive: ifTrue: [ 
+			^ self
+				  primitive: stmt arguments first value
+				  parameters: (Array new: args size withAll: #Oop)
+				  receiver: #Oop ].
+		stmt selector = #primitive:parameters: ifTrue: [ 
+			^ self
+				  primitive: stmt args first value
+				  parameters: stmt args second value
+				  receiver: #Oop ].
+		stmt selector = #primitive:parameters:receiver: ifTrue: [ 
+			^ self
+				  primitive: stmt arguments first value
+				  parameters: stmt arguments second value
+				  receiver: stmt arguments third value ].
+		^ false ].
+	^ false
 ]
 
 { #category : #'specifying primitives' }
@@ -365,6 +365,7 @@ SmartSyntaxPluginTMethod >> rcvrSpec [
 
 { #category : #transforming }
 SmartSyntaxPluginTMethod >> recordDeclarationsIn: aCCodeGen [
+
 	"Record C type declarations of the forms
 		<returnTypeC: 'float'>
 		<var: #foo declareC: 'float foo'>
@@ -390,9 +391,7 @@ SmartSyntaxPluginTMethod >> recordDeclarationsIn: aCCodeGen [
 				varType := aCCodeGen conventionalTypeForType:
 					           pragma arguments last.
 				varType last == $* ifFalse: [ varType := varType , ' ' ].
-				self
-					declarationAt: varName
-					put: varType , varName ].
+				self declarationAt: varName put: varType , varName ].
 			pragma key == #var:as: ifTrue: [ 
 				| theClass |
 				theClass := Smalltalk
@@ -405,7 +404,7 @@ SmartSyntaxPluginTMethod >> recordDeclarationsIn: aCCodeGen [
 					put:
 					(theClass ccgDeclareCForVar: pragma arguments first asString) ].
 			pragma key == #returnTypeC: ifTrue: [ 
-				self returnType: pragma arguments last ]].
+				self returnType: pragma arguments last ] ].
 		^ self ].
 	newStatements := OrderedCollection new: parseTree statements size.
 	parseTree statements do: [ :stmt | 
@@ -439,7 +438,7 @@ SmartSyntaxPluginTMethod >> recordDeclarationsIn: aCCodeGen [
 				isDeclaration := true.
 				returnType := stmt args last value ] ].
 		isDeclaration ifFalse: [ newStatements add: stmt ] ].
-	parseTree setStatements: newStatements asArray
+	parseTree statements: newStatements asArray
 ]
 
 { #category : #transforming }


### PR DESCRIPTION
Small fixes for the StackInterpreter simulation to execute:
```
InterpreterStackPages initialize.
options := {
    #ObjectMemory -> #Spur64BitCoMemoryManager.
    #BytesPerWord -> 8
} asDictionary.

c := StackInterpreterSimulator newWithOptions: options.
c openOn: Smalltalk imagePath extraMemory: 100000.
c run.
```

now fails on file issues.

Commits include:
- `long32` now use unsigned
- `SmartSyntaxPluginTMethod >> setSelector: sel definingClass: class args: argList` reordering of local allocations
