### PR TITLE
[improvement] update class name index to reflect new classes IV

### DIFF
--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -7754,12 +7754,12 @@ StackInterpreter >> initializeExtraClassInstVarIndices [
 	classArrayObj := objectMemory splObj: ClassArray.
 	classArrayClass := objectMemory fetchClassOfNonImm: classArrayObj.
 	metaclassNumSlots := objectMemory numSlotsOf: classArrayClass.	"determine actual Metaclass instSize"
-	thisClassIndex := 5. "default"
+	thisClassIndex := 6. "default"
 	InstanceSpecificationIndex + 1 to: (objectMemory lengthOf: classArrayClass) do:
 		[:i|
 		(objectMemory fetchPointer: i - 1 ofObject: classArrayClass) = classArrayObj ifTrue:
 			[thisClassIndex := i - 1]].
-	classNameIndex := 6. "default"
+	classNameIndex := 7. "default"
 	InstanceSpecificationIndex + 1 to: (objectMemory lengthOf: classArrayObj) do:
 		[:i| | oop |
 		oop := objectMemory fetchPointer: i - 1 ofObject: classArrayObj.


### PR DESCRIPTION
Hello,
The class index have changed in the latest Pharo 11 images.
This simply updates them to the +1.
note that this is not enough, it is just a quick PR, that ignores older images ect.
Please simply delete this PR/branch if you don't want to update just yet, but keep this in mind !

Pierre