### PR TITLE
Testing scavenger tenuring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -366,3 +366,5 @@ healthchecksdb
 /out/build
 /stack32/generated
 /stack64/generated
+
+**/.DS_Store

--- a/smalltalksrc/VMMaker/SpurGenerationScavenger.class.st
+++ b/smalltalksrc/VMMaker/SpurGenerationScavenger.class.st
@@ -1283,7 +1283,7 @@ SpurGenerationScavenger >> scavengeUnfiredEphemeronsOnEphemeronList [
 ]
 
 { #category : #accessing }
-SpurGenerationScavenger >> scavengerTenuringThreshold [ "(Slang flattens so need unique selectors)"
+SpurGenerationScavenger >> scavengerTenuringProportion [ "(Slang flattens so need unique selectors)"
 	<returnTypeC: #float>
 	^tenureThreshold >= pastSpace start
 		ifTrue: [(tenureThreshold - pastSpace start) asFloat / (pastSpace limit - pastSpace start)]
@@ -1291,7 +1291,7 @@ SpurGenerationScavenger >> scavengerTenuringThreshold [ "(Slang flattens so need
 ]
 
 { #category : #accessing }
-SpurGenerationScavenger >> scavengerTenuringThreshold: aProportion [ "(Slang flattens so need unique selectors)"
+SpurGenerationScavenger >> scavengerTenuringProportionToKeepInPastSpace: aProportion [ "(Slang flattens so need unique selectors)"
 	<var: 'aProportion' type: #double>
 	tenuringProportion := aProportion.
 	tenureThreshold := aProportion = 0.0

--- a/smalltalksrc/VMMaker/SpurGenerationScavenger.class.st
+++ b/smalltalksrc/VMMaker/SpurGenerationScavenger.class.st
@@ -1282,15 +1282,15 @@ SpurGenerationScavenger >> scavengeUnfiredEphemeronsOnEphemeronList [
 	^unfiredEphemeronsScavenged
 ]
 
-{ #category : #accessing }
-SpurGenerationScavenger >> scavengerTenuringProportion [ "(Slang flattens so need unique selectors)"
+{ #category : #tenuring }
+SpurGenerationScavenger >> scavengerTenuringProportion [
 	<returnTypeC: #float>
 	^tenureThreshold >= pastSpace start
 		ifTrue: [(tenureThreshold - pastSpace start) asFloat / (pastSpace limit - pastSpace start)]
 		ifFalse: [0]
 ]
 
-{ #category : #accessing }
+{ #category : #tenuring }
 SpurGenerationScavenger >> scavengerTenuringProportionToKeepInPastSpace: aProportion [ "(Slang flattens so need unique selectors)"
 	<var: 'aProportion' type: #double>
 	tenuringProportion := aProportion.
@@ -1325,7 +1325,7 @@ SpurGenerationScavenger >> setCorpseOffsetOf: corpse to: offset [
 						classIndex: manager isForwardedObjectClassIndexPun)]
 ]
 
-{ #category : #accessing }
+{ #category : #tenuring }
 SpurGenerationScavenger >> setRawTenuringThreshold: threshold [
 	tenureThreshold := threshold
 ]
@@ -1348,7 +1348,7 @@ SpurGenerationScavenger >> setRefCountToShrinkRT: population [
 	refCountToShrinkRT := i max: 0
 ]
 
-{ #category : #scavenger }
+{ #category : #tenuring }
 SpurGenerationScavenger >> shouldBeTenured: survivor [
 	"Answer if an object should be tenured.  The default policy tenuring policy
 	 is to use the tenuringThreshold to decide. If the survivors (measured in
@@ -1404,17 +1404,17 @@ SpurGenerationScavenger >> strategizeToLimitRememberedSet [
 		 self computeRefCountToShrinkRememberedSet]
 ]
 
-{ #category : #accessing }
+{ #category : #tenuring }
 SpurGenerationScavenger >> tenuringClassIndex [
 	^tenuringClassIndex
 ]
 
-{ #category : #accessing }
+{ #category : #tenuring }
 SpurGenerationScavenger >> tenuringClassIndex: anInteger [
 	tenuringClassIndex := anInteger
 ]
 
-{ #category : #accessing }
+{ #category : #tenuring }
 SpurGenerationScavenger >> tenuringProportion [
 
 	^ tenuringProportion

--- a/smalltalksrc/VMMaker/SpurGenerationScavenger.class.st
+++ b/smalltalksrc/VMMaker/SpurGenerationScavenger.class.st
@@ -261,22 +261,11 @@ SpurGenerationScavenger >> computeRefCountToShrinkRememberedSet [
 	(manager allNewSpaceObjectsDo: [:o| manager rtRefCountOf: o put: 0])"
 ]
 
-{ #category : #scavenger }
+{ #category : #tenuring }
 SpurGenerationScavenger >> computeTenuringThreshold [
 
-	<var: 'fractionSurvived' type: #float>
-	| fractionSurvived |
-	fractionSurvived := futureSpace limit = futureSpace start
-		                    ifTrue: [ 0.0 ]
-		                    ifFalse: [
-			                    (futureSurvivorStart - futureSpace start) asFloat
-			                    / (futureSpace limit - futureSpace start) ].
-
-	tenureThreshold := fractionSurvived > 0.9
-		                   ifTrue: [ "Duplicated!"
-			                   (futureSpace limit - futureSpace start
-			                    * (1.0 - tenuringProportion)) rounded
-			                   + futureSpace start ]
+	tenureThreshold := self futureSpaceIsFull
+		                   ifTrue: [ self tenuringThresholdForSpace: futureSpace ]
 		                   ifFalse: [ 0 ]
 ]
 
@@ -575,6 +564,23 @@ SpurGenerationScavenger >> futureSpace [
 	^futureSpace
 ]
 
+{ #category : #tenuring }
+SpurGenerationScavenger >> futureSpaceIsFull [
+
+	"After the scavenge, if the future space remains full (more than 90%).
+	Useful to configure tenuring for next pass."
+
+	<var: 'fractionSurvived' type: #float>
+	| fractionSurvived |
+	fractionSurvived := futureSpace limit = futureSpace start
+		                    ifTrue: [ 0.0 ]
+		                    ifFalse: [
+			                    (futureSurvivorStart - futureSpace start) asFloat "Survivor size"
+			                    / futureSpace size ].
+
+	^ fractionSurvived > 0.9 
+]
+
 { #category : #'debug support' }
 SpurGenerationScavenger >> futureSpaceObjectsDo: aBlock [
 	| obj |
@@ -591,7 +597,7 @@ SpurGenerationScavenger >> futureSurvivorStart [
 	^futureSurvivorStart
 ]
 
-{ #category : #accessing }
+{ #category : #tenuring }
 SpurGenerationScavenger >> getRawTenuringThreshold [
 	^tenureThreshold
 ]
@@ -1291,12 +1297,12 @@ SpurGenerationScavenger >> scavengerTenuringProportion [
 ]
 
 { #category : #tenuring }
-SpurGenerationScavenger >> scavengerTenuringProportionToKeepInPastSpace: aProportion [ "(Slang flattens so need unique selectors)"
+SpurGenerationScavenger >> scavengerTenuringProportionToKeepInPastSpace: aProportion [
 	<var: 'aProportion' type: #double>
 	tenuringProportion := aProportion.
 	tenureThreshold := aProportion = 0.0
 							ifTrue: [0]
-							ifFalse: [((pastSpace limit - pastSpace start) * (1.0 - aProportion)) rounded + pastSpace start]
+							ifFalse: [self tenuringThresholdForSpace: pastSpace ]
 ]
 
 { #category : #'weakness and ephemerality' }
@@ -1418,6 +1424,12 @@ SpurGenerationScavenger >> tenuringClassIndex: anInteger [
 SpurGenerationScavenger >> tenuringProportion [
 
 	^ tenuringProportion
+]
+
+{ #category : #tenuring }
+SpurGenerationScavenger >> tenuringThresholdForSpace: aSpace [
+
+	^ (aSpace size * (1.0 - tenuringProportion)) rounded + aSpace start
 ]
 
 { #category : #logging }

--- a/smalltalksrc/VMMaker/SpurGenerationScavenger.class.st
+++ b/smalltalksrc/VMMaker/SpurGenerationScavenger.class.st
@@ -576,7 +576,7 @@ SpurGenerationScavenger >> futureSpaceIsFull [
 		                    ifTrue: [ 0.0 ]
 		                    ifFalse: [
 			                    (futureSurvivorStart - futureSpace start) asFloat "Survivor size"
-			                    / futureSpace size ].
+			                    / futureSpace spaceSize ].
 
 	^ fractionSurvived > 0.9 
 ]
@@ -1429,7 +1429,7 @@ SpurGenerationScavenger >> tenuringProportion [
 { #category : #tenuring }
 SpurGenerationScavenger >> tenuringThresholdForSpace: aSpace [
 
-	^ (aSpace size * (1.0 - tenuringProportion)) rounded + aSpace start
+	^ (aSpace spaceSize * (1.0 - tenuringProportion)) rounded + aSpace start
 ]
 
 { #category : #logging }

--- a/smalltalksrc/VMMaker/SpurGenerationScavenger.class.st
+++ b/smalltalksrc/VMMaker/SpurGenerationScavenger.class.st
@@ -1414,6 +1414,12 @@ SpurGenerationScavenger >> tenuringClassIndex: anInteger [
 	tenuringClassIndex := anInteger
 ]
 
+{ #category : #accessing }
+SpurGenerationScavenger >> tenuringProportion [
+
+	^ tenuringProportion
+]
+
 { #category : #logging }
 SpurGenerationScavenger >> writeScavengeLog [
 	"Output the entire record."

--- a/smalltalksrc/VMMaker/SpurGenerationScavenger.class.st
+++ b/smalltalksrc/VMMaker/SpurGenerationScavenger.class.st
@@ -263,17 +263,21 @@ SpurGenerationScavenger >> computeRefCountToShrinkRememberedSet [
 
 { #category : #scavenger }
 SpurGenerationScavenger >> computeTenuringThreshold [
-	| fractionSurvived |
+
 	<var: 'fractionSurvived' type: #float>
+	| fractionSurvived |
 	fractionSurvived := futureSpace limit = futureSpace start
-							ifTrue:
-								[0.0]
-							ifFalse:
-								[(futureSurvivorStart - futureSpace start) asFloat
-									/ (futureSpace limit - futureSpace start)].
+		                    ifTrue: [ 0.0 ]
+		                    ifFalse: [
+			                    (futureSurvivorStart - futureSpace start) asFloat
+			                    / (futureSpace limit - futureSpace start) ].
+
 	tenureThreshold := fractionSurvived > 0.9
-							ifTrue: [((pastSpace limit - pastSpace start) * (1.0 - tenuringProportion)) rounded + pastSpace start]
-							ifFalse: [0]
+		                   ifTrue: [ "Duplicated!"
+			                   (futureSpace limit - futureSpace start
+			                    * (1.0 - tenuringProportion)) rounded
+			                   + futureSpace start ]
+		                   ifFalse: [ 0 ]
 ]
 
 { #category : #scavenger }

--- a/smalltalksrc/VMMaker/SpurGenerationScavenger.class.st
+++ b/smalltalksrc/VMMaker/SpurGenerationScavenger.class.st
@@ -1357,10 +1357,11 @@ SpurGenerationScavenger >> shouldBeTenured: survivor [
 		ACM TOPLAS, Volume 14 Issue 1, Jan. 1992, pp 1 - 27.
 
 	 The other policies are for special purposes."
+	
 	^tenureCriterion
 		caseOf: {
 			[TenureByAge]	->
-				[survivor < tenureThreshold]. 
+				[survivor < tenureThreshold ifTrue: [ coInterpreter print: 'Tenuring!\n' .true ] ifFalse: [ false ] ]. 
 			[TenureByClass] ->
 				[(manager classIndexOf: survivor) = tenuringClassIndex].
 			[TenureToShrinkRT]	->

--- a/smalltalksrc/VMMaker/SpurGenerationScavenger.class.st
+++ b/smalltalksrc/VMMaker/SpurGenerationScavenger.class.st
@@ -1365,7 +1365,7 @@ SpurGenerationScavenger >> shouldBeTenured: survivor [
 	^tenureCriterion
 		caseOf: {
 			[TenureByAge]	->
-				[survivor < tenureThreshold ifTrue: [ coInterpreter print: 'Tenuring!\n' .true ] ifFalse: [ false ] ]. 
+				[survivor < tenureThreshold]. 
 			[TenureByClass] ->
 				[(manager classIndexOf: survivor) = tenuringClassIndex].
 			[TenureToShrinkRT]	->

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -5207,7 +5207,9 @@ SpurMemoryManager >> flushNewSpace [
 	| savedTenuringThreshold |
 	savedTenuringThreshold := scavenger getRawTenuringThreshold.
 	scavenger setRawTenuringThreshold: memoryMap newSpaceEnd.
+	coInterpreter print: '<Flushing>\n'.
 	self scavengingGCTenuringIf: TenureByAge.
+	coInterpreter print: '</Flushing>\n'.
 	scavenger setRawTenuringThreshold: savedTenuringThreshold.
 	self assert: fromOldSpaceRememberedSet rememberedSetSize = 0.
 	self assert: pastSpaceStart = scavenger pastSpace start.

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -12449,7 +12449,7 @@ SpurMemoryManager >> tenuringThreshold [
 	 accessed as a proportion of pastSpace from 0 to 1.   In the Squeak image the tenuring
 	 threshold is an object count. Marry the two notions by multiplying the proportion by
 	 the size of pastSpace and dividing by the average object size, as derived from observation."
-	^(scavenger scavengerTenuringThreshold * scavenger pastSpaceBytes // self averageObjectSizeInBytes) asInteger
+	^(scavenger scavengerTenuringProportion * scavenger pastSpaceBytes // self averageObjectSizeInBytes) asInteger
 ]
 
 { #category : #accessing }
@@ -12457,7 +12457,7 @@ SpurMemoryManager >> tenuringThreshold: threshold [
 	"c.f. tenuringThreshold"
 	threshold < 0 ifTrue:
 		[^PrimErrBadArgument].
-	scavenger scavengerTenuringThreshold:
+	scavenger scavengerTenuringProportionToKeepInPastSpace:
 		(threshold * self averageObjectSizeInBytes) asFloat
 		/ scavenger pastSpaceBytes asFloat.
 	^0

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -5207,9 +5207,7 @@ SpurMemoryManager >> flushNewSpace [
 	| savedTenuringThreshold |
 	savedTenuringThreshold := scavenger getRawTenuringThreshold.
 	scavenger setRawTenuringThreshold: memoryMap newSpaceEnd.
-	coInterpreter print: '<Flushing>\n'.
 	self scavengingGCTenuringIf: TenureByAge.
-	coInterpreter print: '</Flushing>\n'.
 	scavenger setRawTenuringThreshold: savedTenuringThreshold.
 	self assert: fromOldSpaceRememberedSet rememberedSetSize = 0.
 	self assert: pastSpaceStart = scavenger pastSpace start.

--- a/smalltalksrc/VMMaker/SpurNewSpaceSpace.class.st
+++ b/smalltalksrc/VMMaker/SpurNewSpaceSpace.class.st
@@ -36,6 +36,13 @@ SpurNewSpaceSpace >> printOn: aStream [
 
 { #category : #accessing }
 SpurNewSpaceSpace >> size [
+	<doNotGenerate>
+	
+	^ self limit - self start
+]
+
+{ #category : #accessing }
+SpurNewSpaceSpace >> spaceSize [
 	<inline: true>
 	
 	^ self limit - self start

--- a/smalltalksrc/VMMaker/SpurNewSpaceSpace.class.st
+++ b/smalltalksrc/VMMaker/SpurNewSpaceSpace.class.st
@@ -36,7 +36,7 @@ SpurNewSpaceSpace >> printOn: aStream [
 
 { #category : #accessing }
 SpurNewSpaceSpace >> size [
-	<doNotGenerate>
+	<inline: true>
 	
 	^ self limit - self start
 ]

--- a/smalltalksrc/VMMakerTests/VMImageHeaderWritingTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMImageHeaderWritingTest.class.st
@@ -36,16 +36,6 @@ VMImageHeaderWritingTest >> testImageHeaderWithPermanentObjects [
 ]
 
 { #category : #tests }
-VMImageHeaderWritingTest >> testWritingImageWritesCorrectImageVersion [
-
-	| header |
-
-	header := self readHeader.
-
-	self assert: header imageVersion equals: interpreter getImageVersion
-]
-
-{ #category : #tests }
 VMImageHeaderWritingTest >> testWritingImageWritesCorrectBaseAddress [
 
 	| header |
@@ -165,6 +155,16 @@ VMImageHeaderWritingTest >> testWritingImageWritesCorrectImageFormat [
 	header := self readHeader.
 
 	self assert: header imageFormat equals: interpreter imageFormatVersion
+]
+
+{ #category : #tests }
+VMImageHeaderWritingTest >> testWritingImageWritesCorrectImageVersion [
+
+	| header |
+
+	header := self readHeader.
+
+	self assert: header imageVersion equals: interpreter getImageVersion
 ]
 
 { #category : #tests }

--- a/smalltalksrc/VMMakerTests/VMSpurOldSpaceGarbageCollectorTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurOldSpaceGarbageCollectorTest.class.st
@@ -233,6 +233,53 @@ VMSpurOldSpaceGarbageCollectorTest >> testAnOldObjectReferencedFromVMVariableSho
 	self assertHashOf: self keptObjectInVMVariable1 equals: hash
 ]
 
+{ #category : #'tests-OldSpaceSize' }
+VMSpurOldSpaceGarbageCollectorTest >> testArrayOfPermanentObjectsPointingToOldObjectsIsCorrectlyMantained [
+
+	| deltaFreeSpace arrayOfPerms objectsSize aPermObject anOldObject originalRememberedSetSize afteRememberedSetSize numberOfObjects |
+
+	originalRememberedSetSize := memory bytesInObject: memory fromPermSpaceRememberedSet objectOop. 
+	numberOfObjects := 4096.
+
+	deltaFreeSpace := self deltaFreeSpaceAfterGC: [ 
+								arrayOfPerms := self newOldSpaceArrayWithSlots: numberOfObjects.
+								objectsSize := memory bytesInObject: arrayOfPerms.
+								0 to: numberOfObjects - 1 do: [ :i |
+									anOldObject := self newOldSpaceObjectWithSlots: 0.
+									aPermObject := self newPermanentObjectWithSlots: 1.
+									objectsSize := objectsSize + (memory bytesInObject: anOldObject).
+									memory storePointer: 0 ofObject: aPermObject withValue: anOldObject.
+									memory storePointer: i ofObject: arrayOfPerms withValue: aPermObject ].
+		                  self keepObjectInVMVariable2: arrayOfPerms ].
+
+	afteRememberedSetSize := memory bytesInObject: memory fromPermSpaceRememberedSet objectOop.
+
+	self assert: deltaFreeSpace equals: objectsSize + (afteRememberedSetSize - originalRememberedSetSize)
+]
+
+{ #category : #'tests-OldSpaceSize' }
+VMSpurOldSpaceGarbageCollectorTest >> testArrayOfPermanentObjectsPointingToOldObjectsIsCorrectlyMantainedWhenObjectsMoved [
+
+	| numberOfObjects originalHashes permArray anOldObject |
+	numberOfObjects := 4096.
+	originalHashes := Array new: numberOfObjects.
+
+	self deltaFreeSpaceAfterGC: [ 
+		permArray := self newPermanentObjectWithSlots: numberOfObjects.
+
+		"Objects to be collected"
+		self newOldSpaceObjectWithSlots: 0.
+		self newOldSpaceObjectWithSlots: 0.
+
+		1 to: numberOfObjects do: [ :i |
+			anOldObject := self newOldSpaceObjectWithSlots: 0.
+			originalHashes at: i put: (memory hashBitsOf: anOldObject). 
+			memory storePointer: (i - 1) ofObject: permArray withValue: anOldObject ]].
+
+	1 to: numberOfObjects do: [ :i |
+		self assert: (originalHashes at: i) equals: (memory hashBitsOf: (memory fetchPointer: i - 1 ofObject: permArray))]
+]
+
 { #category : #ephemerons }
 VMSpurOldSpaceGarbageCollectorTest >> testCompactEphemeronQueuePass1 [
 
@@ -283,53 +330,6 @@ VMSpurOldSpaceGarbageCollectorTest >> testCompactEphemeronQueuePass2 [
 	
 	self assert: (memory sizeOfObjStack: memory mournQueue) equals: 1.
 	self assert: memory dequeueMourner equals: self keptObjectInVMVariable1.
-]
-
-{ #category : #'tests-OldSpaceSize' }
-VMSpurOldSpaceGarbageCollectorTest >> testArrayOfPermanentObjectsPointingToOldObjectsIsCorrectlyMantained [
-
-	| deltaFreeSpace arrayOfPerms objectsSize aPermObject anOldObject originalRememberedSetSize afteRememberedSetSize numberOfObjects |
-
-	originalRememberedSetSize := memory bytesInObject: memory fromPermSpaceRememberedSet objectOop. 
-	numberOfObjects := 4096.
-
-	deltaFreeSpace := self deltaFreeSpaceAfterGC: [ 
-								arrayOfPerms := self newOldSpaceArrayWithSlots: numberOfObjects.
-								objectsSize := memory bytesInObject: arrayOfPerms.
-								0 to: numberOfObjects - 1 do: [ :i |
-									anOldObject := self newOldSpaceObjectWithSlots: 0.
-									aPermObject := self newPermanentObjectWithSlots: 1.
-									objectsSize := objectsSize + (memory bytesInObject: anOldObject).
-									memory storePointer: 0 ofObject: aPermObject withValue: anOldObject.
-									memory storePointer: i ofObject: arrayOfPerms withValue: aPermObject ].
-		                  self keepObjectInVMVariable2: arrayOfPerms ].
-
-	afteRememberedSetSize := memory bytesInObject: memory fromPermSpaceRememberedSet objectOop.
-
-	self assert: deltaFreeSpace equals: objectsSize + (afteRememberedSetSize - originalRememberedSetSize)
-]
-
-{ #category : #'tests-OldSpaceSize' }
-VMSpurOldSpaceGarbageCollectorTest >> testArrayOfPermanentObjectsPointingToOldObjectsIsCorrectlyMantainedWhenObjectsMoved [
-
-	| numberOfObjects originalHashes permArray anOldObject |
-	numberOfObjects := 4096.
-	originalHashes := Array new: numberOfObjects.
-
-	self deltaFreeSpaceAfterGC: [ 
-		permArray := self newPermanentObjectWithSlots: numberOfObjects.
-
-		"Objects to be collected"
-		self newOldSpaceObjectWithSlots: 0.
-		self newOldSpaceObjectWithSlots: 0.
-
-		1 to: numberOfObjects do: [ :i |
-			anOldObject := self newOldSpaceObjectWithSlots: 0.
-			originalHashes at: i put: (memory hashBitsOf: anOldObject). 
-			memory storePointer: (i - 1) ofObject: permArray withValue: anOldObject ]].
-
-	1 to: numberOfObjects do: [ :i |
-		self assert: (originalHashes at: i) equals: (memory hashBitsOf: (memory fetchPointer: i - 1 ofObject: permArray))]
 ]
 
 { #category : #'tests-OldSpaceSize' }

--- a/smalltalksrc/VMMakerTests/VMSpurScavengerTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurScavengerTest.class.st
@@ -11,6 +11,27 @@ VMSpurScavengerTest >> assertPastSpaceIsEmpty [
 		equals: memory scavenger pastSpace start
 ]
 
+{ #category : #'as yet unclassified' }
+VMSpurScavengerTest >> fullNewSpace [
+
+	| rootObjectAddress referencedObjectAddress |
+	rootObjectAddress := self newObjectWithSlots: 200.
+
+	1 to: 200 do: [ :i |
+		referencedObjectAddress := self newObjectWithSlots: 100.
+		memory
+			storePointer: i - 1
+			ofObject: rootObjectAddress
+			withValue: referencedObjectAddress.
+		1 to: 100 do: [ :i2 |
+			memory
+				storePointer: i2 - 1
+				ofObject: referencedObjectAddress
+				withValue: (self newObjectWithSlots: 10) ] ].
+
+	^ rootObjectAddress
+]
+
 { #category : #helpers }
 VMSpurScavengerTest >> makeBaseFrameWithMethod: aMethodOop context: aContextOop receiver: aReceiverOop args: argsOops andStack: stackOops [
 	
@@ -137,6 +158,37 @@ VMSpurScavengerTest >> testArgumentInStackShouldSurviveScanvenge [
 	"Remap our object address to its new location"
 	newObjectAddress := memory remapObj: newObjectOop.
 	self assert: (memory hashBitsOf: newObjectAddress) equals: newObjectHash
+]
+
+{ #category : #'tests-8-scavenge-tenuring' }
+VMSpurScavengerTest >> testComputeTenuringThresholdWithFewSurvivors [
+
+	| rootObjectAddress |
+
+	rootObjectAddress := self newZeroSizedObject.
+	memory coInterpreter method: rootObjectAddress.
+
+	self assert: memory scavenger tenuringProportion equals: 0.9. "When tenuring, keep 90% of the objects"
+	self assert: memory scavenger scavengerTenuringThreshold equals: 0 "Not tenure next pass".
+	
+	memory doScavenge: 1 "TenureByAge".
+
+	self assert: memory scavenger scavengerTenuringThreshold closeTo: 0 "Past space keep not full -> Not tenure next pass"
+]
+
+{ #category : #'tests-8-scavenge-tenuring' }
+VMSpurScavengerTest >> testComputeTenuringThresholdWithManySurvivors [
+
+	| rootObjectAddress |
+	rootObjectAddress := self fullNewSpace.
+	memory coInterpreter method: rootObjectAddress.
+
+	self assert: memory scavenger tenuringProportion equals: 0.9. "When tenuring, keep 90% of the objects"
+	self assert: memory scavenger scavengerTenuringThreshold equals: 0. "Not tenure next pass"
+
+	memory doScavenge: 1. "TenureByAge"
+
+	self assert: memory scavenger scavengerTenuringThreshold closeTo: 0.1 "Past space is full -> Tenure next pass"
 ]
 
 { #category : #'tests-4-scavenge-stack' }
@@ -292,9 +344,6 @@ VMSpurScavengerTest >> testMovingReferencedObjectShouldUpdateReference [
 	
 	memory coInterpreter method: rootObjectAddress.
 
-	"Nil should survive, but newObjectOop should survive too.
-	Nil is referenced by the roots because many of their slots are nilled.
-	newObjectOop is referenced by the stack"
 	memory doScavenge: 1 "TenureByAge".
 	
 	"Remap our object address to its new location"
@@ -427,9 +476,6 @@ VMSpurScavengerTest >> testReferencedObjectShouldSurviveScavenge [
 	
 	memory coInterpreter method: rootObjectAddress.
 
-	"Nil should survive, but newObjectOop should survive too.
-	Nil is referenced by the roots because many of their slots are nilled.
-	newObjectOop is referenced by the stack"
 	memory doScavenge: 1 "TenureByAge".
 	
 	"Remap our object address to its new location"
@@ -650,6 +696,62 @@ VMSpurScavengerTest >> testScavengedRootObjectsShouldBeCopiedBeforeOtherObjects 
 	self assert: (memory remapObj: secondRootObjectAddress) < (memory remapObj: nonRootObjectAddress)
 ]
 
+{ #category : #'tests-8-scavenge-tenuring' }
+VMSpurScavengerTest >> testShouldTenureBasedOnTheThreshold [
+
+	| firstObjectAddress secondObjectAddress |
+
+	firstObjectAddress := self newZeroSizedObject.
+	secondObjectAddress := self newZeroSizedObject.
+	memory coInterpreter method: firstObjectAddress.
+	memory coInterpreter profileSemaphore: secondObjectAddress.
+
+	memory doScavenge: 1. "TenureByAge"
+	firstObjectAddress := memory remapObj: firstObjectAddress.
+	secondObjectAddress := memory remapObj: secondObjectAddress.
+
+	"Both still in new space"
+	self assert: (memory isInNewSpace: firstObjectAddress).
+	self assert: (memory isInNewSpace: secondObjectAddress).
+	
+	"Set threshold aftes first object"
+	memory scavenger setRawTenuringThreshold: firstObjectAddress + 1.
+	
+	memory doScavenge: 1. "TenureByAge"
+	firstObjectAddress := memory remapObj: firstObjectAddress.
+	secondObjectAddress := memory remapObj: secondObjectAddress.
+
+	"Objects before the threshold where tenured"
+	self assert: (memory isInOldSpace: firstObjectAddress).
+	"Next objects keep in new space"
+	self assert: (memory isInNewSpace: secondObjectAddress)
+
+]
+
+{ #category : #'tests-8-scavenge-tenuring' }
+VMSpurScavengerTest >> testShouldTenureObjectsWhenPastSpaceIsFull [
+
+	| rootObjectAddress newRootObjectAddress |
+
+	rootObjectAddress := self fullNewSpace.
+	memory coInterpreter method: rootObjectAddress.
+
+	self assert: memory scavenger scavengerTenuringThreshold equals: 0. "Start without tenuring"
+
+	memory doScavenge: 1. "TenureByAge"
+	newRootObjectAddress := memory remapObj: rootObjectAddress.
+
+	"Survivors should touched the threshold, so next scavenge will be tenured"
+	self assert: memory scavenger scavengerTenuringThreshold closeTo: 0.1.
+	self assert: (memory isInNewSpace: newRootObjectAddress).
+	
+	memory doScavenge: 1. "TenureByAge"
+	newRootObjectAddress := memory remapObj: newRootObjectAddress.
+
+	"Some objects should be tenured"
+	self assert: (memory isInOldSpace: newRootObjectAddress)
+]
+
 { #category : #'tests-3-scavenge-basic' }
 VMSpurScavengerTest >> testUnreferencedObjectCycleShouldNotSurviveScavenge [
 	| objectA objectB |
@@ -664,9 +766,6 @@ VMSpurScavengerTest >> testUnreferencedObjectCycleShouldNotSurviveScavenge [
 		ofObject: objectB
 		withValue: objectA.
 
-	"Nil should survive, but newObjectOop should survive too.
-	Nil is referenced by the roots because many of their slots are nilled.
-	newObjectOop is referenced by the stack"
 	memory doScavenge: 1. "TenureByAge"
 	
 	self assertPastSpaceIsEmpty
@@ -682,9 +781,6 @@ VMSpurScavengerTest >> testUnreferencedObjectGraphShouldNotSurviveScavenge [
 		ofObject: unreferencedRootObjectAddress
 		withValue: referencedObjectAddress.
 
-	"Nil should survive, but newObjectOop should survive too.
-	Nil is referenced by the roots because many of their slots are nilled.
-	newObjectOop is referenced by the stack"
 	memory doScavenge: 1. "TenureByAge"
 	
 	self assertPastSpaceIsEmpty

--- a/smalltalksrc/VMMakerTests/VMSpurScavengerTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurScavengerTest.class.st
@@ -11,10 +11,12 @@ VMSpurScavengerTest >> assertPastSpaceIsEmpty [
 		equals: memory scavenger pastSpace start
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #helpers }
 VMSpurScavengerTest >> fullNewSpace [
 
-	| rootObjectAddress referencedObjectAddress |
+	| rootObjectAddress referencedObjectAddress freeStartAtBeginning |
+	freeStartAtBeginning := memory freeStart.
+
 	rootObjectAddress := self newObjectWithSlots: 200.
 
 	1 to: 200 do: [ :i |
@@ -27,9 +29,12 @@ VMSpurScavengerTest >> fullNewSpace [
 			memory
 				storePointer: i2 - 1
 				ofObject: referencedObjectAddress
-				withValue: (self newObjectWithSlots: 10) ] ].
+				withValue: (self newObjectWithSlots: 10).
 
-	^ rootObjectAddress
+			memory freeStart - freeStartAtBeginning
+			> memory scavenger futureSpace size ifTrue: [ ^ rootObjectAddress ] ] ].
+
+	self error: 'New space is not full!'
 ]
 
 { #category : #helpers }

--- a/smalltalksrc/VMMakerTests/VMSpurScavengerTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurScavengerTest.class.st
@@ -169,11 +169,11 @@ VMSpurScavengerTest >> testComputeTenuringThresholdWithFewSurvivors [
 	memory coInterpreter method: rootObjectAddress.
 
 	self assert: memory scavenger tenuringProportion equals: 0.9. "When tenuring, keep 90% of the objects"
-	self assert: memory scavenger scavengerTenuringThreshold equals: 0 "Not tenure next pass".
+	self assert: memory scavenger scavengerTenuringProportion equals: 0 "Not tenure next pass".
 	
 	memory doScavenge: 1 "TenureByAge".
 
-	self assert: memory scavenger scavengerTenuringThreshold closeTo: 0 "Past space keep not full -> Not tenure next pass"
+	self assert: memory scavenger scavengerTenuringProportion closeTo: 0 "Past space keep not full -> Not tenure next pass"
 ]
 
 { #category : #'tests-8-scavenge-tenuring' }
@@ -184,11 +184,11 @@ VMSpurScavengerTest >> testComputeTenuringThresholdWithManySurvivors [
 	memory coInterpreter method: rootObjectAddress.
 
 	self assert: memory scavenger tenuringProportion equals: 0.9. "When tenuring, keep 90% of the objects"
-	self assert: memory scavenger scavengerTenuringThreshold equals: 0. "Not tenure next pass"
+	self assert: memory scavenger scavengerTenuringProportion equals: 0. "Not tenure next pass"
 
 	memory doScavenge: 1. "TenureByAge"
 
-	self assert: memory scavenger scavengerTenuringThreshold closeTo: 0.1 "Past space is full -> Tenure next pass"
+	self assert: memory scavenger scavengerTenuringProportion closeTo: 0.1 "Past space is full -> Tenure next pass"
 ]
 
 { #category : #'tests-4-scavenge-stack' }
@@ -736,13 +736,13 @@ VMSpurScavengerTest >> testShouldTenureObjectsWhenPastSpaceIsFull [
 	rootObjectAddress := self fullNewSpace.
 	memory coInterpreter method: rootObjectAddress.
 
-	self assert: memory scavenger scavengerTenuringThreshold equals: 0. "Start without tenuring"
+	self assert: memory scavenger scavengerTenuringProportion equals: 0. "Start without tenuring"
 
 	memory doScavenge: 1. "TenureByAge"
 	newRootObjectAddress := memory remapObj: rootObjectAddress.
 
 	"Survivors should touched the threshold, so next scavenge will be tenured"
-	self assert: memory scavenger scavengerTenuringThreshold closeTo: 0.1.
+	self assert: memory scavenger scavengerTenuringProportion closeTo: 0.1.
 	self assert: (memory isInNewSpace: newRootObjectAddress).
 	
 	memory doScavenge: 1. "TenureByAge"


### PR DESCRIPTION
With @jordanmontt we started to profile the GC activity, especially the Scavenger.

Looking at the code, we realised that the Tenuring algorithm was not tested.
Then we realise that the Scavenger had a bug setting the `tenureThreshold`, so the tenuring is not working as expected.

In this PR:
- Tenuring algorithm is tested (a bit)
- `tenureThreshold` computation was fixed (_it was setting it in the wrong semi-space_)
- Renaming some methods for clarity (the uses of these methods are strange, we need to improve the API with the image)