### PR TITLE
Fix nextAvailableAddress

### DIFF
--- a/smalltalksrc/Slang/SlangMemoryManager.class.st
+++ b/smalltalksrc/Slang/SlangMemoryManager.class.st
@@ -30,7 +30,7 @@ SlangMemoryManager >> allocate: desiredSize desiredPosition: desiredPos [
 	allocatedAddress := desiredPosition max: nextAvailableAddress.
 	self assert: allocatedAddress \\ 4096 = 0.
 
-	nextAvailableAddress := desiredPosition + allocatedSize.
+	nextAvailableAddress := allocatedAddress + allocatedSize.
 
 	"Warrantee that memory regions do not move, for simulation purposes with the FFI"
 	newMemory := ByteArray new: allocatedSize.

--- a/smalltalksrc/Slang/SlangMemoryRegion.class.st
+++ b/smalltalksrc/Slang/SlangMemoryRegion.class.st
@@ -90,6 +90,18 @@ SlangMemoryRegion >> originallyRequestedMemory: anObject [
 	originallyRequestedMemory := anObject
 ]
 
+{ #category : #printing }
+SlangMemoryRegion >> printOn: aStream [
+
+	super printOn: aStream.
+
+	aStream
+		nextPut: $ ;
+		print: start;
+		nextPut: $-;
+		print: (start+originallyRequestedMemory)
+]
+
 { #category : #'bulk-replace' }
 SlangMemoryRegion >> replaceFrom: anInteger to: anInteger2 with: aSlangMemoryRegion [ 
 

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -5783,12 +5783,13 @@ SpurMemoryManager >> growOldSpaceByAtLeast: minAmmount [
 	start := coInterpreter ioUTCMicrosecondsNow.
 	^(segmentManager addSegmentOfSize: ammount) ifNotNil:
 		[:segInfo|
+		| freeChunk |
 		 self assimilateNewSegment: segInfo.
 		 "and add the new free chunk to the free list; done here
 		  instead of in assimilateNewSegment: for the assert"
-		 self addFreeChunkWithBytes: segInfo segSize - self bridgeSize at: segInfo segStart.
-		 self assert: (self addressAfter: (self objectStartingAt: segInfo segStart))
-					= (segInfo segLimit - self bridgeSize).
+		 freeChunk := self addFreeChunkWithBytes: segInfo segSize - self bridgeSize at: segInfo segStart.
+		 self assert: freeChunk = (self objectStartingAt: segInfo segStart).
+		 self assert: (self addressAfter: freeChunk) = (segInfo segLimit - self bridgeSize).
 		 self checkFreeSpace: GCModeFreeSpace.
 		 segmentManager checkSegments.
 		 interval := coInterpreter ioUTCMicrosecondsNow - start.

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -5800,10 +5800,11 @@ SpurMemoryManager >> growOldSpaceByAtLeast: minAmmount [
 { #category : #'growing/shrinking memory' }
 SpurMemoryManager >> growToAccomodateContainerWithNumSlots: numSlots [
 	"Grow memory to accomodate a container (an Array) with numSlots.
-	 Grow by at least the growHeadroom.  Supports allInstancesOf: and allObjects."
+	 Grow by at least the growHeadroom.  Supports allInstancesOf: and allObjects.
+	 Answer the size of the new segment in bytes, or nil if the attempt failed."
 	| delta |
 	delta := self baseHeaderSize * 2 + (numSlots * self bytesPerOop).
-	self growOldSpaceByAtLeast: (growHeadroom max: delta)
+	^ self growOldSpaceByAtLeast: (growHeadroom max: delta)
 ]
 
 { #category : #'header access' }

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -5754,8 +5754,8 @@ SpurMemoryManager >> growHeadroom: aValue [
 
 { #category : #'growing/shrinking memory' }
 SpurMemoryManager >> growOldSpaceByAtLeast: minAmmount [
-	"Attempt to grow memory by at least minAmmount.
-	 Answer the size of the new segment, or nil if the attempt failed."
+	"Attempt to grow memory by at least minAmmount bytes.
+	 Answer the size of the new segment in bytes, or nil if the attempt failed."
 	| ammount headroom total start interval |
 	<var: #segInfo type: #'SpurSegmentInfo *'>
 	"statGrowMemory counts attempts, not successes."

--- a/smalltalksrc/VMMakerTests/VMSpurOldSpaceGarbageCollectorTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurOldSpaceGarbageCollectorTest.class.st
@@ -223,6 +223,27 @@ VMSpurOldSpaceGarbageCollectorTest >> testEphemeronOverflowUnscannedEphemeronQue
 		equals: numberJustOverLimit
 ]
 
+{ #category : #tests }
+VMSpurOldSpaceGarbageCollectorTest >> testGrowOldSpace [
+
+	| freespace freespace2 slotsNumber anObjectOop |
+	
+	memory fullGC.
+	
+	freespace := memory totalFreeOldSpace.
+	slotsNumber := freespace / memory wordSize.	
+	memory growOldSpaceByAtLeast: slotsNumber.
+	freespace2 := memory totalFreeOldSpace.
+	self assert: freespace*2 <= freespace2.
+	
+	anObjectOop := self newObjectWithSlots: slotsNumber.
+	self deny: anObjectOop equals: nil.
+	self assert: freespace2 - (memory bytesInObject: anObjectOop) equals: memory totalFreeOldSpace.
+	
+	memory fullGC.
+	self assert: freespace equals: memory totalFreeOldSpace.
+]
+
 { #category : #ephemerons }
 VMSpurOldSpaceGarbageCollectorTest >> testMultiPageMournQueue [
 


### PR DESCRIPTION
Expanding the memory and running GC caused memory corruption in the simulator.

The culprit was the (bad) computation of `nextAvailableAddress` that indicates the smallest available address and that is used as a default base in the (simulated) address space for new low-level machine allocation.
This computation error caused previously allocated area (like heap zone) to be mysteriously filled by 0 (thus corrupting existing entities) during unrelated memory allocation (like allocating an unscannedEphemerons queue) because the new allocation was virtually overlapping the previous one.

This bug was discovered by the graybox fuzzer.