### PR TITLE
More constant cleanup

### DIFF
--- a/smalltalksrc/VMMaker/Cogit.class.st
+++ b/smalltalksrc/VMMaker/Cogit.class.st
@@ -268,8 +268,6 @@ Class {
 		'statCompileMethodUsecs'
 	],
 	#classVars : [
-		'AltFirstSpecialSelector',
-		'AltNumSpecialSelectors',
 		'AnnotationConstantNames',
 		'AnnotationShift',
 		'AnnotationsWithBytecodePCs',

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -412,9 +412,6 @@ Class {
 		'imageWriter'
 	],
 	#classVars : [
-		'AccessModifierPrivate',
-		'AccessModifierProtected',
-		'AccessModifierPublic',
 		'AltBytecodeEncoderClassName',
 		'AltLongStoreBytecode',
 		'AlternateHeaderHasPrimFlag',
@@ -943,9 +940,6 @@ StackInterpreter class >> initializeMethodIndices [
 	"The position of the unused flag bit in the method header, not including tag bit(s).
 	 Bits 28 & 29 are free for use as flag bits."
 	MethodHeaderFlagBitPosition := 28 + tagBits.
-	AccessModifierPublic := 2r00.
-	AccessModifierPrivate := 2r01.
-	AccessModifierProtected := 2r10.
 ]
 
 { #category : #initialization }

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -832,11 +832,6 @@ StackInterpreter class >> initializeContextIndices [
 	SmallContextSlots := CtxtTempFrameStart + 16.  "16 indexable fields"
 	"Large contexts have 56 indexable fields.  Max with single header word of ObjectMemory [but not SpurMemoryManager ;-)]."
 	LargeContextSlots := CtxtTempFrameStart + 56.
-	
-	"Including the header size in these sizes is problematic for multiple memory managers,
-	 so we don't use them.  Set to #bogus for error checking."
-	SmallContextSize := #bogus.
-	LargeContextSize := #bogus.
 
 	"Class BlockClosure"
 	FullClosureOuterContextIndex := 0.
@@ -11328,8 +11323,7 @@ StackInterpreter >> primitiveObject: actualReceiver perform: selector withArgume
 	(objectMemory isArray: argumentArray) ifFalse:
 		[^self primitiveFailFor: PrimErrBadArgument].
 
-	"Check if number of arguments is reasonable; MaxNumArgs isn't available
-	 so just use LargeContextSize"
+	"Check if number of arguments is reasonable"
 	arraySize := objectMemory numSlotsOf: argumentArray.
 	arraySize > (LargeContextSlots - CtxtTempFrameStart) ifTrue:
 		[^self primitiveFailFor: PrimErrBadNumArgs].

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -433,7 +433,6 @@ Class {
 		'DumpStackOnLowSpace',
 		'EnclosingMixinIndex',
 		'EnclosingObjectIndex',
-		'EnforceAccessControl',
 		'FailImbalancedPrimitives',
 		'LongStoreBytecode',
 		'MaxExternalPrimitiveTableSize',
@@ -970,7 +969,6 @@ StackInterpreter class >> initializeMiscConstants [
 
 	MaxJumpBuf := 32. "max. callback depth"
 	FailImbalancedPrimitives := InitializationOptions at: #FailImbalancedPrimitives ifAbsentPut: [true].
-	EnforceAccessControl := InitializationOptions at: #EnforceAccessControl ifAbsent: [true].
 
 	ReturnToInterpreter := 1. "setjmp/longjmp code."
 

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -412,8 +412,6 @@ Class {
 		'imageWriter'
 	],
 	#classVars : [
-		'AltBytecodeEncoderClassName',
-		'AltLongStoreBytecode',
 		'AlternateHeaderHasPrimFlag',
 		'AlternateHeaderIsOptimizedFlag',
 		'AlternateHeaderNumLiteralsMask',

--- a/smalltalksrc/VMMaker/VMBytecodeConstants.class.st
+++ b/smalltalksrc/VMMaker/VMBytecodeConstants.class.st
@@ -11,10 +11,8 @@ Class {
 		'BytecodeSetHasDirectedSuperSend',
 		'CtxtTempFrameStart',
 		'LargeContextBit',
-		'LargeContextSize',
 		'LargeContextSlots',
 		'SistaV1BytecodeSet',
-		'SmallContextSize',
 		'SmallContextSlots'
 	],
 	#pools : [


### PR DESCRIPTION
Those shared variables (class variables & pool variables) are not used. They are possible remains of previous cleanups.