### PR TITLE
Druid flavours for Benchy

### DIFF
--- a/smalltalksrc/VMMaker/DruidMirorCogit.class.st
+++ b/smalltalksrc/VMMaker/DruidMirorCogit.class.st
@@ -1,0 +1,25 @@
+Class {
+	#name : #DruidMirorCogit,
+	#superclass : #StackToRegisterMappingCogit,
+	#category : #'VMMaker-JIT'
+}
+
+{ #category : #initialization }
+DruidMirorCogit class >> initializePrimitiveTable [
+
+	<generated>
+	MaxCompiledPrimitiveIndex := 10.
+	primitiveTable := CArrayAccessor on:
+		                  (Array new: MaxCompiledPrimitiveIndex + 1).
+	self table: primitiveTable from: self primitiveTableArray
+]
+
+{ #category : #'class initialization' }
+DruidMirorCogit class >> primitiveTableArray [
+
+	^ DruidJIT primitiveTableArray collect: [ :tuple |
+		  {
+			  tuple first.
+			  (tuple second copyReplaceAll: '_' with: '').
+			  tuple third } ]
+]

--- a/smalltalksrc/VMMaker/DruidMirrorCogit.class.st
+++ b/smalltalksrc/VMMaker/DruidMirrorCogit.class.st
@@ -1,11 +1,11 @@
 Class {
-	#name : #DruidMirorCogit,
+	#name : #DruidMirrorCogit,
 	#superclass : #StackToRegisterMappingCogit,
 	#category : #'VMMaker-JIT'
 }
 
 { #category : #initialization }
-DruidMirorCogit class >> initializePrimitiveTable [
+DruidMirrorCogit class >> initializePrimitiveTable [
 
 	<generated>
 	MaxCompiledPrimitiveIndex := 10.
@@ -15,11 +15,11 @@ DruidMirorCogit class >> initializePrimitiveTable [
 ]
 
 { #category : #'class initialization' }
-DruidMirorCogit class >> primitiveTableArray [
+DruidMirrorCogit class >> primitiveTableArray [
 
 	^ DruidJIT primitiveTableArray collect: [ :tuple |
 		  {
 			  tuple first.
-			  (tuple second copyReplaceAll: '_' with: '').
+			  (tuple second copyReplaceAll: '_' with: '') asSymbol.
 			  tuple third } ]
 ]

--- a/smalltalksrc/VMMaker/JITZeroCogit.class.st
+++ b/smalltalksrc/VMMaker/JITZeroCogit.class.st
@@ -1,0 +1,11 @@
+Class {
+	#name : #JITZeroCogit,
+	#superclass : #DruidMirrorCogit,
+	#category : #'VMMaker-JIT'
+}
+
+{ #category : #'class initialization' }
+JITZeroCogit class >> primitiveTableArray [
+
+	^ {  }
+]

--- a/smalltalksrc/VMMakerCompatibilityForPharo6/PharoVMMaker.class.st
+++ b/smalltalksrc/VMMakerCompatibilityForPharo6/PharoVMMaker.class.st
@@ -152,6 +152,18 @@ PharoVMMaker >> generateDruidVM [
 ]
 
 { #category : #generation }
+PharoVMMaker >> generateJITVM [
+
+	self generateCoInterpreter
+]
+
+{ #category : #generation }
+PharoVMMaker >> generateJITZeroVM [
+
+	self generate: CoInterpreter memoryManager: Spur64BitCoMemoryManager compilerClass: JITZeroCogit	
+]
+
+{ #category : #generation }
 PharoVMMaker >> generateSistaVM [
 
 	self

--- a/smalltalksrc/VMMakerCompatibilityForPharo6/PharoVMMaker.class.st
+++ b/smalltalksrc/VMMakerCompatibilityForPharo6/PharoVMMaker.class.st
@@ -137,9 +137,9 @@ PharoVMMaker >> generateCoInterpreter [
 ]
 
 { #category : #generation }
-PharoVMMaker >> generateDruidMirorVM [
+PharoVMMaker >> generateDruidMirrorVM [
 
-	self generate: CoInterpreter memoryManager: Spur64BitCoMemoryManager compilerClass: DruidMirorCogit	
+	self generate: CoInterpreter memoryManager: Spur64BitCoMemoryManager compilerClass: DruidMirrorCogit	
 ]
 
 { #category : #generation }

--- a/smalltalksrc/VMMakerCompatibilityForPharo6/PharoVMMaker.class.st
+++ b/smalltalksrc/VMMakerCompatibilityForPharo6/PharoVMMaker.class.st
@@ -137,6 +137,12 @@ PharoVMMaker >> generateCoInterpreter [
 ]
 
 { #category : #generation }
+PharoVMMaker >> generateDruidMirorVM [
+
+	self generate: CoInterpreter memoryManager: Spur64BitCoMemoryManager compilerClass: DruidMirorCogit	
+]
+
+{ #category : #generation }
 PharoVMMaker >> generateDruidVM [
 
 	self


### PR DESCRIPTION
Fix https://gitlab.inria.fr/RMOD/alamvic/druid/-/issues/141

Adding new flavours for Druid VM compilation and friends. Now we have:

- `JITVM`: Full JIT VM. (Alias for ex `CoInterpreter`)
- `StackVM`: VM without JIT, just interpreter
- `DruidVM`: VM with JIT generated for Druid (fixed list of primitives to compile)
- `DruidMirrorVM`: JIT handwritten VM with the same support as Druid (same fixed list of primitives to compile)
- `JITZeroVM`: a VM with JIT support but no primitives implemented

All these flavours are available from CMake commands 👍 