### PR TITLE
Tests: make scheduler (and setUpScheduler) more optional

### DIFF
--- a/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
@@ -163,7 +163,7 @@ InterpreterPrimitives >> cStringOrNullFor: oop [
 { #category : #'object access primitives' }
 InterpreterPrimitives >> canBeImmutable: oop [
 	<option: #IMMUTABILITY>
-	| scheduler processLists |
+	| scheduler processLists schedAssoc |
 	
 	self assert: (objectMemory isNonImmediate: oop).
 	
@@ -183,7 +183,10 @@ InterpreterPrimitives >> canBeImmutable: oop [
 	
 	"Simple version of process management: we forbid Process and LinkedList instances to be immutable 
 	 as well as the Processor and the array of activeProcess"
-	scheduler := objectMemory fetchPointer: ValueIndex ofObject: (objectMemory splObj: SchedulerAssociation).
+	schedAssoc := objectMemory splObj: SchedulerAssociation.
+	schedAssoc = objectMemory nilObject ifTrue: [ ^ true ].
+
+	scheduler := objectMemory fetchPointer: ValueIndex ofObject: schedAssoc.
 	processLists := objectMemory fetchPointer: ProcessListsIndex ofObject: scheduler.
 	oop = scheduler ifTrue: [ ^ false ].
 	oop = processLists ifTrue: [ ^ false ].

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -6679,6 +6679,8 @@ StackInterpreter >> followForwardingPointersInScheduler [
 	"Make sure the active process has been followed."
 	objectMemory followForwardedObjectFields: schedAssoc toDepth: 1.
 
+	schedAssoc = objectMemory nilObject ifTrue: [ ^self ].
+
 	sched := objectMemory fetchPointer: ValueIndex ofObject: schedAssoc.
 
 	procLists := objectMemory followObjField: ProcessListsIndex ofObject: sched.

--- a/smalltalksrc/VMMaker/VMClass.extension.st
+++ b/smalltalksrc/VMMaker/VMClass.extension.st
@@ -18,6 +18,7 @@ VMClass class >> initializeMiscConstants [
 	VMBIGENDIAN class. "Mention this for the benefit of CCodeGenerator>>emitCConstantsOn:"
 	STACKVM := COGVM := false.
 
+
 	InitializationOptions ifNil: [ 
 		InitializationOptions := Dictionary new ].
 	omc := InitializationOptions

--- a/smalltalksrc/VMMakerTests/VMAbstractPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMAbstractPrimitiveTest.class.st
@@ -176,6 +176,4 @@ VMAbstractPrimitiveTest >> setUp [
 		storePointer: ClassLargeNegativeIntegerCompactIndex
 		ofObject: memory classTableFirstPage
 		withValue: classLargeNegativeInteger.
-
-	memory lastHash: 1
 ]

--- a/smalltalksrc/VMMakerTests/VMLookUpTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMLookUpTest.class.st
@@ -92,7 +92,6 @@ VMLookUpTest >> setUp [
 		storePointer: ProcessListsIndex
 		ofObject: processorOop
 		withValue: processorListArray.
-	memory lastHash: 1.
 
 	interpreter setBreakSelector: nil
 ]

--- a/smalltalksrc/VMMakerTests/VMPinnedObjectTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPinnedObjectTest.class.st
@@ -38,12 +38,6 @@ VMPinnedObjectTest >> newKeptPinnedObject [
 	^ newPinned
 ]
 
-{ #category : #tests }
-VMPinnedObjectTest >> setUp [
-	super setUp.
-	self setUpScheduler.
-]
-
 { #category : #testCompactor }
 VMPinnedObjectTest >> testAllocatingObjectAfterAPinObjectShouldSlideAtStartOfOldSpace [
 	| aliveObject destination shouldBeFreed aliveHash |

--- a/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
@@ -89,7 +89,6 @@ VMPrimitiveTest >> setUp [
 	interpreter setStackPointersFromPage: page.
 	interpreter setStackPageAndLimit: page.
 
-	self setUpScheduler.
 	imageName := VMPrimitiveTest name
 ]
 
@@ -4561,6 +4560,7 @@ VMPrimitiveTest >> testPrimitiveSnapshotContextsShouldBeTenured [
 
 	| method frame contextOop contextIdentityHash suspendedContext |
 	interpreter pluginList: #(  ).
+	self setUpScheduler.
 	self initializeOldSpaceForFullGC.
 	self setContextClassIntoClassTable.
 	method := methodBuilder newMethod buildMethod.
@@ -4593,6 +4593,7 @@ VMPrimitiveTest >> testPrimitiveSnapshotCreateImage [
 
 	| method file |
 	interpreter pluginList: #(  ).
+	self setUpScheduler.
 	self initializeOldSpaceForFullGC.
 	self setContextClassIntoClassTable.
 	method := methodBuilder newMethod buildMethod.
@@ -4617,7 +4618,7 @@ VMPrimitiveTest >> testPrimitiveSnapshotNewKeptObjectShouldBeTenured [
 
 	| method object objectHash |
 	interpreter pluginList: #(  ).
-
+	self setUpScheduler.
 	self initializeOldSpaceForFullGC.
 	self setContextClassIntoClassTable.
 

--- a/smalltalksrc/VMMakerTests/VMSpurInitializedOldSpaceTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurInitializedOldSpaceTest.class.st
@@ -174,7 +174,6 @@ VMSpurInitializedOldSpaceTest >> setUp [
 	super setUp.
 	self initializeOldSpaceForScavenger.
 	self initializeOldSpaceForFullGC.
-	memory lastHash: 1.
 ]
 
 { #category : #helpers }

--- a/smalltalksrc/VMMakerTests/VMSpurMemoryManagerTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurMemoryManagerTest.class.st
@@ -644,6 +644,8 @@ VMSpurMemoryManagerTest >> setUp [
 		memory: memory;
 		methodBuilder: methodBuilder;
 		yourself.
+	
+	memory lastHash: 1.
 ]
 
 { #category : #running }
@@ -664,7 +666,6 @@ VMSpurMemoryManagerTest >> setUpScheduler [
 	memory splObj: SchedulerAssociation put: processorOopAssociation.
 	memory storePointer: ValueIndex ofObject: processorOopAssociation withValue: processorOop.
 	memory storePointer: ProcessListsIndex ofObject: processorOop withValue: processorListArray.
-	memory lastHash: 1.
 	
 	activeProcessOop := self newObjectWithSlots: 4 "Creates the active process".
 	memory 


### PR DESCRIPTION
Some VM tests (and fuzzing) crashes if setUpScheduler is not called.

There were multiple reasons:

* `canBeImmutable` and `followForwardingPointersInScheduler` have a hard coded assumption that the special scheduler object (and its subobjects) exists. This PR add a nil check at runtime to avoid the crash.
* setUpScheduler initializes `lastHash` that is may be used to compute hash of objects. But since it is not related to scheduling, and is only a small integer, the PR move this initialization to the general `setUp` method