### PR TITLE
Force build of libSDL2 if already present in target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ option(PHARO_DEPENDENCIES_PREFER_DOWNLOAD_BINARIES	"Prefer downloading dependenc
 option(FEATURE_COMPILE_INLINE_MEMORY_ACCESSORS		"Use inline memory accessors instead of macros"					 ON)
 option(PHARO_VM_IN_WORKER_THREAD			"Have support for pharo running in a different thread that the main one"	 ON)
 option(BUILD_IS_RELEASE					"Is this a release version?"							OFF)
+option(DEPENDENCIES_FORCE_BUILD         "Force build libraries" OFF)
 
 set(APPNAME			"Pharo"         CACHE STRING                 "VM Application name")
 set(FLAVOUR			"CoInterpreter" CACHE STRING                 "The kind of VM to generate. Possible values: StackVM, CoInterpreter")

--- a/cmake/importLibGit2.cmake
+++ b/cmake/importLibGit2.cmake
@@ -90,9 +90,8 @@ function(build_git2)
 
 		add_custom_target(libgit2_copy
 			COMMAND ${CMAKE_COMMAND} -E copy_if_different ${LibGit2_BINARY_DIR}/libgit2.1.4.4.dylib ${LIBRARY_OUTPUT_PATH}
-			COMMAND ${CMAKE_COMMAND} -E create_symlink ${LIBRARY_OUTPUT_PATH}/libgit2.1.4.4.dylib ${LIBRARY_OUTPUT_PATH}/libgit2.1.4.dylib
-			COMMAND ${CMAKE_COMMAND} -E create_symlink ${LIBRARY_OUTPUT_PATH}/libgit2.1.4.4.dylib ${LIBRARY_OUTPUT_PATH}/libgit2.dylib
-			COMMAND ${CMAKE_COMMAND} -E create_symlink ${LIBRARY_OUTPUT_PATH}/libgit2.1.4.4.dylib ${LIBRARY_OUTPUT_PATH}/libgit2.1.4.4.dylib
+			COMMAND ${CMAKE_COMMAND} -E create_symlink libgit2.1.4.4.dylib ${LIBRARY_OUTPUT_PATH}/libgit2.1.4.dylib
+			COMMAND ${CMAKE_COMMAND} -E create_symlink libgit2.1.4.4.dylib ${LIBRARY_OUTPUT_PATH}/libgit2.dylib
 			COMMENT "Copying Libgit binaries from '${LibGit2_BINARY_DIR}' to '${LIBRARY_OUTPUT_PATH}'" VERBATIM)
 	else()
 		message(FATAL "Aggggh not implemented yet")

--- a/cmake/importSDL2.cmake
+++ b/cmake/importSDL2.cmake
@@ -43,7 +43,7 @@ function(build_SDL2)
     set_target_properties(SDL2 PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${LIBRARY_OUTPUT_PATH})
     
     add_custom_target(SDL2_copy
-			COMMAND ${CMAKE_COMMAND} -E create_symlink ${LIBRARY_OUTPUT_PATH}/libSDL2-2.0.dylib ${LIBRARY_OUTPUT_PATH}/libSDL2-2.0.0.dylib
+			COMMAND ${CMAKE_COMMAND} -E create_symlink libSDL2-2.0.dylib ${LIBRARY_OUTPUT_PATH}/libSDL2-2.0.0.dylib
     )
     add_dependencies(SDL2_copy SDL2)
     add_dependencies(${VM_LIBRARY_NAME} SDL2_copy)

--- a/cmake/importSDL2.cmake
+++ b/cmake/importSDL2.cmake
@@ -40,15 +40,21 @@ function(build_SDL2)
 	)
     add_subdirectory(${SDL2_SOURCE_DIR} ${SDL2_BINARY_DIR} EXCLUDE_FROM_ALL)
 
-    set_target_properties(SDL2 PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${EXECUTABLE_OUTPUT_PATH})
-    add_dependencies(${VM_LIBRARY_NAME} SDL2)
+    set_target_properties(SDL2 PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${LIBRARY_OUTPUT_PATH})
+    
+    add_custom_target(SDL2_copy
+			COMMAND ${CMAKE_COMMAND} -E create_symlink ${LIBRARY_OUTPUT_PATH}/libSDL2-2.0.dylib ${LIBRARY_OUTPUT_PATH}/libSDL2-2.0.0.dylib
+    )
+    add_dependencies(SDL2_copy SDL2)
+    add_dependencies(${VM_LIBRARY_NAME} SDL2_copy)
     set(SDL2_FOUND "From build_SDL2" PARENT_SCOPE)
 endfunction()
 
 if (BUILD_BUNDLE)
-  #Only get SDL2 if required
-  if(PHARO_DEPENDENCIES_PREFER_DOWNLOAD_BINARIES)
-    #Download SDL2 binaries directly
+  if(DEPENDENCIES_FORCE_BUILD)
+    build_SDL2()
+  elseif(PHARO_DEPENDENCIES_PREFER_DOWNLOAD_BINARIES)
+  #Download SDL2 binaries directly
     download_SDL2()
   else()
     #Look for SDL2 in the system, then build or download if possible


### PR DESCRIPTION
Fix a problem building the VM when the libSDL2 is already present in the target system but the library was not built and copied to the plugins directory.