### PR TITLE
Fix/simulation

### DIFF
--- a/smalltalksrc/VMMaker/CoInterpreterStackPages.class.st
+++ b/smalltalksrc/VMMaker/CoInterpreterStackPages.class.st
@@ -172,7 +172,7 @@ CoInterpreterStackPages >> longAt: byteAddress [
 	<doNotGenerate>
 	"Note: Adjusted for Smalltalk's 1-based array indexing."
 	self assert: (byteAddress >= minStackAddress and: [byteAddress < maxStackAddress]).
-	^objectMemory longAt: byteAddress
+	^objectMemory unsignedLongAt: byteAddress
 ]
 
 { #category : #'memory access' }

--- a/smalltalksrc/VMMaker/CogVMSimulator.class.st
+++ b/smalltalksrc/VMMaker/CogVMSimulator.class.st
@@ -2450,11 +2450,10 @@ CogVMSimulator >> saneFunctionPointerForFailureOfPrimIndex: primIndex [
 	 primitiveFunctionPointer is an invalid address proxy for a primitive."
 	| basePrimitive |
 	
-	((self isOnRumpCStack: instructionPointer)
-	and: [primitiveFunctionPointer isInteger
+	(primitiveFunctionPointer isInteger
 	and: [self isPrimitiveFunctionPointerAnIndex not
 	and: [primIndex ~= PrimNumberExternalCall
-	and: [(self isMetaPrimitiveIndex: primIndex) not]]]]) ifTrue:
+	and: [(self isMetaPrimitiveIndex: primIndex) not]]]) ifTrue:
 		[basePrimitive := self functionPointerFor: primIndex inClass: objectMemory nilObject.
 		 ^(cogit lookupAddress: primitiveFunctionPointer) endsWith: basePrimitive].
 

--- a/smalltalksrc/VMMaker/CogVMSimulator.class.st
+++ b/smalltalksrc/VMMaker/CogVMSimulator.class.st
@@ -2084,18 +2084,6 @@ CogVMSimulator >> primitiveObjectAt [
 	^super primitiveObjectAt
 ]
 
