### PR TITLE
Link against a shared SDL2 if already installed in target

### DIFF
--- a/cmake/FindSDL2.cmake
+++ b/cmake/FindSDL2.cmake
@@ -115,14 +115,6 @@ IF(NOT SDL2_BUILDING_LIBRARY)
 	ENDIF(NOT ${SDL2_INCLUDE_DIR} MATCHES ".framework")
 ENDIF(NOT SDL2_BUILDING_LIBRARY)
 
-if(NOT TARGET SDL2)
-    add_library(SDL2 SHARED IMPORTED)
-    set_target_properties(SDL2 PROPERTIES
-            IMPORTED_LOCATION "${LIBGIT2_LIBRARY}"
-            INTERFACE_INCLUDE_DIRECTORIES "${LIBGIT2_INCLUDE_PATH}"
-    )
-endif()
-
 # SDL2 may require threads on your system.
 # The Apple build may not need an explicit flag because one of the
 # frameworks may already provide it.

--- a/cmake/FindSDL2.cmake
+++ b/cmake/FindSDL2.cmake
@@ -64,14 +64,13 @@
 # (To distribute this file outside of CMake, substitute the full
 #  License text for the above reference.)
 
-# message("<FindSDL2.cmake>")
-
 SET(SDL2_SEARCH_PATHS
 	~/Library/Frameworks
 	/Library/Frameworks
 	/usr/local
 	/usr
 	/sw # Fink
+	/opt/homebrew
 	/opt/local # DarwinPorts
 	/opt/csw # Blastwave
 	/opt
@@ -79,9 +78,9 @@ SET(SDL2_SEARCH_PATHS
 )
 
 FIND_PATH(SDL2_INCLUDE_DIR SDL.h
-	HINTS
-	$ENV{SDL2DIR}
-	PATH_SUFFIXES include/SDL2 include
+	HINTS $ENV{SDL2DIR}
+	# path suffixes to search inside ENV{SDLDIR}
+	PATH_SUFFIXES SDL2 include/SDL2 include
 	PATHS ${SDL2_SEARCH_PATHS}
 )
 
@@ -94,8 +93,9 @@ endif()
 FIND_LIBRARY(SDL2_LIBRARY_TEMP
 	NAMES SDL2
 	HINTS
-	$ENV{SDL2DIR}
-	PATH_SUFFIXES ${PATH_SUFFIXES}
+		$ENV{SDL2DIR}
+	PATH_SUFFIXES 
+		lib ${PATH_SUFFIXES}
 	PATHS ${SDL2_SEARCH_PATHS}
 )
 
@@ -114,6 +114,14 @@ IF(NOT SDL2_BUILDING_LIBRARY)
 		)
 	ENDIF(NOT ${SDL2_INCLUDE_DIR} MATCHES ".framework")
 ENDIF(NOT SDL2_BUILDING_LIBRARY)
+
+if(NOT TARGET SDL2)
+    add_library(SDL2 SHARED IMPORTED)
+    set_target_properties(SDL2 PROPERTIES
+            IMPORTED_LOCATION "${LIBGIT2_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES "${LIBGIT2_INCLUDE_PATH}"
+    )
+endif()
 
 # SDL2 may require threads on your system.
 # The Apple build may not need an explicit flag because one of the
@@ -170,3 +178,4 @@ ENDIF(SDL2_LIBRARY_TEMP)
 INCLUDE(FindPackageHandleStandardArgs)
 
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2 REQUIRED_VARS SDL2_LIBRARY SDL2_INCLUDE_DIR)
+

--- a/cmake/importSDL2.cmake
+++ b/cmake/importSDL2.cmake
@@ -78,8 +78,7 @@ if (BUILD_BUNDLE)
         download_SDL2()
       endif()
     else()
-      # SDL2 found, then make a symlink to it
-      # Obtain the library location from the SDL2 CMake exported properties
+      # SDL2 found, get the library location from the SDL2 CMake exported properties
       get_target_property(SDL2_LIBDIR SDL2::SDL2 IMPORTED_LOCATION)
       # SDL2_LIBDIR now contains the full path to the library including the file (.so/.dll/.dylib)
       message(STATUS "Using system libSDL2 from ${SDL2_LIBDIR}")  

--- a/cmake/importSDL2.cmake
+++ b/cmake/importSDL2.cmake
@@ -1,7 +1,6 @@
 function(find_system_SDL2)
     message(STATUS "Looking for SDL2 in the system")
     # Try to use SDL2 provided .cmake files (see NO_MODULE below)
-    # find_package(SDL2)
     include(FindPackageHandleStandardArgs)
     # first specifically look for the CMake config version of SDL2 (either system or package manager)
     # provides two TARGETs SDL2::SDL2 and SDL2::SDL2Main
@@ -56,25 +55,6 @@ function(build_SDL2)
     set(SDL2_FOUND "From build_SDL2" PARENT_SCOPE)
 endfunction()
 
-function(link_to_system_SDL2)
-  # Obtain the library location from the SDL2 CMake exported properties
-  get_target_property(SDL2_LIBDIR SDL2::SDL2 IMPORTED_LOCATION)
-  # SDL2_LIBDIR now contains the full path to the library including the file (.so/.dll/.dylib)
-  message(STATUS "Linking to system libSDL2 from ${SDL2_LIBDIR}")  
-  # Warning: Symbolic links created here are harcoded in the SDL2 class>>findSDL2 method
-  if (WIN)
-    add_custom_target(libsdl2_copy
-    COMMAND ${CMAKE_COMMAND} -E create_symlink ${SDL2_LIBDIR} ${LIBRARY_OUTPUT_PATH}/SDL2.dll)
-  elseif(OSX)
-      add_custom_target(libsdl2_copy
-        COMMAND ${CMAKE_COMMAND} -E create_symlink ${SDL2_LIBDIR} ${LIBRARY_OUTPUT_PATH}/libSDL2-2.0.0.dylib)
-      else() # LINUX
-        add_custom_target(libsdl2_copy
-        COMMAND ${CMAKE_COMMAND} -E create_symlink ${SDL2_LIBDIR} ${LIBRARY_OUTPUT_PATH}/libSDL2-2.0.so.0.2.1)
-  endif()
-  add_dependencies(${VM_LIBRARY_NAME} libsdl2_copy)
-endfunction()
-
 if (BUILD_BUNDLE)
   if(DEPENDENCIES_FORCE_BUILD)
     build_SDL2()
@@ -99,7 +79,10 @@ if (BUILD_BUNDLE)
       endif()
     else()
       # SDL2 found, then make a symlink to it
-      link_to_system_SDL2()
+      # Obtain the library location from the SDL2 CMake exported properties
+      get_target_property(SDL2_LIBDIR SDL2::SDL2 IMPORTED_LOCATION)
+      # SDL2_LIBDIR now contains the full path to the library including the file (.so/.dll/.dylib)
+      message(STATUS "Using system libSDL2 from ${SDL2_LIBDIR}")  
 	  endif()
   endif()
 endif()


### PR DESCRIPTION
Try to use the SDL2 .cmake files and, if found, use their properties to create a symlink to the detected library.
Add a search path for Apple ARM Macs since now homebrew installs libraries such as SDL2 under /opt/homebrew.
