### PR TITLE
Bytecode unsafe

### DIFF
--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -683,7 +683,9 @@ StackInterpreter class >> initializeBytecodeTableForSistaV1 [
 		( 82	 extPushPseudoVariable)
 		( 83	 duplicateTopBytecode)
 	
-		( 84 87	unknownBytecode)
+		( 84 86	unknownBytecode)
+		( 87	bytecodePrimAddUnsafe)
+			
 		( 88	returnReceiver)
 		( 89	returnTrue)
 		( 90	returnFalse)
@@ -1942,6 +1944,12 @@ StackInterpreter >> addIdleUsecs: idleUsecs [
 	statIdleUsecs := statIdleUsecs + idleUsecs
 ]
 
+{ #category : #'common selector sends' }
+StackInterpreter >> addIntegerObject: rcvr with: arg [
+
+	^ (objectMemory integerValueOf: rcvr) + (objectMemory integerValueOf: arg)
+]
+
 { #category : #'process primitive support' }
 StackInterpreter >> addLastLink: proc toList: aList [ 
 	"Add the given process to the end of the given linked list
@@ -2714,12 +2722,67 @@ StackInterpreter >> booleanValueOf: obj [
 
 { #category : #'common selector sends' }
 StackInterpreter >> bytecodePrimAdd [
+
+	^ self
+		  bytecodePrimAddWithPrecondition: [ :rcvr :arg | objectMemory areIntegers: rcvr and: arg ]
+		  andPostcondition: [ :result | objectMemory isIntegerValue: result ]
+]
+
+{ #category : #'common selector sends' }
+StackInterpreter >> bytecodePrimAdd2 [
 	| rcvr arg result |
 	rcvr := self stackValue: 1.
 	arg := self stackValue: 0.
+	self bytecodePrecondition: [ objectMemory areIntegers: rcvr and: arg ] do: [ 
+		result := self addIntegerObject: rcvr with: arg.
+		self bytecodePostCondition: [ objectMemory isIntegerValue: result ] do: [ 
+			self pop: 2 thenPush: (objectMemory integerObjectOf: result).
+			^ self fetchNextBytecode "success"
+			 ]
+		 ].
+	
+	
+	messageSelector := self specialSelector: 0.
+	argumentCount := 1.
+	self normalSend.
+	
+	
+	
+	
+	
+	
 	(objectMemory areIntegers: rcvr and: arg)
-		ifTrue: [result := (objectMemory integerValueOf: rcvr) + (objectMemory integerValueOf: arg).
+		ifTrue: [result := self addIntegerObject: rcvr with: arg.
 				(objectMemory isIntegerValue: result) ifTrue:
+					[self pop: 2 thenPush: (objectMemory integerObjectOf: result).
+					^ self fetchNextBytecode "success"]]
+		ifFalse: [self initPrimCall.
+				self externalizeIPandSP.
+				self primitiveFloatAdd: rcvr toArg: arg.
+				self internalizeIPandSP.
+				self successful ifTrue: [^ self fetchNextBytecode "success"]].
+
+	messageSelector := self specialSelector: 0.
+	argumentCount := 1.
+	self normalSend
+]
+
+{ #category : #'common selector sends' }
+StackInterpreter >> bytecodePrimAddUnsafe [
+
+	^ self
+		  bytecodePrimAddWithPrecondition: [ :rcvr :arg | true ]
+		  andPostcondition: [ :result | true ]
+]
+
+{ #category : #'common selector sends' }
+StackInterpreter >> bytecodePrimAddWithPrecondition: precondition andPostcondition: postcondition [
+	| rcvr arg result |
+	rcvr := self stackValue: 1.
+	arg := self stackValue: 0.
+	(precondition value: rcvr value: arg)
+		ifTrue: [result := self addIntegerObject: rcvr with: arg.
+				(postcondition value: result) ifTrue:
 					[self pop: 2 thenPush: (objectMemory integerObjectOf: result).
 					^ self fetchNextBytecode "success"]]
 		ifFalse: [self initPrimCall.

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -683,7 +683,8 @@ StackInterpreter class >> initializeBytecodeTableForSistaV1 [
 		( 82	 extPushPseudoVariable)
 		( 83	 duplicateTopBytecode)
 	
-		( 84 86	unknownBytecode)
+		( 84 85	unknownBytecode)
+		( 86	bytecodePrimLessOrEqualSistaV1Unsafe)
 		( 87	bytecodePrimAddUnsafe)
 			
 		( 88	returnReceiver)
@@ -3229,10 +3230,17 @@ StackInterpreter >> bytecodePrimLessOrEqual [
 
 { #category : #'common selector sends' }
 StackInterpreter >> bytecodePrimLessOrEqualSistaV1 [
+
+	^ self bytecodePrimLessOrEqualSistaV1Precondition: [ :rcvr :arg |
+		  objectMemory areIntegers: rcvr and: arg ]
+]
+
+{ #category : #'common selector sends' }
+StackInterpreter >> bytecodePrimLessOrEqualSistaV1Precondition: precondition [
 	| rcvr arg aBool |
 	rcvr := self stackValue: 1.
 	arg := self stackValue: 0.
-	(objectMemory areIntegers: rcvr and: arg) ifTrue:
+	(precondition value: rcvr value: arg) ifTrue:
 		["The C code can avoid detagging since tagged integers are still signed.
 		 But this means the simulator must override to do detagging."
 		^self cCode: [self booleanCheatSistaV1: rcvr <= arg]
@@ -3245,6 +3253,13 @@ StackInterpreter >> bytecodePrimLessOrEqualSistaV1 [
 	messageSelector := self specialSelector: 4.
 	argumentCount := 1.
 	self normalSend
+]
+
+{ #category : #'common selector sends' }
+StackInterpreter >> bytecodePrimLessOrEqualSistaV1Unsafe [
+
+	^ self bytecodePrimLessOrEqualSistaV1Precondition: [ :rcvr :arg |
+		  true ]
 ]
 
 { #category : #'common selector sends' }

--- a/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
+++ b/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
@@ -2642,61 +2642,33 @@ StackToRegisterMappingCogit >> genSpecialSelectorArithmetic [
 
 { #category : #'bytecode generators' }
 StackToRegisterMappingCogit >> genSpecialSelectorArithmeticUnsafe [
-	| primDescriptor rcvrIsConst argIsConst rcvrIsInt argIsInt rcvrInt argInt result |
+
 	<var: #primDescriptor type: #'BytecodeDescriptor *'>
+	| primDescriptor rcvrIsConst argIsConst rcvrIsInt argIsInt rcvrInt argInt result |
 	primDescriptor := self generatorAt: byte0.
 
-	argIsInt := ((argIsConst := self ssTop type = SSConstant)
-				 and: [objectMemory isIntegerObject: (argInt := self ssTop constant)])
-				 or: [self mclassIsSmallInteger and: [self ssTop isSameEntryAs: self simSelf]].
 
-	rcvrIsInt := ((rcvrIsConst := (self ssValue: 1) type = SSConstant)
-				  and: [objectMemory isIntegerObject: (rcvrInt := (self ssValue: 1) constant)])
-				or: [self mclassIsSmallInteger and: [(self ssValue: 1) isSameEntryAs: self simSelf]].
-
-	(argIsInt and: [argIsConst and: [rcvrIsInt and: [rcvrIsConst]]]) ifTrue:
-		[rcvrInt := objectMemory integerValueOf: rcvrInt.
-		 argInt := objectMemory integerValueOf: argInt.
-		 primDescriptor opcode caseOf: {
-			[AddRR]	-> [result := rcvrInt + argInt].
-			[SubRR]	-> [result := rcvrInt - argInt].
-			[AndRR]	-> [result := rcvrInt bitAnd: argInt].
-			[OrRR]	-> [result := rcvrInt bitOr: argInt] }.
-		(objectMemory isIntegerValue: result) ifTrue:
-			["Must annotate the bytecode for correct pc mapping."
-			^self ssPop: 2; ssPushAnnotatedConstant: (objectMemory integerObjectOf: result)].
-		^self genSpecialSelectorSend].
-
-	"If there's any constant involved other than a SmallInteger don't attempt to inline."
-	((rcvrIsConst and: [rcvrIsInt not])
-	 or: [argIsConst and: [argIsInt not]]) ifTrue:
-		[^self genSpecialSelectorSend].
-
-	"If we know nothing about the types then better not to inline as the inline cache and
-	 primitive code is not terribly slow so wasting time on duplicating tag tests is pointless."
-	(argIsInt or: [rcvrIsInt]) ifFalse:
-		[^self genSpecialSelectorSend].
+	argIsConst := self ssTop type = SSConstant.
+	argInt := self ssTop constant.
 
 	argIsConst
-		ifTrue:
-			[self ssFlushTo: simStackPtr - 2.
-			 (self ssValue: 1) moveToReg: ReceiverResultReg.
-			 self ssPop: 2]
-		ifFalse:
-			[self marshallSendArguments: 1].
+		ifTrue: [
+			self ssFlushTo: simStackPtr - 2.
+			(self ssValue: 1) moveToReg: ReceiverResultReg.
+			self ssPop: 2 ]
+		ifFalse: [ self marshallSendArguments: 1 ].
 
-	primDescriptor opcode caseOf: {
-		[AddRR] -> [argIsConst
-						ifTrue:
-							[self AddCq: argInt - ConstZero R: ReceiverResultReg.]
-						ifFalse:
-							[objectRepresentation genRemoveSmallIntegerTagsInScratchReg: ReceiverResultReg.
-							 self AddR: Arg0Reg R: ReceiverResultReg.]
-						]}.
+	primDescriptor opcode caseOf: { ([ AddRR ] -> [
+		 argIsConst
+			 ifTrue: [ self AddCq: argInt - ConstZero R: ReceiverResultReg ]
+			 ifFalse: [
+				 objectRepresentation genRemoveSmallIntegerTagsInScratchReg:
+					 ReceiverResultReg.
+				 self AddR: Arg0Reg R: ReceiverResultReg ] ]) }.
 
 	self annotateInstructionForBytecode.
-	 self ssPushRegister: ReceiverResultReg.
-	 ^0
+	self ssPushRegister: ReceiverResultReg.
+	^ 0
 ]
 
 { #category : #'bytecode generators' }

--- a/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
+++ b/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
@@ -296,7 +296,9 @@ StackToRegisterMappingCogit class >> initializeBytecodeTableForSistaV1 [
 		(1  82   82 genExtPushPseudoVariable)
 		(1  83   83 duplicateTopBytecode								needsFrameNever: 1)
 
-		(1  84   87 unknownBytecode)
+		(1  84   85 unknownBytecode)
+		(1 	 86		86 genSpecialSelectorComparisonUnsafe isMapped JumpLessOrEqual)
+		(1  87   87 genSpecialSelectorArithmeticUnsafe isMapped AddRR)
 
 		"returns"
 		(1  88   88 genReturnReceiver				return needsFrameIfInBlock: isMappedInBlock 0)
@@ -2639,6 +2641,65 @@ StackToRegisterMappingCogit >> genSpecialSelectorArithmetic [
 ]
 
 { #category : #'bytecode generators' }
+StackToRegisterMappingCogit >> genSpecialSelectorArithmeticUnsafe [
+	| primDescriptor rcvrIsConst argIsConst rcvrIsInt argIsInt rcvrInt argInt result |
+	<var: #primDescriptor type: #'BytecodeDescriptor *'>
+	primDescriptor := self generatorAt: byte0.
+
+	argIsInt := ((argIsConst := self ssTop type = SSConstant)
+				 and: [objectMemory isIntegerObject: (argInt := self ssTop constant)])
+				 or: [self mclassIsSmallInteger and: [self ssTop isSameEntryAs: self simSelf]].
+
+	rcvrIsInt := ((rcvrIsConst := (self ssValue: 1) type = SSConstant)
+				  and: [objectMemory isIntegerObject: (rcvrInt := (self ssValue: 1) constant)])
+				or: [self mclassIsSmallInteger and: [(self ssValue: 1) isSameEntryAs: self simSelf]].
+
+	(argIsInt and: [argIsConst and: [rcvrIsInt and: [rcvrIsConst]]]) ifTrue:
+		[rcvrInt := objectMemory integerValueOf: rcvrInt.
+		 argInt := objectMemory integerValueOf: argInt.
+		 primDescriptor opcode caseOf: {
+			[AddRR]	-> [result := rcvrInt + argInt].
+			[SubRR]	-> [result := rcvrInt - argInt].
+			[AndRR]	-> [result := rcvrInt bitAnd: argInt].
+			[OrRR]	-> [result := rcvrInt bitOr: argInt] }.
+		(objectMemory isIntegerValue: result) ifTrue:
+			["Must annotate the bytecode for correct pc mapping."
+			^self ssPop: 2; ssPushAnnotatedConstant: (objectMemory integerObjectOf: result)].
+		^self genSpecialSelectorSend].
+
+	"If there's any constant involved other than a SmallInteger don't attempt to inline."
+	((rcvrIsConst and: [rcvrIsInt not])
+	 or: [argIsConst and: [argIsInt not]]) ifTrue:
+		[^self genSpecialSelectorSend].
+
+	"If we know nothing about the types then better not to inline as the inline cache and
+	 primitive code is not terribly slow so wasting time on duplicating tag tests is pointless."
+	(argIsInt or: [rcvrIsInt]) ifFalse:
+		[^self genSpecialSelectorSend].
+
+	argIsConst
+		ifTrue:
+			[self ssFlushTo: simStackPtr - 2.
+			 (self ssValue: 1) moveToReg: ReceiverResultReg.
+			 self ssPop: 2]
+		ifFalse:
+			[self marshallSendArguments: 1].
+
+	primDescriptor opcode caseOf: {
+		[AddRR] -> [argIsConst
+						ifTrue:
+							[self AddCq: argInt - ConstZero R: ReceiverResultReg.]
+						ifFalse:
+							[objectRepresentation genRemoveSmallIntegerTagsInScratchReg: ReceiverResultReg.
+							 self AddR: Arg0Reg R: ReceiverResultReg.]
+						]}.
+
+	self annotateInstructionForBytecode.
+	 self ssPushRegister: ReceiverResultReg.
+	 ^0
+]
+
+{ #category : #'bytecode generators' }
 StackToRegisterMappingCogit >> genSpecialSelectorClass [
 	| topReg |
 	topReg := self ssTop registerOrNone.
@@ -2720,6 +2781,61 @@ StackToRegisterMappingCogit >> genSpecialSelectorComparison [
 		[self MoveCq: argInt R: Arg0Reg].
 	index := byte0 - self firstSpecialSelectorBytecodeOffset.
 	^self genMarshalledSend: index negated - 1 numArgs: 1 sendTable: ordinarySendTrampolines
+]
+
+{ #category : #'bytecode generators' }
+StackToRegisterMappingCogit >> genSpecialSelectorComparisonUnsafe [
+	| nextPC postBranchPC targetPC primDescriptor branchDescriptor
+	  rcvrIsInt rcvrIsConst argIsIntConst argInt jumpNotSmallInts inlineCAB index |
+	<var: #primDescriptor type: #'BytecodeDescriptor *'>
+	<var: #branchDescriptor type: #'BytecodeDescriptor *'>
+	<var: #jumpNotSmallInts type: #'AbstractInstruction *'>
+	self ssFlushTo: simStackPtr - 2.
+	primDescriptor := self generatorAt: byte0.
+	argIsIntConst := self ssTop type = SSConstant
+				 and: [objectMemory isIntegerObject: (argInt := self ssTop constant)].
+	rcvrIsInt := ((rcvrIsConst := (self ssValue: 1) type = SSConstant)
+				  and: [objectMemory isIntegerObject: (self ssValue: 1) constant])
+				or: [self mclassIsSmallInteger and: [(self ssValue: 1) isSameEntryAs: self simSelf]].
+
+	(argIsIntConst and: [rcvrIsInt and: [rcvrIsConst]]) ifTrue:
+		[^ self genStaticallyResolvedSpecialSelectorComparison].
+
+	self extractMaybeBranchDescriptorInto: [ :descr :next :postBranch :target | 
+		branchDescriptor := descr. nextPC := next. postBranchPC := postBranch. targetPC := target ].
+
+	"Only interested in inlining if followed by a conditional branch."
+	inlineCAB := branchDescriptor isBranchTrue or: [branchDescriptor isBranchFalse].
+	"Further, only interested in inlining = and ~= if there's a SmallInteger constant involved.
+	 The relational operators successfully statically predict SmallIntegers; the equality operators do not."
+	(inlineCAB and: [primDescriptor opcode = JumpZero or: [primDescriptor opcode = JumpNonZero]]) ifTrue:
+		[inlineCAB := argIsIntConst or: [rcvrIsInt]].
+	inlineCAB ifFalse:
+		[^self genSpecialSelectorSend].
+
+	argIsIntConst
+		ifTrue:
+			[(self ssValue: 1) moveToReg: ReceiverResultReg.
+			 self ssPop: 2]
+		ifFalse:
+			[self marshallSendArguments: 1].
+
+	argIsIntConst
+		ifTrue: [self CmpCq: argInt R: ReceiverResultReg]
+		ifFalse: [self CmpR: Arg0Reg R: ReceiverResultReg].
+	"Cmp is weird/backwards so invert the comparison.  Further since there is a following conditional
+	 jump bytecode define non-merge fixups and leave the cond bytecode to set the mergeness."
+	self genConditionalBranch: (branchDescriptor isBranchTrue
+				ifTrue: [primDescriptor opcode]
+				ifFalse: [self inverseBranchFor: primDescriptor opcode])
+		operand: (self ensureNonMergeFixupAt: targetPC) asUnsignedInteger.
+	self Jump: (self ensureNonMergeFixupAt: postBranchPC).
+	self annotateInstructionForBytecode.
+	 self ensureFixupAt: postBranchPC.
+	 self ensureFixupAt: targetPC.
+	 deadCode := true.
+	 ^0.
+
 ]
 
 { #category : #'bytecode generator support' }

--- a/smalltalksrc/VMMakerTests/VMByteCodesTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMByteCodesTest.class.st
@@ -367,6 +367,102 @@ VMByteCodesTest >> testDuplicateStackTop [
 	
 ]
 
+{ #category : #'tests-addition' }
+VMByteCodesTest >> testLessOrEqualEqualIntegerObjects [
+
+	stackBuilder
+		addNewFrame;
+		buildStack.
+
+	interpreter pushInteger: 7.
+	interpreter pushInteger: 7.
+
+	self
+		assert: [ 	self interpret: [ interpreter bytecodePrimLessOrEqualSistaV1 ] ]
+		popped: 2
+		andPushed: memory trueObject
+]
+
+{ #category : #'tests-addition' }
+VMByteCodesTest >> testLessOrEqualEqualIntegerObjectsUnsafe [
+
+	stackBuilder
+		addNewFrame;
+		buildStack.
+
+	interpreter pushInteger: 7.
+	interpreter pushInteger: 7.
+
+	self
+		assert: [ 	self interpret: [ interpreter bytecodePrimLessOrEqualSistaV1Unsafe ] ]
+		popped: 2
+		andPushed: memory trueObject
+]
+
+{ #category : #'tests-addition' }
+VMByteCodesTest >> testLessOrEqualHigherIntegerObjects [
+
+	stackBuilder
+		addNewFrame;
+		buildStack.
+
+	interpreter pushInteger: 13.
+	interpreter pushInteger: 7.
+
+	self
+		assert: [ 	self interpret: [ interpreter bytecodePrimLessOrEqualSistaV1 ] ]
+		popped: 2
+		andPushed: memory falseObject
+]
+
+{ #category : #'tests-addition' }
+VMByteCodesTest >> testLessOrEqualHigherIntegerObjectsUnsafe [
+
+	stackBuilder
+		addNewFrame;
+		buildStack.
+
+	interpreter pushInteger: 13.
+	interpreter pushInteger: 7.
+
+	self
+		assert: [ 	self interpret: [ interpreter bytecodePrimLessOrEqualSistaV1Unsafe ] ]
+		popped: 2
+		andPushed: memory falseObject
+]
+
+{ #category : #'tests-addition' }
+VMByteCodesTest >> testLessOrEqualLowerIntegerObjects [
+
+	stackBuilder
+		addNewFrame;
+		buildStack.
+
+	interpreter pushInteger: 7.
+	interpreter pushInteger: 13.
+
+	self
+		assert: [ 	self interpret: [ interpreter bytecodePrimLessOrEqualSistaV1 ] ]
+		popped: 2
+		andPushed: memory trueObject
+]
+
+{ #category : #'tests-addition' }
+VMByteCodesTest >> testLessOrEqualLowerIntegerObjectsUnsafe [
+
+	stackBuilder
+		addNewFrame;
+		buildStack.
+
+	interpreter pushInteger: 7.
+	interpreter pushInteger: 13.
+
+	self
+		assert: [ 	self interpret: [ interpreter bytecodePrimLessOrEqualSistaV1Unsafe ] ]
+		popped: 2
+		andPushed: memory trueObject
+]
+
 { #category : #'tests-push-simple' }
 VMByteCodesTest >> testPopStackTopBytecode [
 

--- a/smalltalksrc/VMMakerTests/VMByteCodesTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMByteCodesTest.class.st
@@ -21,6 +21,18 @@ VMByteCodesTest >> assert: aBlock pop: anOop intoTemporary: anIndex [
 	self assert: (interpreter temporary: anIndex in: interpreter framePointer) equals: anOop
 ]
 
+{ #category : #asserting }
+VMByteCodesTest >> assert: aBlock popped: nPopped andPushed: pushedObject [ 
+	| oldStackSize |
+	oldStackSize := interpreter stackPointer.
+	
+	aBlock value.
+	
+	self assert: interpreter stackPointer equals: oldStackSize + (memory wordSize * (nPopped - 1)).
+	self assert: interpreter stackTop equals: pushedObject.
+	
+]
+
 { #category : #'helper-assertions' }
 VMByteCodesTest >> assert: aBlock pushed: anOop [
 	| oldStackSize |
@@ -164,6 +176,38 @@ VMByteCodesTest >> testAccessingSenderOfContextShouldReturnContextOfSender [
 	interpreter pushActiveContextBytecode.
 	newMaybeSenderContext := interpreter instVar: SenderIndex ofContext: interpreter stackTop.
 	self assert: oldMaybeSenderContext equals: newMaybeSenderContext
+]
+
+{ #category : #'tests-addition' }
+VMByteCodesTest >> testAddIntegerObjects [
+
+	stackBuilder
+		addNewFrame;
+		buildStack.
+
+	interpreter pushInteger: 7.
+	interpreter pushInteger: 13.
+
+	self
+		assert: [ self interpret: [ interpreter bytecodePrimAdd ] ]
+		popped: 2
+		andPushed: (memory integerObjectOf: 20)
+]
+
+{ #category : #'tests-addition' }
+VMByteCodesTest >> testAddIntegerObjectsUnsafe [
+
+	stackBuilder
+		addNewFrame;
+		buildStack.
+
+	interpreter pushInteger: 7.
+	interpreter pushInteger: 13.
+
+	self
+		assert: [ self interpret: [ interpreter bytecodePrimAddUnsafe ] ]
+		popped: 2
+		andPushed: (memory integerObjectOf: 20)
 ]
 
 { #category : #'tests-simd' }

--- a/smalltalksrc/VMMakerTests/VMImageHeaderWritingTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMImageHeaderWritingTest.class.st
@@ -36,16 +36,6 @@ VMImageHeaderWritingTest >> testImageHeaderWithPermanentObjects [
 ]
 
 { #category : #tests }
-VMImageHeaderWritingTest >> testWritingImageWritesCorrectImageVersion [
-
-	| header |
-
-	header := self readHeader.
-
-	self assert: header imageVersion equals: interpreter getImageVersion
-]
-
-{ #category : #tests }
 VMImageHeaderWritingTest >> testWritingImageWritesCorrectBaseAddress [
 
 	| header |
@@ -165,6 +155,16 @@ VMImageHeaderWritingTest >> testWritingImageWritesCorrectImageFormat [
 	header := self readHeader.
 
 	self assert: header imageFormat equals: interpreter imageFormatVersion
+]
+
+{ #category : #tests }
+VMImageHeaderWritingTest >> testWritingImageWritesCorrectImageVersion [
+
+	| header |
+
+	header := self readHeader.
+
+	self assert: header imageVersion equals: interpreter getImageVersion
 ]
 
 { #category : #tests }

--- a/smalltalksrc/VMMakerTests/VMSpurOldSpaceGarbageCollectorTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurOldSpaceGarbageCollectorTest.class.st
@@ -233,6 +233,53 @@ VMSpurOldSpaceGarbageCollectorTest >> testAnOldObjectReferencedFromVMVariableSho
 	self assertHashOf: self keptObjectInVMVariable1 equals: hash
 ]
 
+{ #category : #'tests-OldSpaceSize' }
+VMSpurOldSpaceGarbageCollectorTest >> testArrayOfPermanentObjectsPointingToOldObjectsIsCorrectlyMantained [
+
+	| deltaFreeSpace arrayOfPerms objectsSize aPermObject anOldObject originalRememberedSetSize afteRememberedSetSize numberOfObjects |
+
+	originalRememberedSetSize := memory bytesInObject: memory fromPermSpaceRememberedSet objectOop. 
+	numberOfObjects := 4096.
+
+	deltaFreeSpace := self deltaFreeSpaceAfterGC: [ 
+								arrayOfPerms := self newOldSpaceArrayWithSlots: numberOfObjects.
+								objectsSize := memory bytesInObject: arrayOfPerms.
+								0 to: numberOfObjects - 1 do: [ :i |
+									anOldObject := self newOldSpaceObjectWithSlots: 0.
+									aPermObject := self newPermanentObjectWithSlots: 1.
+									objectsSize := objectsSize + (memory bytesInObject: anOldObject).
+									memory storePointer: 0 ofObject: aPermObject withValue: anOldObject.
+									memory storePointer: i ofObject: arrayOfPerms withValue: aPermObject ].
+		                  self keepObjectInVMVariable2: arrayOfPerms ].
+
+	afteRememberedSetSize := memory bytesInObject: memory fromPermSpaceRememberedSet objectOop.
+
+	self assert: deltaFreeSpace equals: objectsSize + (afteRememberedSetSize - originalRememberedSetSize)
+]
+
+{ #category : #'tests-OldSpaceSize' }
+VMSpurOldSpaceGarbageCollectorTest >> testArrayOfPermanentObjectsPointingToOldObjectsIsCorrectlyMantainedWhenObjectsMoved [
+
+	| numberOfObjects originalHashes permArray anOldObject |
+	numberOfObjects := 4096.
+	originalHashes := Array new: numberOfObjects.
+
+	self deltaFreeSpaceAfterGC: [ 
+		permArray := self newPermanentObjectWithSlots: numberOfObjects.
+
+		"Objects to be collected"
+		self newOldSpaceObjectWithSlots: 0.
+		self newOldSpaceObjectWithSlots: 0.
+
+		1 to: numberOfObjects do: [ :i |
+			anOldObject := self newOldSpaceObjectWithSlots: 0.
+			originalHashes at: i put: (memory hashBitsOf: anOldObject). 
+			memory storePointer: (i - 1) ofObject: permArray withValue: anOldObject ]].
+
+	1 to: numberOfObjects do: [ :i |
+		self assert: (originalHashes at: i) equals: (memory hashBitsOf: (memory fetchPointer: i - 1 ofObject: permArray))]
+]
+
 { #category : #ephemerons }
 VMSpurOldSpaceGarbageCollectorTest >> testCompactEphemeronQueuePass1 [
 
@@ -283,53 +330,6 @@ VMSpurOldSpaceGarbageCollectorTest >> testCompactEphemeronQueuePass2 [
 	
 	self assert: (memory sizeOfObjStack: memory mournQueue) equals: 1.
 	self assert: memory dequeueMourner equals: self keptObjectInVMVariable1.
-]
-
-{ #category : #'tests-OldSpaceSize' }
-VMSpurOldSpaceGarbageCollectorTest >> testArrayOfPermanentObjectsPointingToOldObjectsIsCorrectlyMantained [
-
-	| deltaFreeSpace arrayOfPerms objectsSize aPermObject anOldObject originalRememberedSetSize afteRememberedSetSize numberOfObjects |
-
-	originalRememberedSetSize := memory bytesInObject: memory fromPermSpaceRememberedSet objectOop. 
-	numberOfObjects := 4096.
-
-	deltaFreeSpace := self deltaFreeSpaceAfterGC: [ 
-								arrayOfPerms := self newOldSpaceArrayWithSlots: numberOfObjects.
-								objectsSize := memory bytesInObject: arrayOfPerms.
-								0 to: numberOfObjects - 1 do: [ :i |
-									anOldObject := self newOldSpaceObjectWithSlots: 0.
-									aPermObject := self newPermanentObjectWithSlots: 1.
-									objectsSize := objectsSize + (memory bytesInObject: anOldObject).
-									memory storePointer: 0 ofObject: aPermObject withValue: anOldObject.
-									memory storePointer: i ofObject: arrayOfPerms withValue: aPermObject ].
-		                  self keepObjectInVMVariable2: arrayOfPerms ].
-
-	afteRememberedSetSize := memory bytesInObject: memory fromPermSpaceRememberedSet objectOop.
-
-	self assert: deltaFreeSpace equals: objectsSize + (afteRememberedSetSize - originalRememberedSetSize)
-]
-
-{ #category : #'tests-OldSpaceSize' }
-VMSpurOldSpaceGarbageCollectorTest >> testArrayOfPermanentObjectsPointingToOldObjectsIsCorrectlyMantainedWhenObjectsMoved [
-
-	| numberOfObjects originalHashes permArray anOldObject |
-	numberOfObjects := 4096.
-	originalHashes := Array new: numberOfObjects.
-
-	self deltaFreeSpaceAfterGC: [ 
-		permArray := self newPermanentObjectWithSlots: numberOfObjects.
-
-		"Objects to be collected"
-		self newOldSpaceObjectWithSlots: 0.
-		self newOldSpaceObjectWithSlots: 0.
-
-		1 to: numberOfObjects do: [ :i |
-			anOldObject := self newOldSpaceObjectWithSlots: 0.
-			originalHashes at: i put: (memory hashBitsOf: anOldObject). 
-			memory storePointer: (i - 1) ofObject: permArray withValue: anOldObject ]].
-
-	1 to: numberOfObjects do: [ :i |
-		self assert: (originalHashes at: i) equals: (memory hashBitsOf: (memory fetchPointer: i - 1 ofObject: permArray))]
 ]
 
 { #category : #'tests-OldSpaceSize' }


### PR DESCRIPTION
_Missing work from dojos on 02/05 and 09/05_

We were making experiments to unsafe bytecode in loops (compiling `to:do:`s). 

We parametrized pre-&post-conditions to reuse the logic in safe and unsafe versions.

This didn't improve the performance too much. Without block inlining, it does not pay off.