### PR TITLE
testAllocateObjectRightBeforeOverflowingFreeChunk

### DIFF
--- a/smalltalksrc/VMMakerTests/VMSpurOldSpaceGarbageCollectorTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurOldSpaceGarbageCollectorTest.class.st
@@ -82,6 +82,41 @@ VMSpurOldSpaceGarbageCollectorTest >> testAllocateObjectBiggerThanSizeOfFreeSpac
 	self assert: memory needGCFlag
 ]
 
+{ #category : #testCompactor }
+VMSpurOldSpaceGarbageCollectorTest >> testAllocateObjectRightBeforeOverflowingFreeChunk [
+	| chuckSize chunk next object free |
+
+	"before GC:
+		dead object
+		free chunk with overflow header
+	after GC:
+		free chunk
+		free chunk with overflow header
+	
+	Note: this scenario expects the free chunks to not be coallesced.
+	Improve this test if the memory manager become more efficient."
+
+	memory fullGC.
+
+	"Allocate a contiguous chunk of memory to be splited into entities"
+	chuckSize := 512*8.
+	chunk := next := memory allocateOldSpaceChunkOfBytes: chuckSize.
+	"first entity is an object to be free"
+	object := next := memory initializeHeaderOfStartAddress: next numSlots: 5 format: memory arrayFormat classIndex: memory arrayClassIndexPun pinned: false.	
+	next := memory objectAfter: next.
+	"second entity is a free chunk with an overflow header"
+	free := next := memory freeChunkWithBytes: chunk + chuckSize - next at: next.
+	next := memory objectAfter: next.
+	
+	self assert: (memory isFreeObject: object) not.
+	self assert: (memory isFreeObject: free).
+		
+	memory fullGC.
+
+	self assert: (memory isFreeObject: object).
+	self assert: (memory isFreeObject: free).
+]
+
 { #category : #'tests-OldSpaceSize' }
 VMSpurOldSpaceGarbageCollectorTest >> testAllocateObjectWithFreeSpaceSize [
 


### PR DESCRIPTION
#490 was missing a test, so here is one

Note: I needed to have the guarantee that both entities (the object and the free chunk) are contiguous. Using high level allocation methods or helpers do not seem to offer such a guarantee (or only in a circumstantial way), or maybe I did not look hard enough.
So I just use the low-level allocation methods to set up the entities in the memory exactly as I wanted.