### PR TITLE
GC should not collect true and false

### DIFF
--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -8151,6 +8151,9 @@ SpurMemoryManager >> markAndTraceHiddenRoots [
 	self markAndTraceObjStack: weaklingStack andContents: false.
 	self markAndTraceObjStack: mournQueue andContents: true.
 
+	self setIsMarkedOf: self nilObject to: true.
+	self setIsMarkedOf: self trueObject to: true.
+	self setIsMarkedOf: self falseObject to: true.
 	self setIsMarkedOf: self rememberedSetObj to: true.
 	self setIsMarkedOf: self freeListsObj to: true.
 

--- a/smalltalksrc/VMMakerTests/VMSpurOldSpaceGarbageCollectorTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurOldSpaceGarbageCollectorTest.class.st
@@ -185,6 +185,17 @@ VMSpurOldSpaceGarbageCollectorTest >> testAnOldObjectReferencedFromVMVariableSho
 	self assertHashOf: self keptObjectInVMVariable1 equals: hash
 ]
 
+{ #category : #'tests-OldSpaceSize' }
+VMSpurOldSpaceGarbageCollectorTest >> testDoNotCollectRoots [
+
+	memory fullGC.
+	
+	self deny: (memory isFreeObject: (memory nilObject)).
+	self deny: (memory isFreeObject: (memory trueObject)).
+	self deny: (memory isFreeObject: (memory falseObject)).
+	self deny: (memory isFreeObject: (memory freeListsObj)).
+]
+
 { #category : #ephemerons }
 VMSpurOldSpaceGarbageCollectorTest >> testEphemeronOverflowUnscannedEphemeronQueue [
 


### PR DESCRIPTION
Usually, nil true and false are safe because they start at the beginning of the oldspace and as a hack, the GC mostly knows to skip them during the collection.

However, relying on this hack is fragile, thus can and will be used as the root (pun) of strange bugs.
Moreover, because nil, true and false are used a lot, they will usually be marked anyway, making such bugs harder to track.

Currently, a simple garbage collection on a fresh oldspace is enough to purge true and false from existence, causing possible issues later on as these object (and their locations) are special.

Instead of tracking and fixing the reason why the hack did not save these two objects, I think it could be better to just mark them. This will also prevent future regressions and weird bugs.

This bug was found with graybox fuzzing. I'm not sure if it can occur in real production unless people use a custom image where true or false are never used.
A more important point is that the fuzzing did not directly complain that true and false were missing, but crashed on a corrupted freespace. And that the issue disappears with this patch applied. Possibly another bug is lurking, I'm not sure yet, I need more investigation to understand.