### PR TITLE
Revert "Make instantiateClass more robust when the format is missing"

### DIFF
--- a/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
@@ -2732,6 +2732,11 @@ InterpreterPrimitives >> primitiveNew [
 
 	(objectMemory instantiateClass: self stackTop)
 		ifNotNil: [ :obj | self pop: argumentCount + 1 thenPush: obj ]
+		ifNil: [ 
+			self primitiveFailFor: ((objectMemory isFixedSizePointerFormat:
+					  (objectMemory instSpecOfClass: self stackTop))
+					 ifTrue: [ PrimErrNoMemory ]
+					 ifFalse: [ PrimErrBadReceiver ]) ]
 ]
 
 { #category : #'compiled methods' }
@@ -2797,6 +2802,13 @@ InterpreterPrimitives >> primitiveNewWithArg [
 		 instantiateClass: (self stackValue: 1)
 		 indexableSize: size)
 		ifNotNil: [ :obj | self pop: argumentCount + 1 thenPush: obj ]
+		ifNil: [ 
+			instSpec := objectMemory instSpecOfClass: (self stackValue: 1).
+			self primitiveFailFor:
+				(((objectMemory isIndexableFormat: instSpec) and: [ 
+					  (objectMemory isCompiledMethodFormat: instSpec) not ])
+					 ifTrue: [ PrimErrNoMemory ]
+					 ifFalse: [ PrimErrBadReceiver ]) ]
 ]
 
 { #category : #'object access primitives' }

--- a/smalltalksrc/VMMaker/Spur32BitMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/Spur32BitMemoryManager.class.st
@@ -384,10 +384,7 @@ Spur32BitMemoryManager >> instantiateClass: classObj indexableSize: nElements is
 	<var: #nElements type: #usqInt>
 	"Allocate an instance of a variable class, excepting CompiledMethod."
 	| instSpec classFormat numSlots classIndex newObj fillValue |
-	classFormat := self formatOfClassSafe: classObj.
-	classFormat ifNil:
-		[self primitiveFailFor: PrimErrBadReceiver. "no format"
-		 ^nil].
+	classFormat := self formatOfClass: classObj.
 	instSpec := self instSpecOfClassFormat: classFormat.
 	classIndex := self rawHashBitsOf: classObj.
 	fillValue := 0.
@@ -424,8 +421,7 @@ Spur32BitMemoryManager >> instantiateClass: classObj indexableSize: nElements is
 			  this method.
 			  Hence allow fixed classes to be instantiated here iff nElements = 0."
 			 (nElements ~= 0 or: [instSpec > self lastPointerFormat]) ifTrue:
-				[coInterpreter primitiveFailFor: PrimErrBadReceiver.
-				 ^nil].
+				[^nil].
 			 numSlots := self fixedFieldsOfClassFormat: classFormat.
 			 fillValue := nilObj].
 	classIndex = 0 ifTrue:
@@ -446,8 +442,7 @@ Spur32BitMemoryManager >> instantiateClass: classObj indexableSize: nElements is
 		ifFalse:
 			[newObj := self allocateSlots: numSlots format: instSpec classIndex: classIndex].
 	newObj ifNotNil:
-		[self fillObj: newObj numSlots: numSlots with: fillValue]
-		ifNil: [ self primitiveFailFor: PrimErrNoMemory ].
+		[self fillObj: newObj numSlots: numSlots with: fillValue].
 	^newObj
 ]
 

--- a/smalltalksrc/VMMaker/Spur64BitMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/Spur64BitMemoryManager.class.st
@@ -425,10 +425,7 @@ Spur64BitMemoryManager >> instantiateClass: classObj indexableSize: nElements is
 	<var: #nElements type: #usqInt>
 	"Allocate an instance of a variable class, excepting CompiledMethod."
 	| instSpec classFormat numSlots classIndex newObj fillValue |
-	classFormat := self formatOfClassSafe: classObj.
-	classFormat ifNil:
-		[self primitiveFailFor: PrimErrBadReceiver. "no format"
-		 ^nil].
+	classFormat := self formatOfClass: classObj.
 	instSpec := self instSpecOfClassFormat: classFormat.
 	classIndex := self rawHashBitsOf: classObj.
 	fillValue := 0.
@@ -463,8 +460,7 @@ Spur64BitMemoryManager >> instantiateClass: classObj indexableSize: nElements is
 			  this method.
 			  Hence allow fixed classes to be instantiated here iff nElements = 0."
 			 (nElements ~= 0 or: [instSpec > self lastPointerFormat]) ifTrue:
-				[coInterpreter primitiveFailFor: PrimErrBadReceiver.
-				 ^nil].
+				[^nil].
 			 numSlots := self fixedFieldsOfClassFormat: classFormat.
 			 fillValue := nilObj].
 	classIndex = 0 ifTrue:
@@ -485,8 +481,7 @@ Spur64BitMemoryManager >> instantiateClass: classObj indexableSize: nElements is
 		ifFalse:
 			[newObj := self allocateSlots: numSlots format: instSpec classIndex: classIndex].
 	newObj ifNotNil:
-		[self fillObj: newObj numSlots: numSlots with: fillValue]
-		ifNil: [ self primitiveFailFor: PrimErrNoMemory ].	
+		[self fillObj: newObj numSlots: numSlots with: fillValue].
 	^newObj
 ]
 

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -5548,21 +5548,6 @@ SpurMemoryManager >> formatOfClass: classPointer [
 	^self integerValueOf: (self fetchPointer: InstanceSpecificationIndex ofObject: classPointer)
 ]
 
