### PR TITLE
Forward VM build parameters from CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,6 @@ set(APPNAME			"Pharo"         CACHE STRING                 "VM Application name"
 set(FLAVOUR			"CoInterpreter" CACHE STRING                 "The kind of VM to generate. Possible values: StackVM, CoInterpreter")
 set(PHARO_LIBRARY_PATH		"@executable_path/Plugins" CACHE STRING      "The RPATH to use in the build")
 set(ICEBERG_DEFAULT_REMOTE	"scpUrl"        CACHE STRING                 "If Iceberg uses HTTPS (httpsUrl) or tries first with SSH (scpUrl)")
-set(IMAGE_FORMAT	"SpurFormat"	CACHE STRING				 "Image Format to use in the builtVM (SpurFormat / ComposedFormat)")
 
 if(VERBOSE_BUILD)
     set(CMAKE_VERBOSE_MAKEFILE TRUE)

--- a/cmake/vmmaker.cmake
+++ b/cmake/vmmaker.cmake
@@ -38,13 +38,15 @@ else()
   endif()
 endif()
 
+# Obtain all the parameters prefixed as VMMaker_
+# Remove the prefix 
 function (getVMMakerParameters _resultVar)
     getListOfVarsStartingWith("VMMaker_" matchedVars)
     set (_pharoParameterArray "")
     foreach (_var IN LISTS matchedVars)
         # VMMaker_ has 8 characters
         string(SUBSTRING ${_var} 8 -1 _name)
-        set (_pharoParameterArray "${_pharoParameterArray} '${_name}' '${${_var}}'")
+        set (_pharoParameterArray ${_pharoParameterArray} "'${_name}'" "'${${_var}}'")
     endforeach()
     set (${_resultVar} "#( ${_pharoParameterArray} )" PARENT_SCOPE)
 endfunction()
@@ -163,7 +165,7 @@ if(GENERATE_SOURCES)
     #Custom command that generates the vm source code from VMMaker into the generated folder
     add_custom_command(
         OUTPUT ${VMSOURCEFILES} ${PLUGIN_GENERATED_FILES}
-        COMMAND ${VMMAKER_VM} --headless ${VMMAKER_IMAGE} --no-default-preferences eval \"PharoVMMaker generate: \#\'${FLAVOUR}\' outputDirectory: \'${CMAKE_CURRENT_BINARY_DIR_TO_OUT}\' options: "${VM_Parameters}"\"
+        COMMAND ${VMMAKER_VM} --headless ${VMMAKER_IMAGE} --no-default-preferences eval \"PharoVMMaker generate: \#\'${FLAVOUR}\' outputDirectory: \'${CMAKE_CURRENT_BINARY_DIR_TO_OUT}\' options: ${VM_Parameters}\"
         DEPENDS vmmaker ${VMMAKER_IMAGE} ${VMMAKER_VM}
         COMMENT "Generating VM files for flavour: ${FLAVOUR} with options: ${VM_Parameters}")
 

--- a/smalltalksrc/VMMakerCompatibilityForPharo6/PharoVMMaker.class.st
+++ b/smalltalksrc/VMMakerCompatibilityForPharo6/PharoVMMaker.class.st
@@ -210,6 +210,18 @@ PharoVMMaker >> initializeOutputDirectory [
 ]
 
 { #category : #accessing }
+PharoVMMaker >> options [
+
+	^ options
+]
+
+{ #category : #accessing }
+PharoVMMaker >> options: anObject [
+
+	options := anObject
+]
+
+{ #category : #accessing }
 PharoVMMaker >> outputDirectory [
 	^ outputDirectory ifNil: [ self initializeOutputDirectory ]
 ]

--- a/smalltalksrc/VMMakerCompatibilityForPharo6/PharoVMMaker.class.st
+++ b/smalltalksrc/VMMakerCompatibilityForPharo6/PharoVMMaker.class.st
@@ -9,7 +9,8 @@ Class {
 		'stopOnErrors',
 		'generatePlugins',
 		'wordSizesToGenerate',
-		'imageFormatName'
+		'imageFormatName',
+		'options'
 	],
 	#category : #'VMMakerCompatibilityForPharo6-CommandLine'
 }
@@ -65,21 +66,10 @@ PharoVMMaker class >> generate: anInterpreterClass outputDirectory: aDirectory [
 ]
 
 { #category : #generation }
-PharoVMMaker class >> generate: anInterpreterClass outputDirectory: aDirectory imageFormat: imageFormatName [
-
-	Transcript
-		nextPutAll: 'Generating ';
-		nextPutAll: anInterpreterClass printString;
-		nextPutAll: ' in ';
-		nextPutAll: aDirectory printString;
-		nextPutAll: ' with ';
-		nextPutAll: imageFormatName;
-		nextPutAll: '...';
-		newLine;
-		flush.
+PharoVMMaker class >> generate: anInterpreterClass outputDirectory: aDirectory options: options [
 
 	self new
-		imageFormatName: imageFormatName;
+		options: options;
 		outputDirectory: aDirectory;
 		perform: #generate , anInterpreterClass asSymbol
 ]
@@ -115,14 +105,9 @@ PharoVMMaker >> generate: interpreterClass memoryManager: memoryManager [
 { #category : #generation }
 PharoVMMaker >> generate: interpreterClass memoryManager: memoryManager compilerClass: compilerClass [
 
-	self generate: interpreterClass memoryManager: memoryManager compilerClass: compilerClass options: #()
-]
-
-{ #category : #generation }
-PharoVMMaker >> generate: interpreterClass memoryManager: memoryManager compilerClass: compilerClass options: options [
-
 	| platformDirectory vmmaker imageReaderClassName imageWriterClassName |
 	
+	imageFormatName := (Dictionary newFromPairs: options) at: 'ImageFormat' ifAbsent: [ imageFormatName ].
 	(#(SpurFormat ComposedFormat) includes: imageFormatName)
 		ifFalse:[ self error: 'Invalid Image Format'].
 	
@@ -182,27 +167,6 @@ PharoVMMaker >> generatePlugins: anObject [
 ]
 
 { #category : #generation }
-PharoVMMaker >> generateSistaVM [
-
-	self generates64Bits ifTrue: [	
-			self
-				generate: CoInterpreter
-				memoryManager: Spur64BitCoMemoryManager
-				compilerClass: SistaCogit
-				options: #( SistaVM true )].
-	
-	
-	self generates32Bits ifTrue: [
-			self
-				generate: CoInterpreter
-				memoryManager: Spur32BitCoMemoryManager
-				compilerClass: SistaCogit
-				options: #( SistaVM true )].
-
-
-]
-
-{ #category : #generation }
 PharoVMMaker >> generateStackVM [
 
 	self generates64Bits ifTrue: [self generate: StackInterpreter memoryManager: Spur64BitMemoryManager].
@@ -234,7 +198,9 @@ PharoVMMaker >> initialize [
 	stopOnErrors := false.
 	generatePlugins := true.
 	wordSizesToGenerate := #(4 8).
-	imageFormatName := self class defaultImageFormatName
+	imageFormatName := self class defaultImageFormatName.
+	
+	options := #()
 ]
 
 { #category : #initialization }

--- a/smalltalksrc/VMMakerCompatibilityForPharo6/PharoVMMaker.class.st
+++ b/smalltalksrc/VMMakerCompatibilityForPharo6/PharoVMMaker.class.st
@@ -108,8 +108,8 @@ PharoVMMaker >> generate: interpreterClass memoryManager: memoryManager compiler
 	| platformDirectory vmmaker imageReaderClassName imageWriterClassName |
 	
 	imageFormatName := (Dictionary newFromPairs: options) at: 'ImageFormat' ifAbsent: [ imageFormatName ].
-	(#(SpurFormat ComposedFormat) includes: imageFormatName)
-		ifFalse:[ self error: 'Invalid Image Format'].
+	(#(SpurFormat ComposedFormat) includes: imageFormatName asSymbol)
+		ifFalse:[ self error: 'Invalid Image Format: ', imageFormatName].
 	
 	imageFormatName = 'ComposedFormat' 
 		ifTrue: [imageReaderClassName 	:= ComposedImageReader name.


### PR DESCRIPTION
This PR introduces the ability to forward arguments from cmake to the VM build, simplifying a lot the build infrastructure.
All arguments prefixed VMMaker_ are taken into account. Then it's up to Slang to take them into account or not.

Example:

```bash
# Forward XXX=17 to the options dictionary of slang VM generation
cmake -S src -B build -DVMMaker_XXX=17
```

As a note for compatibility, now the image format should be passed as argument as follows:

```bash
cmake -S src -B build -DVMMaker_ImageFormat=SpurFormat|ComposedFormat
```

If required, we can keep the old parameter for backwards compatibility, but I felt that the overall simplification was worth it