### PR TITLE
Refactoring the primitive `at:`

### DIFF
--- a/smalltalksrc/VMMaker/CoInterpreter.class.st
+++ b/smalltalksrc/VMMaker/CoInterpreter.class.st
@@ -2699,8 +2699,7 @@ CoInterpreter >> flushExternalPrimitiveOf: methodObj [
 
 { #category : #'method lookup cache' }
 CoInterpreter >> flushMethodCache [
-	"Flush the method cache. The method cache is flushed on every programming change and
-	garbage collect."
+	"Flush the method cache. The method cache is flushed on every programming change and garbage collect."
 
 	super flushMethodCache.
 	cogit unlinkAllSends

--- a/smalltalksrc/VMMaker/CoInterpreter.class.st
+++ b/smalltalksrc/VMMaker/CoInterpreter.class.st
@@ -2697,14 +2697,6 @@ CoInterpreter >> flushExternalPrimitiveOf: methodObj [
 			to: #primitiveExternalCall]
 ]
 
-{ #category : #'method lookup cache' }
-CoInterpreter >> flushMethodCache [
-	"Flush the method cache. The method cache is flushed on every programming change and garbage collect."
-
-	super flushMethodCache.
-	cogit unlinkAllSends
-]
-
 { #category : #'message sending' }
 CoInterpreter >> followForwardedFieldsInCurrentMethod [
 

--- a/smalltalksrc/VMMaker/CoInterpreter.class.st
+++ b/smalltalksrc/VMMaker/CoInterpreter.class.st
@@ -2697,6 +2697,15 @@ CoInterpreter >> flushExternalPrimitiveOf: methodObj [
 			to: #primitiveExternalCall]
 ]
 
+{ #category : #'method lookup cache' }
+CoInterpreter >> flushMethodCache [
+	"Flush the method cache. The method cache is flushed on every programming change and
+	garbage collect."
+
+	super flushMethodCache.
+	cogit unlinkAllSends
+]
+
 { #category : #'message sending' }
 CoInterpreter >> followForwardedFieldsInCurrentMethod [
 

--- a/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
@@ -901,19 +901,19 @@ InterpreterPrimitives >> primitiveAsFloat [
 { #category : #'indexing primitives' }
 InterpreterPrimitives >> primitiveAt [
 	<accessorDepth: 0>
-	self commonAt: false
-]
-
-{ #category : #'indexing primitives' }
-InterpreterPrimitives >> primitiveAtPointerArray [
-	<accessorDepth: 0>
-	self commonAtPointerArray
+	self commonAt
 ]
 
 { #category : #'indexing primitives' }
 InterpreterPrimitives >> primitiveAtPut [
 	<accessorDepth: 0>
 	self commonAtPut: false
+]
+
+{ #category : #'indexing primitives' }
+InterpreterPrimitives >> primitiveAtStringArray [
+	<accessorDepth: 0>
+	self atStringArray
 ]
 
 { #category : #'object access primitives' }
@@ -3957,7 +3957,7 @@ InterpreterPrimitives >> primitiveStopVMProfiling [
 { #category : #'indexing primitives' }
 InterpreterPrimitives >> primitiveStringAt [
 
-	self commonAt: true.
+	self atStringArray
 ]
 
 { #category : #'indexing primitives' }

--- a/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
@@ -910,12 +910,6 @@ InterpreterPrimitives >> primitiveAtPut [
 	self commonAtPut: false
 ]
 
-{ #category : #'indexing primitives' }
-InterpreterPrimitives >> primitiveAtStringArray [
-	<accessorDepth: 0>
-	self atStringArray
-]
-
 { #category : #'object access primitives' }
 InterpreterPrimitives >> primitiveBehaviorHash [
 	| hashOrError |

--- a/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
@@ -3951,7 +3951,7 @@ InterpreterPrimitives >> primitiveStopVMProfiling [
 { #category : #'indexing primitives' }
 InterpreterPrimitives >> primitiveStringAt [
 
-	self atStringArray
+	self stringArrayAt
 ]
 
 { #category : #'indexing primitives' }

--- a/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
@@ -905,6 +905,12 @@ InterpreterPrimitives >> primitiveAt [
 ]
 
 { #category : #'indexing primitives' }
+InterpreterPrimitives >> primitiveAtPointerArray [
+	<accessorDepth: 0>
+	self commonAtPointerArray
+]
+
+{ #category : #'indexing primitives' }
 InterpreterPrimitives >> primitiveAtPut [
 	<accessorDepth: 0>
 	self commonAtPut: false

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -2242,7 +2242,7 @@ StackInterpreter >> atStringArray [
 
 	"No need to test for large positive integers here, no object has 7EB elements."
 	index := objectMemory integerValueOf: index.
-	result := self stPointerArray: array at: index.
+	result := self stObject: array at: index.
 
 	self successful ifFalse: [ ^ self ].
 
@@ -4452,7 +4452,9 @@ StackInterpreter >> commonAt [
 
 	"No need to test for large positive integers here, no object has 7EB elements"
 	index := objectMemory integerValueOf: index.
-	result := self stObject: array at: index.
+	"At this point, we know that we have a pointer array.
+	There is a special method for the String."
+	result := self stPointerArray: array at: index.
 
 	self successful ifFalse: [ ^ self ].
 	self pop: argumentCount + 1 thenPush: result

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -2225,36 +2225,6 @@ StackInterpreter >> assertValidStackLimits: ln [
 		l: ln
 ]
 
-{ #category : #'indexing primitive support' }
-StackInterpreter >> atStringArray [
-	"This is a specialized primitive for strings.
-	The generic primitive is defined in the #commonAt: method.
-	Look at the comment of that method for more information."
-
-	<inline: true>
-	| index array result |
-	self initPrimCall. "to get it inlined in primitiveAt and primitiveStringAt"
-	array := self stackValue: 1.
-	index := self stackTop.
-
-	"validate things like the index is an intefer, the array is not a forwarder, etc."
-	self validateArray: array andIndex: index.
-
-	"No need to test for large positive integers here, no object has 7EB elements."
-	index := objectMemory integerValueOf: index.
-	result := self stObject: array at: index.
-
-	self successful ifFalse: [ ^ self ].
-
-	"Check if the character can be decoded."
-	(objectMemory isInRangeCharacterCode: result)
-		ifFalse: [ ^ self primitiveFailFor: PrimErrBadReceiver ].
-	"Decode"
-	result := self characterForAscii: (objectMemory integerValueOf: result).
-
-	self pop: argumentCount + 1 thenPush: result
-]
-
 { #category : #'return bytecodes' }
 StackInterpreter >> baseFrameCannotReturnTo: contextToReturnTo [
 
@@ -14999,6 +14969,36 @@ StackInterpreter >> storeStackPointerValue: value inContext: aContext [
 	objectMemory storePointerUnchecked: StackPointerIndex
 		ofObject: aContext
 		withValue: (objectMemory integerObjectOf: value)
+]
+
+{ #category : #'indexing primitive support' }
+StackInterpreter >> stringArrayAt [
+	"This is a specialized primitive for strings.
+	The generic primitive is defined in the #commonAt: method.
+	Look at the comment of that method for more information."
+
+	<inline: true>
+	| index array result |
+	self initPrimCall. "to get it inlined in primitiveAt and primitiveStringAt"
+	array := self stackValue: 1.
+	index := self stackTop.
+
+	"validate things like the index is an intefer, the array is not a forwarder, etc."
+	self validateArray: array andIndex: index.
+
+	"No need to test for large positive integers here, no object has 7EB elements."
+	index := objectMemory integerValueOf: index.
+	result := self stObject: array at: index.
+
+	self successful ifFalse: [ ^ self ].
+
+	"Check if the character can be decoded."
+	(objectMemory isInRangeCharacterCode: result)
+		ifFalse: [ ^ self primitiveFailFor: PrimErrBadReceiver ].
+	"Decode"
+	result := self characterForAscii: (objectMemory integerValueOf: result).
+
+	self pop: argumentCount + 1 thenPush: result
 ]
 
 { #category : #'debug support' }

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -1120,7 +1120,7 @@ StackInterpreter class >> initializePrimitiveTable [
 		(79 primitiveNewMethod)
 
 		"Control Primitives (80-89)"
-		(80 primitiveAtStringArray)
+		(80 primitiveFail)
 		(81 primitiveFail)
 		(82 primitiveFail)
 		(83 primitivePerform)

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -1120,7 +1120,7 @@ StackInterpreter class >> initializePrimitiveTable [
 		(79 primitiveNewMethod)
 
 		"Control Primitives (80-89)"
-		(80 primitiveAtPointerArray)
+		(80 primitiveAtStringArray)
 		(81 primitiveFail)
 		(82 primitiveFail)
 		(83 primitivePerform)
@@ -2223,6 +2223,36 @@ StackInterpreter >> assertValidStackLimits: ln [
 	self assert: (stackPage stackLimit = stackPage realStackLimit
 				or: [stackPage stackLimit = self allOnesAsCharStar])
 		l: ln
+]
+
+{ #category : #'indexing primitive support' }
+StackInterpreter >> atStringArray [
+	"This is a specialized primitive for strings.
+	The generic primitive is defined in the #commonAt: method.
+	Look at the comment of that method for more information."
+
+	<inline: true>
+	| index array result |
+	self initPrimCall. "to get it inlined in primitiveAt and primitiveStringAt"
+	array := self stackValue: 1.
+	index := self stackTop.
+
+	"validate things like the index is an intefer, the array is not a forwarder, etc."
+	self validateArray: array andIndex: index.
+
+	"No need to test for large positive integers here, no object has 7EB elements."
+	index := objectMemory integerValueOf: index.
+	result := self stPointerArray: array at: index.
+
+	self successful ifFalse: [ ^ self ].
+
+	"Check if the character can be decoded."
+	(objectMemory isInRangeCharacterCode: result)
+		ifFalse: [ ^ self primitiveFailFor: PrimErrBadReceiver ].
+	"Decode"
+	result := self characterForAscii: (objectMemory integerValueOf: result).
+
+	self pop: argumentCount + 1 thenPush: result
 ]
 
 { #category : #'return bytecodes' }
@@ -4404,7 +4434,7 @@ StackInterpreter >> codeGeneratorToComputeAccessorDepth: aCCodeGenerator [
 ]
 
 { #category : #'indexing primitive support' }
-StackInterpreter >> commonAt: stringy [
+StackInterpreter >> commonAt [
 	"This code is called if the receiver responds primitively to at:.
 	 N.B. this does *not* use the at cache, instead inlining stObject:at:.
 	 Using the at cache here would require that callers set messageSelector
@@ -4417,58 +4447,12 @@ StackInterpreter >> commonAt: stringy [
 	array := self stackValue: 1.
 	index := self stackTop.
 
-	"Validate that the receiver is not "
-	(objectMemory isImmediate: array)
-		ifTrue: [ ^ self primitiveFailFor: PrimErrInappropriate ].
+	"validate things like the index is an intefer, the array is not a forwarder, etc."
+	self validateArray: array andIndex: index.
 
-	"If the index is not an integer, fail"
-	"If the array is a forwarder, for example in the case of e.g. object:basicAt:, fail"
-	((objectMemory isNonIntegerObject: index)
-		or: [ argumentCount > 1
-				and: [ objectMemory isForwarded: array ]  ])
-				ifTrue: [ ^ self primitiveFailFor: PrimErrBadArgument ].
-	
 	"No need to test for large positive integers here, no object has 7EB elements"
 	index := objectMemory integerValueOf: index.
 	result := self stObject: array at: index.
-
-	self successful ifFalse: [ ^ self ].
-
-	stringy ifTrue: [
-		(objectMemory isInRangeCharacterCode: result)
-			ifFalse: [ ^ self primitiveFailFor: PrimErrBadReceiver ].
-		result := self characterForAscii: (objectMemory integerValueOf: result) ].
-	self pop: argumentCount + 1 thenPush: result
-]
-
-{ #category : #'indexing primitive support' }
-StackInterpreter >> commonAtPointerArray [
-	"This code is called if the receiver responds primitively to at:.
-	 N.B. this does *not* use the at cache, instead inlining stObject:at:.
-	 Using the at cache here would require that callers set messageSelector
-	 and lkupClass and that is onerous and error-prone, and in any case,
-	 inlining produces much better performance than using the at cache here."
-
-	<inline: true>
-	| index array result |
-	self initPrimCall. "to get it inlined in primitiveAt and primitiveStringAt"
-	array := self stackValue: 1.
-	index := self stackTop.
-
-	"Validate that the receiver is not immediate"
-	(objectMemory isImmediate: array)
-		ifTrue: [ ^ self primitiveFailFor: PrimErrInappropriate ].
-
-	"If the index is not an integer, fail"
-	"If the array is a forwarder, for example in the case of e.g. object:basicAt:, fail"
-	((objectMemory isNonIntegerObject: index)
-		or: [ argumentCount > 1
-				and: [ objectMemory isForwarded: array ]  ])
-				ifTrue: [ ^ self primitiveFailFor: PrimErrBadArgument ].
-	
-	"No need to test for large positive integers here, no object has 7EB elements"
-	index := objectMemory integerValueOf: index.
-	result := self stPointerArray: array at: index.
 
 	self successful ifFalse: [ ^ self ].
 	self pop: argumentCount + 1 thenPush: result
@@ -16007,6 +15991,24 @@ StackInterpreter >> validStackPageBaseFrames [
 			[(self validStackPageBaseFrame: aPage) ifFalse:
 				[^false]]].
 	^true
+]
+
+{ #category : #'indexing primitive support' }
+StackInterpreter >> validateArray: array andIndex: index [
+	"This is a helper method to valide if the array and the index parameter are valid.
+	For example, that the index is an integer, that the array is not a forwarder, etc."
+
+	<inline: true>
+	"Validate that the receiver is not immediate"
+	(objectMemory isImmediate: array)
+		ifTrue: [ ^ self primitiveFailFor: PrimErrInappropriate ].
+
+	"If the index is not an integer, fail"
+	"If the array is a forwarder, for example in the case of e.g. object:basicAt:, fail"
+	(objectMemory isNonIntegerObject: index)	
+		ifTrue: [ ^ self primitiveFailFor: PrimErrBadArgument ].
+	(objectMemory isForwarded: array)
+		ifTrue: [ ^ self primitiveFailFor: PrimErrBadArgument ]
 ]
 
 { #category : #'primitive support' }

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -1120,7 +1120,7 @@ StackInterpreter class >> initializePrimitiveTable [
 		(79 primitiveNewMethod)
 
 		"Control Primitives (80-89)"
-		(80 primitiveFail)
+		(80 primitiveAtPointerArray)
 		(81 primitiveFail)
 		(82 primitiveFail)
 		(83 primitivePerform)
@@ -4410,26 +4410,68 @@ StackInterpreter >> commonAt: stringy [
 	 Using the at cache here would require that callers set messageSelector
 	 and lkupClass and that is onerous and error-prone, and in any case,
 	 inlining produces much better performance than using the at cache here."
-	| index rcvr result |
-	<inline: true> "to get it inlined in primitiveAt and primitiveStringAt"
-	self initPrimCall.
-	rcvr := self stackValue: 1.
+
+	<inline: true>
+	| index array result |
+	self initPrimCall. "to get it inlined in primitiveAt and primitiveStringAt"
+	array := self stackValue: 1.
 	index := self stackTop.
-	(objectMemory isImmediate: rcvr) ifTrue:
-		[^self primitiveFailFor: PrimErrInappropriate].
-	"No need to test for large positive integers here.  No object has 1g elements"
+
+	"Validate that the receiver is not "
+	(objectMemory isImmediate: array)
+		ifTrue: [ ^ self primitiveFailFor: PrimErrInappropriate ].
+
+	"If the index is not an integer, fail"
+	"If the array is a forwarder, for example in the case of e.g. object:basicAt:, fail"
 	((objectMemory isNonIntegerObject: index)
-	 or: [argumentCount > 1 "e.g. object:basicAt:"
-		 and: [objectMemory isForwarded: rcvr]]) ifTrue:
-		[^self primitiveFailFor: PrimErrBadArgument].
+		or: [ argumentCount > 1
+				and: [ objectMemory isForwarded: array ]  ])
+				ifTrue: [ ^ self primitiveFailFor: PrimErrBadArgument ].
+	
+	"No need to test for large positive integers here, no object has 7EB elements"
 	index := objectMemory integerValueOf: index.
-	result := self stObject: rcvr at: index.
-	self successful ifTrue:
-		[stringy ifTrue:
-			[(objectMemory isInRangeCharacterCode: result) ifFalse:
-				[^self primitiveFailFor: PrimErrBadReceiver].
-			 result := self characterForAscii: (objectMemory integerValueOf: result)].
-		 self pop: argumentCount+1 thenPush: result]
+	result := self stObject: array at: index.
+
+	self successful ifFalse: [ ^ self ].
+
+	stringy ifTrue: [
+		(objectMemory isInRangeCharacterCode: result)
+			ifFalse: [ ^ self primitiveFailFor: PrimErrBadReceiver ].
+		result := self characterForAscii: (objectMemory integerValueOf: result) ].
+	self pop: argumentCount + 1 thenPush: result
+]
+
+{ #category : #'indexing primitive support' }
+StackInterpreter >> commonAtPointerArray [
+	"This code is called if the receiver responds primitively to at:.
+	 N.B. this does *not* use the at cache, instead inlining stObject:at:.
+	 Using the at cache here would require that callers set messageSelector
+	 and lkupClass and that is onerous and error-prone, and in any case,
+	 inlining produces much better performance than using the at cache here."
+
+	<inline: true>
+	| index array result |
+	self initPrimCall. "to get it inlined in primitiveAt and primitiveStringAt"
+	array := self stackValue: 1.
+	index := self stackTop.
+
+	"Validate that the receiver is not immediate"
+	(objectMemory isImmediate: array)
+		ifTrue: [ ^ self primitiveFailFor: PrimErrInappropriate ].
+
+	"If the index is not an integer, fail"
+	"If the array is a forwarder, for example in the case of e.g. object:basicAt:, fail"
+	((objectMemory isNonIntegerObject: index)
+		or: [ argumentCount > 1
+				and: [ objectMemory isForwarded: array ]  ])
+				ifTrue: [ ^ self primitiveFailFor: PrimErrBadArgument ].
+	
+	"No need to test for large positive integers here, no object has 7EB elements"
+	index := objectMemory integerValueOf: index.
+	result := self stPointerArray: array at: index.
+
+	self successful ifFalse: [ ^ self ].
+	self pop: argumentCount + 1 thenPush: result
 ]
 
 { #category : #'indexing primitive support' }
@@ -14445,14 +14487,13 @@ StackInterpreter >> specialSelectorNumArgs: index [
 
 { #category : #'indexing primitive support' }
 StackInterpreter >> stObject: array at: index [
-	"Return what ST would return for <obj> at: index."
-
 	| hdr fmt totalLength fixedFields stSize |
 	<inline: true>
 	hdr := objectMemory baseHeader: array.
 	fmt := objectMemory formatOfHeader: hdr.
 	totalLength := objectMemory lengthOf: array format: fmt.
 	fixedFields := objectMemory fixedFieldsOf: array format: fmt length: totalLength.
+
 	(fmt = objectMemory indexablePointersFormat
 	 and: [objectMemory isContextHeader: hdr])
 		ifTrue:
@@ -14462,9 +14503,11 @@ StackInterpreter >> stObject: array at: index [
 			 and: [self isStillMarriedContext: array]]) ifTrue:
 				[^self noInlineTemporary: index - 1 in: (self frameOfMarriedContext: array)]]
 		ifFalse: [stSize := totalLength - fixedFields].
+
 	((self oop: index isGreaterThanOrEqualTo: (objectMemory firstValidIndexOfIndexableObject: array withFormat: fmt))
 	 and: [self oop: index isLessThanOrEqualTo: stSize]) ifTrue:
 		[^self subscript: array with: (index + fixedFields) format: fmt].
+
 	self primitiveFailFor: (fmt <= 1 ifTrue: [PrimErrBadReceiver] ifFalse: [PrimErrBadIndex]).
 	^0
 ]
@@ -14487,6 +14530,38 @@ StackInterpreter >> stObject: array at: index put: value [
 		ifTrue: [self subscript: array with: (index + fixedFields) storing: value format: fmt]
 		ifFalse: [self primitiveFailFor: (fmt <= 1 ifTrue: [PrimErrBadReceiver] ifFalse: [PrimErrBadIndex])].
 	^value
+]
+
+{ #category : #'indexing primitive support' }
+StackInterpreter >> stPointerArray: array at: index [
+	"Array is always a pointer array, not a forwarder.
+	Index is an native integer."
+
+	<inline: true>
+	| hdr fmt totalLength fixedFields stSize |
+	hdr := objectMemory baseHeader: array.
+	fmt := objectMemory formatOfHeader: hdr.
+
+	"Check it's a pointer object"
+	fmt <= objectMemory lastPointerFormat
+		ifFalse: [ ^ self primitiveFailFor: PrimErrBadReceiver ].
+	"Check it's not a context"
+	(fmt = objectMemory indexablePointersFormat
+		and: [ objectMemory isContextHeader: hdr ])
+			ifTrue: [ ^ self primitiveFailFor: PrimErrBadReceiver ].
+
+
+	totalLength := objectMemory numSlotsOfAny: array.
+	fixedFields := objectMemory fixedFieldsOf: array format: fmt length: totalLength.
+
+	stSize := totalLength - fixedFields.
+
+	"Bound check. The index should be between 1 and the size. Consider 1-based indexing"
+	((self oop: index isGreaterThanOrEqualTo: 1)
+		and: [ self oop: index isLessThanOrEqualTo: stSize ])
+			ifFalse: [ ^ self primitiveFailFor: PrimErrBadIndex ].
+
+	^ objectMemory fetchPointer: index - 1 ofObject: array
 ]
 
 { #category : #'indexing primitive support' }


### PR DESCRIPTION
Re-doing PR: https://github.com/pharo-project/pharo-vm/pull/633

Summary:

 - Dividing the method commonAt: into commonAt and stringArrayAt. Before, the method commonAt: received a parameter that was actually a flag to check if array is a String or not.
 - Updated the senders
 - Created the method stPointerArray:at:.

Actually, there was already the primitive primitiveStringAt that was calling the method commonAt: with the flag set to true. So there is no need to add a new primitive and this is not a breaking change for Pharo.

Missing things:

- Implemented the Jitted primitive
- anything else?
