### PR TITLE
new visual entity inspector for SpurMemoryManager

### DIFF
--- a/smalltalksrc/VMMaker-Tools/SpurMemoryManager.extension.st
+++ b/smalltalksrc/VMMaker-Tools/SpurMemoryManager.extension.st
@@ -1,6 +1,53 @@
 Extension { #name : #SpurMemoryManager }
 
 { #category : #'*VMMaker-Tools' }
+SpurMemoryManager >> inspectorEntities: composite [
+
+	<inspectorPresentationOrder: 2 title: 'Entities'>
+
+	| entities |
+	entities := OrderedCollection new.
+	self allHeapEntitiesDo: [ :e | entities add: e ].
+
+	^ SpTablePresenter new
+		alternateRowsColor;
+		enableSearch;
+		items: entities;
+		addColumn: (SpStringTableColumn title: 'Oop' evaluated: [ :oop | oop ]);
+		addColumn: (SpStringTableColumn title: 'Oop(hex)' evaluated: [ :oop | oop hex ]);
+		addColumn: (SpStringTableColumn title: 'Label' evaluated: [ :oop | self labelOfOop: oop ]);
+		addColumn: (SpStringTableColumn title: 'Type' evaluated: [ :oop |
+				((self isFreeObject: oop) ifTrue: ['free'] ifFalse:
+				[(self isSegmentBridge: oop) ifTrue: ['bridge'] ifFalse:
+				[(self isForwarded: oop) ifTrue: ['forwarder'] ifFalse:
+				[(self classIndexOf: oop) <= self lastClassIndexPun ifTrue: ['pun/obj stack'] ifFalse:
+				['object']]]]) ]);
+		addColumn: (SpStringTableColumn title: 'classIndex' evaluated: [ :oop | self classIndexOf: oop ]);
+		addColumn: (SpStringTableColumn title: 'rawNumSlots' evaluated: [ :oop | self rawNumSlotsOf: oop ]);
+		addColumn: (SpStringTableColumn title: 'numSlots' evaluated: [ :oop |
+			self numSlotsOfAny: oop ]);
+		addColumn: (SpStringTableColumn title: 'bytesInObject' evaluated: [ :oop | self bytesInObject: oop ]);
+		addColumn: (SpStringTableColumn title: '1st field' evaluated: [ :oop |
+			(self isFreeObject: oop) ifTrue: [ self fetchPointer: 0 ofFreeChunk: oop ] ifFalse:
+			[(self isSegmentBridge: oop) ifTrue: [ '' ] ifFalse:
+			[(self isForwarded: oop) ifTrue: [ self followForwarded: oop ] ifFalse:
+			[((self numSlotsOfAny: oop) > 0) ifTrue: [ self fetchPointer: 0 ofObject: oop ] ifFalse:
+			[ '' ]]]]]);
+		addColumn: (SpStringTableColumn title: 'Format' evaluated: [ :oop | 
+			 ((self formatOf: oop) <= 16rF ifTrue: ['0'] ifFalse: ['']),
+			 (self formatOf: oop) printStringHex, ' ',
+			 (self formatStringOf: oop)]);
+		addColumn: (SpStringTableColumn title: 'Flags' evaluated: [ :oop | 
+			 ((self isGrey: oop) ifTrue: ['g'] ifFalse: ['.']),
+			 ((self isImmutable: oop) ifTrue: ['i'] ifFalse: ['.']),
+			 ((self isMarked: oop) ifTrue: ['m'] ifFalse: ['.']),
+			 ((self isPinned: oop) ifTrue: ['p'] ifFalse: ['.']),
+			 ((self isRemembered: oop) ifTrue: ['r'] ifFalse: ['.'])]);
+		yourself
+
+]
+
+{ #category : #'*VMMaker-Tools' }
 SpurMemoryManager >> inspectorFreeListIn: composite [
 
 	<inspectorPresentationOrder: 0 title: 'Free Lists'>

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -1414,6 +1414,15 @@ SpurMemoryManager >> allFreeObjectsDo: aBlock [
 ]
 
 { #category : #'object enumeration' }
+SpurMemoryManager >> allHeapEntities [
+
+	| result |
+	result := OrderedCollection new.
+	self allHeapEntitiesDo: [ :entity | result add: entity ].
+	^ result
+]
+
+{ #category : #'object enumeration' }
 SpurMemoryManager >> allHeapEntitiesDo: aBlock [
 	"N.B. e.g. allObjects relies on the old/new order here."
 
@@ -5378,6 +5387,27 @@ SpurMemoryManager >> formatShift [
 	^24
 ]
 
+{ #category : #'debug support' }
+SpurMemoryManager >> formatStringOf: objOop [
+	
+	| format |
+	format := self formatOf: objOop.
+	
+	format = 0 ifTrue: [ ^ 'empty' ].
+	format = 1 ifTrue: [ ^ 'fixed' ].
+	format = 2 ifTrue: [ ^ 'index' ].
+	format = 3 ifTrue: [ ^ 'mixed' ].
+	format = 4 ifTrue: [ ^ 'weak' ].
+	format = 5 ifTrue: [ ^ 'ephem' ].
+	format = 7 ifTrue: [ ^ 'fwd' ].
+	format = 9 ifTrue: [ ^ 'idx64' ].
+	(format between: 10 and: 11) ifTrue: [ ^ 'idx32' ].
+	(format between: 12 and: 15) ifTrue: [ ^ 'idx16' ].
+	(format between: 16 and: 23) ifTrue: [ ^ 'idx8' ].
+	(format between: 24 and: 31) ifTrue: [ ^ 'meth' ].
+	^ '?'
+]
+
 { #category : #'become implementation' }
 SpurMemoryManager >> forward: obj1 to: obj2 [
 	self set: obj1 classIndexTo: self isForwardedObjectClassIndexPun formatTo: self forwardedFormat.
@@ -7650,6 +7680,23 @@ SpurMemoryManager >> keyOfMaybeFiredEphemeron: objOop [
 SpurMemoryManager >> knownClassAtIndex: classIndex [
 	self assert: (classIndex between: 1 and: self classTablePageSize).
 	^self fetchPointer: classIndex ofObject: classTableFirstPage
+]
+
+{ #category : #'debug support' }
+SpurMemoryManager >> labelOfOop: oop [
+
+self nilObject = oop ifTrue: [ ^ 'nilObject' ].
+self trueObject = oop ifTrue: [ ^ 'trueObject' ].
+self falseObject = oop ifTrue: [ ^ 'falseObject' ].
+self specialObjectsOop = oop ifTrue: [ ^ 'specialObjects' ].
+self hiddenRootsObject = oop ifTrue: [ ^ 'hiddenRoots' ].
+self classTableFirstPage = oop ifTrue: [ ^ 'classTableFirstPage' ].
+self mournQueue = oop ifTrue: [ ^ 'mournQueue' ].
+self markStack = oop ifTrue: [ ^ 'markStack' ].
+self weaklingStack = oop ifTrue: [ ^ 'weaklingStack' ].
+self freeListsObj = oop ifTrue: [ ^ 'freeListsObj' ].
+self rememberedSetObj = oop ifTrue: [ ^ 'rememberedSetObj' ].
+^ ''
 ]
 
 { #category : #'compaction - analysis' }


### PR DESCRIPTION
This provides a new inspector tab for SpurMemoryManager that lists basic (header) information on all entities.

the various `print` methods are nice (and available in the binary executable) but using pharo interactive facilities is also nice.

![inspector screenshot](https://user-images.githubusercontent.com/135828/199305193-c671dc28-5bf6-49ce-aab8-5e81b701a155.png)

Note: this displays only header information on entities (and the first slot as it is meaningful for many entities, especially for forwarders). Selecting an element will inspect the oop integer (not that useful). A future improvement could be instead to display more information on a specific entity, especially the one related to objects (all slots, meta-objects, etc.)