### PR TITLE
Rename reserved words: selectors, locals and instance variables

### DIFF
--- a/smalltalksrc/CAST/CASTNodesTest.class.st
+++ b/smalltalksrc/CAST/CASTNodesTest.class.st
@@ -1,0 +1,21 @@
+Class {
+	#name : #CASTNodesTest,
+	#superclass : #TestCase,
+	#category : #'CAST-Tests'
+}
+
+{ #category : #identifiers }
+CASTNodesTest >> testIdentifierNodeNameIsInvalid [
+
+	| identifier |
+	identifier := CIdentifierNode new name: 'setter:'.
+	self shouldnt: identifier hasValidName
+]
+
+{ #category : #identifiers }
+CASTNodesTest >> testIdentifierNodeNameIsValid [
+
+	| identifier |
+	identifier := CIdentifierNode new name: 'setter'.
+	self should: identifier hasValidName
+]

--- a/smalltalksrc/CAST/CIdentifierNode.class.st
+++ b/smalltalksrc/CAST/CIdentifierNode.class.st
@@ -30,6 +30,15 @@ CIdentifierNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitIdentifier: self
 ]
 
+{ #category : #accessing }
+CIdentifierNode >> hasValidName [
+
+	| cIdentifierRegExp |
+	cIdentifierRegExp := '^[a-zA-Z_][a-zA-Z_0-9]*$' asRegex.
+
+	^ cIdentifierRegExp matches: name
+]
+
 { #category : #comparing }
 CIdentifierNode >> hash [
 

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -5192,6 +5192,28 @@ SlangBasicTranslationTest >> testSendSignedRightBitShiftVariable64Bits [
 	self assert: translation equals: '((sqLong) a ) >> 3'
 ]
 
+{ #category : #'tests-builtins' }
+SlangBasicTranslationTest >> testSendStructAccessorWithReservedWordSelector [
+	"Tests if the renaming of the accessors impacts the struct accessing"
+
+	| translation send |
+	generator addStructClasses: { MockVMStructWithReservedWords }.
+	generator renameKeywordsConflicts.
+
+	generator pushScope:
+		(TStatementListNode new addDeclarations: (Dictionary new
+				  at: 'structInstance' put: 'MockVMStructWithReservedWords*';
+				  yourself)).
+	send := TSendNode
+		        receiver: (TVariableNode named: 'structInstance')
+		        selector: #case
+		        arguments: {  }.
+
+	translation := self translate: send.
+
+	self assert: translation equals: '(structInstance->case_1)'
+]
+
 { #category : #'tests-assignment' }
 SlangBasicTranslationTest >> testSendSubclassResponsibility [
 
@@ -5975,6 +5997,27 @@ SlangBasicTranslationTest >> testSendWordSize [
 			                arguments: { }).
 
 	self assert: translation equals: 'BytesPerWord'
+]
+
+{ #category : #'tests-builtins' }
+SlangBasicTranslationTest >> testStructFieldIsRenamedWithReservedWord [
+	"Tests if the struct field is renamed when it's a reserved word"
+
+	| translation |
+	
+	generator addStructClasses: { MockVMStructWithReservedWords }.
+	generator renameKeywordsConflicts.
+	generator vmClass: VMClass.
+
+	translation := String streamContents: [ :s | generator emitCTypesOn: s ].
+
+	self assert: translation equals: 'typedef struct {
+	char *foo;
+	char *case_1;
+ } MockVMStructWithReservedWords;
+
+
+'
 ]
 
 { #category : #'tests-case' }

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -1405,18 +1405,6 @@ SlangBasicTranslationTest >> testLabelWithCommentWithPreviousCommentMarkingAnInl
 ]
 
 { #category : #'tests-method' }
-SlangBasicTranslationTest >> testMethodCantHaveReservedSelectorName [
-
-	self getTMethodFrom: #continue.
-
-	generator renameKeywordsConflicts.
-
-	self
-		assert: (generator cFunctionNameFor: #continue)
-		equals: #continue_1
-]
-
-{ #category : #'tests-method' }
 SlangBasicTranslationTest >> testMethodComment [
 
 	"Test the smalltalk comment of the function."
@@ -1688,6 +1676,20 @@ SlangBasicTranslationTest >> testMethodPrototypeWithStatic [
 			, (translation lineNumber: 3)
 		equals: 'static sqInt
 increment(sqInt x)'
+]
+
+{ #category : #'tests-method' }
+SlangBasicTranslationTest >> testMethodRenamesReservedSelectorName [
+
+	| method translation |
+	method := self getTMethodFrom: #continue.
+
+	generator renameKeywordsConflicts.
+
+	translation := self translate: method.
+	
+	self should: (translation includesSubstring: 'static sqInt
+continue_1(void)')
 ]
 
 { #category : #'tests-method' }
@@ -6515,17 +6517,18 @@ SlangBasicTranslationTest >> testVariableUpdateAssignmentPlus [
 { #category : #'tests-variables' }
 SlangBasicTranslationTest >> testVariableWithReservedNameShouldBeRenamed [
 
-	| method locals sanitizedLocals |
-	locals := #(case register).
-	sanitizedLocals := locals collect: [ :local | generator sanitizeKeyword: local ] .
+	| method translation |
 	
 	method := self getTMethodFrom: #methodWithReservedWordLocal:.
 	method recordDeclarationsIn: generator.
 	
 	generator renameKeywordsConflicts.
 
-	self shouldnt: (method allLocals includesAny: locals).
-	self should: (method allLocals includesAll: sanitizedLocals).
+	translation := self translate: method.
+	
+	self should: (translation includesSubstring: 'char *case_1').
+	self should: (translation includesSubstring: 'char *register_1').
+	self should: (translation includesSubstring: 'case_1 = nextPutAll(register_1, "foo")')
 ]
 
 { #category : #helpers }

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -6468,13 +6468,6 @@ SlangBasicTranslationTest >> testVariableAssignment [
 	self assert: translation equals: 'var = 7'
 ]
 
-{ #category : #'tests-assignment' }
-SlangBasicTranslationTest >> testVariableCantHaveReservedName [
-
-	self should: [TVariableNode new setName: 'register'] raise: TranslationError.
-
-]
-
 { #category : #'tests-blocks' }
 SlangBasicTranslationTest >> testVariableStatementsInBlockValueAreIgnored [
 
@@ -6547,6 +6540,23 @@ SlangBasicTranslationTest >> testVariableUpdateAssignmentPlus [
 			expression: expression).
 
 	self assert: translation equals: 'var += 7'
+]
+
+{ #category : #'tests-variables' }
+SlangBasicTranslationTest >> testVariableWithReservedNameShouldBeRenamed [
+
+	| method local sanitizedLocal |
+	local := #case.
+	sanitizedLocal := generator sanitizeKeyword: local.
+	method := self getTMethodFrom: #methodWithReservedWordLocal.
+
+	generator renameKeywordsConflicts.
+
+	self shouldnt: (method allLocals includes: local).
+	self should: (method allLocals includes: sanitizedLocal).
+	self shouldnt: (method declarations includes: 'char *' , local).
+	self should:
+		(method declarations includes: 'char *' , sanitizedLocal)
 ]
 
 { #category : #helpers }

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -6545,18 +6545,17 @@ SlangBasicTranslationTest >> testVariableUpdateAssignmentPlus [
 { #category : #'tests-variables' }
 SlangBasicTranslationTest >> testVariableWithReservedNameShouldBeRenamed [
 
-	| method local sanitizedLocal |
-	local := #case.
-	sanitizedLocal := generator sanitizeKeyword: local.
-	method := self getTMethodFrom: #methodWithReservedWordLocal.
-
+	| method locals sanitizedLocals |
+	locals := #(case register).
+	sanitizedLocals := locals collect: [ :local | generator sanitizeKeyword: local ] .
+	
+	method := self getTMethodFrom: #methodWithReservedWordLocal:.
+	method recordDeclarationsIn: generator.
+	
 	generator renameKeywordsConflicts.
 
-	self shouldnt: (method allLocals includes: local).
-	self should: (method allLocals includes: sanitizedLocal).
-	self shouldnt: (method declarations includes: 'char *' , local).
-	self should:
-		(method declarations includes: 'char *' , sanitizedLocal)
+	self shouldnt: (method allLocals includesAny: locals).
+	self should: (method allLocals includesAll: sanitizedLocals).
 ]
 
 { #category : #helpers }

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -1404,46 +1404,16 @@ SlangBasicTranslationTest >> testLabelWithCommentWithPreviousCommentMarkingAnInl
 	self assert: translation equals: ''
 ]
 
-{ #category : #'tests-assignment' }
-SlangBasicTranslationTest >> testMethodCantHaveReservedArgumentNames [
-
-	| methodInitialization |
-	methodInitialization := [
-	                        TMethod new
-		                        setSelector: 'foo'
-		                        definingClass: MockEmptyVMStruct
-		                        args: { RBVariableNode named: 'continue' }
-		                        locals: Array empty
-		                        block:
-		                        (RBBlockNode body:
-			                         (RBSequenceNode statements:
-				                          Array empty))
-		                        primitive: nil
-		                        properties: nil
-		                        comment: nil ].
-
-	self should: methodInitialization raise: TranslationError
-]
-
-{ #category : #'tests-assignment' }
+{ #category : #'tests-method' }
 SlangBasicTranslationTest >> testMethodCantHaveReservedSelectorName [
 
-	| methodInitialization |
-	methodInitialization := [
-	                        TMethod new
-		                        setSelector: 'break'
-		                        definingClass: MockEmptyVMStruct
-		                        args: Array empty
-		                        locals: Array empty
-		                        block:
-		                        (RBBlockNode body:
-			                         (RBSequenceNode statements:
-				                          Array empty))
-		                        primitive: nil
-		                        properties: nil
-		                        comment: nil ].
+	self getTMethodFrom: #continue.
 
-	self should: methodInitialization raise: TranslationError
+	generator renameKeywordsConflicts.
+
+	self
+		assert: (generator cFunctionNameFor: #continue)
+		equals: #continue_1
 ]
 
 { #category : #'tests-method' }

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
@@ -164,8 +164,8 @@ SlangBasicTranslationTestClass >> methodWithReservedWordLocal: register [
 	<var: #case type: 'char *'>
 	<var: #register type: 'char *'>
 	| case |
-	case := 'foo'
-	register , 'foo'
+	case := register nextPutAll: 'foo'
+	
 ]
 
 { #category : #inline }

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
@@ -154,11 +154,13 @@ SlangBasicTranslationTestClass >> methodWithOptionPragma [
 ]
 
 { #category : #inline }
-SlangBasicTranslationTestClass >> methodWithReservedWordLocal [
+SlangBasicTranslationTestClass >> methodWithReservedWordLocal: register [
 
 	<var: #case type: 'char *'>
+	<var: #register type: 'char *'>
 	| case |
 	case := 'foo'
+	register , 'foo'
 ]
 
 { #category : #inline }

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
@@ -154,6 +154,14 @@ SlangBasicTranslationTestClass >> methodWithOptionPragma [
 ]
 
 { #category : #inline }
+SlangBasicTranslationTestClass >> methodWithReservedWordLocal [
+
+	<var: #case type: 'char *'>
+	| case |
+	case := 'foo'
+]
+
+{ #category : #inline }
 SlangBasicTranslationTestClass >> methodWithSharedCase [
 
 	<sharedCodeInCase: 'sharedCase'>

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
@@ -23,6 +23,11 @@ SlangBasicTranslationTestClass class >> objectMemoryClass [
 ]
 
 { #category : #inline }
+SlangBasicTranslationTestClass >> continue [
+	"reserved name selector"
+]
+
+{ #category : #inline }
 SlangBasicTranslationTestClass >> first: param1 second: param2 [
 	"Method with several parameters"
 ]

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -581,12 +581,7 @@ CCodeGenerator >> cFunctionNameFor: aSelector [
 	^selectorTranslations
 		at: aSelector
 		ifAbsent:
-			[| cSelector |
-			 cSelector := aSelector copyWithout: $:.
-			 aSelector last = $: ifTrue:
-				[[cSelector last = $_] whileTrue:
-					[cSelector := cSelector allButLast]].
-			 cSelector]
+			[ self cSelectorName: aSelector ]
 ]
 
 { #category : #'C code generator' }
@@ -708,6 +703,17 @@ CCodeGenerator >> cLiteralForUnsignedInteger: anInteger longlong: llBoolean [
 				and: [(anInteger highBit = anInteger lowBit and: [anInteger > 65536])
 					  or: [anInteger highBit - anInteger lowBit >= 4]]]).
 	^self cLiteralForUnsignedInteger: anInteger hex: hex longlong: llBoolean
+]
+
+{ #category : #'C translation support' }
+CCodeGenerator >> cSelectorName: aSelector [
+
+	| cSelector |
+	cSelector := aSelector copyWithout: $:.
+	aSelector last = $: ifTrue: [
+		[ cSelector last = $_ ] whileTrue: [
+			cSelector := cSelector allButLast ] ].
+	^ cSelector
 ]
 
 { #category : #inlining }
@@ -1025,14 +1031,12 @@ CCodeGenerator >> emitCCodeOn: aStream doInlining: inlineFlag doAssertions: asse
 
 	| verbose methodList |
 	"method preparation"
-	
 	verbose := false.
 	self prepareMethods.
 	verbose ifTrue: [
 		self printUnboundCallWarnings.
 		self printUnboundVariableReferenceWarnings.
-		logger cr.
-	].
+		logger cr ].
 	assertionFlag ifFalse: [ self removeAssertions ].
 
 	self doInlining: inlineFlag.
@@ -1042,9 +1046,9 @@ CCodeGenerator >> emitCCodeOn: aStream doInlining: inlineFlag doAssertions: asse
 		applyMethodNamed: #interpret.
 
 	"code generation"
-	
+
 	self renameKeywordsConflicts.
-	
+
 	"If we're outputting the VM put the main interpreter loop first for two reasons.
 	 1, so that the dispdbg.h header included at the bytecode dispatch can define
 	 macros that affect all C code in the interpreter,  and 2, so that all primitive
@@ -1052,11 +1056,15 @@ CCodeGenerator >> emitCCodeOn: aStream doInlining: inlineFlag doAssertions: asse
 	 in the use of primitiveFunctionPointer as a function pointer and an index by trying
 	 to ensure that primitives have addresses much higher than any indices."
 	methodList := self sortMethods: methods.
-	(methods includesKey: #interpret) ifTrue:
-		[methodList := { methods at: #interpret }, (methodList copyWithout: (methods at: #interpret))].
+	(methods includesKey: #interpret) ifTrue: [
+		methodList := { (methods at: #interpret) }
+		              , (methodList copyWithout: (methods at: #interpret)) ].
 	"clean out no longer valid variable names and then
 	 handle any global variable usage in each method"
-	methodList do: [:m | self checkForGlobalUsage: (m removeUnusedTempsAndNilIfRequiredIn: self) in: m].
+	methodList do: [ :m |
+		self
+			checkForGlobalUsage: (m removeUnusedTempsAndNilIfRequiredIn: self)
+			in: m ].
 	self localizeGlobalVariables.
 
 	self emitCHeaderOn: aStream.
@@ -1066,7 +1074,6 @@ CCodeGenerator >> emitCCodeOn: aStream doInlining: inlineFlag doAssertions: asse
 	self emitCVariablesOn: aStream.
 	self emitCMacros: methodList on: aStream.
 	self emitCMethods: methodList on: aStream
-
 ]
 
 { #category : #'C code generator' }
@@ -4405,13 +4412,23 @@ CCodeGenerator >> removeVariable: aName ifAbsent: ifAbsentBlock [
 CCodeGenerator >> renameKeywordsConflicts [
 
 	methods do: [ :method |
-		| localRewording |
+		| localRewording cSelector |
+		"rename locals"
 		localRewording := Dictionary new.
 
 		(method allLocals select: [ :local |
 			 self reservedWords includes: local ]) do: [ :local |
 			localRewording at: local put: (self sanitizeKeyword: local) ].
-		localRewording ifNotEmpty: [ method renameVariablesUsing: localRewording ]]
+		localRewording ifNotEmpty: [
+			method renameVariablesUsing: localRewording ].
+
+		"translate selector"
+		cSelector := self cSelectorName: method selector.
+
+		(self reservedWords includes: cSelector) ifTrue: [
+			self
+				addSelectorTranslation: method selector
+				to: (self sanitizeKeyword: cSelector) ] ]
 ]
 
 { #category : #'C translation support' }

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -4397,6 +4397,17 @@ CCodeGenerator >> removeVariable: aName ifAbsent: ifAbsentBlock [
 	^variables remove: aName ifAbsent: ifAbsentBlock
 ]
 
+{ #category : #translating }
+CCodeGenerator >> renameKeywordsConflicts [
+
+	methods do: [ :method |
+		method allLocals do: [ :local |
+			(self reservedWords includes: local) ifTrue: [
+				method renameVariablesUsing: (Dictionary new
+						 at: local put: (self sanitizeKeyword: local);
+						 yourself) ] ] ]
+]
+
 { #category : #'C translation support' }
 CCodeGenerator >> reservedWords [
 	^ self class reservedWords
@@ -4551,6 +4562,12 @@ CCodeGenerator >> returnTypeForSend: sendNode in: aTMethod ifNil: typeIfNil [
 		in: aTMethod
 		boundTo: methodOrNil
 		typeIfNil: typeIfNil
+]
+
+{ #category : #'translation support' }
+CCodeGenerator >> sanitizeKeyword: aKeyword [
+
+	^ aKeyword , '_1'
 ]
 
 { #category : #accessing }

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -43,7 +43,8 @@ Class {
 		'stopOnErrors',
 		'castTranslationDict',
 		'castAsArgumentTranslationDict',
-		'wordSize'
+		'wordSize',
+		'structInstanceVariableTranslations'
 	],
 	#classVars : [
 		'NoRegParmsInAssertVMs'
@@ -371,6 +372,11 @@ CCodeGenerator >> addStructClasses: classes silently: aSilentlyBoolean [
 		 (structClass withAllSuperclasses copyUpTo: SlangStructType) do:
 			[:structClassOrSuperclass|
 			 self addStructClass: structClassOrSuperclass silently: aSilentlyBoolean ]]
+]
+
+{ #category : #public }
+CCodeGenerator >> addStructInstanceVariableTranslation: aVariable to: aString [
+	structInstanceVariableTranslations at: aVariable asSymbol put: aString
 ]
 
 { #category : #utilities }
@@ -1234,7 +1240,7 @@ CCodeGenerator >> emitCTypesOn: aStream [
 	"Store local type declarations on the given stream."
 	self structClasses do: [:structClass|
 		(self shouldGenerateStruct: structClass) ifTrue: [
-			structClass printTypedefOn: aStream.
+			structClass printTypedefOn: aStream withTranslations: structInstanceVariableTranslations.
 			aStream cr; cr ] ]
 ]
 
@@ -3103,6 +3109,7 @@ CCodeGenerator >> initialize [
 	logger := (ProvideAnswerNotification new tag: #logger; signal) ifNil: [Transcript].
 	pools := IdentitySet new.
 	selectorTranslations := IdentityDictionary new.
+	structInstanceVariableTranslations := IdentityDictionary new.
 	suppressAsmLabels := false.
 	previousCommentMarksInlining := false.
 	previousCommenter := nil.
@@ -4428,7 +4435,16 @@ CCodeGenerator >> renameKeywordsConflicts [
 		(self reservedWords includes: cSelector) ifTrue: [
 			self
 				addSelectorTranslation: method selector
-				to: (self sanitizeKeyword: cSelector) ] ]
+				to: (self sanitizeKeyword: cSelector) ] ].
+
+	"translate structs instance variables"
+	structClasses ifNotNil: [ :classes |
+		classes do: [ :struct |
+			struct instVarTypeDeclarationsDo: [ :ivn :type |
+				(self reservedWords includes: ivn) ifTrue: [
+					self
+						addStructInstanceVariableTranslation: ivn
+						to: (self sanitizeKeyword: ivn) ] ] ] ]
 ]
 
 { #category : #'C translation support' }

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -1025,6 +1025,7 @@ CCodeGenerator >> emitCCodeOn: aStream doInlining: inlineFlag doAssertions: asse
 
 	| verbose methodList |
 	"method preparation"
+	
 	verbose := false.
 	self prepareMethods.
 	verbose ifTrue: [
@@ -1041,6 +1042,9 @@ CCodeGenerator >> emitCCodeOn: aStream doInlining: inlineFlag doAssertions: asse
 		applyMethodNamed: #interpret.
 
 	"code generation"
+	
+	self renameKeywordsConflicts.
+	
 	"If we're outputting the VM put the main interpreter loop first for two reasons.
 	 1, so that the dispdbg.h header included at the bytecode dispatch can define
 	 macros that affect all C code in the interpreter,  and 2, so that all primitive

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -4423,9 +4423,11 @@ CCodeGenerator >> renameKeywordsConflicts [
 		"rename locals"
 		localRewording := Dictionary new.
 
-		(method allLocals select: [ :local |
-			 self reservedWords includes: local ]) do: [ :local |
-			localRewording at: local put: (self sanitizeKeyword: local) ].
+		
+		method allLocals 
+			select: [ :local | self reservedWords includes: local ]
+			thenDo: [ :local | localRewording at: local put: (self sanitizeKeyword: local) ].
+
 		localRewording ifNotEmpty: [
 			method renameVariablesUsing: localRewording ].
 
@@ -4438,13 +4440,12 @@ CCodeGenerator >> renameKeywordsConflicts [
 				to: (self sanitizeKeyword: cSelector) ] ].
 
 	"translate structs instance variables"
-	structClasses ifNotNil: [ :classes |
-		classes do: [ :struct |
-			struct instVarTypeDeclarationsDo: [ :ivn :type |
-				(self reservedWords includes: ivn) ifTrue: [
-					self
-						addStructInstanceVariableTranslation: ivn
-						to: (self sanitizeKeyword: ivn) ] ] ] ]
+	self structClasses do: [ :struct |
+		struct instVarTypeDeclarationsDo: [ :ivn :type |
+			(self reservedWords includes: ivn) ifTrue: [
+				self
+					addStructInstanceVariableTranslation: ivn
+					to: (self sanitizeKeyword: ivn) ] ] ]
 ]
 
 { #category : #'C translation support' }

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -4405,11 +4405,13 @@ CCodeGenerator >> removeVariable: aName ifAbsent: ifAbsentBlock [
 CCodeGenerator >> renameKeywordsConflicts [
 
 	methods do: [ :method |
-		method allLocals do: [ :local |
-			(self reservedWords includes: local) ifTrue: [
-				method renameVariablesUsing: (Dictionary new
-						 at: local put: (self sanitizeKeyword: local);
-						 yourself) ] ] ]
+		| localRewording |
+		localRewording := Dictionary new.
+
+		(method allLocals select: [ :local |
+			 self reservedWords includes: local ]) do: [ :local |
+			localRewording at: local put: (self sanitizeKeyword: local) ].
+		localRewording ifNotEmpty: [ method renameVariablesUsing: localRewording ]]
 ]
 
 { #category : #'C translation support' }

--- a/smalltalksrc/Slang/SlangStructType.class.st
+++ b/smalltalksrc/Slang/SlangStructType.class.st
@@ -24,6 +24,33 @@ SlangStructType class >> filteredInstVarNames [
 ]
 
 { #category : #translation }
+SlangStructType class >> instVarNamesAndTypesForTranslationDo: aBinaryBlock [
+	"enumerate aBinaryBlock with the names and C type strings for the inst vars to include in a struct of this type."
+
+	self subclassResponsibility
+]
+
+{ #category : #translation }
+SlangStructType class >> instVarTypeDeclarationsDo: aBinaryBlock [
+
+	| instVarNameTypeDeclarations |
+	instVarNameTypeDeclarations := Dictionary new.
+
+	self instVarNamesAndTypesForTranslationDo: [ :ivn :type |
+		instVarNameTypeDeclarations at: ivn put: type ].
+
+
+	self filteredInstVarNames do: [ :ivn |
+		| typeDeclaration |
+		typeDeclaration := instVarNameTypeDeclarations at: ivn ifAbsent: [
+			                   TranslationError signal:
+				                   'Missing type declaration for instance variable '
+				                   , ivn ].
+
+		aBinaryBlock value: ivn value: typeDeclaration ]
+]
+
+{ #category : #translation }
 SlangStructType class >> isAccessor: aSelector [
 	"Answer if aSelector is simply an accessor method for one of our fields."
 	^(self instVarIndexFor: (aSelector copyWithout: $:) ifAbsent: [0]) > 0

--- a/smalltalksrc/Slang/SlangStructType.class.st
+++ b/smalltalksrc/Slang/SlangStructType.class.st
@@ -78,6 +78,12 @@ SlangStructType class >> needsTypeTag [
 { #category : #translation }
 SlangStructType class >> printTypedefOn: aStream [
 
+	^self printTypedefOn: aStream withTranslations: Dictionary new.
+]
+
+{ #category : #translation }
+SlangStructType class >> printTypedefOn: aStream withTranslations: ivnTranslations [
+
 	aStream nextPutAll: 'typedef struct '.
 	self needsTypeTag ifTrue: [
 		aStream
@@ -87,9 +93,10 @@ SlangStructType class >> printTypedefOn: aStream [
 		nextPut: ${;
 		cr.
 	self instVarTypeDeclarationsDo: [ :ivn :typeArg |
-		| type |
-		ivn first == $#
-			ifTrue: [ aStream nextPutAll: ivn ]
+		| type ivnC|
+		ivnC := ivnTranslations at: ivn ifAbsent: [ ivn ].
+		ivnC first == $#
+			ifTrue: [ aStream nextPutAll: ivnC ]
 			ifFalse: [
 				type := typeArg.
 				#( BytesPerWord BaseHeaderSize BytesPerOop ) do: [ :sizeConstant |
@@ -114,7 +121,7 @@ SlangStructType class >> printTypedefOn: aStream [
 							aStream nextPutAll: type first.
 							(type first last isSeparator or: [ type first last = $* ])
 								ifFalse: [ aStream tab: 2 ].
-							aStream nextPutAll: ivn.
+							aStream nextPutAll: ivnC.
 							type last first isSeparator ifFalse: [ aStream space ].
 							aStream nextPutAll: type last ]
 						ifFalse: [
@@ -122,7 +129,7 @@ SlangStructType class >> printTypedefOn: aStream [
 							aStream nextPutAll: type.
 							(type last isSeparator or: [ type last = $* ]) ifFalse: [
 								aStream tab: 1 ].
-							aStream nextPutAll: ivn ] ].
+							aStream nextPutAll: ivnC ] ].
 				aStream nextPut: $; ].
 		aStream cr ].
 	aStream

--- a/smalltalksrc/Slang/TMethod.class.st
+++ b/smalltalksrc/Slang/TMethod.class.st
@@ -2499,6 +2499,7 @@ TMethod >> recordDeclarationsIn: aCCodeGen [
 		pragma selector = #returnTypeC: ifTrue: [ 
 			self returnType: pragma arguments last ] ].
 	
+		"reset cache since declarations changed"
 		cachedLocals := nil
 ]
 

--- a/smalltalksrc/Slang/TMethod.class.st
+++ b/smalltalksrc/Slang/TMethod.class.st
@@ -3295,20 +3295,6 @@ TMethod >> usesVariableUninlinably: argName in: aCodeGen [
 						  subNode isVariable and: [ subNode name = argName ] ] ] ] ] ]
 ]
 
-{ #category : #accessing }
-TMethod >> validateVariableDeclarationExists: aVariableName [
-
-	| shouldCheckVariable |
-	shouldCheckVariable := (aVariableName beginsWithAnyOf:
-		                       #( #self #cascade #toDoLimit )) not.
-
-	(shouldCheckVariable and: [
-		 (self declaresVariableWithName: aVariableName) not]) ifTrue: [
-		TranslationError signal:
-			'Undefined local or argument ' , aVariableName
-			, ' type declaration' ]
-]
-
 { #category : #'C code generation' }
 TMethod >> validateReservedWords [
 	"Validates if there are no reserved words being used as arguments or selector"
@@ -3322,6 +3308,20 @@ TMethod >> validateReservedWords [
 	(reservedWords includes: selector) ifTrue: [
 		TranslationError signal:
 			'Invalid selector ' , selector , ': Reserved word' ]
+]
+
+{ #category : #accessing }
+TMethod >> validateVariableDeclarationExists: aVariableName [
+
+	| shouldCheckVariable |
+	shouldCheckVariable := (aVariableName beginsWithAnyOf:
+		                       #( #self #cascade #toDoLimit )) not.
+
+	(shouldCheckVariable and: [
+		 (self declaresVariableWithName: aVariableName) not]) ifTrue: [
+		TranslationError signal:
+			'Undefined local or argument ' , aVariableName
+			, ' type declaration' ]
 ]
 
 { #category : #utilities }

--- a/smalltalksrc/Slang/TMethod.class.st
+++ b/smalltalksrc/Slang/TMethod.class.st
@@ -2497,7 +2497,9 @@ TMethod >> recordDeclarationsIn: aCCodeGen [
 				declarationAt: varName
 				put: varType , varName ].
 		pragma selector = #returnTypeC: ifTrue: [ 
-			self returnType: pragma arguments last ] ]
+			self returnType: pragma arguments last ] ].
+	
+		cachedLocals := nil
 ]
 
 { #category : #accessing }
@@ -2816,8 +2818,6 @@ TMethod >> setSelector: sel definingClass: class args: argList locals: localList
 	self parseTree: (aBlockNode asTranslatorNodeIn: self).
 	self locals: tempParseTree locals, (localList  collect: [:arg | arg name]).
 	self addTypeForSelf.
-	
-	self validateReservedWords.
 	
 	complete := false.  "set to true when all possible inlining has been done"
 	export := self extractExportDirective.
@@ -3293,21 +3293,6 @@ TMethod >> usesVariableUninlinably: argName in: aCodeGen [
 				  node arguments anySatisfy: [ :argNode | 
 					  argNode anySatisfy: [ :subNode | 
 						  subNode isVariable and: [ subNode name = argName ] ] ] ] ] ]
-]
-
-{ #category : #'C code generation' }
-TMethod >> validateReservedWords [
-	"Validates if there are no reserved words being used as arguments or selector"
-
-	| reservedWords |
-	reservedWords := CCodeGenerator reservedWords.
-
-	(reservedWords includesAnyOf: args) ifTrue: [
-		TranslationError signal: 'Arguments cannot be reserved words' ].
-
-	(reservedWords includes: selector) ifTrue: [
-		TranslationError signal:
-			'Invalid selector ' , selector , ': Reserved word' ]
 ]
 
 { #category : #accessing }

--- a/smalltalksrc/Slang/TVariableNode.class.st
+++ b/smalltalksrc/Slang/TVariableNode.class.st
@@ -127,10 +127,6 @@ TVariableNode >> printOn: aStream level: level [
 { #category : #accessing }
 TVariableNode >> setName: aString [
 
-	(CCodeGenerator reservedWords includes:
-		 aString) ifTrue: [
-		TranslationError signal: aString , ' is a reserved word' ].
-
 	name := aString
 ]
 

--- a/smalltalksrc/VMMaker/LibFFICIF.class.st
+++ b/smalltalksrc/VMMaker/LibFFICIF.class.st
@@ -38,7 +38,7 @@ LibFFICIF class >> instVarNamesAndTypesForTranslationDo: aBinaryBlock [
 ]
 
 { #category : #translation }
-LibFFICIF class >> printTypedefOn: aStream [
+LibFFICIF class >> printTypedefOn: aStream withTranslations: ivnTranslations [
 
 	"This is already defined in ffi.h"
 ]

--- a/smalltalksrc/VMMaker/LibFFIType.class.st
+++ b/smalltalksrc/VMMaker/LibFFIType.class.st
@@ -36,7 +36,7 @@ LibFFIType class >> instVarNamesAndTypesForTranslationDo: aBinaryBlock [
 ]
 
 { #category : #'type constants' }
-LibFFIType class >> printTypedefOn: aStream [
+LibFFIType class >> printTypedefOn: aStream withTranslations: ivnTranslations [
 
 	"This is already defined in ffi.h"
 ]

--- a/smalltalksrc/VMMaker/LibFFIWorkerTask.class.st
+++ b/smalltalksrc/VMMaker/LibFFIWorkerTask.class.st
@@ -35,7 +35,7 @@ LibFFIWorkerTask class >> instVarNamesAndTypesForTranslationDo: aBinaryBlock [
 ]
 
 { #category : #translation }
-LibFFIWorkerTask class >> printTypedefOn: aStream [
+LibFFIWorkerTask class >> printTypedefOn: aStream withTranslations: ivnTranslations [
 
 	"This is already defined in workerTask.h"
 ]

--- a/smalltalksrc/VMMaker/VMCallbackContext.class.st
+++ b/smalltalksrc/VMMaker/VMCallbackContext.class.st
@@ -50,8 +50,8 @@ VMCallbackContext class >> needsTypeTag [
 ]
 
 { #category : #translation }
-VMCallbackContext class >> printTypedefOn: aStream [
-	super printTypedefOn: aStream.
+VMCallbackContext class >> printTypedefOn: aStream  withTranslations: ivnTranslations [
+	super printTypedefOn: aStream  withTranslations: ivnTranslations.
 	aStream
 		newLine;
 		nextPutAll: '/* The callback return type codes */'; newLine;

--- a/smalltalksrc/VMMaker/VMStructType.class.st
+++ b/smalltalksrc/VMMaker/VMStructType.class.st
@@ -215,33 +215,6 @@ VMStructType class >> initializationOptions [
 	^ VMClass initializationOptions 
 ]
 
-{ #category : #translation }
-VMStructType class >> instVarNamesAndTypesForTranslationDo: aBinaryBlock [
-	"enumerate aBinaryBlock with the names and C type strings for the inst vars to include in a struct of this type."
-
-	self subclassResponsibility
-]
-
-{ #category : #translation }
-VMStructType class >> instVarTypeDeclarationsDo: aBinaryBlock [
-
-	| instVarNameTypeDeclarations |
-	instVarNameTypeDeclarations := Dictionary new.
-
-	self instVarNamesAndTypesForTranslationDo: [ :ivn :type |
-		instVarNameTypeDeclarations at: ivn put: type ].
-
-
-	self filteredInstVarNames do: [ :ivn |
-		| typeDeclaration |
-		typeDeclaration := instVarNameTypeDeclarations at: ivn ifAbsent: [
-			                   TranslationError signal:
-				                   'Missing type declaration for instance variable '
-				                   , ivn ].
-
-		aBinaryBlock value: ivn value: typeDeclaration ]
-]
-
 { #category : #accessing }
 VMStructType class >> interpreterClass [
 	

--- a/smalltalksrc/VMMakerTests/MockVMStructWithReservedWords.class.st
+++ b/smalltalksrc/VMMakerTests/MockVMStructWithReservedWords.class.st
@@ -1,0 +1,28 @@
+Class {
+	#name : #MockVMStructWithReservedWords,
+	#superclass : #VMStructType,
+	#instVars : [
+		'foo',
+		'case'
+	],
+	#category : #VMMakerTests
+}
+
+{ #category : #enumerating }
+MockVMStructWithReservedWords class >> instVarNamesAndTypesForTranslationDo: aBinaryBlock [
+	
+	aBinaryBlock value: 'foo' value: 'char *'.
+	aBinaryBlock value: 'case' value: 'char *'
+]
+
+{ #category : #accessing }
+MockVMStructWithReservedWords >> case [
+
+	^ case
+]
+
+{ #category : #accessing }
+MockVMStructWithReservedWords >> case: anObject [
+
+	case := anObject
+]


### PR DESCRIPTION
Rename when they would conflict with C keywords