### PR TITLE
Make instantiateClass more robust when the format is missing

### DIFF
--- a/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
@@ -2732,11 +2732,6 @@ InterpreterPrimitives >> primitiveNew [
 
 	(objectMemory instantiateClass: self stackTop)
 		ifNotNil: [ :obj | self pop: argumentCount + 1 thenPush: obj ]
-		ifNil: [ 
-			self primitiveFailFor: ((objectMemory isFixedSizePointerFormat:
-					  (objectMemory instSpecOfClass: self stackTop))
-					 ifTrue: [ PrimErrNoMemory ]
-					 ifFalse: [ PrimErrBadReceiver ]) ]
 ]
 
 { #category : #'compiled methods' }
@@ -2802,13 +2797,6 @@ InterpreterPrimitives >> primitiveNewWithArg [
 		 instantiateClass: (self stackValue: 1)
 		 indexableSize: size)
 		ifNotNil: [ :obj | self pop: argumentCount + 1 thenPush: obj ]
-		ifNil: [ 
-			instSpec := objectMemory instSpecOfClass: (self stackValue: 1).
-			self primitiveFailFor:
-				(((objectMemory isIndexableFormat: instSpec) and: [ 
-					  (objectMemory isCompiledMethodFormat: instSpec) not ])
-					 ifTrue: [ PrimErrNoMemory ]
-					 ifFalse: [ PrimErrBadReceiver ]) ]
 ]
 
 { #category : #'object access primitives' }

--- a/smalltalksrc/VMMaker/Spur32BitMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/Spur32BitMemoryManager.class.st
@@ -384,10 +384,10 @@ Spur32BitMemoryManager >> instantiateClass: classObj indexableSize: nElements is
 	<var: #nElements type: #usqInt>
 	"Allocate an instance of a variable class, excepting CompiledMethod."
 	| instSpec classFormat numSlots classIndex newObj fillValue |
-	(self numSlotsOfAny: classObj) >= InstanceSpecificationIndex ifFalse:
+	classFormat := self formatOfClassSafe: classObj.
+	classFormat ifNil:
 		[self primitiveFailFor: PrimErrBadReceiver. "no format"
 		 ^nil].
-	classFormat := self formatOfClass: classObj.
 	instSpec := self instSpecOfClassFormat: classFormat.
 	classIndex := self rawHashBitsOf: classObj.
 	fillValue := 0.

--- a/smalltalksrc/VMMaker/Spur32BitMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/Spur32BitMemoryManager.class.st
@@ -384,6 +384,9 @@ Spur32BitMemoryManager >> instantiateClass: classObj indexableSize: nElements is
 	<var: #nElements type: #usqInt>
 	"Allocate an instance of a variable class, excepting CompiledMethod."
 	| instSpec classFormat numSlots classIndex newObj fillValue |
+	(self numSlotsOfAny: classObj) >= InstanceSpecificationIndex ifFalse:
+		[self primitiveFailFor: PrimErrBadReceiver. "no format"
+		 ^nil].
 	classFormat := self formatOfClass: classObj.
 	instSpec := self instSpecOfClassFormat: classFormat.
 	classIndex := self rawHashBitsOf: classObj.
@@ -421,7 +424,8 @@ Spur32BitMemoryManager >> instantiateClass: classObj indexableSize: nElements is
 			  this method.
 			  Hence allow fixed classes to be instantiated here iff nElements = 0."
 			 (nElements ~= 0 or: [instSpec > self lastPointerFormat]) ifTrue:
-				[^nil].
+				[coInterpreter primitiveFailFor: PrimErrBadReceiver.
+				 ^nil].
 			 numSlots := self fixedFieldsOfClassFormat: classFormat.
 			 fillValue := nilObj].
 	classIndex = 0 ifTrue:
@@ -442,7 +446,8 @@ Spur32BitMemoryManager >> instantiateClass: classObj indexableSize: nElements is
 		ifFalse:
 			[newObj := self allocateSlots: numSlots format: instSpec classIndex: classIndex].
 	newObj ifNotNil:
