### PR TITLE
unmarkInitialImmobileObjectsFreeUnmarked: do not coalesce while iterating on objects.

### DIFF
--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -1727,8 +1727,12 @@ SpurMemoryManager >> allOldSpaceObjectsDo: aBlock [
 { #category : #'object enumeration' }
 SpurMemoryManager >> allOldSpaceObjectsFrom: initialObject do: aBlock [
 	"Enumerate all objects (i.e. exclude bridges, forwarders and free chunks)
-	 in oldSpace starting at initialObject."
+	 in oldSpace starting at initialObject.
 
+	Warning: this is a low level iteration using objOop as a current entity pointer,
+	aBlock must ensure that the given objOop pointer remains a valid entity pointer."
+
+	<inline: true>
 	self allOldSpaceEntitiesFrom: initialObject
 		do: [:objOop|
 			 (self isEnumerableObject: objOop) ifTrue:
@@ -5485,7 +5489,9 @@ SpurMemoryManager >> freeListsObject [
 
 { #category : #'free space' }
 SpurMemoryManager >> freeObject: objOop [
-	"Free an object in oldSpace.  Coalesce if possible to reduce fragmentation."
+	"Free an object in oldSpace.  Coalesce if possible to reduce fragmentation.
+	Warning: because of coalescion, the original objOop can become an invalid entity pointer.
+	See freeObjectWithoutCoalesce: for a safer version"
 	<api>
 	<inline: false>
 	| bytes start next |
@@ -5498,6 +5504,22 @@ SpurMemoryManager >> freeObject: objOop [
 	(self isFreeObject: next) ifTrue:
 		[self detachFreeObject: next.
 		 bytes := bytes + (self bytesInObject: next)].
+	totalFreeOldSpace := totalFreeOldSpace + bytes.
+	^self freeChunkWithBytes: bytes at: start
+]
+
+{ #category : #'free space' }
+SpurMemoryManager >> freeObjectWithoutCoalesce: objOop [
+	"Free an object in oldSpace.
+	DO NOT Coalesce, so original objOop remains valid. This could be useful if you (or some iterator) reuse it."
+	<api>
+	<inline: false>
+	| bytes start |
+	self assert: (self isInOldSpace: objOop).
+	(self isRemembered: objOop) ifTrue:
+		[scavenger forgetObject: objOop].
+	bytes := self bytesInObject: objOop.
+	start := self startOfObject: objOop.
 	totalFreeOldSpace := totalFreeOldSpace + bytes.
 	^self freeChunkWithBytes: bytes at: start
 ]

--- a/smalltalksrc/VMMaker/SpurPlanningCompactor.class.st
+++ b/smalltalksrc/VMMaker/SpurPlanningCompactor.class.st
@@ -692,7 +692,7 @@ SpurPlanningCompactor >> unmarkInitialImmobileObjectsFreeUnmarked: freeUnmarked 
 		(self oop: o isGreaterThanOrEqualTo: firstMobileObject)
 			ifTrue: [ ^self ].
 		(freeUnmarked and: [ (manager isMarked: o) not ])
-			ifTrue: [ manager freeObject: o ]
+			ifTrue: [ manager freeObjectWithoutCoalesce: o ]
 			ifFalse: [ manager setIsMarkedOf: o to: false ]]
 ]
 


### PR DESCRIPTION
b8a9a74d956 while fixing some bugs on ephemerons did an optimization where objects are freed during the unmark phase of the mark-and-compact GC,

During this freeing, the now available space of the object can be coalesced with a free chunk that follows it. 
However, if the object is small (there is no size header) and the size of the coalesced space if big (for instance it is the large free space at the end of the memory), then the newly created free chunk will by a large entity with a size followed by the header.
Unfortunately, in this case, the oop that pointed of the header of the original object now points on the size instead of the header of the free chunk. Making the oop invalid if it is reused.

The PR fixes this by 1. adding warnings in the documentation. 2. providing (and using) a new method `freeObjectWithoutCoalesce:` that ensures the validity of the argument.

Fix #489