### PR TITLE
Jitted primitive for string comparison

### DIFF
--- a/smalltalksrc/VMMaker/CogObjectRepresentationForSpur.class.st
+++ b/smalltalksrc/VMMaker/CogObjectRepresentationForSpur.class.st
@@ -2274,7 +2274,11 @@ CogObjectRepresentationForSpur >> genPrimitiveStringCompareWith [
 	cogit AddCq: objectMemory baseHeaderSize R: minSizeReg.
 	
 	instr := cogit MoveXbr: TempReg R: string1Reg R: string1CharOrByteSizeReg.
+		cogit backEnd byteReadsZeroExtend ifFalse:
+			[cogit AndCq: 255 R: string1CharOrByteSizeReg].
 	cogit MoveXbr: TempReg R: string2Reg R: string2CharOrByteSizeReg.
+		cogit backEnd byteReadsZeroExtend ifFalse:
+			[cogit AndCq: 255 R: string2CharOrByteSizeReg].
 	cogit SubR: string2CharOrByteSizeReg R: string1CharOrByteSizeReg. 
 	jumpMidFailure := cogit JumpNonZero: 0. "the 2 compared characters are different, exit the loop"
 	cogit AddCq: 1 R: TempReg.

--- a/smalltalksrc/VMMaker/CogObjectRepresentationForSpur.class.st
+++ b/smalltalksrc/VMMaker/CogObjectRepresentationForSpur.class.st
@@ -2213,7 +2213,6 @@ CogObjectRepresentationForSpur >> genPrimitiveStoreUInt8IntoExternalAddress [
 
 { #category : #'primitive generators' }
 CogObjectRepresentationForSpur >> genPrimitiveStringCompareWith [
-	"primitiveCompareWith:"
 	
 	| instr jump jumpAbove jumpIncorrectFormat1 jumpIncorrectFormat2 jumpIncorrectFormat3 jumpIncorrectFormat4 jumpMidFailure jumpSuccess minSizeReg string1CharOrByteSizeReg string2CharOrByteSizeReg string1Reg string2Reg |
 	

--- a/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
@@ -1278,46 +1278,6 @@ InterpreterPrimitives >> primitiveCompareBytes [
 
 ]
 
-{ #category : #'string primitives' }
-InterpreterPrimitives >> primitiveCompareWith [
-	"<string1> primitiveCompareWith: string2 [collated: order] "
-	<export: true>
-	
-	| string1 string2 order strLength1 strLength2 result |
-
-	"1 - fetch the parameters from the stack"	
-	argumentCount = 1 ifFalse:
-		[argumentCount ~= 2 ifTrue:
-			[^self primitiveFailFor: PrimErrBadNumArgs].
-			 order := self stackTop.
-			 ((objectMemory isBytes: order)
-			 and: [(objectMemory numBytesOfBytes: order) = 256]) ifFalse:
-				[^self primitiveFailFor: PrimErrBadArgument]].
-	string1 := self stackValue: argumentCount.
-	string2 := self stackValue: argumentCount - 1. 
-	
-	"2 - check their types - all parameters are ByteObject"
-	((objectMemory isBytes: string1)
-	 and: [objectMemory isBytes: string2]) ifFalse: 
-		[^self primitiveFailFor: PrimErrBadArgument].
-
-	"3 - compare the strings"	
-	strLength1 := objectMemory numBytesOfBytes: string1.
-	strLength2 := objectMemory numBytesOfBytes: string2.
-	result := order 
-		ifNil: [self rawCompare: string1 length: strLength1 with: string2 length: strLength2 accessBlock:
-				[:str :index | objectMemory fetchByte: index ofObject: str ]]
-		ifNotNil: 
-			[self rawCompare: string1 length: strLength1 with: string2 length: strLength2 accessBlock:
-				[:str :index | 
-					objectMemory fetchByte: (objectMemory fetchByte: index ofObject: str) ofObject: order ]].
-	self methodReturnInteger: result
-
-	
-	
-	
-]
-
 { #category : #'sound primitives' }
 InterpreterPrimitives >> primitiveConstantFill [
 	"Fill the receiver, which must be an indexable non-pointer
@@ -4093,6 +4053,46 @@ InterpreterPrimitives >> primitiveStringAt [
 InterpreterPrimitives >> primitiveStringAtPut [
 
 	self commonAtPut: true.
+]
+
+{ #category : #'string primitives' }
+InterpreterPrimitives >> primitiveStringCompareWith [
+	"<string1> primitiveCompareWith: string2 [collated: order] "
+	<export: true>
+	
+	| string1 string2 order strLength1 strLength2 result |
+
+	"1 - fetch the parameters from the stack"	
+	argumentCount = 1 ifFalse:
+		[argumentCount ~= 2 ifTrue:
+			[^self primitiveFailFor: PrimErrBadNumArgs].
+			 order := self stackTop.
+			 ((objectMemory isBytes: order)
+			 and: [(objectMemory numBytesOfBytes: order) = 256]) ifFalse:
+				[^self primitiveFailFor: PrimErrBadArgument]].
+	string1 := self stackValue: argumentCount.
+	string2 := self stackValue: argumentCount - 1. 
+	
+	"2 - check their types - all parameters are ByteObject"
+	((objectMemory isBytes: string1)
+	 and: [objectMemory isBytes: string2]) ifFalse: 
+		[^self primitiveFailFor: PrimErrBadArgument].
+
+	"3 - compare the strings"	
+	strLength1 := objectMemory numBytesOfBytes: string1.
+	strLength2 := objectMemory numBytesOfBytes: string2.
+	result := order 
+		ifNil: [self rawCompare: string1 length: strLength1 with: string2 length: strLength2 accessBlock:
+				[:str :index | objectMemory fetchByte: index ofObject: str ]]
+		ifNotNil: 
+			[self rawCompare: string1 length: strLength1 with: string2 length: strLength2 accessBlock:
+				[:str :index | 
+					objectMemory fetchByte: (objectMemory fetchByte: index ofObject: str) ofObject: order ]].
+	self methodReturnInteger: result
+
+	
+	
+	
 ]
 
 { #category : #'indexing primitives' }

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -1157,7 +1157,7 @@ StackInterpreter class >> initializePrimitiveTable [
 
 		"Were File Primitives (150-169) - NO LONGER INDEXED"
 		(150 157 primitiveFail)
-		(158 primitiveCompareWith)
+		(158 primitiveStringCompareWith)
 		(159 primitiveHashMultiply)
 		(160 primitiveAdoptInstance)
 		(161 primitiveSetOrHasIdentityHash)

--- a/smalltalksrc/VMMakerTests/VMJittedGeneralPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJittedGeneralPrimitiveTest.class.st
@@ -2154,6 +2154,81 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveQuoReturnsZeroWithZeroReceiver [
 	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 0).
 ]
 
+{ #category : #'tests - primitiveStringCompare' }
+VMJittedGeneralPrimitiveTest >> testPrimitiveStringCompareWithHigherSymbol [
+	
+
+	| aByteSymbol bByteSymbol endInstruction primitiveAddress |
+	aByteSymbol := #a forMemory: memory inMethod: nil.
+	bByteSymbol := #b forMemory: memory inMethod: nil.
+	
+	primitiveAddress := self compile: [ 
+		cogit objectRepresentation genPrimitiveStringCompareWith.
+		"If the primitive fails it continues, so we need to have an instruction to detect the end"
+		endInstruction := cogit Stop ].
+
+	self prepareStackForSendReceiver: bByteSymbol arguments: { aByteSymbol }.
+	self runFrom: primitiveAddress until: callerAddress.
+
+	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 1).
+]
+
+{ #category : #'tests - primitiveStringCompare' }
+VMJittedGeneralPrimitiveTest >> testPrimitiveStringCompareWithIsCaseSensitive [
+	
+
+	| endInstruction primitiveAddress lowerByteSymbol upperByteSymbol |
+	lowerByteSymbol := #z forMemory: memory inMethod: nil.
+	upperByteSymbol := #Z forMemory: memory inMethod: nil.
+	
+	primitiveAddress := self compile: [ 
+		cogit objectRepresentation genPrimitiveStringCompareWith.
+		"If the primitive fails it continues, so we need to have an instruction to detect the end"
+		endInstruction := cogit Stop ].
+
+	self prepareStackForSendReceiver: lowerByteSymbol arguments: { upperByteSymbol }.
+	self runFrom: primitiveAddress until: callerAddress.
+
+	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 32).
+]
+
+{ #category : #'tests - primitiveStringCompare' }
+VMJittedGeneralPrimitiveTest >> testPrimitiveStringCompareWithLowerSymbol [
+	
+
+	| aByteSymbol bByteSymbol endInstruction primitiveAddress |
+	aByteSymbol := #a forMemory: memory inMethod: nil.
+	bByteSymbol := #b forMemory: memory inMethod: nil.
+
+	primitiveAddress := self compile: [ 
+		cogit objectRepresentation genPrimitiveStringCompareWith.
+		"If the primitive fails it continues, so we need to have an instruction to detect the end"
+		endInstruction := cogit Stop ].
+
+	self prepareStackForSendReceiver: aByteSymbol arguments: { bByteSymbol }.
+	self runFrom: primitiveAddress until: callerAddress.
+
+	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: -1).
+]
+
+{ #category : #'tests - primitiveStringCompare' }
+VMJittedGeneralPrimitiveTest >> testPrimitiveStringCompareWithSameSymbol [
+	
+
+	| aByteSymbol endInstruction primitiveAddress |
+	aByteSymbol := #a forMemory: memory inMethod: nil.
+	
+	primitiveAddress := self compile: [ 
+		cogit objectRepresentation genPrimitiveStringCompareWith.
+		"If the primitive fails it continues, so we need to have an instruction to detect the end"
+		endInstruction := cogit Stop ].
+
+	self prepareStackForSendReceiver: aByteSymbol arguments: { aByteSymbol }.
+	self runFrom: primitiveAddress until: callerAddress.
+
+	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 0).
+]
+
 { #category : #'tests - primitiveSubtract' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveSubtractDoesNotCompileIfReceiverTagIsNotSmallInteger [
 	

--- a/smalltalksrc/VMMakerTests/VMJittedGeneralPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJittedGeneralPrimitiveTest.class.st
@@ -2155,6 +2155,25 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveQuoReturnsZeroWithZeroReceiver [
 ]
 
 { #category : #'tests - primitiveStringCompare' }
+VMJittedGeneralPrimitiveTest >> testPrimitiveStringCompareBigString [
+	
+
+	| aByteSymbol endInstruction primitiveAddress |
+	"256 has a size bigger than 8 bits"
+	aByteSymbol := (String loremIpsum: 256) asSymbol forMemory: memory inMethod: nil.
+	
+	primitiveAddress := self compile: [ 
+		cogit objectRepresentation genPrimitiveStringCompareWith.
+		"If the primitive fails it continues, so we need to have an instruction to detect the end"
+		endInstruction := cogit Stop ].
+
+	self prepareStackForSendReceiver: aByteSymbol arguments: { aByteSymbol }.
+	self runFrom: primitiveAddress until: callerAddress.
+
+	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 0).
+]
+
+{ #category : #'tests - primitiveStringCompare' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveStringCompareWithHigherSymbol [
 	
 

--- a/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
@@ -1255,7 +1255,7 @@ VMPrimitiveTest >> testPrimitiveClassReturnsAClass [
 	
 ]
 
-{ #category : #'tests - primitivePin' }
+{ #category : #'tests - primitiveStringCompare' }
 VMPrimitiveTest >> testPrimitiveCompareWithHigherSymbol [
 
 	| asciiOrder aByteSymbol bByteSymbol |
@@ -1275,7 +1275,7 @@ VMPrimitiveTest >> testPrimitiveCompareWithHigherSymbol [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 1)
 ]
 
-{ #category : #'tests - primitivePin' }
+{ #category : #'tests - primitiveStringCompare' }
 VMPrimitiveTest >> testPrimitiveCompareWithIsNotCaseSensitive [
 
 	| nonCaseSensitiveOrder lowerByteSymbol upperByteSymbol |
@@ -1295,7 +1295,7 @@ VMPrimitiveTest >> testPrimitiveCompareWithIsNotCaseSensitive [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 0)
 ]
 
-{ #category : #'tests - primitivePin' }
+{ #category : #'tests - primitiveStringCompare' }
 VMPrimitiveTest >> testPrimitiveCompareWithLimitCaseRegretion [
 
 	| nonCaseSensitiveOrder lowerByteSymbol upperByteSymbol |
@@ -1315,7 +1315,7 @@ VMPrimitiveTest >> testPrimitiveCompareWithLimitCaseRegretion [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 0)
 ]
 
-{ #category : #'tests - primitivePin' }
+{ #category : #'tests - primitiveStringCompare' }
 VMPrimitiveTest >> testPrimitiveCompareWithLowerSymbol [
 
 	| asciiOrder aByteSymbol bByteSymbol |
@@ -1335,7 +1335,7 @@ VMPrimitiveTest >> testPrimitiveCompareWithLowerSymbol [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: -1)
 ]
 
-{ #category : #'tests - primitivePin' }
+{ #category : #'tests - primitiveStringCompare' }
 VMPrimitiveTest >> testPrimitiveCompareWithTheSameSymbol [
 
 	| byteSymbol asciiOrder |

--- a/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
@@ -1255,105 +1255,6 @@ VMPrimitiveTest >> testPrimitiveClassReturnsAClass [
 	
 ]
 
-{ #category : #'tests - primitiveStringCompare' }
-VMPrimitiveTest >> testPrimitiveCompareWithHigherSymbol [
-
-	| asciiOrder aByteSymbol bByteSymbol |
-	aByteSymbol := #a forMemory: memory inMethod: nil.
-	bByteSymbol := #b forMemory: memory inMethod: nil.
-
-	asciiOrder := self newByteArrayWithContent: String newAsciiOrder.
-
-	interpreter push: bByteSymbol.
-	interpreter push: aByteSymbol.
-	interpreter push: asciiOrder.
-
-	interpreter argumentCount: 2.
-	interpreter primitiveCompareWith.
-
-	self deny: interpreter failed.
-	self assert: interpreter stackTop equals: (memory integerObjectOf: 1)
-]
-
-{ #category : #'tests - primitiveStringCompare' }
-VMPrimitiveTest >> testPrimitiveCompareWithIsNotCaseSensitive [
-
-	| nonCaseSensitiveOrder lowerByteSymbol upperByteSymbol |
-	lowerByteSymbol := #a forMemory: memory inMethod: nil.
-	upperByteSymbol := #A forMemory: memory inMethod: nil. 
-
-	nonCaseSensitiveOrder := self newByteArrayWithContent: String newCaseInsensitiveOrder.
-
-	interpreter push: lowerByteSymbol.
-	interpreter push: upperByteSymbol.
-	interpreter push: nonCaseSensitiveOrder.
-
-	interpreter argumentCount: 2.
-	interpreter primitiveCompareWith.
-
-	self deny: interpreter failed.
-	self assert: interpreter stackTop equals: (memory integerObjectOf: 0)
-]
-
-{ #category : #'tests - primitiveStringCompare' }
-VMPrimitiveTest >> testPrimitiveCompareWithLimitCaseRegretion [
-
-	| nonCaseSensitiveOrder lowerByteSymbol upperByteSymbol |
-	lowerByteSymbol := #z forMemory: memory inMethod: nil.
-	upperByteSymbol := #Z forMemory: memory inMethod: nil. 
-
-	nonCaseSensitiveOrder := self newByteArrayWithContent: String newCaseInsensitiveOrder.
-
-	interpreter push: lowerByteSymbol.
-	interpreter push: upperByteSymbol.
-	interpreter push: nonCaseSensitiveOrder.
-
-	interpreter argumentCount: 2.
-	interpreter primitiveCompareWith.
-
-	self deny: interpreter failed.
-	self assert: interpreter stackTop equals: (memory integerObjectOf: 0)
-]
-
-{ #category : #'tests - primitiveStringCompare' }
-VMPrimitiveTest >> testPrimitiveCompareWithLowerSymbol [
-
-	| asciiOrder aByteSymbol bByteSymbol |
-	aByteSymbol := #a forMemory: memory inMethod: nil.
-	bByteSymbol := #b forMemory: memory inMethod: nil.
-
-	asciiOrder := self newByteArrayWithContent: String newAsciiOrder.
-
-	interpreter push: aByteSymbol.
-	interpreter push: bByteSymbol.
-	interpreter push: asciiOrder.
-
-	interpreter argumentCount: 2.
-	interpreter primitiveCompareWith.
-
-	self deny: interpreter failed.
-	self assert: interpreter stackTop equals: (memory integerObjectOf: -1)
-]
-
-{ #category : #'tests - primitiveStringCompare' }
-VMPrimitiveTest >> testPrimitiveCompareWithTheSameSymbol [
-
-	| byteSymbol asciiOrder |
-	byteSymbol := #a forMemory: memory inMethod: nil.
-	
-	asciiOrder := self newByteArrayWithContent: String newAsciiOrder.
-	
-	interpreter push: byteSymbol.
-	interpreter push: byteSymbol.
-	interpreter push: asciiOrder.
-
-	interpreter argumentCount: 2.
-	interpreter primitiveCompareWith.
-
-	self deny: interpreter failed.
-	self assert: interpreter stackTop equals: (memory integerObjectOf: 0)
-]
-
 { #category : #'tests - primitiveDiv' }
 VMPrimitiveTest >> testPrimitiveDiv [
 
@@ -4965,6 +4866,105 @@ VMPrimitiveTest >> testPrimitiveStringAtShouldNotModifyStringIfFailedWhenNonChar
 	self assert: interpreter primFailCode equals: PrimErrBadArgument.
 
 	self assert: string contentEquals: (self newString: 'po')
+]
+
+{ #category : #'tests - primitiveStringCompare' }
+VMPrimitiveTest >> testPrimitiveStringCompareWithHigherSymbol [
+
+	| asciiOrder aByteSymbol bByteSymbol |
+	aByteSymbol := #a forMemory: memory inMethod: nil.
+	bByteSymbol := #b forMemory: memory inMethod: nil.
+
+	asciiOrder := self newByteArrayWithContent: String newAsciiOrder.
+
+	interpreter push: bByteSymbol.
+	interpreter push: aByteSymbol.
+	interpreter push: asciiOrder.
+
+	interpreter argumentCount: 2.
+	interpreter primitiveStringCompareWith.
+
+	self deny: interpreter failed.
+	self assert: interpreter stackTop equals: (memory integerObjectOf: 1)
+]
+
+{ #category : #'tests - primitiveStringCompare' }
+VMPrimitiveTest >> testPrimitiveStringCompareWithIsNotCaseSensitive [
+
+	| nonCaseSensitiveOrder lowerByteSymbol upperByteSymbol |
+	lowerByteSymbol := #a forMemory: memory inMethod: nil.
+	upperByteSymbol := #A forMemory: memory inMethod: nil. 
+
+	nonCaseSensitiveOrder := self newByteArrayWithContent: String newCaseInsensitiveOrder.
+
+	interpreter push: lowerByteSymbol.
+	interpreter push: upperByteSymbol.
+	interpreter push: nonCaseSensitiveOrder.
+
+	interpreter argumentCount: 2.
+	interpreter primitiveStringCompareWith.
+
+	self deny: interpreter failed.
+	self assert: interpreter stackTop equals: (memory integerObjectOf: 0)
+]
+
+{ #category : #'tests - primitiveStringCompare' }
+VMPrimitiveTest >> testPrimitiveStringCompareWithLimitCaseRegretion [
+
+	| nonCaseSensitiveOrder lowerByteSymbol upperByteSymbol |
+	lowerByteSymbol := #z forMemory: memory inMethod: nil.
+	upperByteSymbol := #Z forMemory: memory inMethod: nil. 
+
+	nonCaseSensitiveOrder := self newByteArrayWithContent: String newCaseInsensitiveOrder.
+
+	interpreter push: lowerByteSymbol.
+	interpreter push: upperByteSymbol.
+	interpreter push: nonCaseSensitiveOrder.
+
+	interpreter argumentCount: 2.
+	interpreter primitiveStringCompareWith.
+
+	self deny: interpreter failed.
+	self assert: interpreter stackTop equals: (memory integerObjectOf: 0)
+]
+
+{ #category : #'tests - primitiveStringCompare' }
+VMPrimitiveTest >> testPrimitiveStringCompareWithLowerSymbol [
+
+	| asciiOrder aByteSymbol bByteSymbol |
+	aByteSymbol := #a forMemory: memory inMethod: nil.
+	bByteSymbol := #b forMemory: memory inMethod: nil.
+
+	asciiOrder := self newByteArrayWithContent: String newAsciiOrder.
+
+	interpreter push: aByteSymbol.
+	interpreter push: bByteSymbol.
+	interpreter push: asciiOrder.
+
+	interpreter argumentCount: 2.
+	interpreter primitiveStringCompareWith.
+
+	self deny: interpreter failed.
+	self assert: interpreter stackTop equals: (memory integerObjectOf: -1)
+]
+
+{ #category : #'tests - primitiveStringCompare' }
+VMPrimitiveTest >> testPrimitiveStringCompareWithTheSameSymbol [
+
+	| byteSymbol asciiOrder |
+	byteSymbol := #a forMemory: memory inMethod: nil.
+	
+	asciiOrder := self newByteArrayWithContent: String newAsciiOrder.
+	
+	interpreter push: byteSymbol.
+	interpreter push: byteSymbol.
+	interpreter push: asciiOrder.
+
+	interpreter argumentCount: 2.
+	interpreter primitiveStringCompareWith.
+
+	self deny: interpreter failed.
+	self assert: interpreter stackTop equals: (memory integerObjectOf: 0)
 ]
 
 { #category : #'tests - primitiveSubtract' }


### PR DESCRIPTION
Remaining work from https://github.com/pharo-project/pharo-vm/pull/533

We just added some tests from the primitive in the JIT compiler. 
This version doesn't accept the order (so it doesn't have the bug fixed in the interpreter) as it's described in [this post](https://clementbera.wordpress.com/2018/02/17/massive-string-comparison-performance-boost-up-coming-in-the-cog-vm/).

_with @jecisc in the VM Dojo_