### PR TITLE
Become should not forget to remember

### DIFF
--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -4016,7 +4016,8 @@ SpurMemoryManager >> containsOnlyValidBecomeObjects: array1 and: array2 twoWay: 
 		Shouldn't become immutable objects => PrimErrNoModification.
 		Can't copy hash into immediates => PrimErrInappropriate.
 		Two-way become may require memory to create copies => PrimErrNoMemory.
-	 As a side-effect unforward any forwarders in the two arrays if answering 0."
+
+	 Arrays are not modified (and no forwarders unforward)."
 	<inline: true>
 	| fieldOffset effectsFlags oop1 oop2 size |
 	fieldOffset := self lastPointerOf: array1.
@@ -4025,14 +4026,14 @@ SpurMemoryManager >> containsOnlyValidBecomeObjects: array1 and: array2 twoWay: 
 	[fieldOffset >= self baseHeaderSize] whileTrue:
 		[oop1 := self longAt: array1 + fieldOffset.
 		 (self isOopForwarded: oop1) ifTrue:
-			[oop1 := self followForwarded: oop1.
-			 self longAt: array1 + fieldOffset put: oop1].
+			[oop1 := self followForwarded: oop1
+			"Do not update the array here, or chose to handle the rememberset correctly."].
 		 self ifOopInvalidForBecome: oop1 errorCodeInto: [:errCode| ^errCode].
 		 effectsFlags := effectsFlags bitOr: (self becomeEffectFlagsFor: oop1).
 		 oop2 := self longAt: array2 + fieldOffset.
 		 (self isOopForwarded: oop2) ifTrue:
-			[oop2 := self followForwarded: oop2.
-			 self longAt: array2 + fieldOffset put: oop2].
+			[oop2 := self followForwarded: oop2
+			"Do not update the array here, or chose to handle the rememberset correctly."].
 		 isTwoWay
 			ifTrue:
 				[self ifOopInvalidForBecome: oop2 errorCodeInto: [:errCode| ^errCode].
@@ -6503,11 +6504,10 @@ SpurMemoryManager >> innerBecomeObjectsIn: array1 and: array2 copyHash: copyHash
 	"Inner loop of two-way become."
 	0 to: (self numSlotsOf: array1) - 1 do:
 		[:i| | obj1 obj2 |
-		"At first blush it would appear unnecessary to use followField: here since
-		 the validation in become:with:twoWay:copyHash: follows forwarders.  But
-		 there's nothing to ensure all elements of each array are unique and don't
-		 appear in the other array.  So the enumeration could encounter an object
-		 already becommed earlier in the same enumeration."
+		"Allways use followField: here since there's nothing to ensure all elements
+		 of each array are unique and don't appear in the other array.
+		 So the enumeration could encounter an object already becommed earlier
+		 in the same enumeration."
 		obj1 := self followField: i ofObject: array1.
 		obj2 := self followField: i ofObject: array2.
 		obj1 ~= obj2 ifTrue:
@@ -6521,11 +6521,10 @@ SpurMemoryManager >> innerBecomeObjectsIn: array1 to: array2 copyHash: copyHashF
 	"Inner loop of one-way become."
 	0 to: (self numSlotsOf: array1) - 1 do:
 		[:i| | obj1 obj2 |
-		"At first blush it would appear unnecessary to use followField: here since
-		 the validation in become:with:twoWay:copyHash: follows forwarders.  But
-		 there's nothing to ensure all elements of each array is unique and doesn't
-		 appear in the other array.  So the enumeration could encounter an object
-		 already becommed earlier in the same enumeration."
+		"Allways use followField: here since there's nothing to ensure all elements
+		 of each array are unique and don't appear in the other array.
+		 So the enumeration could encounter an object already becommed earlier
+		 in the same enumeration."
 		obj1 := self followField: i ofObject: array1.
 		obj2 := self followField: i ofObject: array2.
 		obj1 ~= obj2 ifTrue:

--- a/smalltalksrc/VMMakerTests/VMSpurOldSpaceGarbageCollectorTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurOldSpaceGarbageCollectorTest.class.st
@@ -185,6 +185,38 @@ VMSpurOldSpaceGarbageCollectorTest >> testAnOldObjectReferencedFromVMVariableSho
 	self assertHashOf: self keptObjectInVMVariable1 equals: hash
 ]
 
+{ #category : #'tests-OldSpaceSize' }
+VMSpurOldSpaceGarbageCollectorTest >> testDoubleForwardToYoungs [
+
+		| obj1 obj2 obj3 arrFrom arrTo arrFrom2 arrTo2 |
+
+		obj1 := self newObjectWithSlots: 1.
+		obj2 := self newOldSpaceObjectWithSlots: 1.
+		obj3 := self newOldSpaceObjectWithSlots: 1.
+
+		arrFrom := self newArrayWithSlots: 1.
+		arrTo := self newArrayWithSlots: 1.
+
+		memory storePointer: 0 ofObject: arrFrom withValue: obj2.
+		memory storePointer: 0 ofObject: arrTo withValue: obj1.
+		memory become: arrFrom with: arrTo twoWay: false copyHash: false.
+		"obj2 forwards to obj1, but since obj1 is newspace, obj2 is remembered"
+
+		arrFrom2 := self newOldSpaceArrayWithSlots: 1.
+		arrTo2 := self newOldSpaceArrayWithSlots: 1.
+		memory storePointer: 0 ofObject: arrFrom2 withValue: obj3.
+		memory storePointer: 0 ofObject: arrTo2 withValue: obj2.
+		"Here, arrFrom2 & arrTo2 (oldspace) contains only oldspace."
+
+		memory become: arrFrom2 with: arrTo2 twoWay: false copyHash: false.
+
+		"We want arrFrom2 & arrTo2 points to obj1 and be remembered"
+		self assert: (memory fetchPointer: 0 ofObject: arrFrom2) equals: obj1.
+		self assert: (memory isRemembered: arrFrom2).
+		self assert: (memory fetchPointer: 0 ofObject: arrTo2) equals: obj1.
+		self assert: (memory isRemembered: arrTo2).
+]
+
 { #category : #ephemerons }
 VMSpurOldSpaceGarbageCollectorTest >> testEphemeronOverflowUnscannedEphemeronQueue [
 


### PR DESCRIPTION
During the prevalidation of a Become operation (`SpurMemoryManager>>#containsOnlyValidBecomeObjects:and:twoWay:copyHash:`) the arrays are traversed to check that objects are legal to *Become* and to ensure there is available memory. To do so, the elements of the arrays that are forwarders need to be followed. As an optimization, the arrays were also updated to contains the forward resolution.

Unfortunately, the traversal and the update use low level pointer accesses instead of high level slot accesses that know how to handle old->new reference and update the rememberSet. Therefore, after such low-level updates, a oldspace array can contain pointers to the newspace without being remembered.

To solve this, I just propose to remove the low-lovel broken update of pointers. It is not an issue because the real *Become* operation will correctly follow and correctly update pointers. The only drawback is that any possible following will be done twice.

This bug was found with graybox fuzzing. I'm not sure if it can occur in real production unless people directly use primitive 128 `elementsExchangeIdentityWith: and use the provided arrays as the only references to some objects.