### PR TITLE
Updates for plugin generation in pharo-10

### DIFF
--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -626,9 +626,6 @@ StackInterpreter class >> initializeBytecodeTable [
 	VMBytecodeConstants falsifyBytecodeSetFlags: InitializationOptions.
 	BytecodeSetHasDirectedSuperSend := false.
 
-	(InitializationOptions at: #bytecodeTableInitializer ifAbsent: nil) 
-		ifNotNil: [ :initalizer | ^ self perform: initalizer ].
-
 	^ self initializeBytecodeTableForSistaV1
 ]
 

--- a/smalltalksrc/VMMakerCompatibilityForPharo6/PharoVMMaker.class.st
+++ b/smalltalksrc/VMMakerCompatibilityForPharo6/PharoVMMaker.class.st
@@ -211,7 +211,9 @@ PharoVMMaker >> vmMakerWith: interpreterClass memoryManager: memoryManager [
 
 	| platformDirectory |
 	VMMakerConfiguration initializeForPharo.
-	(interpreterClass bindingOf: #COGMTVM) value: false.
+
+	(interpreterClass bindingOf: #COGMTVM)
+		ifNotNil: [ : binding | binding value: false ].
 
 	platformDirectory := self platformDirectoryFor: memoryManager.
 
@@ -219,7 +221,7 @@ PharoVMMaker >> vmMakerWith: interpreterClass memoryManager: memoryManager [
 	^ (VMMaker
 		   makerFor: interpreterClass
 		   and: StackToRegisterMappingCogit
-		   with: { 
+		   with: {
 				   #COGMTVM.
 				   false.
 				   #ObjectMemory.

--- a/smalltalksrc/VMMakerCompatibilityForPharo6/PharoVMMaker.class.st
+++ b/smalltalksrc/VMMakerCompatibilityForPharo6/PharoVMMaker.class.st
@@ -211,25 +211,14 @@ PharoVMMaker >> vmMakerWith: interpreterClass memoryManager: memoryManager [
 
 	| platformDirectory |
 	VMMakerConfiguration initializeForPharo.
-
-	(interpreterClass bindingOf: #COGMTVM)
-		ifNotNil: [ : binding | binding value: false ].
-
 	platformDirectory := self platformDirectoryFor: memoryManager.
-
 
 	^ (VMMaker
 		   makerFor: interpreterClass
 		   and: StackToRegisterMappingCogit
 		   with: {
-				   #COGMTVM.
-				   false.
-				   #ObjectMemory.
-				   memoryManager name.
-				   #MULTIPLEBYTECODESETS.
-				   true.
-				   #bytecodeTableInitializer.
-				   #initializeBytecodeTableForSqueakV3PlusClosuresSistaV1Hybrid }
+				   #ObjectMemory . memoryManager name .
+				   #MULTIPLEBYTECODESETS . true }
 		   to: platformDirectory
 		   platformDir: platformDirectory
 		   including: #(  )


### PR DESCRIPTION
Includes fixes for compiling plugins in pharo-10 branch.
Since we only have #initializeBytecodeTableForSistaV1 in pharo-10 in `StackInterpreter>>initializeBytecodeTable`

However it does not remove the line including the reference to #COGMTVM in `PharoVMMaker>>vmMakerWith:memoryManager: ` since it is included in a compatibility package with Pharo 6.