### PR TITLE
Improve entity inspector

### DIFF
--- a/smalltalksrc/Slang/SlangMemoryManager.class.st
+++ b/smalltalksrc/Slang/SlangMemoryManager.class.st
@@ -149,6 +149,14 @@ SlangMemoryManager >> initialize [
 ]
 
 { #category : #'memory-access' }
+SlangMemoryManager >> isValidAddress: address [
+
+	"Memory regions are allocated in multiples of 4KB (12 bits).
+	The Memory map indexes memory regions by the high part"
+	^ memoryMap includesKey: address >> 12
+]
+
+{ #category : #'memory-access' }
 SlangMemoryManager >> long32At: address [
 	
 	^ self readSignedIntegerAt: address size: 4

--- a/smalltalksrc/VMMaker-Tools/SpurMemoryManager.extension.st
+++ b/smalltalksrc/VMMaker-Tools/SpurMemoryManager.extension.st
@@ -14,44 +14,28 @@ SpurMemoryManager >> inspectorEntities: composite [
 
 	<inspectorPresentationOrder: 2 title: 'Entities'>
 
-	| entities |
-	entities := OrderedCollection new.
-	self allHeapEntitiesDo: [ :e | entities add: e ].
+	| entities unscannedEphemeronList |
+	entities := self allHeapEntities collect: [ :oop | self asVMOop: oop ].
+	unscannedEphemeronList := #().
+	unscannedEphemerons start ifNotNil: [ unscannedEphemeronList := (unscannedEphemerons start to: unscannedEphemerons top - self bytesPerOop by: self bytesPerOop) collect: [ :p | self longAt: p] ].
 
-	^ SpTablePresenter new
-		alternateRowsColor;
+	^ SpTreeTablePresenter new
+"		alternateRowsColor;"
 		enableSearch;
 		items: entities;
-		addColumn: (SpStringTableColumn title: 'Oop' evaluated: [ :oop | oop ]);
-		addColumn: (SpStringTableColumn title: 'Oop(hex)' evaluated: [ :oop | oop hex ]);
-		addColumn: (SpStringTableColumn title: 'Label' evaluated: [ :oop | self labelOfOop: oop ]);
-		addColumn: (SpStringTableColumn title: 'Type' evaluated: [ :oop |
-				((self isFreeObject: oop) ifTrue: ['free'] ifFalse:
-				[(self isSegmentBridge: oop) ifTrue: ['bridge'] ifFalse:
-				[(self isForwarded: oop) ifTrue: ['forwarder'] ifFalse:
-				[(self classIndexOf: oop) <= self lastClassIndexPun ifTrue: ['pun/obj stack'] ifFalse:
-				['object']]]]) ]);
-		addColumn: (SpStringTableColumn title: 'classIndex' evaluated: [ :oop | self classIndexOf: oop ]);
-		addColumn: (SpStringTableColumn title: 'rawNumSlots' evaluated: [ :oop | self rawNumSlotsOf: oop ]);
-		addColumn: (SpStringTableColumn title: 'numSlots' evaluated: [ :oop |
-			self numSlotsOfAny: oop ]);
-		addColumn: (SpStringTableColumn title: 'bytesInObject' evaluated: [ :oop | self bytesInObject: oop ]);
-		addColumn: (SpStringTableColumn title: '1st field' evaluated: [ :oop |
-			(self isFreeObject: oop) ifTrue: [ self fetchPointer: 0 ofFreeChunk: oop ] ifFalse:
-			[(self isSegmentBridge: oop) ifTrue: [ '' ] ifFalse:
-			[(self isForwarded: oop) ifTrue: [ self followForwarded: oop ] ifFalse:
-			[((self numSlotsOfAny: oop) > 0) ifTrue: [ self fetchPointer: 0 ofObject: oop ] ifFalse:
-			[ '' ]]]]]);
-		addColumn: (SpStringTableColumn title: 'Format' evaluated: [ :oop | 
-			 ((self formatOf: oop) <= 16rF ifTrue: ['0'] ifFalse: ['']),
-			 (self formatOf: oop) printStringHex, ' ',
-			 (self formatStringOf: oop)]);
-		addColumn: (SpStringTableColumn title: 'Flags' evaluated: [ :oop | 
-			 ((self isGrey: oop) ifTrue: ['g'] ifFalse: ['.']),
-			 ((self isImmutable: oop) ifTrue: ['i'] ifFalse: ['.']),
-			 ((self isMarked: oop) ifTrue: ['m'] ifFalse: ['.']),
-			 ((self isPinned: oop) ifTrue: ['p'] ifFalse: ['.']),
-			 ((self isRemembered: oop) ifTrue: ['r'] ifFalse: ['.'])]);
+		children: [ :oop | oop pointers ];
+		addColumn: (SpStringTableColumn title: 'Oop' evaluated: [ :oop | oop oop ]);
+		addColumn: (SpStringTableColumn title: 'Oop(hex)' evaluated: [ :oop | oop oop hex ]);
+		addColumn: (SpStringTableColumn title: 'Label' evaluated: [ :oop | oop label ]);
+		addColumn: (SpStringTableColumn title: 'Type' evaluated: [ :oop | oop type ]);
+		addColumn: (SpStringTableColumn title: 'classIndex' evaluated: [ :oop | oop classIndex ]);
+		addColumn: (SpStringTableColumn title: 'rawNumSlots' evaluated: [ :oop | oop rawNumSlots ]);
+		addColumn: (SpStringTableColumn title: 'numSlots' evaluated: [ :oop | oop numSlots ]);
+		addColumn: (SpStringTableColumn title: 'bytes' evaluated: [ :oop | oop bytes ]);
+		addColumn: (SpStringTableColumn title: '1st pointer' evaluated: [ :oop | oop pointer: 0 ]);
+		addColumn: (SpStringTableColumn title: 'Format' evaluated: [ :oop | oop format ]);
+		addColumn: (SpStringTableColumn title: 'Flags&Misc' evaluated: [ :oop | oop flags,
+			 ((unscannedEphemeronList includes: oop oop) ifTrue: ['U'] ifFalse: ['.'])]);
 		yourself
 
 ]

--- a/smalltalksrc/VMMaker-Tools/SpurMemoryManager.extension.st
+++ b/smalltalksrc/VMMaker-Tools/SpurMemoryManager.extension.st
@@ -2,6 +2,7 @@ Extension { #name : #SpurMemoryManager }
 
 { #category : #'*VMMaker-Tools' }
 SpurMemoryManager >> asVMOop: oop [
+	<doNotGenerate>
 
 	^ VMOop new
 		memory: self;

--- a/smalltalksrc/VMMaker-Tools/SpurMemoryManager.extension.st
+++ b/smalltalksrc/VMMaker-Tools/SpurMemoryManager.extension.st
@@ -1,6 +1,15 @@
 Extension { #name : #SpurMemoryManager }
 
 { #category : #'*VMMaker-Tools' }
+SpurMemoryManager >> asVMOop: oop [
+
+	^ VMOop new
+		memory: self;
+		oop: oop;
+		yourself.
+]
+
+{ #category : #'*VMMaker-Tools' }
 SpurMemoryManager >> inspectorEntities: composite [
 
 	<inspectorPresentationOrder: 2 title: 'Entities'>

--- a/smalltalksrc/VMMaker-Tools/VMOop.class.st
+++ b/smalltalksrc/VMMaker-Tools/VMOop.class.st
@@ -1,0 +1,159 @@
+"
+A reified view of a `oop` (an integer address) for a `memory` manager.
+
+This class is used for debuging and vizualisation to handle oops as first object-oriented programing citizens when coding visual inspectors.
+They obviously *should not* be used for implementing runtime behavior.
+
+VMOops are also indented to be robust and capable of dealing with corrupted things (because we rarely debug uncorrupted memory), or during low-level operations (durring GC for instance).
+"
+Class {
+	#name : #VMOop,
+	#superclass : #Object,
+	#instVars : [
+		'oop',
+		'memory'
+	],
+	#category : #'VMMaker-Tools'
+}
+
+{ #category : #'object access' }
+VMOop >> bytes [
+
+	self ifBroken: [ ^ nil ].
+	^ memory bytesInObject: oop
+]
+
+{ #category : #'object access' }
+VMOop >> classIndex [
+
+	self ifBroken: [ ^ nil ].
+	^ memory classIndexOf: oop
+]
+
+{ #category : #printing }
+VMOop >> flags [
+
+	self ifBroken: [ ^ 'broken' ].
+	^ ((memory isGrey: oop) ifTrue: ['g'] ifFalse: ['.']),
+			 ((memory isImmutable: oop) ifTrue: ['i'] ifFalse: ['.']),
+			 ((memory isMarked: oop) ifTrue: ['m'] ifFalse: ['.']),
+			 ((memory isPinned: oop) ifTrue: ['p'] ifFalse: ['.']),
+			 ((memory isRemembered: oop) ifTrue: ['r'] ifFalse: ['.'])
+]
+
+{ #category : #printing }
+VMOop >> format [
+
+	self ifBroken: [ ^ 'broken' ].
+	^ ((memory formatOf: oop) <= 16rF ifTrue: ['0'] ifFalse: ['']),
+	  (memory formatOf: oop) printStringHex, ' ',
+	  (memory formatStringOf: oop)
+
+]
+
+{ #category : #testing }
+VMOop >> ifBroken: aBlock [
+
+	^ self isBroken ifTrue: aBlock.
+]
+
+{ #category : #testing }
+VMOop >> isBroken [
+
+	oop ifNil: [ ^true ].
+	^ (memory memoryManager isValidAddress: oop) not.
+]
+
+{ #category : #printing }
+VMOop >> label [
+
+	self ifBroken: [ ^ 'broken' ].
+	^ memory labelOfOop: oop
+]
+
+{ #category : #accessing }
+VMOop >> memory [
+
+	^ memory
+]
+
+{ #category : #accessing }
+VMOop >> memory: anObject [
+
+	memory := anObject
+]
+
+{ #category : #'object access' }
+VMOop >> numSlots [
+
+	self ifBroken: [ ^ nil ].
+	^ memory numSlotsOfAny: oop
+]
+
+{ #category : #accessing }
+VMOop >> oop [
+
+	^ oop
+]
+
+{ #category : #accessing }
+VMOop >> oop: anObject [
+
+	oop := anObject
+]
+
+{ #category : #'object access' }
+VMOop >> pointer: idx [
+
+	^ memory asVMOop: (self rawPointer: idx)
+]
+
+{ #category : #'object access' }
+VMOop >> pointers [
+
+	"Return a collection of all pointed `VMOop` (in slots)"
+
+	| n |
+	
+	n := self numSlots.
+	n ifNil: [ ^ #() ].
+	^ (1 to: n) collect: [ :i | self pointer: i-1 ].
+]
+
+{ #category : #printing }
+VMOop >> printOn: aStream [
+
+	^ aStream print: oop
+]
+
+{ #category : #'object access' }
+VMOop >> rawNumSlots [
+
+	self ifBroken: [ ^ nil ].
+	^ memory rawNumSlotsOf: oop
+]
+
+{ #category : #'object access' }
+VMOop >> rawPointer: idx [
+
+	"0 based pointer, as a classic integer oop"
+
+	self ifBroken: [ ^ nil ].
+	(memory isFreeObject: oop) ifTrue: [ ^ memory fetchPointer: idx ofFreeChunk: oop ].
+	(memory isSegmentBridge: oop) ifTrue: [ ^ nil ].
+	((memory numSlotsOfAny: oop) > 0) ifTrue: [ ^ memory fetchPointer: idx ofMaybeForwardedObject: oop ].
+	^ nil.
+
+]
+
+{ #category : #printing }
+VMOop >> type [
+
+	self ifBroken: [ ^ 'broken' ].
+	(memory isFreeObject: oop) ifTrue: [ ^ 'free'].
+	(memory isSegmentBridge: oop) ifTrue: [ ^ 'bridge'].
+	(memory isForwarded: oop) ifTrue: [ ^ 'forwarder'].
+	(memory classIndexOf: oop) <= memory lastClassIndexPun ifTrue: [ ^ 'pun/obj stack'].
+	^ 'object'
+
+]

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -5658,7 +5658,8 @@ SpurMemoryManager >> freeTreeOverlapCheck [
 SpurMemoryManager >> freeUnscannedEphemerons [
 	"Free all the memory allocated to keep the unscanned ephemerons"
 	
-	self free: unscannedEphemerons start
+	self free: unscannedEphemerons start.
+	unscannedEphemerons start: nil
 ]
 
 { #category : #'gc - global' }


### PR DESCRIPTION
In order to make the entity inspector more robust and simplfy its code, a new class `VMOop` is introduced to provide better inspection service, when debugging the GC for instance.

New features:

* Broken oop do not crash the inspector
* Use a SpTreeTablePresenter so slots can be easily navigated (with the arrow icon)
* `U` flag for unscanned ephemerons

Screenshot:

![Capture d’écran du 2022-12-05 16-30-25](https://user-images.githubusercontent.com/135828/205747490-46ccfb66-2561-4c3a-b339-194f3254435e.png)