-{ #category : #'object format' }
-SpurMemoryManager >> formatOfClassSafe: oop [
-	"like formatOfClass: but check the existence of the format.
-	return nil there is no format or a non integer format"
-	<api>
-	<inline: true>
-	| classObj classFormat |
-	classObj := self followMaybeForwarded: oop. 
-	(self isNonImmediate: classObj) ifFalse: [ ^nil].
-	(self numSlotsOfAny: classObj) >= InstanceSpecificationIndex ifFalse: [^nil].
-	classFormat := self fetchPointer: InstanceSpecificationIndex ofObject: classObj.
-	(self isIntegerObject: classFormat) ifFalse: [^nil].
-	^self integerValueOf: classFormat
-]
-
 { #category : #'object access' }
 SpurMemoryManager >> formatOfHeader: header [
 	"0 = 0 sized objects (UndefinedObject True False et al)
@@ -6956,14 +6941,10 @@ SpurMemoryManager >> instantiateClass: classObj indexableSize: nElements isPinne
 { #category : #instantiation }
 SpurMemoryManager >> instantiateClass: classObj isPinned: isPinned [
 	| instSpec classFormat numSlots classIndex newObj |
-	classFormat := self formatOfClassSafe: classObj.
-	classFormat ifNil:
-		[self primitiveFailFor: PrimErrBadReceiver. "no format"
-		 ^nil].
+	classFormat := self formatOfClass: classObj.
 	instSpec := self instSpecOfClassFormat: classFormat.
 	(self isFixedSizePointerFormat: instSpec) ifFalse:
-		[self primitiveFailFor: PrimErrBadReceiver. "bad format"
-		 ^nil].
+		[^nil].
 	classIndex := self ensureBehaviorHash: classObj.
 	classIndex < 0 ifTrue:
 		[coInterpreter primitiveFailFor: classIndex negated.
@@ -6971,8 +6952,7 @@ SpurMemoryManager >> instantiateClass: classObj isPinned: isPinned [
 	numSlots := self fixedFieldsOfClassFormat: classFormat.
 	newObj := self allocateSlots: numSlots format: instSpec classIndex: classIndex isPinned: isPinned.
 	newObj ifNotNil:
-		[self fillObj: newObj numSlots: numSlots with: nilObj]
-		ifNil: [ self primitiveFailFor: PrimErrNoMemory ].
+		[self fillObj: newObj numSlots: numSlots with: nilObj].
 	^newObj
 ]
 

--- a/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
@@ -2865,37 +2865,6 @@ VMPrimitiveTest >> testPrimitiveNewWithArgWithInvalidClassFails [
 ]
 
 { #category : #'tests - primitiveNewWithArgs' }
-VMPrimitiveTest >> testPrimitiveNewWithArgWithInvalidClassFails2 [
-	| class |
-
-	"class object with no slots, so no format"
-	class := self newObjectWithSlots: 0.
-
-	interpreter push: class.
-	interpreter push: (memory integerObjectOf: 256).
-
-	interpreter primitiveNewWithArg.
-
-	self assert: interpreter primFailCode equals: PrimErrBadReceiver
-]
-
-{ #category : #'tests - primitiveNewWithArgs' }
-VMPrimitiveTest >> testPrimitiveNewWithArgWithInvalidClassFails3 [
-	| class |
-
-	"class with nil as format"
-	class := self newClassInOldSpaceWithSlots: 0 instSpec: memory nonIndexablePointerFormat.
-	memory storePointer: 2 ofObject: class withValue: memory nilObject.
-
-	interpreter push: class.
-	interpreter push: (memory integerObjectOf: 256).
-
-	interpreter primitiveNewWithArg.
-
-	self assert: interpreter primFailCode equals: PrimErrBadReceiver
-]
-
-{ #category : #'tests - primitiveNewWithArgs' }
 VMPrimitiveTest >> testPrimitiveNewWithArgWithNegativeArgumentFails [
 	| class |
 
@@ -2914,31 +2883,6 @@ VMPrimitiveTest >> testPrimitiveNewWithInvalidClassFails [
 	| class |
 	class := self newClassInOldSpaceWithSlots: 0 instSpec: memory arrayFormat.
 
-	interpreter push: class.
-	interpreter primitiveNew.
-
-	self assert: interpreter primFailCode equals: PrimErrBadReceiver
-]
-
-{ #category : #'tests - primitiveNew' }
-VMPrimitiveTest >> testPrimitiveNewWithInvalidClassFails2 [
-	| class |
-	"class object with no slots, so no format"
-	class := self newObjectWithSlots: 0.
-
-	interpreter push: class.
-	interpreter primitiveNew.
-
-	self assert: interpreter primFailCode equals: PrimErrBadReceiver
-]
-
-{ #category : #'tests - primitiveNew' }
-VMPrimitiveTest >> testPrimitiveNewWithInvalidClassFails3 [
-	| class |
-	"class with nil used as format"
-	class := self newClassInOldSpaceWithSlots: 0 instSpec: memory nonIndexablePointerFormat.
-	memory storePointer: 2 ofObject: class withValue: memory nilObject.
-	
 	interpreter push: class.
 	interpreter primitiveNew.
 


### PR DESCRIPTION
Reverts pharo-project/pharo-vm#629 because of CI hiccups