### PR TITLE
sizeOfIntegralCType: bytesPerWord

### DIFF
--- a/smalltalksrc/Melchor/VMPluginCodeGenerator.class.st
+++ b/smalltalksrc/Melchor/VMPluginCodeGenerator.class.st
@@ -520,7 +520,7 @@ VMPluginCodeGenerator >> sizeOfIntegralCType: anIntegralCType [ "<String>"
 		['short']			->	[2].
 		['short int']		->	[2].
 		['char']			->	[1].
-		['long']			->	[BytesPerWord]. "It's ambiguous on LLP64 and we'll later remove it"
+		['long']			->	[ self bytesPerWord ]. "It's ambiguous on LLP64 and we'll later remove it"
 		['size_t']		->	[6].
 		['pid_t']			->	[6].
 	}


### PR DESCRIPTION
Just a small fix to use #bytesPerWord instead of BytesPerWord which is undeclared.