-{ #category : #'object access primitives' }
-CogVMSimulator >> primitiveObjectAtPut [
-	| newValue |
-	newValue := self stackValue: 0.
-	((self stackValue: 1) = ConstOne
-	 and: [(objectMemory isIntegerObject: newValue) not
-		   or: [MULTIPLEBYTECODESETS not
-			and: [(objectMemory integerValueOf: newValue) < 0]]]) ifTrue:
-		[self halt].
-	^super primitiveObjectAtPut
-]
-
 { #category : #'debugging traps' }
 CogVMSimulator >> primitiveObjectPointsTo [
 	"self halt."

--- a/smalltalksrc/VMMaker/FakeStdinStream.class.st
+++ b/smalltalksrc/VMMaker/FakeStdinStream.class.st
@@ -3,7 +3,7 @@ Fake Standard input using a dialog to prompt for a line of input at a time.
 "
 Class {
 	#name : #FakeStdinStream,
-	#superclass : #ReadStream,
+	#superclass : #WriteStream,
 	#instVars : [
 		'atEnd',
 		'simulator'

--- a/smalltalksrc/VMMaker/SmartSyntaxInterpreterPlugin.class.st
+++ b/smalltalksrc/VMMaker/SmartSyntaxInterpreterPlugin.class.st
@@ -34,11 +34,6 @@ SmartSyntaxInterpreterPlugin class >> implicitReturnTypeFor: aSelector [
 ]
 
 { #category : #translation }
-SmartSyntaxInterpreterPlugin class >> prepareToBeAddedToCodeGenerator: aCodeGen [
-	aCodeGen removeVariable: 'simulator'
-]
-
-{ #category : #translation }
 SmartSyntaxInterpreterPlugin class >> shouldBeTranslated [
 "SmartSyntaxInterpreterPlugin should not be translated but its subclasses should"
 	^self ~= SmartSyntaxInterpreterPlugin

--- a/smalltalksrc/VMMaker/SmartSyntaxPluginTMethod.class.st
+++ b/smalltalksrc/VMMaker/SmartSyntaxPluginTMethod.class.st
@@ -51,6 +51,7 @@ SmartSyntaxPluginTMethod >> emitCLocalsOn: aStream generator: aCodeGen [
 
 { #category : #'specifying primitives' }
 SmartSyntaxPluginTMethod >> extractPrimitiveDirectives [
+
 	"Save selector in fullSelector and args in fullArgs.  Scan top-level statements for a directive of the form:
 
 		self	
@@ -67,23 +68,20 @@ or
 
 or an assignment of that expression to a local, and manipulate the state and parse tree accordingly."
 
-	parseTree setStatements: (Array streamContents:
-		[:sStream |
-			parseTree statements do:
-				[:stmt |
-				 (self primitiveDirectiveWasHandled: stmt on: sStream)
-					ifFalse: [sStream nextPut: stmt]]]).
-	isPrimitive 
-		ifTrue:
-			[export := true.
-			 parseTree 
-				setStatements: self namedPrimitiveProlog, 
-								parseTree statements.
-			 self fixUpReturns.
-			 self replaceSizeMessages.
-			 ^true]
-		ifFalse: [self removeFinalSelfReturnIn: nil].
-	^false
+	parseTree statements: (Array streamContents: [ :sStream | 
+			 parseTree statements do: [ :stmt | 
+				 (self primitiveDirectiveWasHandled: stmt on: sStream) ifFalse: [ 
+					 sStream nextPut: stmt ] ] ]).
+	isPrimitive
+		ifTrue: [ 
+			export := true.
+			parseTree statements:
+				self namedPrimitiveProlog , parseTree statements.
+			self fixUpReturns.
+			self replaceSizeMessages.
+			^ true ]
+		ifFalse: [ self removeFinalSelfReturnIn: nil ].
+	^ false
 ]
 
 { #category : #transforming }
@@ -145,14 +143,14 @@ SmartSyntaxPluginTMethod >> fixUpReturnOneStmt: stmt on: sStream [
 
 { #category : #transforming }
 SmartSyntaxPluginTMethod >> fixUpReturns [
+
 	"Replace each return statement in this method with (a) the given postlog, (b) code to pop the receiver and the given number of arguments, and (c) code to push the integer result and return."
 
-	parseTree nodesDo: [:node |
-		node isStatementList ifTrue: [
-			node setStatements: (Array streamContents:
-				[:sStream |
-				 node statements do: 
-					[:stmt | self fixUpReturnOneStmt: stmt on: sStream]])]]
+	parseTree nodesDo: [ :node | 
+		node isStatementList ifTrue: [ 
+			node statements: (Array streamContents: [ :sStream | 
+					 node statements do: [ :stmt | 
+						 self fixUpReturnOneStmt: stmt on: sStream ] ]) ] ]
 ]
 
 { #category : #initialization }
@@ -200,23 +198,25 @@ SmartSyntaxPluginTMethod >> handlePrimitiveDirective: aStmt on: sStream [
 
 { #category : #'specifying primitives' }
 SmartSyntaxPluginTMethod >> isPrimitiveDirectiveSend: stmt [
-	
-	stmt isSend ifTrue:
-		[stmt selector = #primitive: ifTrue:
-			[^self primitive: 	stmt args first value
-				   parameters:	(Array new: args size withAll: #Oop)
-				   receiver:		#Oop].
-		 stmt selector = #primitive:parameters: ifTrue:
-			[^self primitive: 	stmt args first value
-				   parameters: 	stmt args second value
-				   receiver:		#Oop].
-		 stmt selector = #primitive:parameters:receiver: ifTrue:
-			[^self primitive:		stmt args first value
-				   parameters:	stmt args second value
-				   receiver:		stmt args third value].
-		^false].
-	^false.
 
+	stmt isSend ifTrue: [ 
+		stmt selector = #primitive: ifTrue: [ 
+			^ self
+				  primitive: stmt arguments first value
+				  parameters: (Array new: args size withAll: #Oop)
+				  receiver: #Oop ].
+		stmt selector = #primitive:parameters: ifTrue: [ 
+			^ self
+				  primitive: stmt args first value
+				  parameters: stmt args second value
+				  receiver: #Oop ].
+		stmt selector = #primitive:parameters:receiver: ifTrue: [ 
+			^ self
+				  primitive: stmt arguments first value
+				  parameters: stmt arguments second value
+				  receiver: stmt arguments third value ].
+		^ false ].
+	^ false
 ]
 
 { #category : #'specifying primitives' }
@@ -365,6 +365,7 @@ SmartSyntaxPluginTMethod >> rcvrSpec [
 
 { #category : #transforming }
 SmartSyntaxPluginTMethod >> recordDeclarationsIn: aCCodeGen [
+
 	"Record C type declarations of the forms
 		<returnTypeC: 'float'>
 		<var: #foo declareC: 'float foo'>
@@ -390,9 +391,7 @@ SmartSyntaxPluginTMethod >> recordDeclarationsIn: aCCodeGen [
 				varType := aCCodeGen conventionalTypeForType:
 					           pragma arguments last.
 				varType last == $* ifFalse: [ varType := varType , ' ' ].
-				self
-					declarationAt: varName
-					put: varType , varName ].
+				self declarationAt: varName put: varType , varName ].
 			pragma key == #var:as: ifTrue: [ 
 				| theClass |
 				theClass := Smalltalk
@@ -405,7 +404,7 @@ SmartSyntaxPluginTMethod >> recordDeclarationsIn: aCCodeGen [
 					put:
 					(theClass ccgDeclareCForVar: pragma arguments first asString) ].
 			pragma key == #returnTypeC: ifTrue: [ 
-				self returnType: pragma arguments last ]].
+				self returnType: pragma arguments last ] ].
 		^ self ].
 	newStatements := OrderedCollection new: parseTree statements size.
 	parseTree statements do: [ :stmt | 
@@ -439,7 +438,7 @@ SmartSyntaxPluginTMethod >> recordDeclarationsIn: aCCodeGen [
 				isDeclaration := true.
 				returnType := stmt args last value ] ].
 		isDeclaration ifFalse: [ newStatements add: stmt ] ].
-	parseTree setStatements: newStatements asArray
+	parseTree statements: newStatements asArray
 ]
 
 { #category : #transforming }
@@ -476,7 +475,7 @@ SmartSyntaxPluginTMethod >> setSelector: sel definingClass: class args: argList 
 	selector := sel.
 	definingClass := class.
 	returnType := #sqInt. 	 "assume return type is sqInt for now"
-	args := argList asOrderedCollection collect: [:arg | arg key].	
+	args := argList asOrderedCollection collect: [:arg | arg name].	
 	declarations := Dictionary new.
 	primitive := aNumber.
 	properties := methodProperties.

--- a/smalltalksrc/VMMaker/SmartSyntaxPluginTMethod.class.st
+++ b/smalltalksrc/VMMaker/SmartSyntaxPluginTMethod.class.st
@@ -476,13 +476,13 @@ SmartSyntaxPluginTMethod >> setSelector: sel definingClass: class args: argList 
 	selector := sel.
 	definingClass := class.
 	returnType := #sqInt. 	 "assume return type is sqInt for now"
-	args := argList asOrderedCollection collect: [:arg | arg key].
-	self locals: (localList collect: [:arg | arg key]) asSet.
+	args := argList asOrderedCollection collect: [:arg | arg key].	
 	declarations := Dictionary new.
 	primitive := aNumber.
 	properties := methodProperties.
 	comment := aComment.
 	self parseTree: (aBlockNode asTranslatorNodeIn: self).
+	self locals: (localList collect: [:arg | arg key]) asSet.
 	labels := Set new.
 	complete := false.  "set to true when all possible inlining has been done"
 	export := self extractExportDirective.

--- a/smalltalksrc/VMMaker/Spur64BitMMLECoSimulator.class.st
+++ b/smalltalksrc/VMMaker/Spur64BitMMLECoSimulator.class.st
@@ -222,7 +222,7 @@ Spur64BitMMLECoSimulator >> long32At: byteAddress put: a32BitValue [
 		[self halt]."
 	"(byteAddress between: 16r33FBB8 and: 16r33FBCF) ifTrue:
 		[self halt]."
-	^ memoryManager long32At: byteAddress put: a32BitValue
+	^ memoryManager unsignedLong32At: byteAddress put: a32BitValue
 ]
 
 { #category : #'memory access' }

--- a/smalltalksrc/VMMakerTests/UnicornProcessor.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornProcessor.class.st
@@ -264,6 +264,12 @@ UnicornProcessor >> rcx: anInteger [
 	machineSimulator rcx: anInteger
 ]
 
+{ #category : #'as yet unclassified' }
+UnicornProcessor >> rdi: anInteger [ 
+
+	machineSimulator rdi: anInteger 
+]
+
 { #category : #registers }
 UnicornProcessor >> rdx: anInteger [ 
 	

--- a/smalltalksrc/VMMakerTests/VMJITPrimitiveCallingTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJITPrimitiveCallingTest.class.st
@@ -19,9 +19,6 @@ VMJITPrimitiveCallingTest >> initStack [
 	machineSimulator smalltalkStackPointerRegisterValue: interpreter stackPointer.
 	machineSimulator framePointerRegisterValue: interpreter framePointer.
 	machineSimulator baseRegisterValue: cogit varBaseAddress.
-	
-	cogit setCStackPointer: interpreter rumpCStackAddress.
-	cogit setCFramePointer: interpreter rumpCStackAddress.
 
 ]
 

--- a/smalltalksrc/VMMakerTests/VMJitMethodTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJitMethodTest.class.st
@@ -35,9 +35,6 @@ VMJitMethodTest >> initStack [
 	machineSimulator smalltalkStackPointerRegisterValue: interpreter stackPointer.
 	machineSimulator framePointerRegisterValue: interpreter framePointer.
 	machineSimulator baseRegisterValue: cogit varBaseAddress.
-	
-	cogit setCStackPointer: interpreter rumpCStackAddress.
-	cogit setCFramePointer: interpreter rumpCStackAddress.
 
 ]
 


### PR DESCRIPTION
Fixing the simulation running with:
```smalltalk
InterpreterStackPages initialize.
options := {
    #ObjectMemory -> #Spur64BitCoMemoryManager.
    #ISA -> #aarch64.
    #BytesPerWord -> 8
} asDictionary.

c := CogVMSimulator newWithOptions: options.
c openOn: <path_to_simulated_image> extraMemory: 100000.
c run.
```

The list and reasoning behind changes is listed here:
- Some signed memory accesses should be unsigned
- `setSelector: sel definingClass: class args: argList` should initialize local variable `parseTree` before `locals`
- `prepareToBeAddedToCodeGenerator: aCodeGen` should not remove the variable if it has not been set (which it is not the case so the method can be removed)
- `saneFunctionPointerForFailureOfPrimIndex: primIndex` should not check for the instruction pointer to be in the rump c stack as this cannot be the case (figure below)
- `primitiveObjectAtPut` in the `CogVMSimulator` is not really needed anymore
- the c stack/frame pointers were overridden at the end of the `initStack` methods

---

Commit 355d03b explanation:
![pharotrampolinestacks](https://user-images.githubusercontent.com/32014573/191009987-747da58f-3bfa-4e93-a9b7-18db58059d51.png)

The initial state of the Pharo stack before calling a machine code trampoline is shown in black and has: PC (or IP) set to its corresponding bytecode PC, SP and FP pointing to the smalltalk stack. To run a trampoline, the FP/SP should be swap to the actual rump C stack while the PC should point to the location of the trampoline in machine code. It should not be set to point to the rump C stack at any point.
