### PR TITLE
slang: automatic inline method that use blocks

### DIFF
--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -172,7 +172,7 @@ SlangBasicTranslationTest >> testAssignementAsExpressionWithExpressionBlockWithL
 		equals: 'y = (foo(1, 2), foo(3, 4), foo(5, 6), a)'
 ]
 
-{ #category : #'tests-method' }
+{ #category : #'tests-inlinemethod' }
 SlangBasicTranslationTest >> testBasicInlineAsSpecified [
 	
 	"Method with inline pragma are compiled anyway."
@@ -194,11 +194,21 @@ methodCallingMethodWithInlinePragma(void)
 	methodWithoutInlinePragma();
 	/* begin methodWithInlinePragma */
 	bodyOfMethodWithInlinePragma();
+	
+	{
+		blockBody1();
+		blockBody2();
+	}
+	
+	{
+		blockBody3();
+		blockBody4();
+	}
 	return 0;
 }'
 ]
 
-{ #category : #'tests-method' }
+{ #category : #'tests-inlinemethod' }
 SlangBasicTranslationTest >> testBasicInlineAsSpecifiedOrQuick [
 	
 	"Method with inline pragma are compiled anyway."
@@ -220,11 +230,21 @@ methodCallingMethodWithInlinePragma(void)
 	methodWithoutInlinePragma();
 	/* begin methodWithInlinePragma */
 	bodyOfMethodWithInlinePragma();
+	
+	{
+		blockBody1();
+		blockBody2();
+	}
+	
+	{
+		blockBody3();
+		blockBody4();
+	}
 	return 0;
 }'
 ]
 
-{ #category : #'tests-method' }
+{ #category : #'tests-inlinemethod' }
 SlangBasicTranslationTest >> testBasicInlineFalse [
 	
 	"Method with inline pragma are compiled anyway."
@@ -245,11 +265,21 @@ methodCallingMethodWithInlinePragma(void)
 {
 	methodWithoutInlinePragma();
 	methodWithInlinePragma();
+	/* begin methodWithoutInlinePragmaAndBlock: */
+	{
+		blockBody1();
+		blockBody2();
+	}
+	
+	{
+		blockBody3();
+		blockBody4();
+	}
 	return 0;
 }'
 ]
 
-{ #category : #'tests-method' }
+{ #category : #'tests-inlinemethod' }
 SlangBasicTranslationTest >> testBasicInlineNone [
 	
 	"Method with inline pragma are compiled anyway."
@@ -257,6 +287,8 @@ SlangBasicTranslationTest >> testBasicInlineNone [
 	| translation tMethod |
 	tMethod := self getTMethodFrom: #methodCallingMethodWithInlinePragma.
 	tMethod recordDeclarationsIn: generator.
+	
+	"FIXME: without calling doBasicInlining: the block, the content is inlined as is. This basically make no sense and slang should have aborted somewere."
 	"generator doBasicInlining: false."
 	
 	translation := self translate: tMethod.
@@ -270,11 +302,13 @@ methodCallingMethodWithInlinePragma(void)
 {
 	methodWithoutInlinePragma();
 	methodWithInlinePragma();
+	methodWithoutInlinePragmaAndBlock((blockBody1(), blockBody2()));
+	methodWithInlinePragmaAndBlock((blockBody3(), blockBody4()));
 	return 0;
 }'
 ]
 
-{ #category : #'tests-method' }
+{ #category : #'tests-inlinemethod' }
 SlangBasicTranslationTest >> testBasicInlineTrue [
 	
 	"Method with inline pragma are compiled anyway."
@@ -297,6 +331,16 @@ methodCallingMethodWithInlinePragma(void)
 	bodyOfMethodWithoutInlinePragma();
 	
 	bodyOfMethodWithInlinePragma();
+	
+	{
+		blockBody1();
+		blockBody2();
+	}
+	
+	{
+		blockBody3();
+		blockBody4();
+	}
 	return 0;
 }'
 ]

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -172,6 +172,135 @@ SlangBasicTranslationTest >> testAssignementAsExpressionWithExpressionBlockWithL
 		equals: 'y = (foo(1, 2), foo(3, 4), foo(5, 6), a)'
 ]
 
+{ #category : #'tests-method' }
+SlangBasicTranslationTest >> testBasicInlineAsSpecified [
+	
+	"Method with inline pragma are compiled anyway."
+	
+	| translation tMethod |
+	tMethod := self getTMethodFrom: #methodCallingMethodWithInlinePragma.
+	tMethod recordDeclarationsIn: generator.
+	generator doBasicInlining: #asSpecified.
+	
+	translation := self translate: tMethod.
+	translation := translation trimBoth.
+	
+	self
+		assert: translation
+		equals: '/* SlangBasicTranslationTestClass>>#methodCallingMethodWithInlinePragma */
+static sqInt
+methodCallingMethodWithInlinePragma(void)
+{
+	methodWithoutInlinePragma();
+	/* begin methodWithInlinePragma */
+	bodyOfMethodWithInlinePragma();
+	return 0;
+}'
+]
+
+{ #category : #'tests-method' }
+SlangBasicTranslationTest >> testBasicInlineAsSpecifiedOrQuick [
+	
+	"Method with inline pragma are compiled anyway."
+	
+	| translation tMethod |
+	tMethod := self getTMethodFrom: #methodCallingMethodWithInlinePragma.
+	tMethod recordDeclarationsIn: generator.
+	generator doBasicInlining: #asSpecifiedOrQuick.
+	
+	translation := self translate: tMethod.
+	translation := translation trimBoth.
+	
+	self
+		assert: translation
+		equals: '/* SlangBasicTranslationTestClass>>#methodCallingMethodWithInlinePragma */
+static sqInt
+methodCallingMethodWithInlinePragma(void)
+{
+	methodWithoutInlinePragma();
+	/* begin methodWithInlinePragma */
+	bodyOfMethodWithInlinePragma();
+	return 0;
+}'
+]
+
+{ #category : #'tests-method' }
+SlangBasicTranslationTest >> testBasicInlineFalse [
+	
+	"Method with inline pragma are compiled anyway."
+	
+	| translation tMethod |
+	tMethod := self getTMethodFrom: #methodCallingMethodWithInlinePragma.
+	tMethod recordDeclarationsIn: generator.
+	generator doBasicInlining: false.
+	
+	translation := self translate: tMethod.
+	translation := translation trimBoth.
+	
+	self
+		assert: translation
+		equals: '/* SlangBasicTranslationTestClass>>#methodCallingMethodWithInlinePragma */
+static sqInt
+methodCallingMethodWithInlinePragma(void)
+{
+	methodWithoutInlinePragma();
+	methodWithInlinePragma();
+	return 0;
+}'
+]
+
+{ #category : #'tests-method' }
+SlangBasicTranslationTest >> testBasicInlineNone [
+	
+	"Method with inline pragma are compiled anyway."
+	
+	| translation tMethod |
+	tMethod := self getTMethodFrom: #methodCallingMethodWithInlinePragma.
+	tMethod recordDeclarationsIn: generator.
+	"generator doBasicInlining: false."
+	
+	translation := self translate: tMethod.
+	translation := translation trimBoth.
+	
+	self
+		assert: translation
+		equals: '/* SlangBasicTranslationTestClass>>#methodCallingMethodWithInlinePragma */
+static sqInt
+methodCallingMethodWithInlinePragma(void)
+{
+	methodWithoutInlinePragma();
+	methodWithInlinePragma();
+	return 0;
+}'
+]
+
+{ #category : #'tests-method' }
+SlangBasicTranslationTest >> testBasicInlineTrue [
+	
+	"Method with inline pragma are compiled anyway."
+	
+	| translation tMethod |
+	tMethod := self getTMethodFrom: #methodCallingMethodWithInlinePragma.
+	tMethod recordDeclarationsIn: generator.
+	generator doBasicInlining: true.
+	
+	translation := self translate: tMethod.
+	translation := translation trimBoth.
+	
+	self
+		assert: translation
+		equals: '/* SlangBasicTranslationTestClass>>#methodCallingMethodWithInlinePragma */
+static sqInt
+methodCallingMethodWithInlinePragma(void)
+{
+	/* begin methodWithoutInlinePragma */
+	bodyOfMethodWithoutInlinePragma();
+	
+	bodyOfMethodWithInlinePragma();
+	return 0;
+}'
+]
+
 { #category : #'tests-return' }
 SlangBasicTranslationTest >> testBitShiftIfTrue [
 

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
@@ -43,7 +43,9 @@ SlangBasicTranslationTestClass >> initializationOptions [
 SlangBasicTranslationTestClass >> methodCallingMethodWithInlinePragma [
 
 	self methodWithoutInlinePragma.
-	self methodWithInlinePragma
+	self methodWithInlinePragma.
+	self methodWithoutInlinePragmaAndBlock: [ self blockBody1. self blockBody2 ].
+	self methodWithInlinePragmaAndBlock: [ self blockBody3. self blockBody4 ].
 ]
 
 { #category : #inline }
@@ -120,6 +122,13 @@ SlangBasicTranslationTestClass >> methodWithInlinePragma [
 ]
 
 { #category : #inline }
+SlangBasicTranslationTestClass >> methodWithInlinePragmaAndBlock: aBlock [
+
+	<inline: true>
+	aBlock value
+]
+
+{ #category : #inline }
 SlangBasicTranslationTestClass >> methodWithLocalVariables [
 
 	<var: #foo declareC: 'float foo'>
@@ -187,6 +196,12 @@ SlangBasicTranslationTestClass >> methodWithVolatilePragma [
 SlangBasicTranslationTestClass >> methodWithoutInlinePragma [
 
 	self bodyOfMethodWithoutInlinePragma.
+]
+
+{ #category : #inline }
+SlangBasicTranslationTestClass >> methodWithoutInlinePragmaAndBlock: aBlock [
+
+	aBlock value
 ]
 
 { #category : #inline }

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
@@ -40,6 +40,13 @@ SlangBasicTranslationTestClass >> initializationOptions [
 ]
 
 { #category : #inline }
+SlangBasicTranslationTestClass >> methodCallingMethodWithInlinePragma [
+
+	self methodWithoutInlinePragma.
+	self methodWithInlinePragma
+]
+
+{ #category : #inline }
 SlangBasicTranslationTestClass >> methodDefiningSingleExternVariable [
 
 	<var: 'foo' type: #'extern int' >
@@ -106,6 +113,13 @@ SlangBasicTranslationTestClass >> methodWithAnOptionPragma [
 ]
 
 { #category : #inline }
+SlangBasicTranslationTestClass >> methodWithInlinePragma [
+
+	<inline: true>
+	self bodyOfMethodWithInlinePragma
+]
+
+{ #category : #inline }
 SlangBasicTranslationTestClass >> methodWithLocalVariables [
 
 	<var: #foo declareC: 'float foo'>
@@ -167,6 +181,12 @@ SlangBasicTranslationTestClass >> methodWithVolatilePragma [
 
 	<volatile>
 	
+]
+
+{ #category : #inline }
+SlangBasicTranslationTestClass >> methodWithoutInlinePragma [
+
+	self bodyOfMethodWithoutInlinePragma.
 ]
 
 { #category : #inline }

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -768,9 +768,12 @@ CCodeGenerator >> collectInlineList: strategy [
 	 translator cannot currently map variable names in inlined C code.
 	 Methods to be inlined must be small or called from only one place."
 	
-	| selectorsOfMethodsNotToInline callsOf inlineStrategy |
+	| selectorsOfMethodsNotToInline callsOf inlineStrategy selectorsWithBlocks |
 	inlineStrategy := strategy asCCodeInlineStrategy.
 	inlineStrategy codeGenerator: self.
+	
+	"Set of selectors that takes blocks as argument. The associated methods must be inlined and not compiled separately."
+	selectorsWithBlocks := Set new.
 		
 	selectorsOfMethodsNotToInline := Set new: methods size.
 	selectorsOfMethodsNotToInline addAll: macros keys.
@@ -797,6 +800,13 @@ CCodeGenerator >> collectInlineList: strategy [
 		thenDo: [:m|
 			m parseTree nodesDo: [:node|
 				node isSend ifTrue: [
+					
+					"Special case of methods that takes block as arguments.
+					The only way to call them is to inline them since blocks are not values in C."
+					(node arguments anySatisfy: [ :arg | arg class == TStatementListNode ])
+						ifTrue: [ selectorsWithBlocks add: node selector. ].
+					
+					"Increase call count"
 					callsOf
 						at: node selector
 						ifPresent: [:senderCount| callsOf at: node selector put: senderCount + 1 ] ] ].
@@ -812,6 +822,10 @@ CCodeGenerator >> collectInlineList: strategy [
 					ifFalse: [
 						inlineStrategy isSelectiveInlineStrategy
 							ifTrue: [selectorsOfMethodsNotToInline add: m selector] ] ] ].
+
+	"Inline all methods that takes block and mark them inline:#always to ensure they are not compiled sepately"
+	inlineList addAll: selectorsWithBlocks.
+	methods select: [ :m | selectorsWithBlocks includes: m selector ] thenDo: [ :m | m inline: #always ].
 
 	inlineStrategy isSelectiveInlineStrategy
 		ifTrue:

--- a/smalltalksrc/Slang/CCodeGeneratorInlineAlwaysStrategy.class.st
+++ b/smalltalksrc/Slang/CCodeGeneratorInlineAlwaysStrategy.class.st
@@ -4,6 +4,12 @@ Class {
 	#category : #'Slang-CodeGeneration'
 }
 
+{ #category : #testing }
+CCodeGeneratorInlineAlwaysStrategy >> isSelectiveInlineStrategy [
+
+	^ false
+]
+
 { #category : #accessing }
 CCodeGeneratorInlineAlwaysStrategy >> nodeCountOfMethod: aTMethod [
 

--- a/smalltalksrc/Slang/CCodeGeneratorInlineAsSpecifiedStrategy.class.st
+++ b/smalltalksrc/Slang/CCodeGeneratorInlineAsSpecifiedStrategy.class.st
@@ -15,12 +15,6 @@ CCodeGeneratorInlineAsSpecifiedStrategy >> initialize [
 ]
 
 { #category : #asserting }
-CCodeGeneratorInlineAsSpecifiedStrategy >> isSelectiveInlineStrategy [
-
-	^ true
-]
-
-{ #category : #asserting }
 CCodeGeneratorInlineAsSpecifiedStrategy >> shouldInlineMethod: aMethod [
 
 	^ (super shouldInlineMethod: aMethod) and: [ self wantsInline: aMethod ]

--- a/smalltalksrc/Slang/CCodeGeneratorInlineStrategy.class.st
+++ b/smalltalksrc/Slang/CCodeGeneratorInlineStrategy.class.st
@@ -75,8 +75,10 @@ CCodeGeneratorInlineStrategy >> hasUnrenamableCCode: aTMethod [
 
 { #category : #testing }
 CCodeGeneratorInlineStrategy >> isSelectiveInlineStrategy [
+	"If true, it can answers yes or no. If false it always answers true.
+	Note: I'm not sur of the point of such optimisation path."
 	
-	^ false
+	^ true
 ]
 
 { #category : #asserting }

--- a/smalltalksrc/Slang/CCodeGeneratorInlineStrategy.class.st
+++ b/smalltalksrc/Slang/CCodeGeneratorInlineStrategy.class.st
@@ -28,7 +28,7 @@ CCodeGeneratorInlineStrategy class >> asSpecifiedOrQuick [
 { #category : #'instance creation' }
 CCodeGeneratorInlineStrategy class >> from: anObject [
 	
-	"The argument is either a boolean or a sumbol.
+	"The argument is either a boolean or a symbol.
 	If a boolean, it indicates if we need to inline or not.
 	If == #asSpecified only inline methods marked with <inline: true>.
 	If == #asSpecifiedOrQuick only inline methods marked with <inline: true> or methods that are quick (^constant, ^inst var)."

--- a/smalltalksrc/Slang/TParseNode.class.st
+++ b/smalltalksrc/Slang/TParseNode.class.st
@@ -473,6 +473,19 @@ TParseNode >> structTargetKindIn: aCodeGen [
 	^nil
 ]
 
+{ #category : #accessing }
+TParseNode >> tMethod [
+
+	"Climb up the parent links up to the TMethod node"
+
+	| n |
+	n := self.
+	[ true ] whileTrue: [
+		n ifNil: [ ^ nil ].
+		n class == TMethod ifTrue: [ ^ n ].
+		n := n parent ]
+]
+
 { #category : #'type inference' }
 TParseNode >> typeFrom: aCodeGenerator in: aTMethod [
 	"This is the default type in case of doubt"

--- a/smalltalksrc/VMMaker/CogARMCompiler.class.st
+++ b/smalltalksrc/VMMaker/CogARMCompiler.class.st
@@ -2538,7 +2538,7 @@ CogARMCompiler >> inverseOpcodeFor: armOpcode [
 CogARMCompiler >> is12BitValue: constant ifTrue: trueAlternativeBlock	ifFalse: falseAlternativeBlock [
 	"For LDR and STR, there is an instruction allowing for one instruction encoding if the offset is encodable in signed 12 bit form. pass the trueBlock the value and a 1-bit flag to tell it the sign.
 	The falseBlock can do whatever it needs to, typically building the constant as a full 32bit value and then ld/st with that as a register offset"
-	<inline: true>
+
 	constant abs <= 4095 "(2 raisedTo: 12)-1"
 		ifTrue:
 			[constant >= 0 
@@ -2550,7 +2550,7 @@ CogARMCompiler >> is12BitValue: constant ifTrue: trueAlternativeBlock	ifFalse: f
 { #category : #testing }
 CogARMCompiler >> is8BitValue: constant ifTrue: trueAlternativeBlock	ifFalse: falseAlternativeBlock [
 	"For extended LDR and STR for half & double, there is an instruction allowing for one instruction encoding if the offset is encodable in 8 bit."
-	<inline: true>
+
 	constant abs <= 255 "(2 raisedTo: 8)-1"
 		ifTrue:
 			[constant >= 0 
@@ -3176,7 +3176,7 @@ CogARMCompiler >> rewriteTransferAt: callSiteReturnAddress target: callTargetAdd
 
 { #category : #testing }
 CogARMCompiler >> rotateable8bitBitwiseImmediate: constant ifTrue: trueAlternativeBlock ifFalse: falseAlternativeBlock [
-	<inline: true>
+
 	"Invoke trueAlternativeBlock with shift, value and inverted if constant can be represented
 	 by a possibly rotated 8-bit constant, otherwise invoke falseAlternativeBlock. For data
 	 processing operands, there is the immediate shifter_operand variant,  where an 8 bit value
@@ -3202,7 +3202,7 @@ CogARMCompiler >> rotateable8bitBitwiseImmediate: constant ifTrue: trueAlternati
 
 { #category : #testing }
 CogARMCompiler >> rotateable8bitImmediate: constant ifTrue: trueAlternativeBlock ifFalse: falseAlternativeBlock [
-	<inline: true>
+
 	"For data processing operands, there is the immediate shifter_operand variant, 
 	 where an 8 bit value is ring shifted _right_ by i.
 	 This is only suitable for quick constants(Cq), which won't change."
@@ -3218,7 +3218,7 @@ CogARMCompiler >> rotateable8bitImmediate: constant ifTrue: trueAlternativeBlock
 
 { #category : #testing }
 CogARMCompiler >> rotateable8bitSignedImmediate: constant ifTrue: trueAlternativeBlock ifFalse: falseAlternativeBlock [
-	<inline: true>
+
 	"Invoke trueAlternativeBlock with shift, value and negated if constant can be represented
 	 by a possibly rotated 8-bit constant, otherwise invoke falseAlternativeBlock. For data
 	 processing operands, there is the immediate shifter_operand variant,  where an 8 bit value
@@ -3244,7 +3244,7 @@ CogARMCompiler >> rotateable8bitSignedImmediate: constant ifTrue: trueAlternativ
 CogARMCompiler >> saveAndRestoreLinkRegAround: aBlock [
 	"If the processor's ABI includes a link register, generate instructions
 	 to save and restore it around aBlock, which is assumed to generate code."
-	<inline: true>
+
 	| inst |
 	inst := cogit PushR: LinkReg.
 	aBlock value.

--- a/smalltalksrc/VMMaker/CogARMv8Compiler.class.st
+++ b/smalltalksrc/VMMaker/CogARMv8Compiler.class.st
@@ -4469,7 +4469,6 @@ CogARMv8Compiler >> is9BitValue: originalConstant ifTrue: aTrueBlock ifFalse: aF
 	
 	| constant |
 	
-	<inline: true>
 	<var: #constant type: 'sqInt'>
 	
 	"This is needed to force the type conversion in an inlined function.
@@ -5719,7 +5718,7 @@ CogARMv8Compiler >> rorSize: is64bits sourceRegister: sourceRegister rotationBit
 
 { #category : #testing }
 CogARMv8Compiler >> rotateable8bitBitwiseImmediate: constant ifTrue: trueAlternativeBlock ifFalse: falseAlternativeBlock [
-	<inline: true>
+
 	"Invoke trueAlternativeBlock with shift, value and inverted if constant can be represented
 	 by a possibly rotated 8-bit constant, otherwise invoke falseAlternativeBlock. For data
 	 processing operands, there is the immediate shifter_operand variant,  where an 8 bit value
@@ -5745,7 +5744,7 @@ CogARMv8Compiler >> rotateable8bitBitwiseImmediate: constant ifTrue: trueAlterna
 
 { #category : #testing }
 CogARMv8Compiler >> rotateable8bitImmediate: constant ifTrue: trueAlternativeBlock ifFalse: falseAlternativeBlock [
-	<inline: true>
+
 	"For data processing operands, there is the immediate shifter_operand variant, 
 	 where an 8 bit value is ring shifted _right_ by i.
 	 This is only suitable for quick constants(Cq), which won't change."
@@ -5761,7 +5760,7 @@ CogARMv8Compiler >> rotateable8bitImmediate: constant ifTrue: trueAlternativeBlo
 
 { #category : #testing }
 CogARMv8Compiler >> rotateable8bitSignedImmediate: constant ifTrue: trueAlternativeBlock ifFalse: falseAlternativeBlock [
-	<inline: true>
+
 	"Invoke trueAlternativeBlock with shift, value and negated if constant can be represented
 	 by a possibly rotated 8-bit constant, otherwise invoke falseAlternativeBlock. For data
 	 processing operands, there is the immediate shifter_operand variant,  where an 8 bit value
@@ -5787,7 +5786,7 @@ CogARMv8Compiler >> rotateable8bitSignedImmediate: constant ifTrue: trueAlternat
 CogARMv8Compiler >> saveAndRestoreLinkRegAround: aBlock [
 	"If the processor's ABI includes a link register, generate instructions
 	 to save and restore it around aBlock, which is assumed to generate code."
-	<inline: true>
+
 	| inst |
 	inst := cogit PushR: LinkReg.
 	aBlock value.
@@ -5860,7 +5859,7 @@ CogARMv8Compiler >> shiftSetsConditionCodesFor: aConditionalJumpOpcode [
 
 { #category : #testing }
 CogARMv8Compiler >> shiftable16bitImmediate: constant ifTrue: trueAlternativeBlock ifFalse: falseAlternativeBlock [
-	<inline: true>
+
 	"For data processing operands, there is the immediate shifter_operand variant, 
 	 where an 16 bit value is left shifted by i.
 	 This is only suitable for quick constants(Cq), which won't change."

--- a/smalltalksrc/VMMaker/CogIA32Compiler.class.st
+++ b/smalltalksrc/VMMaker/CogIA32Compiler.class.st
@@ -4035,7 +4035,7 @@ CogIA32Compiler >> s: scale i: indexReg b: baseReg [
 CogIA32Compiler >> saveAndRestoreLinkRegAround: aBlock [
 	"If the processor's ABI includes a link register, generate instructions
 	 to save and restore it around aBlock, which is assumed to generate code."
-	<inline: true>
+
 	^aBlock value
 ]
 

--- a/smalltalksrc/VMMaker/CogMIPSELCompiler.class.st
+++ b/smalltalksrc/VMMaker/CogMIPSELCompiler.class.st
@@ -2813,7 +2813,7 @@ CogMIPSELCompiler >> rtype: op rs: rs rt: rt rd: rd sa: sa funct: funct [
 CogMIPSELCompiler >> saveAndRestoreLinkRegAround: aBlock [
 	"If the processor's ABI includes a link register, generate instructions
 	 to save and restore it around aBlock, which is assumed to generate code."
-	<inline: true>
+
 	| inst |
 	inst := cogit PushR: LinkReg.
 	aBlock value.

--- a/smalltalksrc/VMMaker/CogObjectRepresentationFor32BitSpur.class.st
+++ b/smalltalksrc/VMMaker/CogObjectRepresentationFor32BitSpur.class.st
@@ -270,7 +270,7 @@ CogObjectRepresentationFor32BitSpur >> genGetSizeOf: sourceReg into: destReg for
 	| jumpNotIndexable
 	  jumpBytesDone jumpShortsDone jumpArrayDone jump32BitLongsDone jump64BitLongsDone
 	  jumpIsBytes jumpHasFixedFields jumpIsShorts jumpIs64BitLongs jumpIsContext  |
-	<inline: true>
+
 	"c.f. StackInterpreter>>stSizeOf: SpurMemoryManager>>lengthOf:format: fixedFieldsOf:format:length:"
 
 	"formatReg := self formatOf: sourceReg"

--- a/smalltalksrc/VMMaker/CogObjectRepresentationFor64BitSpur.class.st
+++ b/smalltalksrc/VMMaker/CogObjectRepresentationFor64BitSpur.class.st
@@ -62,7 +62,7 @@ CogObjectRepresentationFor64BitSpur >> allocateCounters: nCounters [
 
 { #category : #'in-line cacheing' }
 CogObjectRepresentationFor64BitSpur >> bitAndByteOffsetOfIsFullBlockBitInto: aBlock [
-	<inline: true>
+
 	"This supplies the bitmask for the isFullBlock bit, and the offset of the byte containing
 	 that bit in a CogMethod header to aBlock.  We don't have named variables holding this
 	 offset.  The following assert tests whether the values are correct by creating a surrogate
@@ -598,7 +598,7 @@ CogObjectRepresentationFor64BitSpur >> genGetSizeOf: sourceReg into: destReg for
 	| jumpNotIndexable
 	  jumpBytesDone jumpShortsDone jumpArrayDone jump32BitLongsDone jump64BitLongsDone
 	  jumpIsBytes jumpHasFixedFields jumpIsShorts jumpIs32BitLongs jumpIsContext  |
-	<inline: true>
+
 	"c.f. StackInterpreter>>stSizeOf: SpurMemoryManager>>lengthOf:format: fixedFieldsOf:format:length:"
 
 	"formatReg := self formatOf: sourceReg"

--- a/smalltalksrc/VMMaker/CogObjectRepresentationForSpur.class.st
+++ b/smalltalksrc/VMMaker/CogObjectRepresentationForSpur.class.st
@@ -1296,13 +1296,13 @@ CogObjectRepresentationForSpur >> genPrimitiveIntegerAtPut [
 
 { #category : #'primitive generators' }
 CogObjectRepresentationForSpur >> genPrimitiveLoad: accessedElementByteSize fromBytesWith: aBlock [
-	<inline: true>
+
 	^ self genPrimitiveLoad: accessedElementByteSize fromBytesWith: aBlock needsToTrap: false
 ]
 
 { #category : #'primitive generators' }
 CogObjectRepresentationForSpur >> genPrimitiveLoad: accessedElementByteSize fromBytesWith: aBlock needsToTrap: needsToTrap [
-	<inline: true>
+
 	| nSlotsOrBytesReg jumpBadIndex formatReg jumpIsPointers jumpOutOfBounds jumpSmaller jumpImmediate |
 	nSlotsOrBytesReg := ClassReg.
 	
@@ -1538,13 +1538,13 @@ CogObjectRepresentationForSpur >> genPrimitiveLoadFloat64FromExternalAddress [
 
 { #category : #'primitive generators' }
 CogObjectRepresentationForSpur >> genPrimitiveLoadFromExternalAddressWith: aBlock [
-	<inline: true>
+
 	^ self genPrimitiveLoadFromExternalAddressWith: aBlock needsToTrap: false
 ]
 
 { #category : #'primitive generators' }
 CogObjectRepresentationForSpur >> genPrimitiveLoadFromExternalAddressWith: aBlock needsToTrap: needsToTrap [
-	<inline: true>
+
 	| jumpBadIndex jumpImmediate jumpNonExternalAddress |
 
 	cogit genLoadArgAtDepth: 0 into: Arg0Reg.
@@ -1746,13 +1746,13 @@ CogObjectRepresentationForSpur >> genPrimitiveSize [
 
 { #category : #'primitive generators' }
 CogObjectRepresentationForSpur >> genPrimitiveStore: accessedElementByteSize intoBytesWith: aBlock [
-	<inline: true>
+
 	^ self genPrimitiveStore: accessedElementByteSize intoBytesWith: aBlock needsToTrap: false
 ]
 
 { #category : #'primitive generators' }
 CogObjectRepresentationForSpur >> genPrimitiveStore: accessedElementByteSize intoBytesWith: aBlock needsToTrap: needsToTrap [
-	<inline: true>
+
 	| nSlotsOrBytesReg jumpBadIndex formatReg jumpIsPointers jumpOutOfBounds jumpSmaller jumpImmediate destPointerRegister |
 	nSlotsOrBytesReg := ClassReg.
 	destPointerRegister := ClassReg.
@@ -2073,13 +2073,13 @@ CogObjectRepresentationForSpur >> genPrimitiveStoreInt8IntoExternalAddress [
 
 { #category : #'primitive generators' }
 CogObjectRepresentationForSpur >> genPrimitiveStoreIntoExternalAddressWith: aBlock [
-	<inline: true>
+
 	^ self genPrimitiveStoreIntoExternalAddressWith: aBlock needsToTrap: false
 ]
 
 { #category : #'primitive generators' }
 CogObjectRepresentationForSpur >> genPrimitiveStoreIntoExternalAddressWith: aBlock needsToTrap: needsToTrap [
-	<inline: true>
+
 	| jumpBadIndex jumpNonExternalAddress jumpImmediate destPointerRegister |
 	destPointerRegister := ClassReg.
 

--- a/smalltalksrc/VMMaker/CogX64Compiler.class.st
+++ b/smalltalksrc/VMMaker/CogX64Compiler.class.st
@@ -4693,7 +4693,7 @@ CogX64Compiler >> s: scale i: indexReg b: baseReg [
 CogX64Compiler >> saveAndRestoreLinkRegAround: aBlock [
 	"If the processor's ABI includes a link register, generate instructions
 	 to save and restore it around aBlock, which is assumed to generate code."
-	<inline: true>
+
 	^aBlock value
 ]
 

--- a/smalltalksrc/VMMaker/Cogit.class.st
+++ b/smalltalksrc/VMMaker/Cogit.class.st
@@ -3266,7 +3266,6 @@ Cogit >> allocateOpcodes: numberOfAbstractOpcodes bytecodes: numberOfBytecodes i
 	 needed is considered too high.  Notionally we only need as many fixups as there are
 	 bytecodes.  But we reuse fixups to record pc-dependent instructions in
 	 generateInstructionsAt: and so need at least as many as there are abstract opcodes."
-	<inline: true>
 
 	numberOfAbstractOpcodes > MaxNumberOfAbstractOpcodes ifTrue:
 		[^failBlock value].
@@ -6134,15 +6133,11 @@ Cogit >> enableCodeZoneWrite [
 { #category : #'code generation' }
 Cogit >> enableCodeZoneWriteDuring: codeGenerationBlock [ 
 
-	<inline: true>
-
 	self enableCodeZoneWriteDuring: codeGenerationBlock flushingCacheWith: [  ]
 ]
 
 { #category : #'code generation' }
 Cogit >> enableCodeZoneWriteDuring: codeGenerationBlock flushingCacheWith: flushBlock [
-
-	<inline: true>
 
 	self enableCodeZoneWrite.
 	codeGenerationBlock value.
@@ -6234,7 +6229,7 @@ Cogit >> enterCogCodePopReceiver [
 Cogit >> entryCacheTagAndCouldBeObjectAt: mcpc annotation: annotation into: trinaryBlock [
 	"Evaluate trinaryBlock with the entryPoint, inline cache tag and whether the cache
 	 tag could be an object, for the send at mcpc with annotation annotation."
-	<inline: true>
+
 	| cacheTag entryPoint tagCouldBeObj |
 	cacheTag := backEnd inlineCacheTagAt: mcpc asInteger.
 	entryPoint := backEnd callTargetFromReturnAddress: mcpc asInteger.
@@ -8946,7 +8941,7 @@ Cogit >> lookup: selector for: receiver methodAndErrorSelectorInto: binaryBlock 
 	 and evaluate binaryBlock with the MNU method, cogged if appropriate..  If not found
 	 due to cannot interpret, evaluate binaryBlock with a nil method and the error selector."
 	| methodOrSelectorIndex |
-	<inline: true>
+
 	methodOrSelectorIndex := coInterpreter
 									lookupOrdinary: selector
 									receiver: receiver.
@@ -10165,7 +10160,7 @@ Cogit >> nextBytecodePCFor: descriptor exts: nExts [
 { #category : #'bytecode generator support' }
 Cogit >> nextDescriptorExtensionsAndNextPCInto: aQuaternaryBlock [
 	"Peek ahead and deliver the next descriptor, extension bytes and next pc."
-	<inline: true>
+
 	| savedB0 savedB1 savedB2 savedB3 savedEA savedEB savedNEB descriptor bcpc |
 	<var: #descriptor type: #'BytecodeDescriptor *'>
 	descriptor := self generatorAt: byte0.
@@ -10259,7 +10254,7 @@ Cogit >> offset: aClass of: fieldSymbol [
 Cogit >> offsetAndSendTableFor: entryPoint annotation: annotation into: binaryBlock [
 	"Find the relevant sendTable for a linked-send to entryPoint.  Do this based on the
 	 annotation.  c.f. annotationForSendTable:"
-	<inline: true>
+
 	| offset sendTable |
 	<var: #sendTable type: #'sqInt *'>
 	annotation = IsSendCall ifTrue:
@@ -11802,7 +11797,7 @@ Cogit >> subsequentPrototypeMethodOop [
 Cogit >> targetMethodAndSendTableFor: entryPoint annotation: annotation into: binaryBlock [
 	"Evaluate binaryBlock with the targetMethod and relevant send table for a linked-send
 	 to entryPoint.  Do so based on the alignment of entryPoint."
-	<inline: true>
+
 	<var: #targetMethod type: #'CogMethod *'>
 
 	self offsetAndSendTableFor: entryPoint

--- a/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
@@ -4722,7 +4722,7 @@ InterpreterPrimitives >> quot: integerRcvr ient: integerArg [
 { #category : #'string primitives' }
 InterpreterPrimitives >> rawCompare: string1 length: strLength1 with: string2 length: strLength2 accessBlock: accessBlock [
 	| c1 c2 min |
-	<inline: true> "needs to be forced else slang does not inline it by default"
+
 	min := strLength1 min: strLength2.
 	0 to: min-1 do: 
 		[:i | c1 := accessBlock value: string1 value: i.

--- a/smalltalksrc/VMMaker/SimpleStackBasedCogit.class.st
+++ b/smalltalksrc/VMMaker/SimpleStackBasedCogit.class.st
@@ -1026,7 +1026,7 @@ SimpleStackBasedCogit >> entryOffset: anInteger [
 
 { #category : #'trampoline support' }
 SimpleStackBasedCogit >> evaluateTrampolineCallBlock: block protectLinkRegIfNot: inFrame [
-	<inline: true>
+
 	inFrame 
 		ifFalse: 
 			[ backEnd saveAndRestoreLinkRegAround: [ block value ] ]
@@ -2814,8 +2814,6 @@ SimpleStackBasedCogit >> genUpArrowReturn [
 { #category : #'primitive generators - call' }
 SimpleStackBasedCogit >> generateCheckProfileTickFromJump: arrivingJmp returningTo: returningLabel beforeCallDo: aBlockClosure [
 
-	<inline: true>
-
 	arrivingJmp jmpTarget: self Label.
 
 	aBlockClosure value.
@@ -2987,7 +2985,7 @@ SimpleStackBasedCogit >> parseV4Exts: nExts priorTo: bcpc in: aMethodObj into: a
 	"224		11100000	aaaaaaaa	Extend A (Ext A = Ext A prev * 256 + Ext A)
 	 225		11100001	sbbbbbbb	Extend B (Ext B = Ext B prev * 256 + Ext B)"
 	| extAValue extBValue pc byte extByte |
-	<inline: true>
+
 	extAValue := extBValue := 0.
 	pc := bcpc - nExts - nExts.
 	[pc < bcpc] whileTrue:

--- a/smalltalksrc/VMMaker/SpurGenerationScavenger.class.st
+++ b/smalltalksrc/VMMaker/SpurGenerationScavenger.class.st
@@ -200,7 +200,7 @@ SpurGenerationScavenger >> addToWeakList: weakCorpse [
 { #category : #'weakness and ephemerality' }
 SpurGenerationScavenger >> allFutureSpaceEntitiesDo: aBlock [
 	"Enumerate all future space objects, including free objects."
-	<inline: true>
+
 	| prevObj prevPrevObj objOop limit |
 	prevPrevObj := prevObj := nil.
 	objOop := manager objectStartingAt: futureSpace start.

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -1430,7 +1430,7 @@ SpurMemoryManager >> allFreeObjectsDo: aBlock [
 { #category : #'object enumeration' }
 SpurMemoryManager >> allHeapEntitiesDo: aBlock [
 	"N.B. e.g. allObjects relies on the old/new order here."
-	<inline: true>
+
 	self allOldSpaceEntitiesDo: aBlock.
 	self allNewSpaceEntitiesDo: aBlock
 ]
@@ -1495,7 +1495,7 @@ SpurMemoryManager >> allInstancesOf: aClass [
 { #category : #'object enumeration' }
 SpurMemoryManager >> allNewSpaceEntitiesDo: aBlock [
 	"Enumerate all new space objects, including free objects."
-	<inline: true>
+
 	| prevObj prevPrevObj objOop limit |
 	prevPrevObj := prevObj := nil.
 	"After a scavenge eden is empty, futureSpace is empty, and all newSpace objects are
@@ -1521,7 +1521,7 @@ SpurMemoryManager >> allNewSpaceEntitiesDo: aBlock [
 { #category : #'object enumeration' }
 SpurMemoryManager >> allNewSpaceObjectsDo: aBlock [
 	"Enumerate all new space objects, excluding free objects."
-	<inline: true>
+
 	self allNewSpaceEntitiesDo:
 		[:objOop|
 		 self assert: (self isEnumerableObjectNoAssert: objOop).
@@ -1588,7 +1588,7 @@ SpurMemoryManager >> allObjects [
 
 { #category : #'object enumeration' }
 SpurMemoryManager >> allObjectsDo: aBlock [
-	<inline: true>
+
 	self allNewSpaceObjectsDo: aBlock.
 	self allOldSpaceObjectsDo: aBlock
 ]
@@ -1644,7 +1644,7 @@ SpurMemoryManager >> allOldMarkedWeakObjectsOnWeaklingStack [
 
 { #category : #'object enumeration' }
 SpurMemoryManager >> allOldSpaceEntitiesDo: aBlock [
-	<inline: true>
+
 	self allOldSpaceEntitiesFrom: self firstObject do: aBlock
 ]
 
@@ -1676,7 +1676,7 @@ SpurMemoryManager >> allOldSpaceEntitiesForCoalescingFrom: firstObj do: aBlock [
 
 { #category : #'object enumeration' }
 SpurMemoryManager >> allOldSpaceEntitiesForCompactingFrom: initialObject to: finalObject do: aBlock [
-	<inline: true>
+
 	| limit prevObj prevPrevObj objOop nextObj |
 	self assert: (self isOldObject: initialObject).
 	self assert: (self oop: finalObject isLessThanOrEqualTo: endOfMemory).
@@ -1697,7 +1697,7 @@ SpurMemoryManager >> allOldSpaceEntitiesForCompactingFrom: initialObject to: fin
 
 { #category : #'object enumeration' }
 SpurMemoryManager >> allOldSpaceEntitiesFrom: initialObject do: aBlock [
-	<inline: true>
+
 	| prevObj prevPrevObj objOop |
 	self assert: (self isOldObject: initialObject).
 	prevPrevObj := prevObj := nil.
@@ -1715,7 +1715,7 @@ SpurMemoryManager >> allOldSpaceEntitiesFrom: initialObject do: aBlock [
 
 { #category : #'object enumeration' }
 SpurMemoryManager >> allOldSpaceEntitiesFrom: initialObject to: finalObject do: aBlock [
-	<inline: true>
+
 	| prevObj prevPrevObj objOop |
 	self assert: ((self isNonImmediate: initialObject) and: [segmentManager isInSegments: initialObject]).
 	self assert: ((self isNonImmediate: finalObject) and: [segmentManager isInSegments: finalObject]).
@@ -1742,7 +1742,7 @@ SpurMemoryManager >> allOldSpaceObjectsDo: aBlock [
 SpurMemoryManager >> allOldSpaceObjectsFrom: initialObject do: aBlock [
 	"Enumerate all objects (i.e. exclude bridges, forwarders and free chunks)
 	 in oldSpace starting at initialObject."
-	<inline: true>
+
 	self allOldSpaceEntitiesFrom: initialObject
 		do: [:objOop|
 			 (self isEnumerableObject: objOop) ifTrue:
@@ -1752,7 +1752,7 @@ SpurMemoryManager >> allOldSpaceObjectsFrom: initialObject do: aBlock [
 { #category : #'object enumeration' }
 SpurMemoryManager >> allPastSpaceEntitiesDo: aBlock [
 	"Enumerate all past space objects, including free objects."
-	<inline: true>
+
 	| prevObj prevPrevObj objOop |
 	prevPrevObj := prevObj := nil.
 	objOop := self objectStartingAt: scavenger pastSpace start.
@@ -1768,7 +1768,7 @@ SpurMemoryManager >> allPastSpaceEntitiesDo: aBlock [
 { #category : #'object enumeration' }
 SpurMemoryManager >> allPastSpaceObjectsDo: aBlock [
 	"Enumerate all past space objects, excluding free objects."
-	<inline: true>
+
 	self allPastSpaceEntitiesDo:
 		[:objOop|
 		 self assert: (self isEnumerableObjectNoAssert: objOop).
@@ -2115,7 +2115,7 @@ SpurMemoryManager >> allocateOldSpaceChunkOfBytes: chunkBytes suchThat: acceptan
 	 The caller *must* fill in the header correctly."
 	<var: #chunkBytes type: #usqInt>
 	| initialIndex node next prev index child childBytes acceptedChunk acceptedNode |
-	<inline: true> "must inline for acceptanceBlock"
+
 	"for debugging:" "totalFreeOldSpace := self totalFreeListBytes"
 	totalFreeOldSpace := totalFreeOldSpace - chunkBytes. "be optimistic (& don't wait for the write)"
 	initialIndex := chunkBytes / self allocationUnit.
@@ -2444,7 +2444,7 @@ SpurMemoryManager >> allocationUnit [
 { #category : #'primitive support' }
 SpurMemoryManager >> ambiguousClass: aClass allInstancesInto: start limit: limit resultsInto: binaryBlock [
 	"Dea with ambiguity and normalize indices."
-	<inline: true>
+
 	| expectedIndex count ptr |
 	count := 0.
 	ptr := start.
@@ -3673,7 +3673,7 @@ SpurMemoryManager >> classString [
 { #category : #'class table' }
 SpurMemoryManager >> classTableEntriesDo: binaryBlock [
 	"Evaluate binaryBlock with all non-nil entries in the classTable and their index."
-	<inline: true>
+
 	0 to: numClassTablePages - 1 do:
 		[:i| | page |
 		 page := self fetchPointer: i ofObject: hiddenRootsObj.
@@ -5556,7 +5556,7 @@ SpurMemoryManager >> freeTreeNodesDo: aBlock [
 	 N.B For the convenience of rebuildFreeTreeFromSortedFreeChunks
 	 aBlock *MUST* answer the freeTreeNode it was invoked with, or
 	 its replacement if it was replaced by aBlock."
-	<inline: true>
+
 	| treeNode cameFrom |
 	treeNode := freeLists at: 0.
 	treeNode = 0 ifTrue:
@@ -5969,7 +5969,7 @@ SpurMemoryManager >> identityHashHalfWordMask [
 { #category : #'become implementation' }
 SpurMemoryManager >> ifOopInvalidForBecome: oop errorCodeInto: aBlock [
 	"Evaluates aBlock with an appropriate error if oop is invalid for become."
-	<inline: true>
+
 	(self isImmediate: oop) ifTrue:
 		[^aBlock value: PrimErrInappropriate].
 	(self isPinned: oop) ifTrue:
@@ -9194,7 +9194,7 @@ SpurMemoryManager >> numberOfForwarders [
 { #category : #'obj stacks' }
 SpurMemoryManager >> objStack: objStack do: aBlock [
 	"Evaluate aBinaryBlock with all indices and pages of elements in objStack"
-	<inline: true>
+
 	| objStackPage |
 	objStack = nilObj ifTrue:
 		[^self].
@@ -9215,7 +9215,7 @@ SpurMemoryManager >> objStack: objStack from: start do: aBlock [
 	 This evaluates in top-of-stack-to-bottom order.  N.B. this is also stable
 	 if aBlock causes new elements to be added to the objStack, but
 	 unstable if aBlock causes elements to be removed."
-	<inline: true>
+
 	| size objStackPage numToEnumerate |
 	self eassert: [self isValidObjStack: weaklingStack].
 	size := self fetchPointer: ObjStackTopx ofObject: objStack.
@@ -12221,7 +12221,7 @@ SpurMemoryManager >> unalignedShortAt: index put: aValue [
 
 { #category : #'primitive support' }
 SpurMemoryManager >> uniqueIndex: classIndex allInstancesInto: start limit: limit resultsInto: binaryBlock [
-	<inline: true>
+
 	| count ptr |
 	count := 0.
 	ptr := start.

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -15924,7 +15924,7 @@ StackInterpreter >> unknownBytecode [
 
 { #category : #'sista bytecodes' }
 StackInterpreter >> unknownInlinePrimitive [
-	<inline: true> "Should be inlined everywhere to access localIP"
+	<inline: #always> "Should be inlined everywhere to access localIP"
 	instructionPointer := instructionPointer - 3.
 	self respondToUnknownBytecode
 ]

--- a/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
+++ b/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
@@ -607,7 +607,7 @@ StackToRegisterMappingCogit >> adjustArgumentsForPerform: numArgs [
 
 { #category : #'bytecode generator support' }
 StackToRegisterMappingCogit >> allocateEqualsEqualsRegistersArgNeedsReg: argNeedsReg rcvrNeedsReg: rcvrNeedsReg into: binaryBlock [
-	<inline: true>
+
 	| argReg rcvrReg |
 	self assert: (argNeedsReg or: [rcvrNeedsReg]).
 	argReg := rcvrReg := NoReg.
@@ -726,7 +726,7 @@ StackToRegisterMappingCogit >> allocateRegForStackTopThreeEntriesInto: trinaryBl
 StackToRegisterMappingCogit >> allocateRegForStackTopTwoEntriesInto: binaryBlock [
 	"Answers registers for the 2 top values on stack. If the values are already in registers, answers
 	these registers, else allocate registers not conflicting with each others."
-	<inline: true>
+
 	| topRegistersMask rTop rNext |
 	
 	topRegistersMask := 0.
@@ -1293,7 +1293,7 @@ StackToRegisterMappingCogit >> extractMaybeBranchDescriptorInto: fourArgBlock [
 	 If the instruction found is a branch, also answers the pc after the branch and the pc targeted by the branch.
 	 For convenience, avoiding duplication in the senders, it follows those two pcs to their eventual targets."
 	| primDescriptor nextPC nExts branchDescriptor targetBytecodePC postBranchPC |
-	<inline: true>
+
 	<var: #primDescriptor type: #'BytecodeDescriptor *'>
 	<var: #branchDescriptor type: #'BytecodeDescriptor *'>
 	
@@ -4434,7 +4434,7 @@ StackToRegisterMappingCogit >> ssFlushTo: index [
 StackToRegisterMappingCogit >> ssFlushUpThrough: unaryBlock [
 	"Any occurrences on the stack of the value being stored (which is the top of stack)
 	 must be flushed, and hence any values colder than them stack."
-	<inline: true>
+
 	self assert: simSpillBase >= 0.
 	simStackPtr - 1 to: simSpillBase by: -1 do:
 		[ :index |


### PR DESCRIPTION
As blocks are not valid values in C code, Pharo (Slang) methods of the VM that use them must be inlined before producing C code.
Instead of requiring the user to annotate each of these methods with an inline pragma, the cgenerator detects (and add to the inlinelist) methods called with a literal block as an argument.

This allows to remove dozens of inline pragma in the VM code.

Note: if blocks used as argument are not literals (variables, parameters, complex expressions, etc.) the inline pragma is still required. But this seems quite uncommon (or forbidden) in the current VM code.