### PR TITLE
fix markWeaklingsAndMarkAndFireEphemerons

### DIFF
--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -8051,6 +8051,7 @@ SpurMemoryManager >> markAndShouldScan: objOop [
 	 Already marked objects have already been processed.
 	 Pure bits objects don't need scanning, although their class does.
 	 Weak objects should be pushed on the weakling stack.
+	TODO: something about ephemerons.
 	 Anything else need scanning."
 	| format |
 	<inline: true>
@@ -8216,10 +8217,16 @@ SpurMemoryManager >> markAndTraceWeaklingsFrom: startIndex [
 SpurMemoryManager >> markInactiveEphemerons [
 
 	"Go through the unscanned ephemerons, marking the inactive ones, and
-	 removing them from the unscanned ephemerons. Answer if any inactive
-	 ones were found. We cannot fire the ephemerons until all are found to
+	 removing them from the unscanned ephemerons.
+	 Answer true if any inactive ones were found.
+	 Answer false if all unscanned ephemerons are active one (that could be fired).
+	
+	 We cannot fire the ephemerons until all are found to
 	 be active since scan-marking an inactive ephemeron later in the set may
-	 render a previously-observed active ephemeron as inactive."
+	 render a previously-observed ephemeron (that remains in unscannedEphemerons) as inactive.
+	
+	 Note: the current vocabulary *active* and *inactive* is insane, and badly defined because it mixes *possibly* and *certainly*.
+	"
 
 	| foundInactive ptr |
 	foundInactive := false.
@@ -8366,25 +8373,43 @@ SpurMemoryManager >> markWeaklingsAndMarkAndFireEphemerons [
 	 Weaklings have accumulated on the weaklingStack, but more may be
 	 uncovered during ephemeron processing.  So trace the strong slots
 	 of the weaklings, and as ephemerons are processed ensure any newly
-	 reached weaklings are also traced."
+	 reached weaklings are also traced.
+
+	 Moreover, marking ephemerons from unscannedEphemerons (because we fire
+	 them, or because we realize that they are inactive (ie have a marked key))
+	 leads to the discover (and markind) of new objects that are possibly
+	 weak objects, ephemerons or keys of unscanned ephemerons, forcing us to
+	 continue the work (thus the `repeat` block)"
 	| numTracedWeaklings |
 	<inline: false>
 	numTracedWeaklings := 0.
-	[coInterpreter markAndTraceUntracedReachableStackPages.
+	[
+	 "FIXME: Why the two following methods are *inside* the loop?"
+	 coInterpreter markAndTraceUntracedReachableStackPages.
 	 coInterpreter markAndTraceMachineCodeOfMarkedMethods.
+
 	 "Make sure all reached weaklings have their strong slots traced before firing ephemerons..."
 	 [numTracedWeaklings := self markAndTraceWeaklingsFrom: numTracedWeaklings.
 	  (self sizeOfObjStack: weaklingStack) > numTracedWeaklings] whileTrue.
+
 	 self noUnscannedEphemerons ifTrue:
+	   "There is no unscanned ephemerons, every live object is now marked"
 		[coInterpreter
 			markAndTraceUntracedReachableStackPages;
 	 		markAndTraceMachineCodeOfMarkedMethods;
 			freeUntracedStackPages;
 			freeUnmarkedMachineCode.
 		 ^self].
+
+	 "There is unscanned ephemerons, but their key could have been marked later, so process the list.
+	  ifFalse: all unscanned ephemerons of the list are active (still have a unmarked key), so fire them!
+	  ifTrue: some ephemerons are in fact inactive, and where just scanned. So do another turn."
+	
 	 self markInactiveEphemerons ifFalse:
-		[self fireAllUnscannedEphemerons].
-	 self markAllUnscannedEphemerons]
+		[ self fireAllUnscannedEphemerons.
+		  self markAllUnscannedEphemerons
+		  "Scanning fired ephemerons may discover new object, so do another turn." ].
+	 ]
 		repeat
 ]
 

--- a/smalltalksrc/VMMakerTests/VMSpurOldSpaceGarbageCollectorTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurOldSpaceGarbageCollectorTest.class.st
@@ -224,6 +224,69 @@ VMSpurOldSpaceGarbageCollectorTest >> testEphemeronOverflowUnscannedEphemeronQue
 ]
 
 { #category : #ephemerons }
+VMSpurOldSpaceGarbageCollectorTest >> testEphemeronDiscoverKey [
+
+	| roots ephemeron1 ephemeron2 ephemeron3 key1 key2 key3 |
+
+	"roots: E1 E2 K2
+	 E1 key: K1
+	 E2 Key: K2 value: K1.
+	 E3 key: K3.
+	
+	We assume the the scaning order E1 E2 E3 K2.
+	* E1 is marked but not scanned since K1 is not marked, E1 instead is put on unscannedEphemerons for future processing.
+	* Same for E2 because K2 is not marked.
+	* Same for E3 because K3 is not marked.
+	* K2 is then marked.
+	Then
+	* E1 remains on unscannedEphemerons because K1 is still unmarked.
+	* E2 is removed from unscannedEphemerons because K2 is marked. This triggers a scan on E2, that marks K1.
+	* E3 remains on unscannedEphemerons because K3 is still unmarked.
+	Then
+	* E1 is removed from unscannedEphemerons because K1 is marked. This triggers a scan on E1, that does nothing here.
+	* E3 remains on unscannedEphemerons because K3 is still unmarked.
+	Then
+	* E3 remains on unscannedEphemerons because K3 is still unmarked.
+	Then
+	* E3 is fired, removed from unscannedEphemerons, and scanned (that does nothing here).
+	Then
+	* unscannedEphemerons is empty, we leave
+	"
+
+	"Note: roots are stored in reverse order because slots are scanned from the last one to the first one"
+	roots := self newOldSpaceArrayWithSlots: 4. "K2 E3 E2 E1"
+	self keepObjectInVMVariable1: roots.
+
+	ephemeron1 := self newOldEphemeronObjectWithSlots: 1. "K1"
+	memory storePointer: 3 ofObject: roots withValue: ephemeron1.
+
+	key1 := self newOldSpaceObjectWithSlots: 0.
+	memory storePointer: 0 ofObject: ephemeron1 withValue: key1.
+
+	ephemeron2 := self newOldEphemeronObjectWithSlots: 2. "K2 K1"
+	memory storePointer: 2 ofObject: roots withValue: ephemeron2.
+
+	key2 := self newOldSpaceObjectWithSlots: 0.
+	memory storePointer: 0 ofObject: roots withValue: key2.
+	memory storePointer: 0 ofObject: ephemeron2 withValue: key2.
+	memory storePointer: 1 ofObject: ephemeron2 withValue: key1.
+
+	ephemeron3 := self newOldEphemeronObjectWithSlots: 1. "K3"
+	memory storePointer: 1 ofObject: roots withValue: ephemeron3.
+
+	key3 := self newOldSpaceObjectWithSlots: 0.
+	memory storePointer: 0 ofObject: ephemeron3 withValue: key3.
+	
+	memory setCheckForLeaks: 63 "all".
+	memory fullGC.
+	
+	self assert: memory coInterpreter pendingFinalizationSignals equals: 1.
+	self assert: memory dequeueMourner equals: ephemeron3.
+	self assert: memory dequeueMourner equals: nil.
+
+]
+
+{ #category : #ephemerons }
 VMSpurOldSpaceGarbageCollectorTest >> testMultiPageMournQueue [
 
 	"This test Fires more ephemerons than those that fit in a single page of the mourn queue.


### PR DESCRIPTION
The method `markWeaklingsAndMarkAndFireEphemerons` deals with one of the major complexities of ephemerons, that is that the scanning (marking) should not automatically deep visit ephemerons but choose to do so according to the liveness (marking) of its key: if the key is marked, the ephemeron is still good, we must scan&marks the values; if the key is *definitively non-marked* (ie dead), but the ephemeron is marked, then the ephemeron is said *active* (terminology is bad) and should be fired.

The hard part is the *definitively non-marked* because a key might be visited after its ephemeron and the GC do not have the key->ephemeron information (that is n->1).
So a list of ephemerons to possibly fire is kept at `unscannedEphemerons`. After a pass of scan&mark `markInactiveEphemerons` checks if the ephemerons are really active or not, and if not: remove them from the list and scan them (because inactive ephemerions must be scanned).

If all were active, then we can safely fire them (`fireAllUnscannedEphemerons`), then scan them (`markAllUnscannedEphemerons`) because fired ephemerons must also be scanned, but we cannot scan them before knowing we have to fire them.

Unfortunately, the previous code did systematically call `markAllUnscannedEphemerons` that might break the assertion `allUnscannedEphemeronsAreActive` in the rare cases of `markInactiveEphemerons` marking new keys.

When assertions are disabled (production), calling `markAllUnscannedEphemerons` will not corrupt the memory but prevents active ephemerons to be fired: if `markInactiveEphemerons` returned true, then we don't fire the active ephemerons of the list, but the call to `markAllUnscannedEphemerons` will remove them from the list (and scan them), so they are no more considered during the next loops. (the whole thing is in a `repeat` block.)

Note: if `markInactiveEphemerons` return false, the `unscannedEphemerons` can contain both active and inactive ephemerons, the situation will be handled correctly on the next loop by `markInactiveEphemerons`.

The fix is quite short: just put the `markAllUnscannedEphemerons` inside the `ifFalse:` block. The rest of the PR is documentation (because understanding what is happening was hard) and a test.

This bug was found by the graybox fuzzer.