-		[self fillObj: newObj numSlots: numSlots with: fillValue].
+		[self fillObj: newObj numSlots: numSlots with: fillValue]
+		ifNil: [ self primitiveFailFor: PrimErrNoMemory ].
 	^newObj
 ]
 

--- a/smalltalksrc/VMMaker/Spur64BitMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/Spur64BitMemoryManager.class.st
@@ -425,6 +425,9 @@ Spur64BitMemoryManager >> instantiateClass: classObj indexableSize: nElements is
 	<var: #nElements type: #usqInt>
 	"Allocate an instance of a variable class, excepting CompiledMethod."
 	| instSpec classFormat numSlots classIndex newObj fillValue |
+	(self numSlotsOfAny: classObj) >= InstanceSpecificationIndex ifFalse:
+		[self primitiveFailFor: PrimErrBadReceiver. "no format"
+		 ^nil].
 	classFormat := self formatOfClass: classObj.
 	instSpec := self instSpecOfClassFormat: classFormat.
 	classIndex := self rawHashBitsOf: classObj.
@@ -460,7 +463,8 @@ Spur64BitMemoryManager >> instantiateClass: classObj indexableSize: nElements is
 			  this method.
 			  Hence allow fixed classes to be instantiated here iff nElements = 0."
 			 (nElements ~= 0 or: [instSpec > self lastPointerFormat]) ifTrue:
-				[^nil].
+				[coInterpreter primitiveFailFor: PrimErrBadReceiver.
+				 ^nil].
 			 numSlots := self fixedFieldsOfClassFormat: classFormat.
 			 fillValue := nilObj].
 	classIndex = 0 ifTrue:
@@ -481,7 +485,8 @@ Spur64BitMemoryManager >> instantiateClass: classObj indexableSize: nElements is
 		ifFalse:
 			[newObj := self allocateSlots: numSlots format: instSpec classIndex: classIndex].
 	newObj ifNotNil:
-		[self fillObj: newObj numSlots: numSlots with: fillValue].
+		[self fillObj: newObj numSlots: numSlots with: fillValue]
+		ifNil: [ self primitiveFailFor: PrimErrNoMemory ].	
 	^newObj
 ]
 

--- a/smalltalksrc/VMMaker/Spur64BitMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/Spur64BitMemoryManager.class.st
@@ -425,10 +425,10 @@ Spur64BitMemoryManager >> instantiateClass: classObj indexableSize: nElements is
 	<var: #nElements type: #usqInt>
 	"Allocate an instance of a variable class, excepting CompiledMethod."
 	| instSpec classFormat numSlots classIndex newObj fillValue |
-	(self numSlotsOfAny: classObj) >= InstanceSpecificationIndex ifFalse:
+	classFormat := self formatOfClassSafe: classObj.
+	classFormat ifNil:
 		[self primitiveFailFor: PrimErrBadReceiver. "no format"
 		 ^nil].
