### PR TITLE
Reject reserved words

### DIFF
--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -1404,6 +1404,13 @@ SlangBasicTranslationTest >> testLabelWithCommentWithPreviousCommentMarkingAnInl
 	self assert: translation equals: ''
 ]
 
+{ #category : #'tests-assignment' }
+SlangBasicTranslationTest >> testMethodCantHaveReservedSelectorName [
+
+	self should: [TMethod new selector: 'register'] raise: TranslationError.
+
+]
+
 { #category : #'tests-method' }
 SlangBasicTranslationTest >> testMethodComment [
 
@@ -6388,6 +6395,13 @@ SlangBasicTranslationTest >> testVariableAssignment [
 			expression: expression).
 
 	self assert: translation equals: 'var = 7'
+]
+
+{ #category : #'tests-assignment' }
+SlangBasicTranslationTest >> testVariableCantHaveReservedName [
+
+	self should: [TVariableNode new setName: 'register'] raise: TranslationError.
+
 ]
 
 { #category : #'tests-blocks' }

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -1405,10 +1405,45 @@ SlangBasicTranslationTest >> testLabelWithCommentWithPreviousCommentMarkingAnInl
 ]
 
 { #category : #'tests-assignment' }
+SlangBasicTranslationTest >> testMethodCantHaveReservedArgumentNames [
+
+	| methodInitialization |
+	methodInitialization := [
+	                        TMethod new
+		                        setSelector: 'foo'
+		                        definingClass: MockEmptyVMStruct
+		                        args: { RBVariableNode named: 'continue' }
+		                        locals: Array empty
+		                        block:
+		                        (RBBlockNode body:
+			                         (RBSequenceNode statements:
+				                          Array empty))
+		                        primitive: nil
+		                        properties: nil
+		                        comment: nil ].
+
+	self should: methodInitialization raise: TranslationError
+]
+
+{ #category : #'tests-assignment' }
 SlangBasicTranslationTest >> testMethodCantHaveReservedSelectorName [
 
-	self should: [TMethod new selector: 'register'] raise: TranslationError.
+	| methodInitialization |
+	methodInitialization := [
+	                        TMethod new
+		                        setSelector: 'break'
+		                        definingClass: MockEmptyVMStruct
+		                        args: Array empty
+		                        locals: Array empty
+		                        block:
+		                        (RBBlockNode body:
+			                         (RBSequenceNode statements:
+				                          Array empty))
+		                        primitive: nil
+		                        properties: nil
+		                        comment: nil ].
 
+	self should: methodInitialization raise: TranslationError
 ]
 
 { #category : #'tests-method' }
@@ -3295,14 +3330,14 @@ SlangBasicTranslationTest >> testSendIfFalseIfTrueWithSingleStatementArguments [
 		        setSelector: #ifFalse:ifTrue:
 		        receiver: (TVariableNode new setName: 'x')
 		        arguments: { 
-				        TVariableNode new setName: 'break'.
-				        TVariableNode new setName: 'continue' }.
+				        TVariableNode new setName: 'foo'.
+				        TVariableNode new setName: 'bar' }.
 	translation := self translate: send.
 
 	self assert: translation trimBoth equals: 'if (x) 
-	continue;
+	bar;
  else 
-	break;'
+	foo;'
 ]
 
 { #category : #'tests-builtins' }
@@ -4087,14 +4122,14 @@ SlangBasicTranslationTest >> testSendIfTrueIfFalseWithSingleStatementArguments [
 		        setSelector: #ifTrue:ifFalse:
 		        receiver: (TVariableNode new setName: 'x')
 		        arguments: { 
-				        TVariableNode new setName: 'break'.
-				        TVariableNode new setName: 'continue' }.
+				        TVariableNode new setName: 'foo'.
+				        TVariableNode new setName: 'bar' }.
 	translation := self translate: send.
 
 	self assert: translation trimBoth equals: 'if (x) 
-	break;
+	foo;
  else 
-	continue;'
+	bar;'
 ]
 
 { #category : #'tests-builtins' }
@@ -4198,11 +4233,11 @@ SlangBasicTranslationTest >> testSendIfTrueWithSingleStatementArgument [
 	send := TSendNode new
 		        setSelector: #ifTrue:
 		        receiver: (TVariableNode new setName: 'x')
-		        arguments: { TVariableNode new setName: 'break' }.
+		        arguments: { TVariableNode new setName: 'foo' }.
 	translation := self translate: send.
 
 	self assert: translation trimBoth equals: 'if (x) 
-	break;'
+	foo;'
 ]
 
 { #category : #'tests-builtins' }

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -75,6 +75,25 @@ CCodeGenerator class >> monticelloDescriptionFor: aClass [
 	^aClass name, (pkg modified ifTrue: [' * '] ifFalse: [' ']), pkg ancestry ancestorString, ' uuid: ', uuid asString
 ]
 
+{ #category : #'C translation support' }
+CCodeGenerator class >> reservedWords [
+	^#(	'auto'
+		'break'
+		'case' 'char' 'const' 'continue'
+		'default' 'do' 'double'
+		'else' "'entry' obsolete" 'enum' 'extern'
+		'float' 'for'
+		'goto'
+		'if' 'int'
+		'long'
+		'register' 'return'
+		'short' 'signed' 'sizeof' 'static' 'struct' 'switch'
+		'typedef'
+		'union' 'unsigned'
+		'void' 'volatile'
+		'while')
+]
+
 { #category : #'C code generator' }
 CCodeGenerator class >> shortMonticelloDescriptionForClass: aClass [
 	"Answer a suitable Monticello package stamp to include in a moduleName."
@@ -4380,21 +4399,7 @@ CCodeGenerator >> removeVariable: aName ifAbsent: ifAbsentBlock [
 
 { #category : #'C translation support' }
 CCodeGenerator >> reservedWords [
-	^#(	'auto'
-		'break'
-		'case' 'char' 'const' 'continue'
-		'default' 'do' 'double'
-		'else' "'entry' obsolete" 'enum' 'extern'
-		'float' 'for'
-		'goto'
-		'if' 'int'
-		'long'
-		'register' 'return'
-		'short' 'signed' 'sizeof' 'static' 'struct' 'switch'
-		'typedef'
-		'union' 'unsigned'
-		'void' 'volatile'
-		'while')
+	^ self class reservedWords
 ]
 
 { #category : #inlining }

--- a/smalltalksrc/Slang/TMethod.class.st
+++ b/smalltalksrc/Slang/TMethod.class.st
@@ -2799,6 +2799,8 @@ TMethod >> setSelector: sel definingClass: class args: argList locals: localList
 	self locals: tempParseTree locals, (localList  collect: [:arg | arg name]).
 	
 	
+	self validateReservedWords.
+	
 	complete := false.  "set to true when all possible inlining has been done"
 	export := self extractExportDirective.
 	static := self extractStaticDirective.
@@ -3273,6 +3275,21 @@ TMethod >> usesVariableUninlinably: argName in: aCodeGen [
 				  node arguments anySatisfy: [ :argNode | 
 					  argNode anySatisfy: [ :subNode | 
 						  subNode isVariable and: [ subNode name = argName ] ] ] ] ] ]
+]
+
+{ #category : #'C code generation' }
+TMethod >> validateReservedWords [
+	"Validates if there are no reserved words being used as arguments or selector"
+
+	| reservedWords |
+	reservedWords := CCodeGenerator reservedWords.
+
+	(reservedWords includesAnyOf: args) ifTrue: [
+		TranslationError signal: 'Arguments cannot be reserved words' ].
+
+	(reservedWords includes: selector) ifTrue: [
+		TranslationError signal:
+			'Invalid selector ' , selector , ': Reserved word' ]
 ]
 
 { #category : #utilities }

--- a/smalltalksrc/Slang/TVariableNode.class.st
+++ b/smalltalksrc/Slang/TVariableNode.class.st
@@ -127,7 +127,10 @@ TVariableNode >> printOn: aStream level: level [
 { #category : #accessing }
 TVariableNode >> setName: aString [
 
-	name := aString.
+	(CCodeGenerator reservedWords includes: aString) ifTrue: [
+		TranslationError signal: aString , ' is a reserved word' ].
+
+	name := aString
 ]
 
 { #category : #testing }

--- a/smalltalksrc/Slang/TVariableNode.class.st
+++ b/smalltalksrc/Slang/TVariableNode.class.st
@@ -127,7 +127,8 @@ TVariableNode >> printOn: aStream level: level [
 { #category : #accessing }
 TVariableNode >> setName: aString [
 
-	(CCodeGenerator reservedWords includes: aString) ifTrue: [
+	(CCodeGenerator reservedWords includes:
+		 aString) ifTrue: [
 		TranslationError signal: aString , ' is a reserved word' ].
 
 	name := aString

--- a/smalltalksrc/VMMaker/CogIA32Compiler.class.st
+++ b/smalltalksrc/VMMaker/CogIA32Compiler.class.st
@@ -3328,24 +3328,24 @@ CogIA32Compiler >> genMemCopy: originalSourceReg to: originalDestReg size: origi
 ]
 
 { #category : #'abstract instructions' }
-CogIA32Compiler >> genMoveCf32: constantFloat32 Rs: register [
+CogIA32Compiler >> genMoveCf32: constantFloat32 Rs: reg [
 	<inline: true>
 	<returnTypeC: #'AbstractInstruction *'>
 	<var: #constantFloat32 type: #float>
 	| inst |
 	inst := cogit PushCw: constantFloat32 asIEEE32BitWord.
-	cogit PopRs: register.
+	cogit PopRs: reg.
 	^ inst
 ]
 
 { #category : #'abstract instructions' }
-CogIA32Compiler >> genMoveCf64: constantFloat64 Rd: register [
+CogIA32Compiler >> genMoveCf64: constantFloat64 Rd: reg [
 	<inline: true>
 	<returnTypeC: #'AbstractInstruction *'>
 	<var: #constantFloat64 type: #double>
 	| inst |
 	inst := cogit PushC64: constantFloat64 asIEEE64BitWord.
-	cogit PopRd: register.
+	cogit PopRd: reg.
 	^ inst
 ]
 

--- a/smalltalksrc/VMMaker/CogRegisterAllocatingSimStackEntry.class.st
+++ b/smalltalksrc/VMMaker/CogRegisterAllocatingSimStackEntry.class.st
@@ -11,7 +11,7 @@ CogRegisterAllocatingSimStackEntry >> copyLiveRegisterIfSameAs: simStackEntry [
 	(self ~~ simStackEntry
 	 and: [type = simStackEntry type
 	 and: [type = SSBaseOffset
-	 and: [register = simStackEntry register and: [offset = simStackEntry offset]]]]) ifTrue:
+	 and: [registerr = simStackEntry registerr and: [offset = simStackEntry offset]]]]) ifTrue:
 		[liveRegister := simStackEntry liveRegister]
 ]
 
@@ -19,7 +19,7 @@ CogRegisterAllocatingSimStackEntry >> copyLiveRegisterIfSameAs: simStackEntry [
 CogRegisterAllocatingSimStackEntry >> ensureSpilledAt: baseOffset from: baseRegister [
 	spilled ifTrue:
 		[type = SSSpill ifTrue:
-			[self assert: ((offset = baseOffset and: [register = baseRegister]) or: [cogit violatesEnsureSpilledSpillAssert]).
+			[self assert: ((offset = baseOffset and: [registerr = baseRegister]) or: [cogit violatesEnsureSpilledSpillAssert]).
 			 liveRegister := NoReg.
 			 ^self]].
 	self assert: type ~= SSSpill.
@@ -38,17 +38,17 @@ CogRegisterAllocatingSimStackEntry >> ensureSpilledAt: baseOffset from: baseRegi
 				ifTrue:
 					[liveRegister = NoReg
 						ifTrue: 
-							[cogit MoveMw: offset r: register R: TempReg.
+							[cogit MoveMw: offset r: registerr R: TempReg.
 					 		 cogit PushR: TempReg]
 						ifFalse: [cogit PushR: liveRegister]]
 				ifFalse:
 					[self assert: type = SSRegister.
-					 cogit PushR: register].
+					 cogit PushR: registerr].
 			 type := SSSpill].
 	liveRegister := NoReg.
 	spilled := true.
 	offset := baseOffset.
-	register := baseRegister
+	registerr := baseRegister
 ]
 
 { #category : #comparing }
@@ -56,8 +56,8 @@ CogRegisterAllocatingSimStackEntry >> isIdenticalEntryAs: ssEntry [
 	<var: 'ssEntry' type: #'CogSimStackEntry *'>
 	^type = ssEntry type
 	  and: [liveRegister = ssEntry liveRegister
-	  and: [((type = SSBaseOffset or: [type == SSSpill]) and: [offset = ssEntry offset and: [register = ssEntry register]])
-		or: [(type = SSRegister and: [register = ssEntry register])
+	  and: [((type = SSBaseOffset or: [type == SSSpill]) and: [offset = ssEntry offset and: [registerr = ssEntry registerr]])
+		or: [(type = SSRegister and: [registerr = ssEntry registerr])
 		or: [(type = SSConstant and: [constant = ssEntry constant])]]]]
 ]
 
@@ -72,15 +72,15 @@ CogRegisterAllocatingSimStackEntry >> isMergedWithTargetEntry: targetEntry [
 		[^false].
 	(self isSameEntryAs: targetEntry) ifTrue:
 		[^liveRegister = targetEntry liveRegister].
-	(type = SSConstant and: [targetEntry type = SSRegister and: [liveRegister = targetEntry register]]) ifTrue:
+	(type = SSConstant and: [targetEntry type = SSRegister and: [liveRegister = targetEntry registerr]]) ifTrue:
 		[^true].
 	"self: const =1 (16r1) (live: Extra4Reg) {172} vs reg ReceiverResultReg {127}"
 	"self: reg ReceiverResultReg {95} vs reg Extra5Reg {85}"
 	"self: (bo ReceiverResultReg+296 (live: Extra5Reg) {88} vs reg ReceiverResultReg {84}"
 	"self: const =1 (16r1) (spilled) {167} vs spill @ FPReg-48 {122}"
 	((type = SSConstant and: [targetEntry type = SSRegister and: [liveRegister ~= targetEntry registerOrNone]])
-	 or: [(type = SSRegister and: [targetEntry type = SSRegister and: [register ~= targetEntry registerOrNone]])
-	 or: [(type = SSBaseOffset and: [register = ReceiverResultReg and: [targetEntry type = SSRegister]])
+	 or: [(type = SSRegister and: [targetEntry type = SSRegister and: [registerr ~= targetEntry registerOrNone]])
+	 or: [(type = SSBaseOffset and: [registerr = ReceiverResultReg and: [targetEntry type = SSRegister]])
 	 or: [(type = SSConstant and: [targetEntry type = SSSpill])]]]) ifFalse:
 		[self halt: 'comment the incompatible pair please'].
 	^false
@@ -96,7 +96,7 @@ CogRegisterAllocatingSimStackEntry >> liveRegister [
 CogRegisterAllocatingSimStackEntry >> moveToReg: reg [
 	liveRegister ~= NoReg
 		ifTrue: 
-			[self deny: (type = SSRegister and: [register ~= liveRegister and: [cogit needsFrame]]).
+			[self deny: (type = SSRegister and: [registerr ~= liveRegister and: [cogit needsFrame]]).
 			 spilled ifTrue: "This is rare, and in some cases it isn't even needed (e.g. frameful return) but we can't tell as yet."
 				[cogit AddCq: objectRepresentation wordSize R: SPReg].
 			 reg ~= liveRegister
@@ -108,11 +108,11 @@ CogRegisterAllocatingSimStackEntry >> moveToReg: reg [
 					[cogit PopR: reg]
 				ifFalse:
 					[type caseOf: {
-						[SSBaseOffset]	-> [cogit MoveMw: offset r: register R: reg].
-						[SSSpill]		-> [cogit MoveMw: offset r: register R: reg].
+						[SSBaseOffset]	-> [cogit MoveMw: offset r: registerr R: reg].
+						[SSSpill]		-> [cogit MoveMw: offset r: registerr R: reg].
 						[SSConstant]	-> [cogit genMoveConstant: constant R: reg].
-						[SSRegister]	-> [reg ~= register
-												ifTrue: [cogit MoveR: register R: reg]
+						[SSRegister]	-> [reg ~= registerr
+												ifTrue: [cogit MoveR: registerr R: reg]
 												ifFalse: [cogit Label]] }]].
 
 	(reg ~= TempReg and: [liveRegister = NoReg and: [type ~= SSRegister]]) ifTrue:
@@ -131,7 +131,7 @@ CogRegisterAllocatingSimStackEntry >> offset [
 CogRegisterAllocatingSimStackEntry >> popToRegNoAssign: reg [
 	liveRegister ~= NoReg
 		ifTrue: 
-			[self deny: (type = SSRegister and: [register ~= liveRegister and: [cogit needsFrame]]).
+			[self deny: (type = SSRegister and: [registerr ~= liveRegister and: [cogit needsFrame]]).
 			 spilled ifTrue: "This is rare, and in some cases it isn't even needed (e.g. frameful return) but we can't tell as yet."
 				[cogit AddCq: objectRepresentation wordSize R: SPReg].
 			 reg ~= liveRegister
@@ -143,11 +143,11 @@ CogRegisterAllocatingSimStackEntry >> popToRegNoAssign: reg [
 					[cogit PopR: reg]
 				ifFalse:
 					[type caseOf: {
-						[SSBaseOffset]	-> [cogit MoveMw: offset r: register R: reg].
-						[SSSpill]		-> [cogit MoveMw: offset r: register R: reg].
+						[SSBaseOffset]	-> [cogit MoveMw: offset r: registerr R: reg].
+						[SSSpill]		-> [cogit MoveMw: offset r: registerr R: reg].
 						[SSConstant]	-> [cogit genMoveConstant: constant R: reg].
-						[SSRegister]	-> [reg ~= register
-												ifTrue: [cogit MoveR: register R: reg]
+						[SSRegister]	-> [reg ~= registerr
+												ifTrue: [cogit MoveR: registerr R: reg]
 												ifFalse: [cogit Label]] }]]
 ]
 
@@ -159,7 +159,7 @@ CogRegisterAllocatingSimStackEntry >> printStateOn: aStream [
 	type caseOf: {
 		[SSBaseOffset]	-> [aStream
 								nextPutAll: 'bo ';
-								nextPutAll: (cogit backEnd nameForRegister: register).
+								nextPutAll: (cogit backEnd nameForRegister: registerr).
 							offset negative ifFalse: [aStream nextPut: $+].
 							aStream print: offset].
 		[SSConstant]	-> [aStream
@@ -167,10 +167,10 @@ CogRegisterAllocatingSimStackEntry >> printStateOn: aStream [
 								nextPutAll: (cogit coInterpreter shortPrint: constant)].
 		[SSRegister]	-> [aStream
 								nextPutAll: 'reg ';
-								nextPutAll: (cogit backEnd nameForRegister: register)].
+								nextPutAll: (cogit backEnd nameForRegister: registerr)].
 		[SSSpill]		-> [aStream
 								nextPutAll: 'spill @ ';
-								nextPutAll: (cogit backEnd nameForRegister: register).
+								nextPutAll: (cogit backEnd nameForRegister: registerr).
 							offset negative ifFalse: [aStream nextPut: $+].
 							aStream print: offset] }.
 	(spilled and: [type ~= SSSpill]) ifTrue:
@@ -204,7 +204,7 @@ CogRegisterAllocatingSimStackEntry >> reconcileWith: targetEntry spillOffset: sp
 		 type caseOf: {
 			[SSBaseOffset]	-> [liveRegister ~= targetReg ifTrue:
 									[liveRegister = NoReg
-										ifTrue: [cogit MoveMw: offset r: register R: targetReg]
+										ifTrue: [cogit MoveMw: offset r: registerr R: targetReg]
 										ifFalse: [cogit MoveR: liveRegister R: targetReg].
 									 mergedRegister := true].
 								targetEntry type caseOf: {
@@ -216,9 +216,9 @@ CogRegisterAllocatingSimStackEntry >> reconcileWith: targetEntry spillOffset: sp
 														offset := spillOffset].
 									[SSConstant]	-> [liveRegister := targetReg. type := SSSpill.
 														offset := spillOffset].
-									[SSRegister]	-> [register := targetReg. type := SSRegister. liveRegister := NoReg] }].
+									[SSRegister]	-> [registerr := targetReg. type := SSRegister. liveRegister := NoReg] }].
 			[SSSpill]		-> [liveRegister = NoReg
-									ifTrue: [cogit MoveMw: offset r: register R: targetReg]
+									ifTrue: [cogit MoveMw: offset r: registerr R: targetReg]
 									ifFalse: [cogit MoveR: liveRegister R: targetReg].
 								liveRegister := targetReg.
 								mergedRegister := true].
@@ -228,31 +228,24 @@ CogRegisterAllocatingSimStackEntry >> reconcileWith: targetEntry spillOffset: sp
 									[liveRegister = NoReg
 										ifTrue: [cogit genMoveConstant: constant R: targetReg]
 										ifFalse: [cogit MoveR: liveRegister R: targetReg].
-									type := SSRegister. register := targetReg. liveRegister := NoReg.
+									type := SSRegister. registerr := targetReg. liveRegister := NoReg.
 									mergedRegister := true]].
-			[SSRegister]	-> [targetReg ~= register ifTrue:
-									[cogit MoveR: register R: targetReg.
-									 register := targetReg. liveRegister := NoReg.
+			[SSRegister]	-> [targetReg ~= registerr ifTrue:
+									[cogit MoveR: registerr R: targetReg.
+									 registerr := targetReg. liveRegister := NoReg.
 									 mergedRegister := true]] }.
 		 ^mergedRegister].
 	targetReg := targetEntry registerOrNone.
 	spillOrUnspillBlock value: targetReg.
 	(type = SSConstant
 	 and: [targetEntry type ~= SSConstant or: [targetEntry constant ~= constant]]) ifTrue:
-		[type := SSSpill. offset := spillOffset. register := FPReg].
+		[type := SSSpill. offset := spillOffset. registerr := FPReg].
 	(spilled not and: [type = SSSpill]) ifTrue:
-		[self assert: targetReg ~= NoReg. type := SSRegister. register := targetReg].
+		[self assert: targetReg ~= NoReg. type := SSRegister. registerr := targetReg].
 	liveRegister ~= targetReg ifTrue:
 		[liveRegister := NoReg.
 		 ^true].
 	^false
-]
-
-{ #category : #accessing }
-CogRegisterAllocatingSimStackEntry >> register [
-	"Answer the value of register"
-	self assert: (type = SSBaseOffset or: [type = SSRegister or: [type = SSSpill]]).
-	^register
 ]
 
 { #category : #accessing }
@@ -277,21 +270,28 @@ CogRegisterAllocatingSimStackEntry >> registerOrNone [
 	^super registerOrNone
 ]
 
+{ #category : #accessing }
+CogRegisterAllocatingSimStackEntry >> registerr [
+	"Answer the value of register"
+	self assert: (type = SSBaseOffset or: [type = SSRegister or: [type = SSSpill]]).
+	^registerr
+]
+
 { #category : #'compile abstract instructions' }
 CogRegisterAllocatingSimStackEntry >> storeToReg: reg [
 	liveRegister ~= NoReg
 		ifTrue:
-			[self deny: (type = SSRegister and: [register ~= liveRegister]).
+			[self deny: (type = SSRegister and: [registerr ~= liveRegister]).
 			 reg ~= liveRegister
 				ifTrue: [cogit MoveR: liveRegister R: reg]
 				ifFalse: [cogit Label]]
 		ifFalse:
 			[type caseOf: {
-				[SSBaseOffset]	-> [cogit MoveMw: offset r: register R: reg].
-				[SSSpill]		-> [cogit MoveMw: offset r: register R: reg].
+				[SSBaseOffset]	-> [cogit MoveMw: offset r: registerr R: reg].
+				[SSSpill]		-> [cogit MoveMw: offset r: registerr R: reg].
 				[SSConstant]	-> [cogit genMoveConstant: constant R: reg].
-				[SSRegister]	-> [reg ~= register
-											ifTrue: [cogit MoveR: register R: reg]
+				[SSRegister]	-> [reg ~= registerr
+											ifTrue: [cogit MoveR: registerr R: reg]
 											ifFalse: [cogit Label]] }].
 
 	(reg ~= TempReg and: [liveRegister = NoReg and: [type ~= SSRegister]]) ifTrue:
@@ -303,16 +303,16 @@ CogRegisterAllocatingSimStackEntry >> storeToReg: reg [
 CogRegisterAllocatingSimStackEntry >> storeToRegNoAssign: reg [
 	liveRegister ~= NoReg
 		ifTrue:
-			[self deny: (type = SSRegister and: [register ~= liveRegister]).
+			[self deny: (type = SSRegister and: [registerr ~= liveRegister]).
 			 reg ~= liveRegister
 				ifTrue: [cogit MoveR: liveRegister R: reg]
 				ifFalse: [cogit Label]]
 		ifFalse:
 			[type caseOf: {
-				[SSBaseOffset]	-> [cogit MoveMw: offset r: register R: reg].
-				[SSSpill]		-> [cogit MoveMw: offset r: register R: reg].
+				[SSBaseOffset]	-> [cogit MoveMw: offset r: registerr R: reg].
+				[SSSpill]		-> [cogit MoveMw: offset r: registerr R: reg].
 				[SSConstant]	-> [cogit genMoveConstant: constant R: reg].
-				[SSRegister]	-> [reg ~= register
-											ifTrue: [cogit MoveR: register R: reg]
+				[SSRegister]	-> [reg ~= registerr
+											ifTrue: [cogit MoveR: registerr R: reg]
 											ifFalse: [cogit Label]] }]
 ]

--- a/smalltalksrc/VMMaker/CogSimStackEntry.class.st
+++ b/smalltalksrc/VMMaker/CogSimStackEntry.class.st
@@ -48,7 +48,7 @@ Class {
 		'type',
 		'spilled',
 		'liveRegister',
-		'register',
+		'registerr',
 		'offset',
 		'constant',
 		'bcptr'
@@ -76,11 +76,11 @@ CogSimStackEntry class >> instVarNamesAndTypesForTranslationDo: aBinaryBlock [
 	self filteredInstVarNames do:
 		[:ivn|
 		aBinaryBlock
-			value: (ivn = 'register' ifTrue: ['registerr'] ifFalse: [ivn]) "avoid reservedWord conflict"
+			value: ivn
 			value: (ivn caseOf: {
 						['type']			-> [#char].
 						['spilled']		-> [#char].
-						['register']		-> [#'signed char']. "because NoReg = -1"
+						['registerr']		-> [#'signed char']. "because NoReg = -1"
 						['liveRegister']	-> [#'signed char'].}
 					otherwise:
 						[#sqInt])]
@@ -140,7 +140,7 @@ CogSimStackEntry >> ensureSpilledAt: baseOffset from: baseRegister [
 	<var: #inst type: #'AbstractInstruction *'>
 	spilled ifTrue:
 		[type = SSSpill ifTrue:
-			[self assert: ((offset = baseOffset and: [register = baseRegister]) or: [cogit violatesEnsureSpilledSpillAssert]).
+			[self assert: ((offset = baseOffset and: [registerr = baseRegister]) or: [cogit violatesEnsureSpilledSpillAssert]).
 			 ^self]].
 	self assert: type ~= SSSpill.
 	cogit traceSpill: self.
@@ -150,14 +150,14 @@ CogSimStackEntry >> ensureSpilledAt: baseOffset from: baseRegister [
 		ifFalse:
 			[type = SSBaseOffset
 				ifTrue:
-					[cogit MoveMw: offset r: register R: TempReg.
+					[cogit MoveMw: offset r: registerr R: TempReg.
 					 inst := cogit PushR: TempReg]
 				ifFalse:
 					[self assert: type = SSRegister.
-					 inst := cogit PushR: register].
+					 inst := cogit PushR: registerr].
 			 type := SSSpill.
 			 offset := baseOffset.
-			 register := baseRegister].
+			 registerr := baseRegister].
 	spilled := true.
 ]
 
@@ -170,7 +170,7 @@ CogSimStackEntry >> floatRegisterMask [
 CogSimStackEntry >> isFrameSimSelf [
 	"Answer if the receiver is self.  This only works in a frameful method, hence the weird name."
 	<inline: true>
-	^type = SSBaseOffset and: [register = FPReg and: [offset = FoxMFReceiver]]
+	^type = SSBaseOffset and: [registerr = FPReg and: [offset = FoxMFReceiver]]
 ]
 
 { #category : #comparing }
@@ -178,7 +178,7 @@ CogSimStackEntry >> isFrameTempVar [
 	"Answer if the receiver is a temporary variable.  This
 	 only works in a frameful method, hence the weird name."
 	<inline: true>
-	^type = SSBaseOffset and: [register = FPReg and: [offset ~= FoxMFReceiver]]
+	^type = SSBaseOffset and: [registerr = FPReg and: [offset ~= FoxMFReceiver]]
 ]
 
 { #category : #comparing }
@@ -186,15 +186,15 @@ CogSimStackEntry >> isFrameVar [
 	"Answer if the receiver is a temporary variable or self.  This
 	 only works in a frameful method, hence the weird name."
 	<inline: true>
-	^type = SSBaseOffset and: [register = FPReg]
+	^type = SSBaseOffset and: [registerr = FPReg]
 ]
 
 { #category : #comparing }
 CogSimStackEntry >> isSameEntryAs: ssEntry [
 	<var: 'ssEntry' type: #'CogSimStackEntry *'>
 	^type = ssEntry type
-	  and: [((type = SSBaseOffset or: [type == SSSpill]) and: [offset = ssEntry offset and: [register = ssEntry register]])
-		or: [(type = SSRegister and: [register = ssEntry register])
+	  and: [((type = SSBaseOffset or: [type == SSSpill]) and: [offset = ssEntry offset and: [registerr = ssEntry registerr]])
+		or: [(type = SSRegister and: [registerr = ssEntry registerr])
 		or: [(type = SSConstant and: [constant = ssEntry constant])]]]
 ]
 
@@ -224,10 +224,10 @@ CogSimStackEntry >> moveToReg: reg [
 			[cogit PopR: reg]
 		ifFalse:
 			[type caseOf: {
-				[SSBaseOffset]	-> [cogit MoveMw: offset r: register R: reg].
+				[SSBaseOffset]	-> [cogit MoveMw: offset r: registerr R: reg].
 				[SSConstant]	-> [cogit genMoveConstant: constant R: reg].
-				[SSRegister]	-> [reg ~= register
-										ifTrue: [cogit MoveR: register R: reg]
+				[SSRegister]	-> [reg ~= registerr
+										ifTrue: [cogit MoveR: registerr R: reg]
 										ifFalse: [cogit Label]] }]
 ]
 
@@ -239,7 +239,7 @@ CogSimStackEntry >> moveToVectorReg: reg [
 			[self notYetImplemented]
 		ifFalse:
 			[type caseOf: {
-				[SSVectorRegister]	-> [reg ~= register
+				[SSVectorRegister]	-> [reg ~= registerr
 										ifTrue: [self notYetImplemented]
 										ifFalse: [cogit Label]] }]
 ]
@@ -266,7 +266,7 @@ CogSimStackEntry >> printStateOn: aStream [
 	type caseOf: {
 		[SSBaseOffset]	-> [aStream
 								nextPutAll: 'bo ';
-								nextPutAll: (cogit backEnd nameForRegister: register).
+								nextPutAll: (cogit backEnd nameForRegister: registerr).
 							offset negative ifFalse: [aStream nextPut: $+].
 							aStream print: offset].
 		[SSConstant]	-> [aStream
@@ -274,15 +274,15 @@ CogSimStackEntry >> printStateOn: aStream [
 								nextPutAll: (cogit coInterpreter shortPrint: constant)].
 		[SSRegister]	-> [aStream
 								nextPutAll: 'reg ';
-								nextPutAll: (cogit backEnd nameForRegister: register)].
+								nextPutAll: (cogit backEnd nameForRegister: registerr)].
 		[SSSpill]		-> [aStream
 								nextPutAll: 'spill @ ';
-								nextPutAll: (cogit backEnd nameForRegister: register).
+								nextPutAll: (cogit backEnd nameForRegister: registerr).
 							offset negative ifFalse: [aStream nextPut: $+].
 							aStream print: offset].
 		[SSVectorRegister] -> [ aStream
 											nextPutAll: 'Vector Register ';
-											print: register ] }.
+											print: registerr ] }.
 	(spilled and: [type ~= SSSpill]) ifTrue:
 		[aStream nextPutAll: ' (spilled)'].
 	bcptr ifNotNil:
@@ -291,37 +291,37 @@ CogSimStackEntry >> printStateOn: aStream [
 ]
 
 { #category : #accessing }
-CogSimStackEntry >> register [
-	"Answer the value of register"
-	self assert: (type = SSBaseOffset or: [type = SSRegister or: [type = SSVectorRegister]]).
-	^register
-]
-
-{ #category : #accessing }
-CogSimStackEntry >> register: anObject [
-	"Set the value of register"
-
-	^register := anObject
-]
-
-{ #category : #accessing }
 CogSimStackEntry >> registerMask [
 	"Answer a bit mask for the receiver's register, if any."
 	^ (type = SSBaseOffset or: [ type = SSRegister or: [ type = SSVectorRegister ] ])
-		ifTrue: [ cogit registerMaskFor: register ]
+		ifTrue: [ cogit registerMaskFor: registerr ]
 		ifFalse: [ 0 ]
 ]
 
 { #category : #accessing }
 CogSimStackEntry >> registerMaskOrNone [
-	^(type = SSRegister or: [ type = SSVectorRegister ]) ifTrue: [cogit registerMaskFor: register] ifFalse: [0]
+	^(type = SSRegister or: [ type = SSVectorRegister ]) ifTrue: [cogit registerMaskFor: registerr] ifFalse: [0]
 ]
 
 { #category : #accessing }
 CogSimStackEntry >> registerOrNone [
 	^ ((type = SSRegister) or: [ type = SSVectorRegister ])
-		ifTrue: [register] 
+		ifTrue: [registerr] 
 		ifFalse: [NoReg]
+]
+
+{ #category : #accessing }
+CogSimStackEntry >> registerr [
+	"Answer the value of register"
+	self assert: (type = SSBaseOffset or: [type = SSRegister or: [type = SSVectorRegister]]).
+	^registerr
+]
+
+{ #category : #accessing }
+CogSimStackEntry >> registerr: anObject [
+	"Set the value of register"
+
+	^registerr := anObject
 ]
 
 { #category : #accessing }
@@ -341,11 +341,11 @@ CogSimStackEntry >> spilled: anObject [
 { #category : #'compile abstract instructions' }
 CogSimStackEntry >> storeToReg: reg [
 	type caseOf: {
-		[SSBaseOffset]	-> [cogit MoveMw: offset r: register R: reg].
-		[SSSpill]		-> [cogit MoveMw: offset r: register R: reg].
+		[SSBaseOffset]	-> [cogit MoveMw: offset r: registerr R: reg].
+		[SSSpill]		-> [cogit MoveMw: offset r: registerr R: reg].
 		[SSConstant]	-> [cogit genMoveConstant: constant R: reg].
-		[SSRegister]	-> [reg ~= register
-								ifTrue: [cogit MoveR: register R: reg]
+		[SSRegister]	-> [reg ~= registerr
+								ifTrue: [cogit MoveR: registerr R: reg]
 								ifFalse: [cogit Label]] }
 ]
 

--- a/smalltalksrc/VMMaker/CogX64Compiler.class.st
+++ b/smalltalksrc/VMMaker/CogX64Compiler.class.st
@@ -3957,24 +3957,24 @@ CogX64Compiler >> genMemCopy: originalSourceReg to: originalDestReg size: origin
 ]
 
 { #category : #'abstract instructions' }
-CogX64Compiler >> genMoveCf32: constantFloat32 Rs: register [
+CogX64Compiler >> genMoveCf32: constantFloat32 Rs: reg [
 	<inline: true>
 	<returnTypeC: #'AbstractInstruction *'>
 	<var: #constantFloat32 type: #float>
 	| inst |
 	inst := cogit PushCw: constantFloat32 asIEEE32BitWord.
-	cogit PopRs: register.
+	cogit PopRs: reg.
 	^ inst
 ]
 
 { #category : #'abstract instructions' }
-CogX64Compiler >> genMoveCf64: constantFloat64 Rd: register [
+CogX64Compiler >> genMoveCf64: constantFloat64 Rd: reg [
 	<inline: true>
 	<returnTypeC: #'AbstractInstruction *'>
 	<var: #constantFloat64 type: #double>
 	| inst |
 	inst := cogit PushCw: constantFloat64 asIEEE64BitWord.
-	cogit PopRd: register.
+	cogit PopRd: reg.
 	^ inst
 ]
 

--- a/smalltalksrc/VMMaker/Cogit.class.st
+++ b/smalltalksrc/VMMaker/Cogit.class.st
@@ -2376,19 +2376,19 @@ Cogit >> MoveC32: wordConstant R: reg [
 ]
 
 { #category : #'abstract instructions' }
-Cogit >> MoveCf32: constantFloat32 Rs: register [
+Cogit >> MoveCf32: constantFloat32 Rs: reg [
 	<inline: true>
 	<var: #constantFloat32 type: #float>
 	<returnTypeC: #'AbstractInstruction *'>
-	^ backEnd genMoveCf32: constantFloat32 Rs: register
+	^ backEnd genMoveCf32: constantFloat32 Rs: reg
 ]
 
 { #category : #'abstract instructions' }
-Cogit >> MoveCf64: constantFloat64 Rd: register [
+Cogit >> MoveCf64: constantFloat64 Rd: reg [
 	<inline: true>
 	<returnTypeC: #'AbstractInstruction *'>
 	<var: #constantFloat64 type: #double>
-	^ backEnd genMoveCf64: constantFloat64 Rd: register
+	^ backEnd genMoveCf64: constantFloat64 Rd: reg
 ]
 
 { #category : #'abstract instructions' }

--- a/smalltalksrc/VMMaker/ComposedImageWriter.class.st
+++ b/smalltalksrc/VMMaker/ComposedImageWriter.class.st
@@ -195,11 +195,11 @@ ComposedImageWriter >> writePermanentSpaceMetadata: imageFileName [
 ]
 
 { #category : #writing }
-ComposedImageWriter >> writeSTON: struct toFile: f [
+ComposedImageWriter >> writeSTON: aStruct toFile: f [
 
 	<inline: true>
-	struct withStructNameDo: [ :name | self fprintf: f _: self headFormat _: name ].
-	struct withFieldsDo: [ :fieldName :fieldValue |
+	aStruct withStructNameDo: [ :name | self fprintf: f _: self headFormat _: name ].
+	aStruct withFieldsDo: [ :fieldName :fieldValue |
 			self fprintf: f _: self fieldFormat _: fieldName _: (self cCoerce: fieldValue to: #sqInt)]
 		separatedBy: [ self fprintf: f _: ',\n'].
 		

--- a/smalltalksrc/VMMaker/RegisterAllocatingCogit.class.st
+++ b/smalltalksrc/VMMaker/RegisterAllocatingCogit.class.st
@@ -350,7 +350,7 @@ RegisterAllocatingCogit >> ensureReceiverResultRegContainsSelf [
 							[:e|
 							 e registerOrNone = ReceiverResultReg ifTrue:
 								[e type = SSRegister
-									ifTrue: [e register: freeReg]
+									ifTrue: [e registerr: freeReg]
 									ifFalse: [e liveRegister: freeReg]]]]
 					ifFalse:
 						[self ssAllocateRequiredReg: ReceiverResultReg].
@@ -358,7 +358,7 @@ RegisterAllocatingCogit >> ensureReceiverResultRegContainsSelf [
 				 self simSelf liveRegister: ReceiverResultReg]]
 		ifFalse:
 			[self assert: (self simSelf type = SSRegister
-						  and: [self simSelf register = ReceiverResultReg
+						  and: [self simSelf registerr = ReceiverResultReg
 						  and: [self receiverIsInReceiverResultReg]])].
 	"the storeToReg: in putSelfInReceiverResultReg in
 	 ensureReceiverResultRegContainsSelf copies the register to all copies.
@@ -442,7 +442,7 @@ RegisterAllocatingCogit >> flushLiveRegistersForSend [
 						or: [((self simStackAt: i) type = SSBaseOffset
 							or: [i > methodOrBlockNumTemps
 								and: [(self simStackAt: i) type = SSSpill]])
-							 and: [(self simStackAt: i) register = FPReg
+							 and: [(self simStackAt: i) registerr = FPReg
 							 and: [i = 0
 								or: [(self simStackAt: i) offset = (self frameOffsetOfTemporary: i - 1)]]]]]).
 		 (self simStackAt: i) liveRegister: NoReg]
@@ -496,9 +496,9 @@ RegisterAllocatingCogit >> freeAnyRegNotConflictingWith: regMask [
 	[index < simStackPtr] whileTrue: 
 		[desc := self simStackAt: index.
 		 desc type = SSRegister ifTrue:
-			[(regMask anyMask: (self registerMaskFor: desc register)) ifFalse: 
-				[self ssAllocateRequiredReg: desc register.
-				 ^desc register]].
+			[(regMask anyMask: (self registerMaskFor: desc registerr)) ifFalse: 
+				[self ssAllocateRequiredReg: desc registerr.
+				 ^desc registerr]].
 		 index := index + 1].
 	1 to: methodOrBlockNumTemps do:
 		[:i|
@@ -700,10 +700,10 @@ RegisterAllocatingCogit >> genJumpIf: boolean to: targetBytecodePC [
 
 	"try and use the top entry's register if any, but only if it can be destroyed."
 	reg := (desc type ~= SSRegister
-			or: [(self anyReferencesToRegister: desc register inAllButTopNItems: 0)
-			or: [(desc register = ReceiverResultReg and: [self receiverIsInReceiverResultReg])]])
+			or: [(self anyReferencesToRegister: desc registerr inAllButTopNItems: 0)
+			or: [(desc registerr = ReceiverResultReg and: [self receiverIsInReceiverResultReg])]])
 				ifTrue: [TempReg]
-				ifFalse: [desc register].
+				ifFalse: [desc registerr].
 	desc moveToReg: reg.
 	"Cunning trick by LPD.  If true and false are contiguous subtract the smaller.
 	 Correct result is either 0 or the distance between them.  If result is not 0 or
@@ -1230,7 +1230,7 @@ RegisterAllocatingCogit >> initSimStackForFramelessMethod: startpc [
 	0 to: simStackPtr do:
 		[:i| | desc |
 		desc := self simStackAt: i.
-		desc liveRegister: (desc type = SSRegister ifTrue: [desc register] ifFalse: [NoReg])]
+		desc liveRegister: (desc type = SSRegister ifTrue: [desc registerr] ifFalse: [NoReg])]
 ]
 
 { #category : #initialization }
@@ -1582,7 +1582,7 @@ RegisterAllocatingCogit >> receiverRefOnScratchSimStack [
 	self assert: scratchSpillBase >= 0.
 	simStackPtr to: scratchSpillBase by: -1 do:
 		[:i|
-		 ((self simStack: scratchSimStack at: i) register = ReceiverResultReg
+		 ((self simStack: scratchSimStack at: i) registerr = ReceiverResultReg
 		  and: [(self simStack: scratchSimStack at: i) type = SSBaseOffset]) ifTrue:
 			[^true]].
 	^false
@@ -1743,7 +1743,7 @@ RegisterAllocatingCogit >> resolveConflicts: registersInCommon with: mergeSimSta
 		 and: [(self register: reg isInMask: registersInCommon)
 		 and: [reg ~= (self simStack: mergeSimStack at: i) registerOrNone]]) ifTrue:
 			[ssEntry type = SSRegister
-				ifTrue: [ssEntry register: (registerLocations at: reg)]
+				ifTrue: [ssEntry registerr: (registerLocations at: reg)]
 				ifFalse: [ssEntry liveRegister: (registerLocations at: reg)]]].
 	self deny: self duplicateRegisterAssignmentsInTemporaries.
 	self assert: (self conflictsResolvedBetweenSimStackAnd: mergeSimStack)
@@ -1844,7 +1844,7 @@ RegisterAllocatingCogit >> simStackMergeCompatibleWith: fixup [
 		(target isSameEntryAs: current) ifFalse:
 			[^current type caseOf: {
 				[SSBaseOffset]	-> [(current offset = (self frameOffsetOfTemporary: i - 1)
-									and: [current register = FPReg])
+									and: [current registerr = FPReg])
 										ifTrue: [true] "current has been spilled virtually"
 										ifFalse:
 											[target type caseOf: {
@@ -1863,10 +1863,10 @@ RegisterAllocatingCogit >> simStackMergeCompatibleWith: fixup [
 										[SSConstant]	-> [current constant = target constant].
 										[SSRegister]	-> [false] }].
 				[SSRegister]	-> [target type caseOf: {
-										[SSBaseOffset]	-> [current register = target liveRegister].
-										[SSSpill]		-> [current register = target liveRegister].
-										[SSConstant]	-> [current register = target liveRegister].
-										[SSRegister]	-> [current register = target register] }] }]].
+										[SSBaseOffset]	-> [current registerr = target liveRegister].
+										[SSSpill]		-> [current registerr = target liveRegister].
+										[SSConstant]	-> [current registerr = target liveRegister].
+										[SSRegister]	-> [current registerr = target registerr] }] }]].
 	^true
 ]
 
@@ -1933,7 +1933,7 @@ RegisterAllocatingCogit >> ssFlushFrom: start upThroughRegister: reg [
 	"Any occurrences on the stack of the register must be
 	 flushed, and hence any values colder than them stack."
 	<var: #desc type: #'SimStackEntry *'>
-	self ssFlushFrom: start upThrough: [ :desc | desc type = SSRegister and: [ desc register = reg ] ]
+	self ssFlushFrom: start upThrough: [ :desc | desc type = SSRegister and: [ desc registerr = reg ] ]
 ]
 
 { #category : #'simulation stack' }
@@ -1973,9 +1973,9 @@ RegisterAllocatingCogit >> ssStorePop: popBoolean toPreferredReg: preferredReg [
 	actualReg := preferredReg.
 	self ssTop type = SSRegister ifTrue: 
 		[self assert: (self ssTop liveRegister = NoReg
-					  or: [self ssTop liveRegister = self ssTop register]).
+					  or: [self ssTop liveRegister = self ssTop registerr]).
 		self assert: self ssTop spilled not.
-		actualReg := self ssTop register].
+		actualReg := self ssTop registerr].
 	self ssTop liveRegister ~= NoReg ifTrue:
 		[actualReg := self ssTop liveRegister].
 	liveRegisters := self liveRegistersExceptingTopNItems: 1 in: simStack.

--- a/smalltalksrc/VMMaker/SimpleStackBasedCogit.class.st
+++ b/smalltalksrc/VMMaker/SimpleStackBasedCogit.class.st
@@ -1128,12 +1128,12 @@ SimpleStackBasedCogit >> genCallPrimitiveBytecode [
 ]
 
 { #category : #'constant support' }
-SimpleStackBasedCogit >> genCmpConstant: constant R: register [
+SimpleStackBasedCogit >> genCmpConstant: constant R: reg [
 	"If the objectMemory allows it, generates a quick constant cmp, else generates a word constant cmp"
 	<inline: true>
 	^ (objectRepresentation shouldAnnotateObjectReference: constant)
-		ifTrue: [ self annotate: (self CmpCw: constant R: register) objRef: constant ]
-		ifFalse: [ self CmpCq: constant R: register ]
+		ifTrue: [ self annotate: (self CmpCw: constant R: reg) objRef: constant ]
+		ifFalse: [ self CmpCq: constant R: reg ]
 	
 ]
 

--- a/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
+++ b/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
@@ -257,10 +257,6 @@ StackToRegisterMappingCogit class >> declareCVarsIn: aCodeGen [
 				declareC: 'sqInt (* const numPushNilsFunction)(struct _BytecodeDescriptor *,sqInt,sqInt,sqInt) = ', (aCodeGen cFunctionNameFor: self numPushNilsFunction);
 			var: 'pushNilSizeFunction'
 				declareC: 'sqInt (* const pushNilSizeFunction)(sqInt,sqInt) = ', (aCodeGen cFunctionNameFor: self pushNilSizeFunction)].
-
-	aCodeGen
-		addSelectorTranslation: #register to: (aCodeGen cFunctionNameFor: 'registerr');
-		addSelectorTranslation: #register: to: (aCodeGen cFunctionNameFor: 'registerr:')
 ]
 
 { #category : #'class initialization' }
@@ -1189,7 +1185,7 @@ StackToRegisterMappingCogit >> ensureReceiverResultRegContainsSelf [
 				 self simSelf liveRegister: ReceiverResultReg]]
 		ifFalse:
 			[self assert: (self simSelf type = SSRegister
-						  and: [self simSelf register = ReceiverResultReg
+						  and: [self simSelf registerr = ReceiverResultReg
 						  and: [self receiverIsInReceiverResultReg]])]
 ]
 
@@ -1364,8 +1360,8 @@ StackToRegisterMappingCogit >> freeAnyRegNotConflictingWith: regMask [
 		[ | desc |
 		 desc := self simStackAt: index.
 		 desc type = SSRegister ifTrue:
-			[(regMask anyMask: (self registerMaskFor: desc register)) ifFalse: 
-				[reg := desc register]].
+			[(regMask anyMask: (self registerMaskFor: desc registerr)) ifFalse: 
+				[reg := desc registerr]].
 		 index := index + 1].
 	self deny: reg = NoReg.
 	self ssAllocateRequiredReg: reg.
@@ -3331,7 +3327,7 @@ StackToRegisterMappingCogit >> initSimStackForFramefulMethod: startpc [
 	self simSelf
 		type: SSBaseOffset;
 		spilled: true;
-		register: FPReg;
+		registerr: FPReg;
 		offset: FoxMFReceiver;
 		liveRegister: NoReg.
 	"args"
@@ -3341,7 +3337,7 @@ StackToRegisterMappingCogit >> initSimStackForFramefulMethod: startpc [
 		desc
 			type: SSBaseOffset;
 			spilled: true;
-			register: FPReg;
+			registerr: FPReg;
 			offset: FoxCallerSavedIP + ((methodOrBlockNumArgs - i + 1) * objectMemory wordSize);
 			bcptr: startpc].
 	"temps"
@@ -3351,7 +3347,7 @@ StackToRegisterMappingCogit >> initSimStackForFramefulMethod: startpc [
 		desc
 			type: SSBaseOffset;
 			spilled: true;
-			register: FPReg;
+			registerr: FPReg;
 			offset: FoxMFReceiver - (i - methodOrBlockNumArgs * objectMemory wordSize);
 			bcptr: startpc]
 ]
@@ -3365,7 +3361,7 @@ StackToRegisterMappingCogit >> initSimStackForFramelessBlock: startpc [
 	self simSelf
 		type: SSRegister;
 		spilled: false;
-		register: ReceiverResultReg;
+		registerr: ReceiverResultReg;
 		liveRegister: ReceiverResultReg.
 	self assert: methodOrBlockNumTemps >= methodOrBlockNumArgs.
 	1 to: methodOrBlockNumTemps do:
@@ -3374,7 +3370,7 @@ StackToRegisterMappingCogit >> initSimStackForFramelessBlock: startpc [
 		desc
 			type: SSBaseOffset;
 			spilled: true;
-			register: SPReg;
+			registerr: SPReg;
 			offset: ((backEnd hasLinkRegister
 								ifTrue: [methodOrBlockNumArgs - i]
 								ifFalse: [methodOrBlockNumArgs + 1 - i]) * objectMemory wordSize);
@@ -3390,7 +3386,7 @@ StackToRegisterMappingCogit >> initSimStackForFramelessMethod: startpc [
 	self simSelf
 		type: SSRegister;
 		spilled: false;
-		register: ReceiverResultReg;
+		registerr: ReceiverResultReg;
 		liveRegister: ReceiverResultReg.
 	self assert: methodOrBlockNumTemps = methodOrBlockNumArgs.
 	self assert: self numRegArgs <= 2.
@@ -3400,14 +3396,14 @@ StackToRegisterMappingCogit >> initSimStackForFramelessMethod: startpc [
 			 desc
 				type: SSRegister;
 				spilled: false;
-				register: Arg0Reg;
+				registerr: Arg0Reg;
 				bcptr: startpc.
 			 methodOrBlockNumArgs > 1 ifTrue:
 				[desc := self simStackAt: 2.
 				 desc
 					type: SSRegister;
 					spilled: false;
-					register: Arg1Reg;
+					registerr: Arg1Reg;
 					bcptr: startpc]]
 		ifFalse:
 			[1 to: methodOrBlockNumArgs do:
@@ -3415,7 +3411,7 @@ StackToRegisterMappingCogit >> initSimStackForFramelessMethod: startpc [
 				desc := self simStackAt: i.
 				desc
 					type: SSBaseOffset;
-					register: SPReg;
+					registerr: SPReg;
 					spilled: true;
 					offset: ((backEnd hasLinkRegister
 								ifTrue: [methodOrBlockNumArgs - i]
@@ -3587,7 +3583,7 @@ StackToRegisterMappingCogit >> marshallSendArguments: numArgs [
 					[(self simStackAt: simStackPtr - numArgs)
 						storeToReg: ReceiverResultReg;
 					 	type: SSRegister;
-						register: ReceiverResultReg.
+						registerr: ReceiverResultReg.
 					 self ssFlushTo: simStackPtr]]
 		ifFalse:
 			"Move the args to the register arguments, being careful to do
@@ -4133,7 +4129,7 @@ StackToRegisterMappingCogit >> restoreSimStackAtMergePoint: fixup [
 		 (self simStackAt: i)
 			type: SSSpill;
 			offset: FoxMFReceiver - (i - methodOrBlockNumArgs * objectMemory bytesPerOop);
-			register: FPReg;
+			registerr: FPReg;
 			spilled: true].
 	simSpillBase := simStackPtr + 1.
 	^ 0
@@ -4450,7 +4446,7 @@ StackToRegisterMappingCogit >> ssFlushUpThroughReceiverVariable: slotIndex [
 	self ssFlushUpThrough: 
 		[ :desc |  
 			desc type = SSBaseOffset
-			 and: [desc register = ReceiverResultReg
+			 and: [desc registerr = ReceiverResultReg
 			 and: [desc offset = (objectRepresentation slotOffsetOfInstVarIndex: slotIndex) ] ] ]
 ]
 
@@ -4459,7 +4455,7 @@ StackToRegisterMappingCogit >> ssFlushUpThroughRegister: reg [
 	"Any occurrences on the stack of the register must be
 	 flushed, and hence any values colder than them stack."
 	<var: #desc type: #'CogSimStackEntry *'>
-	self ssFlushUpThrough: [ :desc | desc type = SSRegister and: [ desc register = reg ] ]
+	self ssFlushUpThrough: [ :desc | desc type = SSRegister and: [ desc registerr = reg ] ]
 ]
 
 { #category : #'simulation stack' }
@@ -4473,7 +4469,7 @@ StackToRegisterMappingCogit >> ssFlushUpThroughTemporaryVariable: tempIndex [
 	self ssFlushUpThrough: 
 		[ :desc |
 			desc type = SSBaseOffset
-		 	and: [desc register = FPReg
+		 	and: [desc registerr = FPReg
 		 	and: [desc offset = offset ] ] ]
 ]
 
@@ -4503,7 +4499,7 @@ StackToRegisterMappingCogit >> ssPushBase: reg offset: offset [
 	self ssTop
 		type: SSBaseOffset;
 		spilled: false;
-		register: reg;
+		registerr: reg;
 		offset: offset;
 		bcptr: bytecodePC.
 	self updateSimSpillBase.
@@ -4552,7 +4548,7 @@ StackToRegisterMappingCogit >> ssPushRegister: reg [
 	self ssTop
 		type: SSRegister;
 		spilled: false;
-		register: reg;
+		registerr: reg;
 		bcptr: bytecodePC.
 	self updateSimSpillBase.
 	^0
@@ -4564,7 +4560,7 @@ StackToRegisterMappingCogit >> ssPushVectorRegister: reg [
 	self ssTop
 		type: SSVectorRegister;
 		spilled: false;
-		register: reg;
+		registerr: reg;
 		bcptr: bytecodePC.
 	self ssTop.
 	self updateSimSpillBase.
@@ -4600,7 +4596,7 @@ StackToRegisterMappingCogit >> ssStorePop: popBoolean toPreferredReg: preferredR
 	actualReg := preferredReg.
 	self ssTop type = SSRegister ifTrue: 
 		[self assert: self ssTop spilled not.
-		 actualReg := self ssTop register].
+		 actualReg := self ssTop registerr].
 	self ssStorePop: popBoolean toReg: actualReg. "generates nothing if ssTop is already in actualReg"
 	^ actualReg
 ]

--- a/smalltalksrc/VMMakerTests/VMJitMethodTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJitMethodTest.class.st
@@ -13,7 +13,7 @@ VMJitMethodTest >> addVector: arg1 with: arg2 intoVector: arg3 [
 	| tmp1 tmp2 |
 	tmp1 := 0.
 	tmp2 := 2.
-	[ tmp2 == tmp1 ] whileFalse: [ 
+	[ tmp2 == tmp1 ] whileFalse: [
 		arg3.
 		tmp1 := tmp1 + 2 ].
 	^ arg3

--- a/smalltalksrc/VMMakerTests/VMJitSimdBytecode.class.st
+++ b/smalltalksrc/VMMakerTests/VMJitSimdBytecode.class.st
@@ -126,7 +126,7 @@ VMJitSimdBytecode >> testAddVectorPushesArraySumIntoSimulatedStack [
 	entry := cogit ssTop.
 	"The register with the result is the same as the first one"
 	self assert: (entry type) equals: SSVectorRegister.
-	self assert: (entry register) equals: 0.
+	self assert: (entry registerr) equals: 0.
 
 ]
 
@@ -188,7 +188,7 @@ VMJitSimdBytecode >> testPushArrayToRegisterPushesArrayChunkIntoSimulatedStack [
 	entry := cogit ssTop.
 	
 	self assert: (entry type) equals: SSVectorRegister.
-	self assert: (entry register) equals: 0.
+	self assert: (entry registerr) equals: 0.
 ]
 
 { #category : #tests }


### PR DESCRIPTION
fixes #429 

- Checks for keywords in
  - Arguments
  - Selector
  - Variable (instance, parameters, temporary) names
- Changed parameters named 'register' to 'reg'
- Changed `CogSimStackEntry` Selector + accessors named `register` to `registerr`