### PR TITLE
Rename conflicting identifiers

### DIFF
--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -105,6 +105,16 @@ SlangBasicTranslationTest >> shouldGenerateDeadCode [
 	^ true
 ]
 
+{ #category : #'tests-method' }
+SlangBasicTranslationTest >> testApiMethodsWithConflictingName [
+	
+	generator addClass: SlangConflictingApiTestClass.
+	
+	self should: [generator renameConflictingMethods] raise: TranslationError.
+	
+	
+]
+
 { #category : #'tests-blocks' }
 SlangBasicTranslationTest >> testAssignBlockValueValueValue [
 

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -39,6 +39,17 @@ SlangBasicTranslationTest >> defineAtCompileTime: aString [
 	^ #(#OPTION1 #OPTION3 #OPTION) includes: aString
 ]
 
+{ #category : #helpers }
+SlangBasicTranslationTest >> functionIdentifier: aMethodTranslation [
+	| prototype matchIdentifier |
+	
+	prototype := aMethodTranslation lineNumber: 3.
+	
+	matchIdentifier := '([a-zA-Z0-9_])+\(' asRegex.
+	
+	^((matchIdentifier matchesIn: prototype) first) copyWithout: $(
+]
+
 { #category : #accessing }
 SlangBasicTranslationTest >> generator [
 
@@ -1777,6 +1788,23 @@ methodWithoutReturn(void)
 {
 	return 0;
 }'
+]
+
+{ #category : #'tests-method' }
+SlangBasicTranslationTest >> testMethodsWithConflictingName [
+
+	| translation1 translation2 tMethod1 tMethod2 |
+	
+	tMethod1 := self getTMethodFrom: #methodWithRepeatedCFunctionName.
+	tMethod2 := generator methods at: #methodWithRepeatedCFunctionName:.
+
+	generator renameConflictingMethods.
+
+	translation1 := self translate: tMethod1.
+	translation2 := self translate: tMethod2.
+	
+	self assert: (self functionIdentifier: translation1)
+		~= (self functionIdentifier: translation2)
 ]
 
 { #category : #'tests-case' }

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -6596,6 +6596,23 @@ SlangBasicTranslationTest >> testVariableUpdateAssignmentPlus [
 ]
 
 { #category : #'tests-variables' }
+SlangBasicTranslationTest >> testVariableWithConflictingNameShouldBeRenamed [
+	"tests if a local that would conflict with a function name is renamed"
+
+	| method translation |
+	method := self getTMethodFrom: #methodDefiningConflictingVariable.
+
+	generator renameConflictingLocals.
+
+	translation := self translate: method.
+
+
+	self
+		assert: (translation lineNumber: 5)
+		equals: '	char *l_methodWithoutReturn;'
+]
+
+{ #category : #'tests-variables' }
 SlangBasicTranslationTest >> testVariableWithReservedNameShouldBeRenamed [
 
 	| method translation |

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -1804,7 +1804,6 @@ methodWithoutReturn(void)
 SlangBasicTranslationTest >> testMethodsWithConflictingName [
 
 	| translation1 translation2 tMethod1 tMethod2 |
-	
 	tMethod1 := self getTMethodFrom: #methodWithRepeatedCFunctionName.
 	tMethod2 := generator methods at: #methodWithRepeatedCFunctionName:.
 
@@ -1812,9 +1811,10 @@ SlangBasicTranslationTest >> testMethodsWithConflictingName [
 
 	translation1 := self translate: tMethod1.
 	translation2 := self translate: tMethod2.
-	
-	self assert: (self functionIdentifier: translation1)
-		~= (self functionIdentifier: translation2)
+
+	self
+		deny: (self functionIdentifier: translation1)
+		equals: (self functionIdentifier: translation2)
 ]
 
 { #category : #'tests-case' }
@@ -6607,9 +6607,7 @@ SlangBasicTranslationTest >> testVariableWithConflictingNameShouldBeRenamed [
 	translation := self translate: method.
 
 
-	self
-		assert: (translation lineNumber: 5)
-		equals: '	char *l_methodWithoutReturn;'
+	self assert: (translation includesSubstring: 'char *l_methodWithoutReturn').
 ]
 
 { #category : #'tests-variables' }

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
@@ -54,6 +54,13 @@ SlangBasicTranslationTestClass >> methodCallingMethodWithInlinePragma [
 ]
 
 { #category : #inline }
+SlangBasicTranslationTestClass >> methodDefiningConflictingVariable [
+
+	<var: 'methodWithoutReturn' type: 'char *'>
+	| methodWithoutReturn |
+]
+
+{ #category : #inline }
 SlangBasicTranslationTestClass >> methodDefiningSingleExternVariable [
 
 	<var: 'foo' type: #'extern int' >

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
@@ -158,6 +158,18 @@ SlangBasicTranslationTestClass >> methodWithOptionPragma [
 	
 ]
 
+{ #category : #'as yet unclassified' }
+SlangBasicTranslationTestClass >> methodWithRepeatedCFunctionName [
+
+	^ true
+]
+
+{ #category : #'as yet unclassified' }
+SlangBasicTranslationTestClass >> methodWithRepeatedCFunctionName: arg1 [
+
+	^ true
+]
+
 { #category : #inline }
 SlangBasicTranslationTestClass >> methodWithReservedWordLocal: register [
 

--- a/smalltalksrc/Slang-Tests/SlangConflictingApiTestClass.class.st
+++ b/smalltalksrc/Slang-Tests/SlangConflictingApiTestClass.class.st
@@ -1,0 +1,37 @@
+Class {
+	#name : #SlangConflictingApiTestClass,
+	#superclass : #SlangClass,
+	#category : #'Slang-Tests'
+}
+
+{ #category : #accessing }
+SlangConflictingApiTestClass class >> initializationOptions [
+
+	^ nil
+]
+
+{ #category : #accessing }
+SlangConflictingApiTestClass class >> interpreterClass [
+
+	^ nil
+]
+
+{ #category : #accessing }
+SlangConflictingApiTestClass class >> objectMemoryClass [
+
+	^ nil
+]
+
+{ #category : #accessing }
+SlangConflictingApiTestClass >> main [
+
+	<api>
+	
+]
+
+{ #category : #accessing }
+SlangConflictingApiTestClass >> main: arg1 [
+
+	<api>
+	
+]

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -4417,6 +4417,26 @@ CCodeGenerator >> removeVariable: aName ifAbsent: ifAbsentBlock [
 ]
 
 { #category : #renaming }
+CCodeGenerator >> renameConflictingLocals [
+	"renames locals that would conflict with a declared function"
+
+	| allFunctions |
+	allFunctions := methods values collect: [ :method |
+		                self cFunctionNameFor: method selector ].
+
+
+
+	methods do: [ :method |
+		| renames |
+		renames := Dictionary new.
+		method allLocals
+			select: [ :local | allFunctions includes: local ]
+			thenDo: [ :local | renames at: local put: 'l_' , local ].
+
+		method renameVariablesUsing: renames ]
+]
+
+{ #category : #renaming }
 CCodeGenerator >> renameConflictingMethods [
 
 	| cFunctionNames toRename |
@@ -4458,9 +4478,11 @@ CCodeGenerator >> renameKeywordsConflicts [
 		"rename locals"
 		localRewording := Dictionary new.
 
-		(method allLocals select: [ :local |
-			 self reservedWords includes: local ]) do: [ :local |
-			localRewording at: local put: (self sanitizeKeyword: local) ].
+		
+		method allLocals 
+			select: [ :local | self reservedWords includes: local ]
+			thenDo: [ :local | localRewording at: local put: (self sanitizeKeyword: local) ].
+
 		localRewording ifNotEmpty: [
 			method renameVariablesUsing: localRewording ].
 
@@ -4473,13 +4495,12 @@ CCodeGenerator >> renameKeywordsConflicts [
 				to: (self sanitizeKeyword: cSelector) ] ].
 
 	"translate structs instance variables"
-	structClasses ifNotNil: [ :classes |
-		classes do: [ :struct |
-			struct instVarTypeDeclarationsDo: [ :ivn :type |
-				(self reservedWords includes: ivn) ifTrue: [
-					self
-						addStructInstanceVariableTranslation: ivn
-						to: (self sanitizeKeyword: ivn) ] ] ] ]
+	self structClasses do: [ :struct |
+		struct instVarTypeDeclarationsDo: [ :ivn :type |
+			(self reservedWords includes: ivn) ifTrue: [
+				self
+					addStructInstanceVariableTranslation: ivn
+					to: (self sanitizeKeyword: ivn) ] ] ]
 ]
 
 { #category : #'C translation support' }

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -4433,6 +4433,11 @@ CCodeGenerator >> renameConflictingMethods [
 	toRename := cFunctionNames select: [ :conflicts | conflicts size > 1 ].
 
 	toRename keysDo: [ :key |
+		|conflictingMethods|
+		conflictingMethods := toRename at: key.
+		
+		((conflictingMethods select: [:m | m isAPIMethod ]) size > 1 ) ifTrue: [TranslationError signal: 'Conflicting API methods with name "', key, '"' ].
+		
 		(toRename at: key) do: [ :method |
 			method isStructAccessor ifFalse: [
 				self

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -4416,7 +4416,7 @@ CCodeGenerator >> removeVariable: aName ifAbsent: ifAbsentBlock [
 	^variables remove: aName ifAbsent: ifAbsentBlock
 ]
 
-{ #category : #translating }
+{ #category : #renaming }
 CCodeGenerator >> renameConflictingMethods [
 
 	| cFunctionNames toRename |
@@ -4433,19 +4433,24 @@ CCodeGenerator >> renameConflictingMethods [
 	toRename := cFunctionNames select: [ :conflicts | conflicts size > 1 ].
 
 	toRename keysDo: [ :key |
-		|conflictingMethods|
+		| conflictingMethods |
 		conflictingMethods := toRename at: key.
-		
-		((conflictingMethods select: [:m | m isAPIMethod ]) size > 1 ) ifTrue: [TranslationError signal: 'Conflicting API methods with name "', key, '"' ].
-		
-		(toRename at: key) do: [ :method |
+
+		"api methods cannot be renamed"
+		(conflictingMethods select: [ :m | m isAPIMethod ]) size > 1
+			ifTrue: [
+				TranslationError signal:
+					'Conflicting API methods would be translated to "' , key , '"' ].
+
+
+		(conflictingMethods reject: [ :m | m isAPIMethod ]) do: [ :method |
 			method isStructAccessor ifFalse: [
 				self
 					addSelectorTranslation: method selector
 					to: key , method args size asString ] ] ]
 ]
 
-{ #category : #translating }
+{ #category : #renaming }
 CCodeGenerator >> renameKeywordsConflicts [
 
 	methods do: [ :method |

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -4427,8 +4427,6 @@ CCodeGenerator >> renameConflictingLocals [
 	allFunctions := methods values collect: [ :method |
 		                self cFunctionNameFor: method selector ].
 
-
-
 	methods do: [ :method |
 		| renames |
 		renames := Dictionary new.
@@ -4456,14 +4454,17 @@ CCodeGenerator >> renameConflictingMethods [
 	toRename := cFunctionNames select: [ :conflicts | conflicts size > 1 ].
 
 	toRename keysAndValuesDo: [ :key :conflictingMethods |
-		conflictingMethods do: [ :method |
-			method isAPIMethod ifTrue: [ "api methods cannot be renamed"
+		(conflictingMethods select: [ :m | m isAPIMethod ]) size > 1
+			ifTrue: [ "api methods cannot be renamed"
 				TranslationError signal:
 					'Conflicting API methods would be translated to "' , key , '"' ].
 
-			self
-				addSelectorTranslation: method selector
-				to: key , method args size asString ] ]
+		conflictingMethods
+			reject: [ :m | m isAPIMethod ]
+			thenDo: [ :m |
+				self
+					addSelectorTranslation: m selector
+					to: key , m args size asString ] ]
 ]
 
 { #category : #renaming }

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -4445,7 +4445,7 @@ CCodeGenerator >> renameConflictingMethods [
 	| cFunctionNames toRename |
 	cFunctionNames := IdentityDictionary new.
 
-	methods do: [ :m |
+	methods reject: [ :m | m isStructAccessor ] thenDo: [ :m |
 		| functionName conflicts |
 		functionName := self cFunctionNameFor: m selector.
 
@@ -4455,22 +4455,15 @@ CCodeGenerator >> renameConflictingMethods [
 
 	toRename := cFunctionNames select: [ :conflicts | conflicts size > 1 ].
 
-	toRename keysDo: [ :key |
-		| conflictingMethods |
-		conflictingMethods := toRename at: key.
-
-		"api methods cannot be renamed"
-		(conflictingMethods select: [ :m | m isAPIMethod ]) size > 1
-			ifTrue: [
+	toRename keysAndValuesDo: [ :key :conflictingMethods |
+		conflictingMethods do: [ :method |
+			method isAPIMethod ifTrue: [ "api methods cannot be renamed"
 				TranslationError signal:
 					'Conflicting API methods would be translated to "' , key , '"' ].
 
-
-		(conflictingMethods reject: [ :m | m isAPIMethod ]) do: [ :method |
-			method isStructAccessor ifFalse: [
-				self
-					addSelectorTranslation: method selector
-					to: key , method args size asString ] ] ]
+			self
+				addSelectorTranslation: method selector
+				to: key , method args size asString ] ]
 ]
 
 { #category : #renaming }

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -1053,6 +1053,7 @@ CCodeGenerator >> emitCCodeOn: aStream doInlining: inlineFlag doAssertions: asse
 
 	"code generation"
 
+	self renameConflictingMethods.
 	self renameKeywordsConflicts.
 
 	"If we're outputting the VM put the main interpreter loop first for two reasons.
@@ -4416,6 +4417,30 @@ CCodeGenerator >> removeVariable: aName ifAbsent: ifAbsentBlock [
 ]
 
 { #category : #translating }
+CCodeGenerator >> renameConflictingMethods [
+
+	| cFunctionNames toRename |
+	cFunctionNames := IdentityDictionary new.
+
+	methods do: [ :m |
+		| functionName conflicts |
+		functionName := self cFunctionNameFor: m selector.
+
+		conflicts := cFunctionNames at: functionName ifAbsent: [ #(  ) ].
+
+		cFunctionNames at: functionName put: (conflicts copyWith: m) ].
+
+	toRename := cFunctionNames select: [ :conflicts | conflicts size > 1 ].
+
+	toRename keysDo: [ :key |
+		(toRename at: key) do: [ :method |
+			method isStructAccessor ifFalse: [
+				self
+					addSelectorTranslation: method selector
+					to: key , method args size asString ] ] ]
+]
+
+{ #category : #translating }
 CCodeGenerator >> renameKeywordsConflicts [
 
 	methods do: [ :method |
@@ -4430,7 +4455,7 @@ CCodeGenerator >> renameKeywordsConflicts [
 			method renameVariablesUsing: localRewording ].
 
 		"translate selector"
-		cSelector := self cSelectorName: method selector.
+		cSelector := self cFunctionNameFor: method selector.
 
 		(self reservedWords includes: cSelector) ifTrue: [
 			self

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -1045,6 +1045,9 @@ CCodeGenerator >> emitCCodeOn: aStream doInlining: inlineFlag doAssertions: asse
 		logger cr ].
 	assertionFlag ifFalse: [ self removeAssertions ].
 
+	self renameConflictingMethods.
+	self renameKeywordsConflicts.
+	self renameConflictingLocals.
 
 	self doInlining: inlineFlag.
 
@@ -1053,11 +1056,6 @@ CCodeGenerator >> emitCCodeOn: aStream doInlining: inlineFlag doAssertions: asse
 		applyMethodNamed: #interpret.
 
 	"code generation"
-
-	self renameConflictingMethods.
-	self renameKeywordsConflicts.
-
-	self renameConflictingLocals.
 
 	"If we're outputting the VM put the main interpreter loop first for two reasons.
 	 1, so that the dispdbg.h header included at the bytecode dispatch can define

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -1045,6 +1045,7 @@ CCodeGenerator >> emitCCodeOn: aStream doInlining: inlineFlag doAssertions: asse
 		logger cr ].
 	assertionFlag ifFalse: [ self removeAssertions ].
 
+
 	self doInlining: inlineFlag.
 
 	SLAutomaticLocalization new
@@ -1055,6 +1056,8 @@ CCodeGenerator >> emitCCodeOn: aStream doInlining: inlineFlag doAssertions: asse
 
 	self renameConflictingMethods.
 	self renameKeywordsConflicts.
+
+	self renameConflictingLocals.
 
 	"If we're outputting the VM put the main interpreter loop first for two reasons.
 	 1, so that the dispdbg.h header included at the bytecode dispatch can define
@@ -1073,6 +1076,8 @@ CCodeGenerator >> emitCCodeOn: aStream doInlining: inlineFlag doAssertions: asse
 			checkForGlobalUsage: (m removeUnusedTempsAndNilIfRequiredIn: self)
 			in: m ].
 	self localizeGlobalVariables.
+
+
 
 	self emitCHeaderOn: aStream.
 	self emitCConstantsOn: aStream.

--- a/smalltalksrc/Slang/TMethod.class.st
+++ b/smalltalksrc/Slang/TMethod.class.st
@@ -3300,7 +3300,7 @@ TMethod >> validateVariableDeclarationExists: aVariableName [
 
 	| shouldCheckVariable |
 	shouldCheckVariable := (aVariableName beginsWithAnyOf:
-		                       #( #self #cascade #toDoLimit )) not.
+		                       #( #self #cascade #toDoLimit #std )) not.
 
 	(shouldCheckVariable and: [
 		 (self declaresVariableWithName: aVariableName) not]) ifTrue: [

--- a/smalltalksrc/VMMaker/Cogit.class.st
+++ b/smalltalksrc/VMMaker/Cogit.class.st
@@ -3140,7 +3140,8 @@ Cogit >> addressIsInCurrentCompilation: address [
 { #category : #testing }
 Cogit >> addressIsInFixups: address [
 	<var: #address type: #'BytecodeFixup *'>
-	^self cCode: '(BytecodeFixup *)address >= fixups && (BytecodeFixup *)address < (fixups + numAbstractOpcodes)'
+	"Hardcode renaming to l_address"
+	^self cCode: '(BytecodeFixup *)l_address >= fixups && (BytecodeFixup *)l_address < (fixups + numAbstractOpcodes)'
 		inSmalltalk:
 			[fixups notNil
 			 and: [(fixups object identityIndexOf: address) between: 1 and: numAbstractOpcodes]]
@@ -3149,9 +3150,10 @@ Cogit >> addressIsInFixups: address [
 { #category : #testing }
 Cogit >> addressIsInInstructions: address [
 	<var: #address type: #'AbstractInstruction *'>
-	^self cCode: '!((usqInt)(address) & BytesPerWord-1) \
-				&& (address) >= &abstractOpcodes[0] \
-				&& (address) < &abstractOpcodes[opcodeIndex]'
+	"Hardcode renaming to l_address"
+	^self cCode: '!((usqInt)(l_address) & BytesPerWord-1) \
+				&& (l_address) >= &abstractOpcodes[0] \
+				&& (l_address) < &abstractOpcodes[opcodeIndex]'
 		inSmalltalk: [(abstractOpcodes object identityIndexOf: address) between: 1 and: opcodeIndex]
 ]
 

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -12324,9 +12324,9 @@ StackInterpreter >> printStackPage: page useCount: n [
 		[self cr; tab; print: 'baseFP '; printHexPtr: page baseFP.
 		 self "cr;" tab; print: 'headFP '; printHexPtr: page headFP.
 		 self "cr;" tab; print: 'headSP '; printHexPtr: page headSP].
-	self cr; tab; print: 'prev '; printHexPtr: (self cCode: 'page->prevPage' inSmalltalk: [page prevPage baseAddress]);
+	self cr; tab; print: 'prev '; printHexPtr: (self cCode: 'l_page->prevPage' inSmalltalk: [page prevPage baseAddress]);
 		print: ' ('; printNum: (stackPages pageIndexFor: page prevPage realStackLimit); printChar: $).
-	self tab; print: 'next '; printHexPtr: (self cCode: 'page->nextPage' inSmalltalk: [page nextPage baseAddress]);
+	self tab; print: 'next '; printHexPtr: (self cCode: 'l_page->nextPage' inSmalltalk: [page nextPage baseAddress]);
 		print: ' ('; printNum: (stackPages pageIndexFor: page nextPage realStackLimit); printChar: $).
 	self cr
 ]


### PR DESCRIPTION
closes #628 

Checks and renames this conflicts:

- Selector vs other selectors when translated to functions
- Locals vs other selectors when translated to functions


