### PR TITLE
Do not use newer CMAKE features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,6 +299,9 @@ message(STATUS "Full Platform name: ${FULL_PLATFORM_NAME}")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g ${COMMON_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g ${COMMON_FLAGS}")
 
+# Set compilation flags for debug (or not)
+# This could be replaced by CMake generator expressions in newer versions
+# However, we need to stay compatible with old CMake versions for builds in old debians
 if (${CMAKE_BUILD_TYPE} MATCHES "Debug")
 	set(OPTIMIZATION_LEVEL -O0)
 	set(DEBUGVM 1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,9 +299,16 @@ message(STATUS "Full Platform name: ${FULL_PLATFORM_NAME}")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g ${COMMON_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g ${COMMON_FLAGS}")
 
+if (${CMAKE_BUILD_TYPE} MATCHES "Debug")
+	set(OPTIMIZATION_LEVEL -O0)
+	set(DEBUGVM 1)
+else()
+	set(OPTIMIZATION_LEVEL -O2)
+	set(DEBUGVM 0)
+endif()
+
 add_compile_options(
-    $<$<CONFIG:DEBUG>:-O0>
-    $<$<NOT:$<CONFIG:DEBUG>>:-O2>
+	${OPTIMIZATION_LEVEL}
     -Wno-sometimes-uninitialized
     -Wno-self-assign
     -Wno-unused-variable
@@ -327,12 +334,13 @@ add_compile_options(
     -Wno-shift-negative-value
 )
 
+
+
 add_compile_definitions(
     IMMUTABILITY=1
     COGMTVM=0
     PharoVM=1
-    $<$<CONFIG:DEBUG>:DEBUGVM=1>
-    $<$<NOT:$<CONFIG:DEBUG>>:DEBUGVM=0>
+    DEBUGVM=${DEBUGVM}
     _FILE_OFFSET_BITS=64
 )
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -278,6 +278,7 @@ def upload(platform, configuration, archiveName, isStableRelease = false) {
 	def wordSize = is32Bits(platform) ? "32" : "64"
 	def expandedBinaryFileName = sh(returnStdout: true, script: "ls build/build/packages/PharoVM-*-${archiveName}-bin.zip").trim()
 	def expandedCSourceFileName = sh(returnStdout: true, script: "ls build/build/packages/PharoVM-*-${archiveName}-c-src.zip").trim()
+	def expandedCSourceTarName = sh(returnStdout: true, script: "ls build/build/packages/PharoVM-*-${archiveName}-c-src.tar.gz").trim()
 	def expandedHeadersFileName = sh(returnStdout: true, script: "ls build/build/packages/PharoVM-*-${archiveName}-include.zip").trim()
 
 	sshagent (credentials: ['b5248b59-a193-4457-8459-e28e9eb29ed7']) {
@@ -295,12 +296,21 @@ def upload(platform, configuration, archiveName, isStableRelease = false) {
 		${expandedHeadersFileName} \
 		pharoorgde@ssh.cluster023.hosting.ovh.net:/home/pharoorgde/files/vm/pharo-spur${wordSize}-headless/${platform}/include/latest${mainBranchVersion()}.zip"
 
+		// Upload Souces ZIP 
 		sh "scp -o StrictHostKeyChecking=no \
 		${expandedCSourceFileName} \
 		pharoorgde@ssh.cluster023.hosting.ovh.net:/home/pharoorgde/files/vm/pharo-spur${wordSize}-headless/${platform}/source"
 		sh "scp -o StrictHostKeyChecking=no \
 		${expandedCSourceFileName} \
 		pharoorgde@ssh.cluster023.hosting.ovh.net:/home/pharoorgde/files/vm/pharo-spur${wordSize}-headless/${platform}/source/latest${mainBranchVersion()}.zip"
+
+		// Upload Sources TAR.GZ
+		sh "scp -o StrictHostKeyChecking=no \
+		${expandedCSourceTarName} \
+		pharoorgde@ssh.cluster023.hosting.ovh.net:/home/pharoorgde/files/vm/pharo-spur${wordSize}-headless/${platform}/source"
+		sh "scp -o StrictHostKeyChecking=no \
+		${expandedCSourceTarName} \
+		pharoorgde@ssh.cluster023.hosting.ovh.net:/home/pharoorgde/files/vm/pharo-spur${wordSize}-headless/${platform}/source/latest${mainBranchVersion()}.tar.gz"
 		
 		if(isStableRelease){
 			sh "scp -o StrictHostKeyChecking=no \


### PR DESCRIPTION
Do not use newer features because in OBS we build for very old debian distros (debian9, ubuntu18) and we do not want to drop them right now.
Also, upload the tar.gz source along with the zip