### PR TITLE
Add import <Security/SecureTransport.h> in sqMacSSL.c

### DIFF
--- a/extracted/plugins/SqueakSSL/src/osx/sqMacSSL.c
+++ b/extracted/plugins/SqueakSSL/src/osx/sqMacSSL.c
@@ -14,6 +14,7 @@
 #include <stdarg.h>
 
 #import <Security/Security.h>
+#import <Security/SecureTransport.h>
 
 typedef struct sqSSL {
     int state;


### PR DESCRIPTION
On mac we should also import `#import <Security/SecureTransport.h>` otherwise `errSSLServerAuthCompleted` may not be declared.
Related documentation: https://developer.apple.com/documentation/security/1503828-secure_transport_result_codes