### PR TITLE
Fix #493

### DIFF
--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -7674,7 +7674,12 @@ SpurMemoryManager >> isYoungObject: objOop [
 { #category : #'object access' }
 SpurMemoryManager >> keyOfEphemeron: objOop [
 	"Answer the object the ephemeron guards.  This is its first element."
-	self assert: ((self isNonImmediate: objOop) and: [self isObjEphemeron: objOop]).
+	self assert: ((self isNonImmediate: objOop)
+		and: [ (self isObjEphemeron: objOop) ]).
+		
+	"Accessing the first slot of an ephemeron always works.
+	All objects have always at least one slot to use as a forwarding pointer, initialized as nil.
+	0-sized ephemeron will have this slot and work as a normal object"
 	^self fetchPointer: 0 ofObject: objOop
 ]
 

--- a/smalltalksrc/VMMakerTests/VMSpurInitializedOldSpaceTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurInitializedOldSpaceTest.class.st
@@ -21,12 +21,7 @@ VMSpurInitializedOldSpaceTest >> assertFreeListEmpty: aFreeListOop [
 
 { #category : #helpers }
 VMSpurInitializedOldSpaceTest >> createEphemeronClass [
-	ourEphemeronClass := self newObjectWithSlots: 3.
-	memory 
-		storePointer: "InstanceSpecificationIndex" 2
-		ofObject: ourEphemeronClass
-		withValue: (memory integerObjectOf: Ephemeron format).
-	memory ensureBehaviorHash: ourEphemeronClass.
+	ourEphemeronClass := self createEphemeronClassForSlots: 3
 ]
 
 { #category : #helpers }

--- a/smalltalksrc/VMMakerTests/VMSpurScavengeEphemeronTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurScavengeEphemeronTest.class.st
@@ -499,3 +499,29 @@ VMSpurScavengeEphemeronTest >> testScavengeTwoEphemeronObjectsReferencingSameDyi
 		assert: (memory fetchPointer: 0 ofObject: ephemeronObjectOop)
 		equals: (memory remapObj: nonEphemeronObjectOop)
 ]
+
+{ #category : #'tests-ephemerons-globals' }
+VMSpurScavengeEphemeronTest >> testScavengeZeroSizedEphemeronShouldTreatItAsNormalObject [
+	| ephemeronObjectOop zeroSizedEphemeronClass hashBefore addressBefore |
+	
+	"Create a zero sized ephemeron"
+	zeroSizedEphemeronClass := self createEphemeronClassForSlots: 0.
+	ephemeronObjectOop := memory instantiateClass: zeroSizedEphemeronClass.
+		
+	"Force object to not be collected by putting them in special variables"
+	hashBefore := memory hashBitsOf: ephemeronObjectOop.
+	addressBefore := ephemeronObjectOop.
+	self keepObjectInVMVariable1: ephemeronObjectOop.
+
+	"This should work ok, as the minimal object always at least one slot to use as a forwarding pointer.
+	This means that a 0 sized ephemeron will have a slot referencing nil and it should work as a normal object"
+	memory fullGC.
+
+	"The object should move, but should be the same and keep the same hash"
+	self
+		deny: addressBefore
+		equals: self keptObjectInVMVariable1.
+	self
+		assert: hashBefore
+		equals: (memory hashBitsOf: self keptObjectInVMVariable1).
+]


### PR DESCRIPTION
[Fix](https://github.com/pharo-project/pharo-vm/commit/f02def9af5eaf7fb77c89de3ae6866f9f627b258) https://github.com/pharo-project/pharo-vm/issues/493 [Accessing the first slot of an ephemeron always works.](https://github.com/pharo-project/pharo-vm/commit/f02def9af5eaf7fb77c89de3ae6866f9f627b258) 

All objects have always at least one slot to use as a forwarding pointer, initialized as nil.
0-sized ephemeron will have this slot and work as a normal object