### PR TITLE
Druid zero

### DIFF
--- a/smalltalksrc/VMMaker/Cogit.class.st
+++ b/smalltalksrc/VMMaker/Cogit.class.st
@@ -6860,7 +6860,7 @@ Cogit >> gen: opcode operand: operand [
 	<returnTypeC: #'AbstractInstruction *'>
 	<var: #abstractInstruction type: #'AbstractInstruction *'>
 	| abstractInstruction |
-	abstractInstruction := self gen: opcodeIndex.
+	abstractInstruction := self gen: opcode.
 	abstractInstruction operands at: 0 put: operand.
 	^ abstractInstruction
 ]

--- a/smalltalksrc/VMMaker/Cogit.class.st
+++ b/smalltalksrc/VMMaker/Cogit.class.st
@@ -6175,29 +6175,33 @@ Cogit >> endPCOf: aMethod [
 { #category : #initialization }
 Cogit >> ensureAndClearAbstractOpcodes: numberOfAbstractOpcodes [
 
-	| opcodeBytes fixupBytes allocBytes clearFixupsBytes clearOpcodesBytes|
+	| opcodeBytes fixupBytes allocBytes clearFixupsBytes clearOpcodesBytes |
 	numAbstractOpcodes := numberOfAbstractOpcodes.
-	
-	opcodeBytes := (self sizeof: CogAbstractInstruction) * MaxNumberOfAbstractOpcodes.
-	fixupBytes := (self sizeof: CogBytecodeFixup) * MaxNumberOfAbstractOpcodes.
-	allocBytes := opcodeBytes + fixupBytes.
-	
-	clearOpcodesBytes := (self sizeof: CogAbstractInstruction) * numberOfAbstractOpcodes.
-	clearFixupsBytes := (self sizeof: CogBytecodeFixup) * numberOfAbstractOpcodes.
-		
-	self
-		cCode:
-			[abstractOpcodes 
-				ifNil: [
-					abstractOpcodes := self malloc: allocBytes.
-					fixups := (abstractOpcodes asUnsignedInteger + opcodeBytes) asVoidPointer].
-				
-			 self b: abstractOpcodes zero: clearOpcodesBytes.
-			 self b: fixups zero: clearFixupsBytes]
-		inSmalltalk:
-			[abstractOpcodes := CArrayAccessor on: ((1 to: numAbstractOpcodes) collect: [:ign| CogCompilerClass for: self]).
-			 fixups := CArrayAccessor on: ((1 to: numAbstractOpcodes) collect: [:ign| self bytecodeFixupClass for: self])].
 
+	opcodeBytes := (self sizeof: CogAbstractInstruction)
+	               * MaxNumberOfAbstractOpcodes.
+	fixupBytes := (self sizeof: CogBytecodeFixup)
+	              * MaxNumberOfAbstractOpcodes.
+	allocBytes := opcodeBytes + fixupBytes.
+
+	clearOpcodesBytes := (self sizeof: CogAbstractInstruction)
+	                     * numberOfAbstractOpcodes.
+	clearFixupsBytes := (self sizeof: CogBytecodeFixup)
+	                    * numberOfAbstractOpcodes.
+
+	abstractOpcodes ifNil: [
+		self
+			cCode: [
+				abstractOpcodes := self malloc: allocBytes.
+				fixups := (abstractOpcodes asUnsignedInteger + opcodeBytes)
+					          asVoidPointer ]
+			inSmalltalk: [
+				abstractOpcodes := CArrayAccessor on:
+					                   ((1 to: MaxNumberOfAbstractOpcodes) collect: [
+						                    :ign | CogCompilerClass for: self ]).
+				fixups := CArrayAccessor on:
+					          ((1 to: MaxNumberOfAbstractOpcodes) collect: [ :ign |
+						           self bytecodeFixupClass for: self ]) ] ]
 ]
 
 { #category : #'compile abstract instructions' }

--- a/smalltalksrc/VMMaker/Cogit.class.st
+++ b/smalltalksrc/VMMaker/Cogit.class.st
@@ -3260,31 +3260,51 @@ Cogit >> allMethodsHaveCorrectHeader [
 
 { #category : #initialization }
 Cogit >> allocateOpcodes: numberOfAbstractOpcodes bytecodes: numberOfBytecodes [
-
 	"Allocate the various arrays needed to compile abstract instructions.
 	 Notionally we only need as many fixups as there are bytecodes.  But we
 	 reuse fixups to record pc-dependent instructions in generateInstructionsAt:
 	 and so need at least as many as there are abstract opcodes."
 
 	<inline: true>
-	self ensureAndClearAbstractOpcodes: numberOfAbstractOpcodes.
-	self zeroOpcodeIndexForNewOpcodes.
-	labelCounter := 0
+	self
+		allocateOpcodes: numberOfAbstractOpcodes
+		bytecodes: numberOfBytecodes
+		ifFail: [ self error: 'Cannot allocate requested opcodes' ]
 ]
 
 { #category : #initialization }
 Cogit >> allocateOpcodes: numberOfAbstractOpcodes bytecodes: numberOfBytecodes ifFail: failBlock [
-
 	"Allocate the various arrays needed to compile abstract instructions, failing if the size
 	 needed is considered too high.  Notionally we only need as many fixups as there are
 	 bytecodes.  But we reuse fixups to record pc-dependent instructions in
 	 generateInstructionsAt: and so need at least as many as there are abstract opcodes."
 
 	<inline: true>
-	numberOfAbstractOpcodes > MaxNumberOfAbstractOpcodes ifTrue: [ 
+	numberOfAbstractOpcodes > MaxNumberOfAbstractOpcodes ifTrue: [
 		^ failBlock value ].
+	
+	"Remember how many opcodes were allocated, then lazy initialize to max"
+	numAbstractOpcodes := numberOfAbstractOpcodes.
+	abstractOpcodes ifNil: [
+		| opcodeBytes fixupBytes allocBytes |
+		opcodeBytes := (self sizeof: CogAbstractInstruction)
+		               * MaxNumberOfAbstractOpcodes.
+		fixupBytes := (self sizeof: CogBytecodeFixup)
+		              * MaxNumberOfAbstractOpcodes.
+		allocBytes := opcodeBytes + fixupBytes.
 
-	self ensureAndClearAbstractOpcodes: numberOfAbstractOpcodes.
+		self
+			cCode: [
+				abstractOpcodes := self malloc: allocBytes.
+				fixups := (abstractOpcodes asUnsignedInteger + opcodeBytes)
+					          asVoidPointer ]
+			inSmalltalk: [
+				abstractOpcodes := CArrayAccessor on:
+					                   ((1 to: MaxNumberOfAbstractOpcodes) collect: [
+						                    :ign | CogCompilerClass for: self ]).
+				fixups := CArrayAccessor on:
+					          ((1 to: MaxNumberOfAbstractOpcodes) collect: [ :ign |
+						           self bytecodeFixupClass for: self ]) ] ].
 
 	self zeroOpcodeIndexForNewOpcodes.
 	labelCounter := 0
@@ -6170,38 +6190,6 @@ Cogit >> endPCOf: aMethod [
 		nExts := descriptor isExtension ifTrue: [nExts + 1] ifFalse: [0].
 		pc := pc + descriptor numBytes].
 	^end
-]
-
-{ #category : #initialization }
-Cogit >> ensureAndClearAbstractOpcodes: numberOfAbstractOpcodes [
-
-	| opcodeBytes fixupBytes allocBytes clearFixupsBytes clearOpcodesBytes |
-	numAbstractOpcodes := numberOfAbstractOpcodes.
-
-	opcodeBytes := (self sizeof: CogAbstractInstruction)
-	               * MaxNumberOfAbstractOpcodes.
-	fixupBytes := (self sizeof: CogBytecodeFixup)
-	              * MaxNumberOfAbstractOpcodes.
-	allocBytes := opcodeBytes + fixupBytes.
-
-	clearOpcodesBytes := (self sizeof: CogAbstractInstruction)
-	                     * numberOfAbstractOpcodes.
-	clearFixupsBytes := (self sizeof: CogBytecodeFixup)
-	                    * numberOfAbstractOpcodes.
-
-	abstractOpcodes ifNil: [
-		self
-			cCode: [
-				abstractOpcodes := self malloc: allocBytes.
-				fixups := (abstractOpcodes asUnsignedInteger + opcodeBytes)
-					          asVoidPointer ]
-			inSmalltalk: [
-				abstractOpcodes := CArrayAccessor on:
-					                   ((1 to: MaxNumberOfAbstractOpcodes) collect: [
-						                    :ign | CogCompilerClass for: self ]).
-				fixups := CArrayAccessor on:
-					          ((1 to: MaxNumberOfAbstractOpcodes) collect: [ :ign |
-						           self bytecodeFixupClass for: self ]) ] ]
 ]
 
 { #category : #'compile abstract instructions' }

--- a/smalltalksrc/VMMaker/Cogit.class.st
+++ b/smalltalksrc/VMMaker/Cogit.class.st
@@ -6821,6 +6821,10 @@ Cogit >> gen: opcode [ "<Integer>"
 	opcodeIndex := opcodeIndex + 1.
 	abstractInstruction opcode: opcode.
 	self cCode: '' inSmalltalk: [abstractInstruction bcpc: bytecodePC].
+	
+	"Force the initialization of the annotation to nil"
+	abstractInstruction annotation: nil.
+	
 	^abstractInstruction
 ]
 
@@ -6849,18 +6853,16 @@ Cogit >> gen: opcode "<Integer>" literal: operandOne "<Integer>" operand: operan
 ]
 
 { #category : #'compile abstract instructions' }
-Cogit >> gen: opcode "<Integer>" operand: operand [ "<Integer|CogAbstractInstruction>"
-	| abstractInstruction |
+Cogit >> gen: opcode operand: operand [
+	"<Integer|CogAbstractInstruction>"
+
 	<inline: false>
 	<returnTypeC: #'AbstractInstruction *'>
 	<var: #abstractInstruction type: #'AbstractInstruction *'>
-	self assert: opcodeIndex < numAbstractOpcodes.
-	abstractInstruction := self abstractInstructionAt: opcodeIndex.
-	opcodeIndex := opcodeIndex + 1.
-	abstractInstruction opcode: opcode.
+	| abstractInstruction |
+	abstractInstruction := self gen: opcodeIndex.
 	abstractInstruction operands at: 0 put: operand.
-	self cCode: '' inSmalltalk: [abstractInstruction bcpc: bytecodePC].
-	^abstractInstruction
+	^ abstractInstruction
 ]
 
 { #category : #'compile abstract instructions' }
@@ -6876,54 +6878,49 @@ Cogit >> gen: opcode "<Integer>" operand: operandOne "<Integer|CogAbstractInstru
 ]
 
 { #category : #'compile abstract instructions' }
-Cogit >> gen: opcode "<Integer>" operand: operandOne "<Integer|CogAbstractInstruction>" operand: operandTwo [ "<Integer|CogAbstractInstruction>"
-	| abstractInstruction |
+Cogit >> gen: opcode operand: operandOne operand: operandTwo [
+	"<Integer|CogAbstractInstruction>"
+
 	<inline: false>
 	<returnTypeC: #'AbstractInstruction *'>
 	<var: #abstractInstruction type: #'AbstractInstruction *'>
-	self assert: opcodeIndex < numAbstractOpcodes.
-	abstractInstruction := self abstractInstructionAt: opcodeIndex.
-	opcodeIndex := opcodeIndex + 1.
-	abstractInstruction opcode: opcode.
-	abstractInstruction operands at: 0 put: operandOne.
+	| abstractInstruction |
+	abstractInstruction := self gen: opcode operand: operandOne.
 	abstractInstruction operands at: 1 put: operandTwo.
-	self cCode: '' inSmalltalk: [abstractInstruction bcpc: bytecodePC].
-	^abstractInstruction
+	^ abstractInstruction
 ]
 
 { #category : #'compile abstract instructions' }
-Cogit >> gen: opcode "<Integer>" operand: operandOne "<Integer|CogAbstractInstruction>" operand: operandTwo "<Integer|CogAbstractInstruction>" operand: operandThree [ "<Integer|CogAbstractInstruction>"
-	| abstractInstruction |
+Cogit >> gen: opcode operand: operandOne operand: operandTwo operand: operandThree [
+	"<Integer|CogAbstractInstruction>"
+
 	<inline: false>
 	<returnTypeC: #'AbstractInstruction *'>
 	<var: #abstractInstruction type: #'AbstractInstruction *'>
-	self assert: opcodeIndex < numAbstractOpcodes.
-	abstractInstruction := self abstractInstructionAt: opcodeIndex.
-	opcodeIndex := opcodeIndex + 1.
-	abstractInstruction opcode: opcode.
-	abstractInstruction operands at: 0 put: operandOne.
-	abstractInstruction operands at: 1 put: operandTwo.
+	| abstractInstruction |
+	abstractInstruction := self
+		                       gen: opcode
+		                       operand: operandOne
+		                       operand: operandTwo.
 	abstractInstruction operands at: 2 put: operandThree.
-	self cCode: '' inSmalltalk: [abstractInstruction bcpc: bytecodePC].
-	^abstractInstruction
+	^ abstractInstruction
 ]
 
 { #category : #'compile abstract instructions' }
-Cogit >> gen: opcode "<Integer>" operand: operandOne "<Integer|CogAbstractInstruction>" operand: operandTwo "<Integer|CogAbstractInstruction>" operand: operandThree "<Integer|CogAbstractInstruction>" operand: operandFour [ "<Integer|CogAbstractInstruction>"
-	| abstractInstruction |
+Cogit >> gen: opcode operand: operandOne operand: operandTwo operand: operandThree operand: operandFour [
+	"<Integer|CogAbstractInstruction>"
+
 	<inline: false>
 	<returnTypeC: #'AbstractInstruction *'>
 	<var: #abstractInstruction type: #'AbstractInstruction *'>
-	self assert: opcodeIndex < numAbstractOpcodes.
-	abstractInstruction := self abstractInstructionAt: opcodeIndex.
-	opcodeIndex := opcodeIndex + 1.
-	abstractInstruction opcode: opcode.
-	abstractInstruction operands at: 0 put: operandOne.
-	abstractInstruction operands at: 1 put: operandTwo.
-	abstractInstruction operands at: 2 put: operandThree.
+	| abstractInstruction |
+	abstractInstruction := self
+		                       gen: opcode
+		                       operand: operandOne
+		                       operand: operandTwo
+		                       operand: operandThree.
 	abstractInstruction operands at: 3 put: operandFour.
-	self cCode: '' inSmalltalk: [abstractInstruction bcpc: bytecodePC].
-	^abstractInstruction
+	^ abstractInstruction
 ]
 
 { #category : #'compile abstract instructions' }

--- a/smalltalksrc/VMMaker/DruidJIT.class.st
+++ b/smalltalksrc/VMMaker/DruidJIT.class.st
@@ -59,14 +59,17 @@ DruidJIT class >> initializeBytecodeTableForSistaV1 [
 	BytecodeSetHasExtensions := true.
 	FirstSpecialSelector := 96.
 	NumSpecialSelectors := 32.
-	self generatorTableFrom: {  }
+	self generatorTableFrom: { 
+		#(1   0 223 unknownBytecode).
+		#(2 224 247 unknownBytecode).
+		#(3 248 255 unknownBytecode) }
 ]
 
 { #category : #'class initialization' }
 DruidJIT class >> initializePrimitiveTable [
 
 	<generated>
-	MaxCompiledPrimitiveIndex := 9.
+	MaxCompiledPrimitiveIndex := 17.
 	primitiveTable := CArrayAccessor on:
 		                  (Array new: MaxCompiledPrimitiveIndex + 1).
 	self table: primitiveTable from: self primitiveTableArray.
@@ -97,7 +100,15 @@ DruidJIT class >> primitiveTableArray [
 		  { 6. #gen_PrimitiveGreaterOrEqual. 1 }.
 		  { 7. #gen_PrimitiveEqual. 1 }.
 		  { 8. #gen_PrimitiveNotEqual. 1 }.
-		  { 9. #gen_PrimitiveMultiply. 1 } }
+		  { 9. #gen_PrimitiveMultiply. 1 }.
+		  { 10. #gen_primitiveDivide. 1 }.
+		  { 73. #genNonImplementedPrimitive. -1. #maycallback }.
+		  { 117. #genNonImplementedPrimitive. -1. #maycallback }.
+		  { 120. #genNonImplementedPrimitive. -1. #maycallback }.
+		  { 148. #genNonImplementedPrimitive. -1. #maycallback }.
+		  { 160. #genNonImplementedPrimitive. -1. #maycallback }.
+		  { 173. #genNonImplementedPrimitive. -1. #maycallback }.
+		  { 216. #genNonImplementedPrimitive. -1. #maycallback } }
 ]
 
 { #category : #'trait candidates' }

--- a/smalltalksrc/VMMaker/DruidJIT.class.st
+++ b/smalltalksrc/VMMaker/DruidJIT.class.st
@@ -50,12 +50,27 @@ DruidJIT class >> initialize [
 ]
 
 { #category : #'class initialization' }
+DruidJIT class >> initializeBytecodeTableForSistaV1 [
+
+	<generated>
+	numPushNilsFunction := #sistaV1:Num:Push:Nils:.
+	pushNilSizeFunction := #sistaV1PushNilSize:numInitialNils:.
+	BytecodeSetHasDirectedSuperSend := true.
+	BytecodeSetHasExtensions := true.
+	FirstSpecialSelector := 96.
+	NumSpecialSelectors := 32.
+	self generatorTableFrom: {  }
+]
+
+{ #category : #'class initialization' }
 DruidJIT class >> initializePrimitiveTable [
 
 	<generated>
-	MaxCompiledPrimitiveIndex := 17.
-	primitiveTable := CArrayAccessor on: (Array new: MaxCompiledPrimitiveIndex + 1).
-	self table: primitiveTable from: self primitiveTableArray
+	MaxCompiledPrimitiveIndex := 9.
+	primitiveTable := CArrayAccessor on:
+		                  (Array new: MaxCompiledPrimitiveIndex + 1).
+	self table: primitiveTable from: self primitiveTableArray.
+	^ primitiveTable
 ]
 
 { #category : #translation }
@@ -74,23 +89,15 @@ DruidJIT class >> primitiveTableArray [
 
 	<generated>
 	^ {
-		  { 1. #gen_primitiveAdd. 1 }.
-		  { 2. #gen_primitiveSubtract. 1 }.
-		  { 3. #gen_primitiveLessThan. 1 }.
-		  { 4. #gen_primitiveGreaterThan. 1 }.
-		  { 5. #gen_primitiveLessOrEqual. 1 }.
-		  { 6. #gen_primitiveGreaterOrEqual. 1 }.
-		  { 7. #gen_primitiveEqual. 1 }.
-		  { 8. #gen_primitiveNotEqual. 1 }.
-		  { 9. #gen_primitiveMultiply. 1 }.
-		  { 10. #gen_primitiveDivide. 1 }.
-		  { 73. #genNonImplementedPrimitive.  -1. #maycallback }.
-		  { 117. #genNonImplementedPrimitive.  -1. #maycallback }.
-		  { 120. #genNonImplementedPrimitive.  -1. #maycallback }.
-		  { 148. #genNonImplementedPrimitive.  -1. #maycallback }.
-		  { 160. #genNonImplementedPrimitive.  -1. #maycallback }.
-		  { 173. #genNonImplementedPrimitive.  -1. #maycallback }.
-		  { 216. #genNonImplementedPrimitive.  -1. #maycallback } }
+		  { 1. #gen_PrimitiveAdd. 1 }.
+		  { 2. #gen_PrimitiveSubtract. 1 }.
+		  { 3. #gen_PrimitiveLessThan. 1 }.
+		  { 4. #gen_PrimitiveGreaterThan. 1 }.
+		  { 5. #gen_PrimitiveLessOrEqual. 1 }.
+		  { 6. #gen_PrimitiveGreaterOrEqual. 1 }.
+		  { 7. #gen_PrimitiveEqual. 1 }.
+		  { 8. #gen_PrimitiveNotEqual. 1 }.
+		  { 9. #gen_PrimitiveMultiply. 1 } }
 ]
 
 { #category : #'trait candidates' }

--- a/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
+++ b/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
@@ -921,9 +921,10 @@ StackToRegisterMappingCogit >> ceCallCogCodePopReceiverArg1Arg0Regs [
 	self simulateEnilopmart: ceCallCogCodePopReceiverArg1Arg0Regs numArgs: 3
 ]
 
-{ #category : #trampolines }
+{ #category : #accessing }
 StackToRegisterMappingCogit >> ceMethodAbortTrampoline: trampoline [
 
+	<doNotGenerate>
 	super ceMethodAbortTrampoline: trampoline.
 	^ methodAbortTrampolines at: 0 put: trampoline
 ]


### PR DESCRIPTION
- do not eagerly clean ir memory on each compilation
- Druid maps all bytecodes to unknownBytecode