### PR TITLE
Dont allocate a mourn queue during GC

### DIFF
--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -6357,6 +6357,11 @@ SpurMemoryManager >> initializeMarkStack [
 	self ensureRoomOnObjStackAt: MarkStackRootIndex
 ]
 
+{ #category : #'gc - global' }
+SpurMemoryManager >> initializeMournQueue [
+	self ensureRoomOnObjStackAt: MournQueueRootIndex
+]
+
 { #category : #'gc - scavenging' }
 SpurMemoryManager >> initializeNewSpaceVariables [
 	<inline: #never>
@@ -8330,6 +8335,7 @@ SpurMemoryManager >> markObjects: objectsShouldBeUnmarkedAndUnmarkedClassesShoul
 	self initializeUnscannedEphemerons.
 	self initializeMarkStack.
 	self initializeWeaklingStack.
+	self initializeMournQueue.
 	marking := true.
 	self markAccessibleObjectsAndFireEphemerons.
 	self expungeDuplicateAndUnmarkedClasses: objectsShouldBeUnmarkedAndUnmarkedClassesShouldBeExpunged.
@@ -10395,7 +10401,6 @@ SpurMemoryManager >> queueMourner: anEphemeronOrWeakArray [
 				   or: [(self formatOf: anEphemeronOrWeakArray) = self weakArrayFormat]]).
 	self deny: ((self formatOf: anEphemeronOrWeakArray) = self ephemeronFormat
 				and: [self is: anEphemeronOrWeakArray onObjStack: mournQueue]).
-	self ensureRoomOnObjStackAt: MournQueueRootIndex.
 	self push: anEphemeronOrWeakArray onObjStack: mournQueue
 ]
 

--- a/smalltalksrc/VMMaker/SpurPlanningCompactor.class.st
+++ b/smalltalksrc/VMMaker/SpurPlanningCompactor.class.st
@@ -749,7 +749,10 @@ SpurPlanningCompactor >> updatePointer: i in: obj [
 	| oop fwd |
 	oop := manager fetchPointer: i ofObject: obj.
 	((manager isNonImmediate: oop) and: [self isMobile: oop]) ifTrue:
-		[self assert: ((manager isMarked: oop) or: [obj = manager hiddenRootsObject]).
+		[self assert: (manager isMarked: oop).
+		 "If for some reason a hidden root is unmarked at this point, the status of this object is far from clear.
+		  Possibly, the object was created during the GC, so its status related to a possible forward pointer is unknown.
+		  So better just forbids this."
 		 fwd := manager fetchPointer: 0 ofObject: oop.
 		 self assert: (self isPostMobile: fwd).
 		 manager storePointerUnchecked: i ofObject: obj withValue: fwd]

--- a/smalltalksrc/VMMaker/SpurPlanningCompactor.class.st
+++ b/smalltalksrc/VMMaker/SpurPlanningCompactor.class.st
@@ -743,6 +743,19 @@ SpurPlanningCompactor >> unpinRememberedSet [
 ]
 
 { #category : #compaction }
+SpurPlanningCompactor >> updatePointer: i in: obj [
+	"Sweep the pointer i-th field in obj, updating its possible reference to a mobile object to its eventual location."
+	<inline: true>
+	| oop fwd |
+	oop := manager fetchPointer: i ofObject: obj.
+	((manager isNonImmediate: oop) and: [self isMobile: oop]) ifTrue:
+		[self assert: ((manager isMarked: oop) or: [obj = manager hiddenRootsObject]).
+		 fwd := manager fetchPointer: 0 ofObject: oop.
+		 self assert: (self isPostMobile: fwd).
+		 manager storePointerUnchecked: i ofObject: obj withValue: fwd]
+]
+
+{ #category : #compaction }
 SpurPlanningCompactor >> updatePointers [
 	"Sweep the heap, updating all objects to their eventual locations.
 	 Remember to update the savedFirstFields of pointer objects, as these have been forwarded."
@@ -769,13 +782,7 @@ SpurPlanningCompactor >> updatePointersIn: obj [
 	| numPointerSlots |
 	numPointerSlots := manager numPointerSlotsOf: obj.
 	0 to: numPointerSlots - 1 do:
-		[:i| | oop fwd |
-		 oop := manager fetchPointer: i ofObject: obj.
-		 ((manager isNonImmediate: oop) and: [self isMobile: oop]) ifTrue:
-			[self assert: ((manager isMarked: oop) or: [obj = manager hiddenRootsObject]).
-			 fwd := manager fetchPointer: 0 ofObject: oop.
-			 self assert: (self isPostMobile: fwd).
-			 manager storePointerUnchecked: i ofObject: obj withValue: fwd]]
+		[:i| self updatePointer: i in: obj ]
 ]
 
 { #category : #compaction }
@@ -799,13 +806,7 @@ SpurPlanningCompactor >> updatePointersIn: obj savedFirstFieldPointer: firstFiel
 			 self assert: (self isPostMobile: fwd).
 			 manager longAt: firstFieldPtr put: fwd]].
 	1 to: numPointerSlots - 1 do:
-		[:i|
-		 oop := manager fetchPointer: i ofObject: obj.
-		 ((manager isNonImmediate: oop) and: [self isMobile: oop]) ifTrue:
-			[self assert: ((manager isMarked: oop) or: [obj = manager hiddenRootsObject]).
-			 fwd := manager fetchPointer: 0 ofObject: oop.
-			 self assert: (self isPostMobile: fwd).
-			 manager storePointerUnchecked: i ofObject: obj withValue: fwd]]
+		[:i| self updatePointer: i in: obj ]
 ]
 
 { #category : #compaction }

--- a/smalltalksrc/VMMakerTests/VMSpurOldSpaceGarbageCollectorTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurOldSpaceGarbageCollectorTest.class.st
@@ -224,6 +224,52 @@ VMSpurOldSpaceGarbageCollectorTest >> testEphemeronOverflowUnscannedEphemeronQue
 ]
 
 { #category : #ephemerons }
+VMSpurOldSpaceGarbageCollectorTest >> testMournQueue [
+
+	| roots keyObj ephemeronObj |
+
+	roots := self newArrayWithSlots: 1.
+	self keepObjectInVMVariable1: roots.	
+
+	keyObj := self newObjectWithSlots: 1.
+	ephemeronObj := self newOldEphemeronObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: ephemeronObj withValue: keyObj.
+	memory storePointer: 0 ofObject: roots withValue: ephemeronObj.
+
+	memory fullGC.
+	
+	self assert: memory dequeueMourner equals: ephemeronObj.
+	self assert: memory dequeueMourner equals: nil.
+]
+
+{ #category : #ephemerons }
+VMSpurOldSpaceGarbageCollectorTest >> testMournQueue2 [
+
+	| roots keyObj ephemeronObj keyObj2 ephemeronObj2 |
+
+	"This test covers a diferent path in the CG code than testMournQueue."
+
+	roots := self newArrayWithSlots: 3.
+	self keepObjectInVMVariable1: roots.	
+
+	keyObj := self newObjectWithSlots: 1.
+	ephemeronObj := self newOldEphemeronObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: ephemeronObj withValue: keyObj.
+	memory storePointer: 0 ofObject: roots withValue: ephemeronObj.
+
+	keyObj2 := self newObjectWithSlots: 1.
+	ephemeronObj2 := self newOldEphemeronObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: ephemeronObj2 withValue: keyObj2.
+	memory storePointer: 1 ofObject: roots withValue: keyObj2.
+	memory storePointer: 2 ofObject: roots withValue: ephemeronObj2.
+
+	memory fullGC.
+	
+	self assert: memory dequeueMourner equals: ephemeronObj.
+	self assert: memory dequeueMourner equals: nil.
+]
+
+{ #category : #ephemerons }
 VMSpurOldSpaceGarbageCollectorTest >> testMultiPageMournQueue [
 
 	"This test Fires more ephemerons than those that fit in a single page of the mourn queue.

--- a/smalltalksrc/VMMakerTests/VMSpurScavengeEphemeronTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurScavengeEphemeronTest.class.st
@@ -4,6 +4,13 @@ Class {
 	#category : #'VMMakerTests-MemoryTests'
 }
 
+{ #category : #initialization }
+VMSpurScavengeEphemeronTest >> setUp [
+
+	super setUp.
+	memory initializeMournQueue
+]
+
 { #category : #'tests-ephemerons-globals' }
 VMSpurScavengeEphemeronTest >> testDequeueMournerWithOnlyOneEphemeronShouldEmptyMournQueue [
 	| ephemeronObjectOop nonEphemeronObjectOop |


### PR DESCRIPTION
This bug was found with the graybox fuzzer. It involves a complex code path in the GC related to ephemerons, but the underlying issue can be more general.

The issue was a failed assert when updating pointers to their new location after compaction. 
The failing scenario involved an attempt to relocate (during the GC) the mourn queue, but that failed because the first pointer of the mourn queue was not a forward pointer (but the first slot of the object stack that is a direct small integer).

During a compaction GC, all marked objects that reside in the moving area behave like forwarders, and the first pointer if overwritten to be the new location of the object (the original content of the bytes is saved).

For some reason (still unknown while writing the cover letter of this PR), a hack was added to force the update of pointers of the hidden roots, even when unmarked. The issue is that if such an unmarked object exists, it could be in an inconsistent state in regard to the forward status (i.e is the first byte are a forward pointer or real data?)

The mourn queue was unmarked because it was created lazily during a scavenging in the failing scenario, so after the mark pass. In most of the cases, the mourn queue is allocated earlier (in a different GC code path or during a previous GC), so that the mourn queue will be correctly marked, and the compactor will correctly do its job.

Because of that, this bug could be very rare in production because it requires a precise code path to be executed, a non-existing mourn queue before the GC invocation and having a non-empty mourn queue at the end of the GC.

This PR try to fixes by allocating the mourn queue early, along with the other object stacks.
Also, the GC now refuse to update pointers of unmarked moving objects, even for hidden roots.