-	classFormat := self formatOfClass: classObj.
 	instSpec := self instSpecOfClassFormat: classFormat.
 	classIndex := self rawHashBitsOf: classObj.
 	fillValue := 0.

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -6844,10 +6844,14 @@ SpurMemoryManager >> instantiateClass: classObj indexableSize: nElements isPinne
 { #category : #instantiation }
 SpurMemoryManager >> instantiateClass: classObj isPinned: isPinned [
 	| instSpec classFormat numSlots classIndex newObj |
+	(self numSlotsOfAny: classObj) >= InstanceSpecificationIndex ifFalse:
+		[self primitiveFailFor: PrimErrBadReceiver. "no format"
+		 ^nil].
 	classFormat := self formatOfClass: classObj.
 	instSpec := self instSpecOfClassFormat: classFormat.
 	(self isFixedSizePointerFormat: instSpec) ifFalse:
-		[^nil].
+		[self primitiveFailFor: PrimErrBadReceiver. "bad format"
+		^nil].
 	classIndex := self ensureBehaviorHash: classObj.
 	classIndex < 0 ifTrue:
 		[coInterpreter primitiveFailFor: classIndex negated.
@@ -6855,7 +6859,8 @@ SpurMemoryManager >> instantiateClass: classObj isPinned: isPinned [
 	numSlots := self fixedFieldsOfClassFormat: classFormat.
 	newObj := self allocateSlots: numSlots format: instSpec classIndex: classIndex isPinned: isPinned.
 	newObj ifNotNil:
-		[self fillObj: newObj numSlots: numSlots with: nilObj].
+		[self fillObj: newObj numSlots: numSlots with: nilObj]
+		ifNil: [ self primitiveFailFor: PrimErrNoMemory ].
 	^newObj
 ]
 

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -5482,6 +5482,21 @@ SpurMemoryManager >> formatOfClass: classPointer [
 	^self integerValueOf: (self fetchPointer: InstanceSpecificationIndex ofObject: classPointer)
 ]
 
+{ #category : #'object format' }
+SpurMemoryManager >> formatOfClassSafe: oop [
+	"like formatOfClass: but check the existence of the format.
+	return nil there is no format or a non integer format"
+	<api>
+	<inline: true>
+	| classObj classFormat |
+	classObj := self followMaybeForwarded: oop. 
+	(self isNonImmediate: classObj) ifFalse: [ ^nil].
+	(self numSlotsOfAny: classObj) >= InstanceSpecificationIndex ifFalse: [^nil].
+	classFormat := self fetchPointer: InstanceSpecificationIndex ofObject: classObj.
+	(self isIntegerObject: classFormat) ifFalse: [^nil].
+	^self integerValueOf: classFormat
+]
+
 { #category : #'object access' }
 SpurMemoryManager >> formatOfHeader: header [
 	"0 = 0 sized objects (UndefinedObject True False et al)
@@ -6844,14 +6859,14 @@ SpurMemoryManager >> instantiateClass: classObj indexableSize: nElements isPinne
 { #category : #instantiation }
 SpurMemoryManager >> instantiateClass: classObj isPinned: isPinned [
 	| instSpec classFormat numSlots classIndex newObj |
-	(self numSlotsOfAny: classObj) >= InstanceSpecificationIndex ifFalse:
+	classFormat := self formatOfClassSafe: classObj.
+	classFormat ifNil:
 		[self primitiveFailFor: PrimErrBadReceiver. "no format"
 		 ^nil].
-	classFormat := self formatOfClass: classObj.
 	instSpec := self instSpecOfClassFormat: classFormat.
 	(self isFixedSizePointerFormat: instSpec) ifFalse:
 		[self primitiveFailFor: PrimErrBadReceiver. "bad format"
-		^nil].
+		 ^nil].
 	classIndex := self ensureBehaviorHash: classObj.
 	classIndex < 0 ifTrue:
 		[coInterpreter primitiveFailFor: classIndex negated.

--- a/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
@@ -2880,6 +2880,22 @@ VMPrimitiveTest >> testPrimitiveNewWithArgWithInvalidClassFails2 [
 ]
 
 { #category : #'tests - primitiveNewWithArgs' }
+VMPrimitiveTest >> testPrimitiveNewWithArgWithInvalidClassFails3 [
+	| class |
+
+	"class with nil as format"
+	class := self newClassInOldSpaceWithSlots: 0 instSpec: memory nonIndexablePointerFormat.
+	memory storePointer: 2 ofObject: class withValue: memory nilObject.
+
+	interpreter push: class.
+	interpreter push: (memory integerObjectOf: 256).
+
+	interpreter primitiveNewWithArg.
+
+	self assert: interpreter primFailCode equals: PrimErrBadReceiver
+]
+
+{ #category : #'tests - primitiveNewWithArgs' }
 VMPrimitiveTest >> testPrimitiveNewWithArgWithNegativeArgumentFails [
 	| class |
 
@@ -2910,6 +2926,19 @@ VMPrimitiveTest >> testPrimitiveNewWithInvalidClassFails2 [
 	"class object with no slots, so no format"
 	class := self newObjectWithSlots: 0.
 
+	interpreter push: class.
+	interpreter primitiveNew.
+
+	self assert: interpreter primFailCode equals: PrimErrBadReceiver
+]
+
+{ #category : #'tests - primitiveNew' }
+VMPrimitiveTest >> testPrimitiveNewWithInvalidClassFails3 [
+	| class |
+	"class with nil used as format"
+	class := self newClassInOldSpaceWithSlots: 0 instSpec: memory nonIndexablePointerFormat.
+	memory storePointer: 2 ofObject: class withValue: memory nilObject.
+	
 	interpreter push: class.
 	interpreter primitiveNew.
 

--- a/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
@@ -2869,10 +2869,7 @@ VMPrimitiveTest >> testPrimitiveNewWithArgWithInvalidClassFails2 [
 	| class |
 
 	"class object with no slots, so no format"
-	class := self memory
-		allocateSlotsInOldSpace: 0
-		format: memory nonIndexablePointerFormat
-		classIndex: memory arrayClassIndexPun.
+	class := self newObjectWithSlots: 0.
 
 	interpreter push: class.
 	interpreter push: (memory integerObjectOf: 256).
@@ -2911,10 +2908,7 @@ VMPrimitiveTest >> testPrimitiveNewWithInvalidClassFails [
 VMPrimitiveTest >> testPrimitiveNewWithInvalidClassFails2 [
 	| class |
 	"class object with no slots, so no format"
-	class := self memory
-		allocateSlotsInOldSpace: 0
-		format: memory nonIndexablePointerFormat
-		classIndex: memory arrayClassIndexPun.
+	class := self newObjectWithSlots: 0.
 
 	interpreter push: class.
 	interpreter primitiveNew.

--- a/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
@@ -2865,6 +2865,24 @@ VMPrimitiveTest >> testPrimitiveNewWithArgWithInvalidClassFails [
 ]
 
 { #category : #'tests - primitiveNewWithArgs' }
+VMPrimitiveTest >> testPrimitiveNewWithArgWithInvalidClassFails2 [
+	| class |
+
+	"class object with no slots, so no format"
+	class := self memory
+		allocateSlotsInOldSpace: 0
+		format: memory nonIndexablePointerFormat
+		classIndex: memory arrayClassIndexPun.
+
+	interpreter push: class.
+	interpreter push: (memory integerObjectOf: 256).
+
+	interpreter primitiveNewWithArg.
+
+	self assert: interpreter primFailCode equals: PrimErrBadReceiver
+]
+
+{ #category : #'tests - primitiveNewWithArgs' }
 VMPrimitiveTest >> testPrimitiveNewWithArgWithNegativeArgumentFails [
 	| class |
 
@@ -2882,6 +2900,21 @@ VMPrimitiveTest >> testPrimitiveNewWithArgWithNegativeArgumentFails [
 VMPrimitiveTest >> testPrimitiveNewWithInvalidClassFails [
 	| class |
 	class := self newClassInOldSpaceWithSlots: 0 instSpec: memory arrayFormat.
+
+	interpreter push: class.
+	interpreter primitiveNew.
+
+	self assert: interpreter primFailCode equals: PrimErrBadReceiver
+]
+
+{ #category : #'tests - primitiveNew' }
+VMPrimitiveTest >> testPrimitiveNewWithInvalidClassFails2 [
+	| class |
+	"class object with no slots, so no format"
+	class := self memory
+		allocateSlotsInOldSpace: 0
+		format: memory nonIndexablePointerFormat
+		classIndex: memory arrayClassIndexPun.
 
 	interpreter push: class.
 	interpreter primitiveNew.


### PR DESCRIPTION
Calling `primitiveNew` (`basicNew` in the image parlance) on a an object without a 3rd instance variable (where the format is expected to be) fail with randomly "not enough memory" or "bad receiver" (or can unlikely success) as the non existent 3rd slot is blindly read, thus garbage memory is misinterpreted.

In debug mode some assertions catch the issue, but it's not enough as the VM should try to be robust and consistent in case of wrong user data even in release mode.

The PR add a check of the existence of the format before accessing it and set the primitive fail accordingly.

It also does a small refactor of the related code so that the failure numbers are set at the same place.
Previously, precise error code set by `SpurMemoryManager >> instantiateClass:` (&cie) might have been overwrote by `InterpreterPrimitives >> primitiveNew` (&cie).

Note: I only check that the format exists, and not that it is a valid integer. Now writing the cover letter I think I should have done that. What do you think?