### PR TITLE
Support for push literal variable compilation

### DIFF
--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -15465,12 +15465,15 @@ StackInterpreter >> undoFetchNextBytecode [
 
 { #category : #'compiled methods' }
 StackInterpreter >> unfollow: litVar atIndex: literalIndex [
+	"So rare it mustn't bulk up the common path"
+
 	<option: #SpurMemoryManager>
-	<inline: #never> "So rare it mustn't bulk up the common path"
+	<inline: #never>
 	| followed |
 	followed := objectMemory followForwarded: litVar.
-	self literal: literalIndex ofMethod: method put: followed.
-	^followed
+	self druidIgnore: [
+		self literal: literalIndex ofMethod: method put: followed ].
+	^ followed
 ]
 
 { #category : #'compiled methods' }

--- a/smalltalksrc/VMMakerTests/Association.extension.st
+++ b/smalltalksrc/VMMakerTests/Association.extension.st
@@ -1,0 +1,22 @@
+Extension { #name : #Association }
+
+{ #category : #'*VMMakerTests' }
+Association >> forMemory: aMemory inMethod: aMethod [
+
+	| association |
+	association := aMemory
+		             allocateSlotsInOldSpace: 2
+		             format: aMemory nonIndexablePointerFormat
+		             classIndex: self class hash.
+
+	aMemory
+		storePointer: 0
+		ofObject: association
+		withValue: (key forMemory: aMemory inMethod: aMethod).
+	aMemory
+		storePointer: 1
+		ofObject: association
+		withValue: (value forMemory: aMemory inMethod: aMethod).
+
+	^ association
+]


### PR DESCRIPTION
Do not store the forwarder resolution in the compiled code.
Add support for Association installation in tests