### PR TITLE
Validate if locals/args exist when adding a type declaration

### DIFF
--- a/smalltalksrc/Slang-Tests/SLBasicTestDeclarationClass.class.st
+++ b/smalltalksrc/Slang-Tests/SLBasicTestDeclarationClass.class.st
@@ -4,6 +4,12 @@ Class {
 	#category : #'Slang-Tests'
 }
 
+{ #category : #translation }
+SLBasicTestDeclarationClass class >> typeForSelf [
+
+	^#implicit
+]
+
 { #category : #'as yet unclassified' }
 SLBasicTestDeclarationClass >> methodWithBlockLocalDeclaration [
 
@@ -29,5 +35,11 @@ SLBasicTestDeclarationClass >> methodWithLocalWithDeclaration [
 SLBasicTestDeclarationClass >> methodWithNonExistingLocalDeclaration [
 
 	"var does not exist"
+	<var: 'var' type: 'toto'>
+]
+
+{ #category : #'as yet unclassified' }
+SLBasicTestDeclarationClass >> methodWithUndefinedLocal [
+
 	<var: 'var' type: 'toto'>
 ]

--- a/smalltalksrc/Slang-Tests/SLBasicTestDeclarationClass.class.st
+++ b/smalltalksrc/Slang-Tests/SLBasicTestDeclarationClass.class.st
@@ -37,9 +37,3 @@ SLBasicTestDeclarationClass >> methodWithNonExistingLocalDeclaration [
 	"var does not exist"
 	<var: 'var' type: 'toto'>
 ]
-
-{ #category : #'as yet unclassified' }
-SLBasicTestDeclarationClass >> methodWithUndefinedLocal [
-
-	<var: 'var' type: 'toto'>
-]

--- a/smalltalksrc/Slang-Tests/SLTestDeclarations.class.st
+++ b/smalltalksrc/Slang-Tests/SLTestDeclarations.class.st
@@ -11,6 +11,14 @@ SLTestDeclarations >> setUp [
 ]
 
 { #category : #tests }
+SLTestDeclarations >> testAddTypeForSelfWithDeclarationsDoesNotThrowError [
+
+	| method |
+	method := ccg methodNamed: #methodWithUndefinedLocal.
+	self shouldnt: [ method addTypeForSelf ] raise: Error
+]
+
+{ #category : #tests }
 SLTestDeclarations >> testAllLocalsReturnsBlockLocals [
 
 	self
@@ -68,4 +76,12 @@ SLTestDeclarations >> testLocalsReturnsDirectLocals [
 	self
 		assertCollection: (ccg methodNamed: #methodWithLocal) locals
 		hasSameElements: #( 'var' )
+]
+
+{ #category : #tests }
+SLTestDeclarations >> testUndefinedLocalWithDeclarationsThrowsError [
+
+	| method |
+	method := ccg methodNamed: #methodWithUndefinedLocal.
+	self should: [ method recordDeclarationsIn: ccg ] raise: Error
 ]

--- a/smalltalksrc/Slang-Tests/SLTestDeclarations.class.st
+++ b/smalltalksrc/Slang-Tests/SLTestDeclarations.class.st
@@ -83,5 +83,5 @@ SLTestDeclarations >> testUndefinedLocalWithDeclarationsThrowsError [
 
 	| method |
 	method := ccg methodNamed: #methodWithUndefinedLocal.
-	self should: [ method recordDeclarationsIn: ccg ] raise: Error
+	self should: [ method recordDeclarationsIn: ccg ] raise: TranslationError
 ]

--- a/smalltalksrc/Slang-Tests/SLTestDeclarations.class.st
+++ b/smalltalksrc/Slang-Tests/SLTestDeclarations.class.st
@@ -14,8 +14,8 @@ SLTestDeclarations >> setUp [
 SLTestDeclarations >> testAddTypeForSelfWithDeclarationsDoesNotThrowError [
 
 	| method |
-	method := ccg methodNamed: #methodWithUndefinedLocal.
-	self shouldnt: [ method addTypeForSelf ] raise: Error
+	method := ccg methodNamed: #methodWithNonExistingLocalDeclaration.
+	self shouldnt: [ method addTypeForSelf ] raise: TranslationError
 ]
 
 { #category : #tests }
@@ -82,6 +82,6 @@ SLTestDeclarations >> testLocalsReturnsDirectLocals [
 SLTestDeclarations >> testUndefinedLocalWithDeclarationsThrowsError [
 
 	| method |
-	method := ccg methodNamed: #methodWithUndefinedLocal.
+	method := ccg methodNamed: #methodWithNonExistingLocalDeclaration.
 	self should: [ method recordDeclarationsIn: ccg ] raise: TranslationError
 ]

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -4217,7 +4217,9 @@ SlangBasicTranslationTest >> testSendIntegerObjectOfConstantValue [
 SlangBasicTranslationTest >> testSendIntegerObjectOfSignedValue [
 
 	| translation send |
-	generator currentMethod declarationAt: 'var' put: 'long'.
+	
+	generator currentMethod addLocal: 'var'; declarationAt: 'var' put: 'long'.
+		
 	send := TSendNode new
 					setSelector: #integerObjectOf:
 					receiver: (TVariableNode named: 'self')
@@ -4231,7 +4233,7 @@ SlangBasicTranslationTest >> testSendIntegerObjectOfSignedValue [
 SlangBasicTranslationTest >> testSendIntegerObjectOfUnsignedSmallValue [
 
 	| translation send |
-	generator currentMethod declarationAt: 'var' put: 'unsigned short'.
+	generator currentMethod addLocal: 'var'; declarationAt: 'var' put: 'unsigned short'.
 	send := TSendNode new
 					setSelector: #integerObjectOf:
 					receiver: (TVariableNode named: 'self')
@@ -4245,14 +4247,18 @@ SlangBasicTranslationTest >> testSendIntegerObjectOfUnsignedSmallValue [
 SlangBasicTranslationTest >> testSendIntegerObjectOfUnsignedValue [
 
 	| translation send |
-	generator currentMethod declarationAt: 'var' put: 'unsigned long'.
+	generator currentMethod
+		addLocal: 'var';
+		declarationAt: 'var' put: 'unsigned long'.
 	send := TSendNode new
-					setSelector: #integerObjectOf:
-					receiver: (TVariableNode named: 'self')
-					arguments: { TVariableNode named: 'var' }.
+		        setSelector: #integerObjectOf:
+		        receiver: (TVariableNode named: 'self')
+		        arguments: { (TVariableNode named: 'var') }.
 	translation := self translate: send.
 
-	self assert: translation equals: '((var << ', numSmallIntegerTagBits asString, ') | 1)'
+	self
+		assert: translation
+		equals: '((var << ' , numSmallIntegerTagBits asString , ') | 1)'
 ]
 
 { #category : #'tests-builtins' }
@@ -4353,7 +4359,7 @@ SlangBasicTranslationTest >> testSendLeftBitShifNegativeLitteralIntegerOverflow 
 SlangBasicTranslationTest >> testSendLeftBitShift [
 
 	| translation send |
-	generator currentMethod declarationAt: 'a' put: 'sqInt'.
+	generator currentMethod addLocal:'a'; declarationAt: 'a' put: 'sqInt'.
 	send := TSendNode new
 		        setSelector: #<<
 		        receiver: (TVariableNode new setName: 'a')
@@ -4367,10 +4373,12 @@ SlangBasicTranslationTest >> testSendLeftBitShift [
 SlangBasicTranslationTest >> testSendLeftBitShiftByVariable [
 
 	| translation send |
-	generator currentMethod declarationAt: 'a' put: 'unsigned short'.
-	
+	generator currentMethod
+		addLocal: 'a';
+		declarationAt: 'a' put: 'unsigned short'.
+
 	send := TSendNode new
-		        setSelector: #<<
+		        setSelector: #'<<'
 		        receiver: (TConstantNode value: 3)
 		        arguments: { (TVariableNode new setName: 'a') }.
 	translation := self translate: send.
@@ -4382,9 +4390,11 @@ SlangBasicTranslationTest >> testSendLeftBitShiftByVariable [
 SlangBasicTranslationTest >> testSendLeftBitShiftByVariableIn32Bits [
 
 	| translation send |
-	generator currentMethod declarationAt: 'a' put: 'sqInt'.
+	generator currentMethod
+		addLocal: 'a';
+		declarationAt: 'a' put: 'sqInt'.
 	send := TSendNode new
-		        setSelector: #<<
+		        setSelector: #'<<'
 		        receiver: (TConstantNode value: 3)
 		        arguments: { (TVariableNode new setName: 'a') }.
 	translation := self translate: send.
@@ -4396,10 +4406,12 @@ SlangBasicTranslationTest >> testSendLeftBitShiftByVariableIn32Bits [
 SlangBasicTranslationTest >> testSendLeftBitShiftByVariableIn64Bits [
 
 	| translation send |
-	generator currentMethod declarationAt: 'a' put: 'sqInt'.
+	generator currentMethod
+		addLocal: 'a';
+		declarationAt: 'a' put: 'sqInt'.
 	generator wordSize: 8.
 	send := TSendNode new
-		        setSelector: #<<
+		        setSelector: #'<<'
 		        receiver: (TConstantNode value: 3)
 		        arguments: { (TVariableNode new setName: 'a') }.
 	translation := self translate: send.
@@ -4411,9 +4423,11 @@ SlangBasicTranslationTest >> testSendLeftBitShiftByVariableIn64Bits [
 SlangBasicTranslationTest >> testSendLeftBitShiftLong [
 
 	| translation send |
-	generator currentMethod declarationAt: 'a' put: 'sqLong'.
+	generator currentMethod
+		addLocal: 'a';
+		declarationAt: 'a' put: 'sqLong'.
 	send := TSendNode new
-		        setSelector: #<<
+		        setSelector: #'<<'
 		        receiver: (TVariableNode new setName: 'a')
 		        arguments: { (TConstantNode value: 3) }.
 	translation := self translate: send.
@@ -4425,9 +4439,11 @@ SlangBasicTranslationTest >> testSendLeftBitShiftLong [
 SlangBasicTranslationTest >> testSendLeftBitShiftShortType [
 
 	| translation send |
-	generator currentMethod declarationAt: 'a' put: 'short'.
+	generator currentMethod
+		addLocal: 'a';
+		declarationAt: 'a' put: 'short'.
 	send := TSendNode new
-		        setSelector: #<<
+		        setSelector: #'<<'
 		        receiver: (TVariableNode new setName: 'a')
 		        arguments: { (TConstantNode value: 3) }.
 	translation := self translate: send.
@@ -4439,9 +4455,11 @@ SlangBasicTranslationTest >> testSendLeftBitShiftShortType [
 SlangBasicTranslationTest >> testSendLeftBitShiftUnsigned [
 
 	| translation send |
-	generator currentMethod declarationAt: 'a' put: 'usqInt'.
+	generator currentMethod
+		addLocal: 'a';
+		declarationAt: 'a' put: 'usqInt'.
 	send := TSendNode new
-		        setSelector: #<<
+		        setSelector: #'<<'
 		        receiver: (TVariableNode new setName: 'a')
 		        arguments: { (TConstantNode value: 3) }.
 	translation := self translate: send.
@@ -4453,9 +4471,11 @@ SlangBasicTranslationTest >> testSendLeftBitShiftUnsigned [
 SlangBasicTranslationTest >> testSendLeftBitShiftUnsignedShortType [
 
 	| translation send |
-	generator currentMethod declarationAt: 'a' put: 'unsigned short'.
+	generator currentMethod
+		addLocal: 'a';
+		declarationAt: 'a' put: 'unsigned short'.
 	send := TSendNode new
-		        setSelector: #<<
+		        setSelector: #'<<'
 		        receiver: (TVariableNode new setName: 'a')
 		        arguments: { (TConstantNode value: 3) }.
 	translation := self translate: send.
@@ -4687,17 +4707,21 @@ SlangBasicTranslationTest >> testSendPerformWith [
 SlangBasicTranslationTest >> testSendPerformWithAccessor [
 
 	| translation send |
-	generator currentMethod declarationAt: 'aPrimitiveDescriptor' put: #'PrimitiveDescriptor *'.
+	generator currentMethod
+		addLocal: 'aPrimitiveDescriptor';
+		declarationAt: 'aPrimitiveDescriptor' put: #'PrimitiveDescriptor *'.
 	send := TSendNode new
 		        setSelector: #perform:
 		        receiver: (TVariableNode named: 'objectRepresentation')
-		        arguments: { TSendNode new
-			        setSelector: #primitiveGenerator
-			        receiver: (TVariableNode named: 'aPrimitiveDescriptor')
-			        arguments: #() }.
+		        arguments: { (TSendNode new
+				         setSelector: #primitiveGenerator
+				         receiver: (TVariableNode named: 'aPrimitiveDescriptor')
+				         arguments: #(  )) }.
 	translation := self translate: send.
 
-	self assert: translation equals: '(primitiveGenerator(aPrimitiveDescriptor))()'
+	self
+		assert: translation
+		equals: '(primitiveGenerator(aPrimitiveDescriptor))()'
 ]
 
 { #category : #'tests-builtins' }
@@ -4836,10 +4860,12 @@ SlangBasicTranslationTest >> testSendRepeat [
 SlangBasicTranslationTest >> testSendRightBitShiftSignedIn64Bits [
 
 	| translation send |
-	generator currentMethod declarationAt: 'a' put: 'sqInt'.
+	generator currentMethod
+		addLocal: 'a';
+		declarationAt: 'a' put: 'sqInt'.
 	generator wordSize: 8.
 	send := TSendNode new
-		        setSelector: #>>
+		        setSelector: #'>>'
 		        receiver: (TVariableNode new setName: 'a')
 		        arguments: { (TConstantNode value: 3) }.
 	translation := self translate: send.
@@ -4851,9 +4877,11 @@ SlangBasicTranslationTest >> testSendRightBitShiftSignedIn64Bits [
 SlangBasicTranslationTest >> testSendRightBitShiftUnsigned [
 
 	| translation send |
-	generator currentMethod declarationAt: 'a' put: 'usqInt'.
+	generator currentMethod
+		addLocal: 'a';
+		declarationAt: 'a' put: 'usqInt'.
 	send := TSendNode new
-		        setSelector: #>>
+		        setSelector: #'>>'
 		        receiver: (TVariableNode new setName: 'a')
 		        arguments: { (TConstantNode value: 3) }.
 	translation := self translate: send.
@@ -4865,10 +4893,12 @@ SlangBasicTranslationTest >> testSendRightBitShiftUnsigned [
 SlangBasicTranslationTest >> testSendRightBitShiftUnsignedIn64Bits [
 
 	| translation send |
-	generator currentMethod declarationAt: 'a' put: 'usqInt'.
+	generator currentMethod
+		addLocal: 'a';
+		declarationAt: 'a' put: 'usqInt'.
 	generator wordSize: 8.
 	send := TSendNode new
-		        setSelector: #>>
+		        setSelector: #'>>'
 		        receiver: (TVariableNode new setName: 'a')
 		        arguments: { (TConstantNode value: 3) }.
 	translation := self translate: send.
@@ -5136,9 +5166,11 @@ SlangBasicTranslationTest >> testSendSignedIntToShort [
 SlangBasicTranslationTest >> testSendSignedRightBitShiftVariable64Bits [
 
 	| translation send |
-	generator currentMethod declarationAt: 'a' put: 'long long'.
+	generator currentMethod
+		addLocal: 'a';
+		declarationAt: 'a' put: 'long long'.
 	send := TSendNode new
-		        setSelector: #>>>
+		        setSelector: #'>>>'
 		        receiver: (TVariableNode new setName: 'a')
 		        arguments: { (TConstantNode value: 3) }.
 	translation := self translate: send.
@@ -6163,7 +6195,9 @@ SlangBasicTranslationTest >> testSwitchStatementInAssignmentAddAssignmentToEndOf
 SlangBasicTranslationTest >> testSwitchStatementInAssignmentAddAssignmentToEndOfCasesWithNoDefaultStatement [
 
 	| translation |
-	generator currentMethod declarationAt: 'toto' put: 'int toto'.
+	generator currentMethod
+		addLocal: 'toto';
+		declarationAt: 'toto' put: 'int toto'.
 	translation := self translate: (TAssignmentNode new
 			                setVariable: (TVariableNode named: 'toto')
 			                expression: (TSwitchStmtNode new
@@ -6197,7 +6231,9 @@ SlangBasicTranslationTest >> testSwitchStatementInAssignmentAddAssignmentToEndOf
 SlangBasicTranslationTest >> testSwitchStatementInAssignmentAddAssignmentToEndOfCasesWithNoDefaultStatementAndAssignmentVariableIsPointer [
 
 	| translation |
-	generator currentMethod declarationAt: 'toto' put: 'int* toto'.
+	generator currentMethod
+		addLocal: 'toto';
+		declarationAt: 'toto' put: 'int* toto'.
 	translation := self translate: (TAssignmentNode new
 			                setVariable: (TVariableNode named: 'toto')
 			                expression: (TSwitchStmtNode new

--- a/smalltalksrc/Slang/TMethod.class.st
+++ b/smalltalksrc/Slang/TMethod.class.st
@@ -3298,7 +3298,7 @@ TMethod >> validateVariableDeclarationExists: aVariableName [
 
 	| shouldCheckVariable |
 	shouldCheckVariable := (aVariableName beginsWithAnyOf:
-		                       #( #self , #cascade , #toDoLimit )) not.
+		                       #( #self #cascade #toDoLimit )) not.
 
 	(shouldCheckVariable and: [
 		 (self declaresVariableWithName: aVariableName) not]) ifTrue: [

--- a/smalltalksrc/Slang/TMethod.class.st
+++ b/smalltalksrc/Slang/TMethod.class.st
@@ -666,8 +666,10 @@ TMethod >> declarationAt: aVariableName put: aDeclaration [
 
 
 	isRelevantVariable and: [
-		(self declaresVariableWithName: aVariableName) not ifTrue: [
-			self error: 'Undefined local type declaration' ] ].
+		(self declaresVariableWithName: aVariableName) ifFalse: [
+			TranslationError signal:
+				'Undefined local or argument ' , aVariableName
+				, ' type declaration' ] ].
 	^ declarations at: aVariableName put: aDeclaration
 ]
 

--- a/smalltalksrc/Slang/TMethod.class.st
+++ b/smalltalksrc/Slang/TMethod.class.st
@@ -118,7 +118,7 @@ TMethod >> addVarsDeclarationsAndLabelsOf: methodToBeInlined except: doNotRename
 
    newLocals := methodToBeInlined args , methodToBeInlined allLocals asOrderedCollection .
 
-	self addLocals: (newLocals reject: [ :v | doNotRename includes: v]).
+	self addLocals: (newLocals copyWithoutAll: doNotRename).
 
 	methodToBeInlined declarations keysAndValuesDo:
 		[ :v :decl |
@@ -660,16 +660,8 @@ TMethod >> declarationAt: aVariableName ifPresent: presentBlock [
 { #category : #accessing }
 TMethod >> declarationAt: aVariableName put: aDeclaration [
 
-	| isRelevantVariable |
-	isRelevantVariable := (aVariableName beginsWithAnyOf:
-		                       #( #self , #cascade , #toDoLimit )) not.
+	self validateVariableDeclarationExists: aVariableName.
 
-
-	isRelevantVariable and: [
-		(self declaresVariableWithName: aVariableName) ifFalse: [
-			TranslationError signal:
-				'Undefined local or argument ' , aVariableName
-				, ' type declaration' ] ].
 	^ declarations at: aVariableName put: aDeclaration
 ]
 
@@ -3299,6 +3291,20 @@ TMethod >> usesVariableUninlinably: argName in: aCodeGen [
 				  node arguments anySatisfy: [ :argNode | 
 					  argNode anySatisfy: [ :subNode | 
 						  subNode isVariable and: [ subNode name = argName ] ] ] ] ] ]
+]
+
+{ #category : #accessing }
+TMethod >> validateVariableDeclarationExists: aVariableName [
+
+	| shouldCheckVariable |
+	shouldCheckVariable := (aVariableName beginsWithAnyOf:
+		                       #( #self , #cascade , #toDoLimit )) not.
+
+	(shouldCheckVariable and: [
+		 (self declaresVariableWithName: aVariableName) not]) ifTrue: [
+		TranslationError signal:
+			'Undefined local or argument ' , aVariableName
+			, ' type declaration' ]
 ]
 
 { #category : #utilities }

--- a/smalltalksrc/Slang/TMethod.class.st
+++ b/smalltalksrc/Slang/TMethod.class.st
@@ -662,12 +662,12 @@ TMethod >> declarationAt: aVariableName put: aDeclaration [
 
 	| isRelevantVariable |
 	isRelevantVariable := (aVariableName beginsWithAnyOf:
-		                       #( #self , #cascade, #toDoLimit )) not.
+		                       #( #self , #cascade , #toDoLimit )) not.
 
-	parseTree notNil and: [
-		isRelevantVariable and: [
-			(self declaresVariableWithName: aVariableName ) not ifTrue: [
-				self error: 'Undefined local type declaration' ] ] ].
+
+	isRelevantVariable and: [
+		(self declaresVariableWithName: aVariableName) not ifTrue: [
+			self error: 'Undefined local type declaration' ] ].
 	^ declarations at: aVariableName put: aDeclaration
 ]
 

--- a/smalltalksrc/Slang/TMethod.class.st
+++ b/smalltalksrc/Slang/TMethod.class.st
@@ -93,6 +93,11 @@ TMethod >> addLocal: aString [
 	self locals add: aString
 ]
 
+{ #category : #adding }
+TMethod >> addLocals: locals [ 
+	locals do: [ :local | self addLocal: local ]
+]
+
 { #category : #initialization }
 TMethod >> addTypeForSelf [
 	"If self should be typed then add a suitable type declaration.
@@ -109,10 +114,12 @@ TMethod >> addTypeForSelf [
 TMethod >> addVarsDeclarationsAndLabelsOf: methodToBeInlined except: doNotRename [
 	"Prepare to inline the body of the given method into the receiver by making the args and locals of the argument to the receiver be locals of the receiver. Record any type declarations for these variables. Record labels. Assumes that the variables have already be renamed to avoid name clashes."
 
-	self locals
-		addAll: (methodToBeInlined args reject: [ :v | doNotRename includes: v]);
-		addAll: (methodToBeInlined locals reject: [ :v | doNotRename includes: v]);
-		yourself.
+    | newLocals |
+
+   newLocals := methodToBeInlined args , methodToBeInlined allLocals asOrderedCollection .
+
+	self addLocals: (newLocals reject: [ :v | doNotRename includes: v]).
+
 	methodToBeInlined declarations keysAndValuesDo:
 		[ :v :decl |
 		(doNotRename includes: v) ifFalse:
@@ -651,9 +658,17 @@ TMethod >> declarationAt: aVariableName ifPresent: presentBlock [
 ]
 
 { #category : #accessing }
-TMethod >> declarationAt: aVariableName  "<String>" put: aDeclaration [ "<String>" "^aDeclaration"
+TMethod >> declarationAt: aVariableName put: aDeclaration [
 
-	^declarations at: aVariableName put: aDeclaration
+	| isRelevantVariable |
+	isRelevantVariable := (aVariableName beginsWithAnyOf:
+		                       #( #self , #cascade, #toDoLimit )) not.
+
+	parseTree notNil and: [
+		isRelevantVariable and: [
+			(self declaresVariableWithName: aVariableName ) not ifTrue: [
+				self error: 'Undefined local type declaration' ] ] ].
+	^ declarations at: aVariableName put: aDeclaration
 ]
 
 { #category : #accessing }
@@ -677,6 +692,15 @@ TMethod >> declareNonConflictingLocalNamedLike: aString [
 	cachedLocals := nil.
 	self locals add: newVarName.
 	^ newVarName
+]
+
+{ #category : #testing }
+TMethod >> declaresVariableWithName: aVariableName [
+
+	| referencesInScope |
+	referencesInScope := self allLocals , self args.
+
+	^ referencesInScope includes: aVariableName
 ]
 
 { #category : #testing }
@@ -2784,7 +2808,7 @@ TMethod >> setSelector: sel definingClass: class args: argList locals: localList
 	definingClass := class.
 	args := argList asOrderedCollection collect: [:arg | arg name].
 	declarations := Dictionary new.
-	self addTypeForSelf.
+	
 	primitive := aNumber.
 	properties := methodProperties.
 	comment := aComment.
@@ -2797,7 +2821,7 @@ TMethod >> setSelector: sel definingClass: class args: argList locals: localList
 
 	self parseTree: (aBlockNode asTranslatorNodeIn: self).
 	self locals: tempParseTree locals, (localList  collect: [:arg | arg name]).
-	
+	self addTypeForSelf.
 	
 	complete := false.  "set to true when all possible inlining has been done"
 	export := self extractExportDirective.

--- a/smalltalksrc/VMMaker/Cogit.class.st
+++ b/smalltalksrc/VMMaker/Cogit.class.st
@@ -11762,15 +11762,15 @@ Cogit >> targetMethodAndSendTableFor: entryPoint annotation: annotation into: bi
 	"Evaluate binaryBlock with the targetMethod and relevant send table for a linked-send
 	 to entryPoint.  Do so based on the alignment of entryPoint."
 
-	<var: #targetMethod type: #'CogMethod *'>
-
-	self offsetAndSendTableFor: entryPoint
+	self
+		offsetAndSendTableFor: entryPoint
 		annotation: annotation
-		into: [:offset :sendTable| | targetCogCode |
-			targetCogCode := self cCoerceSimple: entryPoint - offset to: #'CogMethod *'.
-			binaryBlock
-				value: targetCogCode
-				value: sendTable]
+		into: [ :offset :sendTable |
+			| targetCogCode |
+			targetCogCode := self
+				                 cCoerceSimple: entryPoint - offset
+				                 to: #'CogMethod *'.
+			binaryBlock value: targetCogCode value: sendTable ]
 ]
 
 { #category : #debugging }

--- a/smalltalksrc/VMMaker/ComposedImageReader.class.st
+++ b/smalltalksrc/VMMaker/ComposedImageReader.class.st
@@ -179,7 +179,6 @@ ComposedImageReader >> readPermanentSpaceDataFromImage: imageFileName startingAt
 ComposedImageReader >> readPermanentSpaceFromImageFile: imageFileName header: aHeader [
 
 	<inline: false>
-	<var: #imageFile type: #sqImageFile>
 	<var: #aHeader type: #SpurImageHeaderStruct>
 	<var: #permSpaceMetadata type: #ComposedMetadataStruct>
 	<var: #bytesRead type: #'size_t'>

--- a/smalltalksrc/VMMaker/SlangBasicTranslationTest.extension.st
+++ b/smalltalksrc/VMMaker/SlangBasicTranslationTest.extension.st
@@ -11,6 +11,7 @@ SlangBasicTranslationTest >> setUp [
 		labels: Set new;
 		definingClass: self class;
 		selector: #setUp;
+		parseTree: (TStatementListNode new statements: #[])
 		yourself).
 	generator pushScope: TStatementListNode new.
 	

--- a/smalltalksrc/VMMaker/SlangBasicTranslationTest.extension.st
+++ b/smalltalksrc/VMMaker/SlangBasicTranslationTest.extension.st
@@ -11,7 +11,7 @@ SlangBasicTranslationTest >> setUp [
 		labels: Set new;
 		definingClass: self class;
 		selector: #setUp;
-		parseTree: (TStatementListNode new statements: #[])
+		parseTree: (TStatementListNode new statements: #())
 		yourself).
 	generator pushScope: TStatementListNode new.
 	

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -11544,7 +11544,6 @@ SpurMemoryManager >> setMaxOldSpaceSize: limit [
 SpurMemoryManager >> setMinimalPermSpaceSize: min [
 
 	<api>
-	<var: #limit type: #usqInt>
 	
 	self ensureMemoryMap.
 	self getMemoryMap minPermSpaceSize: min.

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -10967,22 +10967,20 @@ StackInterpreter >> primitiveExitCriticalSection [
 { #category : #'simd primitives' }
 StackInterpreter >> primitiveFloat64ArrayAdd [
 
-	<var: #rcvr type: #'double *'>
-	<var: #arg type: #'double *'>
 	| arg1 arg2 res arraySize |
 	arg1 := self stackValue: 2.
 	arg2 := self stackValue: 1.
 	res := self stackTop.
 	arraySize := objectMemory numSlotsOf: res.
 
-	(objectMemory isSixtyFourBitIndexableOop: arg1)
-		ifFalse: [ ^ self primitiveFailFor: PrimErrBadArgument ].
-	(objectMemory isSixtyFourBitIndexableOop: arg2)
-		ifFalse: [ ^ self primitiveFailFor: PrimErrBadArgument ].
-	(objectMemory isSixtyFourBitIndexableOop: res)
-		ifFalse: [ ^ self primitiveFailFor: PrimErrBadArgument ].
+	(objectMemory isSixtyFourBitIndexableOop: arg1) ifFalse: [
+		^ self primitiveFailFor: PrimErrBadArgument ].
+	(objectMemory isSixtyFourBitIndexableOop: arg2) ifFalse: [
+		^ self primitiveFailFor: PrimErrBadArgument ].
+	(objectMemory isSixtyFourBitIndexableOop: res) ifFalse: [
+		^ self primitiveFailFor: PrimErrBadArgument ].
 
-	0 to: arraySize - 1 do: [ :i | 
+	0 to: arraySize - 1 do: [ :i |
 		| tmp |
 		tmp := (objectMemory fetchFloat64: i ofObject: arg1)
 		       + (objectMemory fetchFloat64: i ofObject: arg2).
@@ -12954,7 +12952,6 @@ StackInterpreter >> reapAndResetErrorCodeTo: theFP header: methodHeader [
 	 and if so, assign it through theFP into the correct temporary variable.
 	Then zero the primFailCode.  This is infrequent code, so keep it out of the common path."
 
-	<var: 'theSP' type: #'char *'>
 	<inline: #never>
 	| initialPC |
 	self assert: primFailCode ~= 0.

--- a/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
+++ b/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
@@ -1341,14 +1341,14 @@ StackToRegisterMappingCogit >> fixupAtIndex: index [
 StackToRegisterMappingCogit >> freeAnyFloatRegNotConflictingWith: regMask [
 	"Spill the closest register on stack not conflicting with regMask. 
 	Assertion Failure if regMask has already all the registers"
-	<var: #desc type: #'CogSimStackEntry *'>
+
 	| reg index |
 	self assert: needsFrame.
 	reg := NoReg.
 	index := simSpillBase max: 0.
 	self deny: reg = NoReg.
 	self ssAllocateRequiredFloatReg: reg.
-	^reg
+	^ reg
 ]
 
 { #category : #'simulation stack' }


### PR DESCRIPTION
fix #598 

Adds a validation at `TMethod >> declarationAt: aVariableName put: aDeclaration` 

Removed unused type declarations and then generated the VM C Code and compiled succesfully :rocket: 


