### PR TITLE
Enable lazy initialization in #inferTypes.

### DIFF
--- a/smalltalksrc/Melchor/VMClass.class.st
+++ b/smalltalksrc/Melchor/VMClass.class.st
@@ -287,6 +287,13 @@ VMClass class >> objectRepresentationClass [
 	^self objectMemoryClass objectRepresentationClass
 ]
 
+{ #category : #accessing }
+VMClass class >> resetInitializationOptions [
+
+	self release.
+	InitializationOptions := nil
+]
+
 { #category : #translation }
 VMClass class >> shouldGenerateTypedefFor: aStructClass [
 	"Hack to work-around multiple definitions.  Sometimes a type has been defined in an include."

--- a/smalltalksrc/Melchor/VMClass.class.st
+++ b/smalltalksrc/Melchor/VMClass.class.st
@@ -287,6 +287,13 @@ VMClass class >> objectRepresentationClass [
 	^self objectMemoryClass objectRepresentationClass
 ]
 
+{ #category : #acccessing }
+VMClass class >> resetInitializationOptions [
+
+	super release.
+	InitializationOptions := nil
+]
+
 { #category : #translation }
 VMClass class >> shouldGenerateTypedefFor: aStructClass [
 	"Hack to work-around multiple definitions.  Sometimes a type has been defined in an include."

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -4755,6 +4755,7 @@ CCodeGenerator >> stepExpressionIsNegative: aNode [
 
 { #category : #accessing }
 CCodeGenerator >> stopOnErrors [
+	"Answer <true> if we should stop on errors during generation"
 
 	^ stopOnErrors
 		ifNil: [ stopOnErrors := true ]

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -3025,7 +3025,7 @@ CCodeGenerator >> includeAPIFrom: aCCodeGenerator [
 CCodeGenerator >> inferTypes [
 	
 	(SlangTyper on: self)
-		stopOnErrors: stopOnErrors;
+		stopOnErrors: self stopOnErrors;
 		inferTypes
 ]
 


### PR DESCRIPTION
Add resetInitializationOptions to clean state after VM generation.