### PR TITLE
[WIP] Incremental gc

### DIFF
--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -618,7 +618,10 @@ Class {
 		'permSpaceFreeStart',
 		'fromOldSpaceRememberedSet',
 		'fromPermToOldSpaceRememberedSet',
-		'fromPermToNewSpaceRememberedSet'
+		'fromPermToNewSpaceRememberedSet',
+		'incrementalGCRunning',
+		'incrementalGCMarkingState',
+		'incrementalGCInterruptible'
 	],
 	#classVars : [
 		'BitsPerByte',
@@ -5021,6 +5024,12 @@ SpurMemoryManager >> findStringBeginningWith: aCString [
 				[coInterpreter printHex: obj; space; printNum: (self lengthOf: obj); space; printOopShort: obj; cr]]
 ]
 
+{ #category : #'gc - incremental' }
+SpurMemoryManager >> finishIncrementalFullGCWithoutInterruption [
+	incrementalGCInterruptible := false.
+	^ self incrementalFullGC
+]
+
 { #category : #'weakness and ephemerality' }
 SpurMemoryManager >> fireAllUnscannedEphemerons [
 	self assert: (self noUnscannedEphemerons) not.
@@ -5873,22 +5882,13 @@ SpurMemoryManager >> fromOldSpaceRememberedSet [
 	^ fromOldSpaceRememberedSet
 ]
 
-{ #category : #'gc - global' }
+{ #category : #'gc - incremental' }
 SpurMemoryManager >> fullGC [
 	"Perform a full eager compacting GC.  Answer the size of the largest free chunk."
 	<returnTypeC: #usqLong>
 	<inline: #never> "for profiling"
-	needGCFlag := false.
-	gcStartUsecs := coInterpreter ioUTCMicrosecondsNow.
-	statMarkCount := 0.
-	coInterpreter preGCAction: GCModeFull.
-	self globalGarbageCollect.
-	coInterpreter postGCAction: GCModeFull.
-	statGCEndUsecs := coInterpreter ioUTCMicrosecondsNow.
-	self updateFullGCStats.
-	^(freeLists at: 0) ~= 0
-		ifTrue: [self bytesInObject: self findLargestFreeChunk]
-		ifFalse: [0]
+	^ self finishIncrementalFullGCWithoutInterruption.
+
 ]
 
 { #category : #'gc - global' }
@@ -6431,6 +6431,113 @@ SpurMemoryManager >> increaseFreeOldSpaceBy: bytes [
 
 ]
 
+{ #category : #'gc - incremental' }
+SpurMemoryManager >> incrementalFullGC [
+	"Perform a full eager compacting GC.  Answer the size of the largest free chunk."
+	"for profiling"
+
+	<returnTypeC: #usqLong>
+	<inline: #never>
+	
+	incrementalGCRunning ifFalse: [
+		incrementalGCRunning := true.
+		needGCFlag := false.
+		gcStartUsecs := coInterpreter ioUTCMicrosecondsNow.
+		statMarkCount := 0.
+		coInterpreter preGCAction: GCModeFull ].
+	self incrementalGlobalGarbageCollect.
+	coInterpreter postGCAction: GCModeFull.
+	statGCEndUsecs := coInterpreter ioUTCMicrosecondsNow.
+	self updateFullGCStats.
+	^ (freeLists at: 0) ~= 0
+		  ifTrue: [ self bytesInObject: self findLargestFreeChunk ]
+		  ifFalse: [ 0 ]
+]
+
+{ #category : #'gc - incremental' }
+SpurMemoryManager >> incrementalGlobalGarbageCollect [
+	"inline into fullGC"
+	<inline: true>
+	self assert: self validObjStacks.
+	self assert: (self isEmptyObjStack: markStack).
+	self assert: (self isEmptyObjStack: weaklingStack).
+
+	"Mark objects /before/ scavenging, to empty the rememberedTable of unmarked roots."
+	self incrementalMarkObjects: true.
+	marking ifFalse: [
+		incrementalGCRunning := false.
+		gcMarkEndUsecs := coInterpreter ioUTCMicrosecondsNow.
+
+		scavenger forgetUnmarkedRememberedObjectsFromOldSpace.
+		self doScavenge: MarkOnTenure.
+
+		"Mid-way the leak check must be more lenient.  Unmarked classes will have been
+	 expunged from the table, but unmarked instances will not yet have been reclaimed."
+		self
+			runLeakCheckerFor: GCModeFull
+			excludeUnmarkedObjs: true
+			classIndicesShouldBeValid: true.
+
+		compactionStartUsecs := coInterpreter ioUTCMicrosecondsNow.
+		segmentManager prepareForGlobalSweep. "for notePinned:"
+		compactor compact.
+		self attemptToShrink.
+		self setHeapSizeAtPreviousGC.
+
+		self assert: self validObjStacks.
+		self assert: (self isEmptyObjStack: markStack).
+		self assert: (self isEmptyObjStack: weaklingStack).
+		self assert: self allObjectsUnmarked.
+		self runLeakCheckerFor: GCModeFull ]
+]
+
+{ #category : #'gc - incremental' }
+SpurMemoryManager >> incrementalMarkObjects: objectsShouldBeUnmarkedAndUnmarkedClassesShouldBeExpunged [
+	"for profiling"
+
+	"Mark all accessible objects.  objectsShouldBeUnmarkedAndUnmarkedClassesShouldBeExpunged
+	 is true if all objects are unmarked and/or if unmarked classes shoud be removed from the class table."
+
+	"If the incremental collector is running mark bits may be set; stop it and clear them if necessary."
+
+	<inline: #never>
+	self cCode: '' inSmalltalk: [
+		coInterpreter transcript
+			nextPutAll: 'marking...';
+			flush ].
+	self runLeakCheckerFor: GCModeFull.
+
+	marking ifFalse: [
+		self shutDownIncrementalGC: objectsShouldBeUnmarkedAndUnmarkedClassesShouldBeExpunged.
+		self initializeUnscannedEphemerons.
+		self initializeMarkStack.
+		self initializeWeaklingStack.
+		self initializeMournQueue.
+		incrementalGCMarkingState := 0.
+		marking := true.
+		incrementalGCInterruptible := true ].
+
+	incrementalGCMarkingState = 0 ifTrue: [
+		self markAccessibleObjectsAndFireEphemerons.
+		incrementalGCMarkingState := 1.		
+		incrementalGCInterruptible ifTrue: [ ^ self ] ].
+
+	incrementalGCMarkingState = 1 ifTrue: [
+		self expungeDuplicateAndUnmarkedClasses:
+			objectsShouldBeUnmarkedAndUnmarkedClassesShouldBeExpunged.
+		incrementalGCMarkingState := 2.
+		incrementalGCInterruptible ifTrue: [ ^ self ] ].
+
+	incrementalGCMarkingState = 2 ifTrue: [
+		self nilUnmarkedWeaklingSlots.
+		incrementalGCMarkingState := 3.
+		incrementalGCInterruptible ifTrue: [ ^ self ] ].
+
+	incrementalGCMarkingState = 3 ifTrue: [
+		self freeUnscannedEphemerons.
+		marking := false ]
+]
+
 { #category : #'debug support' }
 SpurMemoryManager >> indexOf: anElement in: anObject [
 	<api>
@@ -6561,7 +6668,7 @@ SpurMemoryManager >> initialize [
 	remapBufferCount := extraRootCount := 0. "see below"
 	freeListsMask := totalFreeOldSpace := lowSpaceThreshold := 0.
 	checkForLeaks := 0.
-	needGCFlag := signalLowSpace := marking := false.
+	needGCFlag := signalLowSpace := marking := incrementalGCRunning := false.
 	becomeEffectsFlags := gcPhaseInProgress := 0.
 	statScavenges := statFullGCs := 0.
 	statMaxAllocSegmentTime := 0.
@@ -12521,8 +12628,9 @@ SpurMemoryManager >> sufficientSpaceAfterGC: numBytes [
 	self assert: numBytes = 0.
 	self scavengingGCTenuringIf: TenureByAge.
 	heapSizePostGC := segmentManager totalOldSpaceCapacity - totalFreeOldSpace.
+	self incrementalFullGC.
 	(heapSizePostGC - heapSizeAtPreviousGC) asFloat / heapSizeAtPreviousGC >= heapGrowthToSizeGCRatio ifTrue:
-		[self fullGC].
+		[	self finishIncrementalFullGCWithoutInterruption ].
 	[totalFreeOldSpace < growHeadroom
 	 and: [(self growOldSpaceByAtLeast: 0) notNil]] whileTrue:
 		[totalFreeOldSpace >= growHeadroom ifTrue:


### PR DESCRIPTION
Start thinking in an incremental GC during a VM dojo

Entry point of the GC in the VM is in SpurMemoryManager>>sufficientSpaceAfterGC:
We added a call to incrementalFullGC and finishIncrementalFullGCWithoutInterruption
Then, we duplicated the GC logic into these two submethods
Note: we must change SpurMemoryManager>>fullGC primitive that is called from the image side

So far we only tried to let the VM execute Pharo code in between the different steps of the mark phase.
VM compilation is ok but there are VM crashes probably because:
- we should suspend the GC in nicer points (when a given number of objects have been marked for example) instead of what we did 
- newly allocated objects are not marked and will be thrown away
  should we always mark newly allocated objects when the incremental GC is running
- internal data structure used during the mark phase may be lost 
...


Unit test to write:

```
c := OrderedCollection new.
64 timesRepeat: [ c add: (Array new: 1024*1024) pin ].

c := nil.
3 timesRepeat: [ Smalltalk garbageCollect ] 
```

