### PR TITLE
Robust cannotInterpret: in the interpreter

### DIFF
--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -8933,7 +8933,7 @@ StackInterpreter >> lookupMethodFor: selector InDictionary: dictionary [
 
 { #category : #'message sending' }
 StackInterpreter >> lookupMethodInClass: class [
-	| currentClass dictionary found |
+	| currentClass superClass dictionary found |
 	<inline: false>
 	self assert: (self addressCouldBeClassObj: class).
 	self lookupBreakFor: class.
@@ -8942,11 +8942,14 @@ StackInterpreter >> lookupMethodInClass: class [
 		[dictionary := objectMemory followObjField: MethodDictionaryIndex ofObject: currentClass.
 		dictionary = objectMemory nilObject ifTrue:
 			["MethodDict pointer is nil (hopefully due a swapped out stub)
-				-- raise exception #cannotInterpret:."
+				-- send #cannotInterpret: from the superclass."
 			self createActualMessageTo: class.
 			messageSelector := objectMemory splObj: SelectorCannotInterpret.
 			self sendBreakpoint: messageSelector receiver: nil.
-			^self lookupMethodInClass: (self superclassOf: currentClass)].
+			superClass := self superclassOf: currentClass.
+			superClass = objectMemory nilObject ifTrue: [
+				self error: 'cannotInterpret: cannot be send without a superclass' ].
+			^self lookupMethodInClass: superClass ].
 		found := self lookupMethodInDictionary: dictionary.
 		found ifTrue: [^currentClass].
 		currentClass := self superclassOf: currentClass].

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -6140,31 +6140,6 @@ StackInterpreter >> findSPOrNilOf: theFP on: thePage startingFrom: startFrame [
 ]
 
 { #category : #'debug support' }
-StackInterpreter >> findSelectorAndClassForMethod: meth lookupClass: startClass do: binaryBlock [
-	"Search startClass' class hierarchy searching for method and if found, evaluate aBinaryBlock
-	 with the selector and class where the method is found.  Otherwise evaluate aBinaryBlock
-	 with doesNotUnderstand: and nil."
-	| currClass classDict classDictSize methodArray i |
-	currClass := startClass.
-	[classDict := objectMemory fetchPointer: MethodDictionaryIndex ofObject: currClass.
-	 classDictSize := objectMemory numSlotsOf: classDict.
-	 classDictSize > MethodArrayIndex ifTrue:
-		[methodArray := objectMemory fetchPointer: MethodArrayIndex ofObject: classDict.
-		 i := 0.
-		 [i <= (classDictSize - SelectorStart)] whileTrue:
-			[meth = (objectMemory fetchPointer: i ofObject: methodArray) ifTrue:
-				[^binaryBlock
-					value: (objectMemory fetchPointer: i + SelectorStart ofObject: classDict)
-					value: currClass].
-				i := i + 1]].
-	 currClass := self superclassOf: currClass.
-	 currClass = objectMemory nilObject] whileFalse.
-	^binaryBlock    "method not found in superclass chain"
-		value: (objectMemory splObj: SelectorDoesNotUnderstand)
-		value: nil
-]
-
-{ #category : #'debug support' }
 StackInterpreter >> findSelectorOfMethod: meth [
 	| classObj classDict classDictSize methodArray i |
 	(objectMemory addressCouldBeObj: meth) ifFalse:

--- a/smalltalksrc/VMMakerTests/VMLookUpTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMLookUpTest.class.st
@@ -435,6 +435,74 @@ VMLookUpTest >> testLookUpNonExistingSelectorAnswersDNUMethod [
 ]
 
 { #category : #tests }
+VMLookUpTest >> testLookUpWithNilMethodDictionaryAndNilSuperclassFails [
+	"There is no superclass, so no cannotInterpret: to call"
+
+	| nonExistingSelector cannotInterpretSelectorOop |
+	self setUpClassAndMethod.
+	self setArrayClassIntoClassTable.
+	self setMessageClassIntoClassTable.
+
+	cannotInterpretSelectorOop := self newString: 'CannotInterpret'.
+	memory
+		splObj: SelectorCannotInterpret
+		put: cannotInterpretSelectorOop.
+
+	nonExistingSelector := memory integerObjectOf: 41.
+
+	interpreter methodDictLinearSearchLimit: 3.
+	interpreter setBreakSelector: nil.
+	interpreter messageSelector: nonExistingSelector.
+	self should: [ interpreter lookupMethodInClass: receiverClass ] raise: Error
+]
+
+{ #category : #tests }
+VMLookUpTest >> testLookUpWithNilMethodDictionaryAndNoCannotInterpretAnswersDNUMethod [
+	"Class has a nil methodDictionary, so `cannotInterpret:` is send.
+	But superclass does not understand it, so `doesNotUnderstand:` is called instead."
+
+	| nonExistingSelector dnuMethodOop dnuSelectorOop cannotInterpretSelectorOop superclass superclassMethodDictionary |
+	self setUpClassAndMethod.
+	self setArrayClassIntoClassTable.
+	self setMessageClassIntoClassTable.
+
+	superclass := self
+		              newClassInOldSpaceWithSlots: 0
+		              instSpec: memory arrayFormat.
+	self setUpMethodDictionaryIn: superclass.
+	superclassMethodDictionary := memory
+		                              fetchPointer: MethodDictionaryIndex
+		                              ofObject: superclass.
+	memory
+		storePointer: SuperclassIndex
+		ofObject: receiverClass
+		withValue: superclass.
+
+	dnuMethodOop := methodBuilder newMethod buildMethod.
+	dnuSelectorOop := self newString: 'DNU'.
+	cannotInterpretSelectorOop := self newString: 'CannotInterpret'.
+	self
+		installSelector: dnuSelectorOop
+		method: dnuMethodOop
+		inMethodDictionary: superclassMethodDictionary.
+
+	memory
+		splObj: SelectorDoesNotUnderstand
+		put: dnuSelectorOop.
+	memory
+		splObj: SelectorCannotInterpret
+		put: cannotInterpretSelectorOop.
+
+	nonExistingSelector := memory integerObjectOf: 41.
+
+	interpreter methodDictLinearSearchLimit: 3.
+	interpreter setBreakSelector: nil.
+	interpreter messageSelector: nonExistingSelector.
+	interpreter lookupMethodInClass: receiverClass.
+	self assert: interpreter newMethod equals: dnuMethodOop
+]
+
+{ #category : #tests }
 VMLookUpTest >> testLookUpWithNilMethodDictionaryFindsCannotInterpret [
 
 	| nonExistingSelector cannotInterpretMethodOop cannotInterpretSelectorOop superclass superclassMethodDictionary |


### PR DESCRIPTION
If for some reason the `methodDict` of a class is nil (likely uninitialized), the VM send `cannotInterpret:` from the superclass.
I don't know about the history of the feature (and the selector is unfortunately unclear) but it seems to be used to implement a manual message sending policy in the image (e.g. stub classes). see `ProtoObject>>#cannotInterpret:` for details.

Unfortunately, the VM assumed that a super class always exists to lookup `cannotInterpret:` and send the special message.
Therefore, in the situation where a class has a nil `methodDict` and a nil `superclass`, the behaviour is unexpected. Note that in debug mode, an assertion was raised.

The PR add a check and raise an unrecoverable error (the VM aborts).
This is not ideal as the image cannot act on the buggy situation, but is better than some unexpected behaviour.

Note: I updated only the interpreter code path. Cog message sending is a mess (and I'm polite) and might require harder coffee.

Note: I also removed an unused method I found while investigating the issue.