### PR TITLE
Add tests+fix for an incorrectly case of generated inlined C code from CCodeGenerator

### DIFF
--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -1155,6 +1155,163 @@ SlangBasicTranslationTest >> testGoto [
 	self assert: translation equals: 'goto lab'
 ]
 
+{ #category : #'tests-inline-builtins' }
+SlangBasicTranslationTest >> testInlineMethodSumArgumentsNoPrepare [
+	
+	| tMethod translation |
+	tMethod := (self getTMethodFrom: #methodSumParameters:to:with:).
+	generator doBasicInlining: true.
+	
+	translation := self translate: tMethod.
+	translation := translation trimBoth.
+	self
+		assert: translation
+		equals: '/* SlangBasicTranslationTestClass>>#methodSumParameters:to:with: */
+static sqInt
+methodSumParameterstowith(sqInt pFrom, sqInt pTo, sqInt anInteger)
+{
+	sqInt i;
+	sqInt pFrom1;
+	sqInt pTo1;
+
+	/* begin methodFrom:to: */
+	pFrom1 = pFrom + anInteger;
+	pTo1 = pTo + anInteger;
+	for (i = 0; i <= 5; i += 1) {
+		pTo1[i] = pFrom1[i];
+	};
+	return 0;
+}'
+]
+
+{ #category : #'tests-inline-builtins' }
+SlangBasicTranslationTest >> testInlineMethodSumArgumentsPrepared [
+	
+	| tMethod translation |
+	tMethod := (self getTMethodFrom: #methodSumParameters:to:with:).
+	generator 
+		prepareMethods;
+		doBasicInlining: true.
+	
+	translation := self translate: tMethod.
+	translation := translation trimBoth.
+	self
+		assert: translation
+		equals: '/* SlangBasicTranslationTestClass>>#methodSumParameters:to:with: */
+static sqInt
+methodSumParameterstowith(sqInt pFrom, sqInt pTo, sqInt anInteger)
+{
+	sqInt i;
+
+	/* begin methodFrom:to: */
+	for (i = 0; i <= 5; i += 1) {
+		(pTo + anInteger)[i] = pFrom + anInteger[i];
+	};
+	return 0;
+}'
+]
+
+{ #category : #'tests-inline-builtins' }
+SlangBasicTranslationTest >> testInlineMethodSumArgumentsWithAnnotationsNoPrepare [
+	| tMethod translation |
+
+	tMethod := (self getTMethodFrom: #methodSumParametersWithAnnotations:to:with:).
+	generator doBasicInlining: true.
+	
+	translation := self translate: tMethod.
+	translation := translation trimBoth.
+	self
+		assert: translation
+		equals: '/* SlangBasicTranslationTestClass>>#methodSumParametersWithAnnotations:to:with: */
+static sqInt
+methodSumParametersWithAnnotationstowith(unsigned int *pFrom, unsigned int *pTo, sqInt anInteger)
+{
+	sqInt i;
+	unsigned int *pFrom1;
+	unsigned int *pTo1;
+
+	/* begin methodFromWithAnnotations:to:len: */
+	pFrom1 = pFrom + anInteger;
+	pTo1 = pTo + anInteger;
+	for (i = 0, iLimiT = 5 - 1; i <= iLimiT; i += 1) {
+		pTo1[i] = pFrom1[i];
+	};
+	return 0;
+}'
+]
+
+{ #category : #'tests-inline-builtins' }
+SlangBasicTranslationTest >> testInlineMethodSumArgumentsWithAnnotationsPrepared [
+	| tMethod translation |
+
+	tMethod := (self getTMethodFrom: #methodSumParametersWithAnnotations:to:with:).
+	generator 
+		prepareMethods;
+		doBasicInlining: true.
+
+	translation := self translate: tMethod.
+	translation := translation trimBoth.
+	self
+		assert: translation
+		equals: '/* SlangBasicTranslationTestClass>>#methodSumParametersWithAnnotations:to:with: */
+static sqInt
+methodSumParametersWithAnnotationstowith(unsigned int *pFrom, unsigned int *pTo, sqInt anInteger)
+{
+	sqInt i;
+	sqInt pFrom1;
+	sqInt pTo1;
+
+	/* begin methodFromWithAnnotations:to:len: */
+	for (i = 0; i < 5; i += 1) {
+		(pTo + anInteger)[i] = pFrom + anInteger[i];
+	};
+	return 0;
+}'
+]
+
+{ #category : #'tests-inline-builtins' }
+SlangBasicTranslationTest >> testInlineMethodSumArgumentsWithLengthNoPrepare [
+	| translation codeGenerator inlinedMethod |
+
+	translation := self getTMethodFrom: #methodSumParameters:to:with:len:.
+	inlinedMethod := ((SlangBasicTranslationTestClass >> #methodFrom:to:len:) asTranslationMethodOfClass: TMethod).
+	
+	codeGenerator := CCodeGeneratorGlobalStructure new.
+	codeGenerator vmMaker: VMMaker new.
+	codeGenerator vmMaker vmmakerConfiguration: VMMakerConfiguration.	
+	codeGenerator 
+		addMethod: translation;
+		addMethod: inlinedMethod;
+		doInlining: true.
+
+	(translation asCASTIn: codeGenerator) asString.
+	(inlinedMethod asCASTIn: codeGenerator) asString.
+	
+	self assert: (translation locals includesAll: inlinedMethod locals)
+]
+
+{ #category : #'tests-inline-builtins' }
+SlangBasicTranslationTest >> testInlineMethodSumArgumentsWithLengthPrepared [
+	| translation codeGenerator inlinedMethod |
+
+	translation := self getTMethodFrom: #methodSumParameters:to:with:len:.
+	inlinedMethod := ((SlangBasicTranslationTestClass >> #methodFrom:to:len:) asTranslationMethodOfClass: TMethod).
+	
+	codeGenerator := CCodeGeneratorGlobalStructure new.
+	codeGenerator vmMaker: VMMaker new.
+	codeGenerator vmMaker vmmakerConfiguration: VMMakerConfiguration.	
+	codeGenerator 
+		addMethod: translation;
+		addMethod: inlinedMethod;
+		prepareMethods;
+		doInlining: true.
+
+	(translation asCASTIn: codeGenerator) asString.
+	(inlinedMethod asCASTIn: codeGenerator) asString.
+	
+	self assert: (translation locals includesAll: inlinedMethod locals)
+]
+
 { #category : #'tests-inlinenode' }
 SlangBasicTranslationTest >> testInlineNodeDoesNotInitializeReadBeforeWrittenArrayTemp [
 

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -57,7 +57,9 @@ SlangBasicTranslationTest >> getTMethodFrom: selector [
 	"Generate a TMethod from a SlangBasicTranslationTestClass method."
 
 	generator addClass: SlangBasicTranslationTestClass.
-	generator inferTypes.
+	generator 
+		inferTypes;
+		prepareMethods.
 	^ generator methodNamed: selector
 ]
 
@@ -1156,160 +1158,71 @@ SlangBasicTranslationTest >> testGoto [
 ]
 
 { #category : #'tests-inline-builtins' }
-SlangBasicTranslationTest >> testInlineMethodSumArgumentsNoPrepare [
-	
+SlangBasicTranslationTest >> testInlineMethodSumArgumentsWithAnnotations [
 	| tMethod translation |
-	tMethod := (self getTMethodFrom: #methodSumParameters:to:with:).
+
+	tMethod := (self getTMethodFrom: #methodUseParametersWithAnnotations:to:with:).
+	" Adding a method already does prepare methods "
 	generator doBasicInlining: true.
-	
+
 	translation := self translate: tMethod.
 	translation := translation trimBoth.
 	self
 		assert: translation
-		equals: '/* SlangBasicTranslationTestClass>>#methodSumParameters:to:with: */
+		equals: '/* SlangBasicTranslationTestClass>>#methodUseParametersWithAnnotations:to:with: */
 static sqInt
-methodSumParameterstowith(sqInt pFrom, sqInt pTo, sqInt anInteger)
+methodUseParametersWithAnnotationstowith(unsigned int *pFrom, unsigned int *pTo, sqInt anInteger)
 {
 	sqInt i;
 	sqInt pFrom1;
-	sqInt pTo1;
-
-	/* begin methodFrom:to: */
-	pFrom1 = pFrom + anInteger;
-	pTo1 = pTo + anInteger;
-	for (i = 0; i <= 5; i += 1) {
-		pTo1[i] = pFrom1[i];
-	};
-	return 0;
-}'
-]
-
-{ #category : #'tests-inline-builtins' }
-SlangBasicTranslationTest >> testInlineMethodSumArgumentsPrepared [
-	
-	| tMethod translation |
-	tMethod := (self getTMethodFrom: #methodSumParameters:to:with:).
-	generator 
-		prepareMethods;
-		doBasicInlining: true.
-	
-	translation := self translate: tMethod.
-	translation := translation trimBoth.
-	self
-		assert: translation
-		equals: '/* SlangBasicTranslationTestClass>>#methodSumParameters:to:with: */
-static sqInt
-methodSumParameterstowith(sqInt pFrom, sqInt pTo, sqInt anInteger)
-{
-	sqInt i;
-
-	/* begin methodFrom:to: */
-	for (i = 0; i <= 5; i += 1) {
-		(pTo + anInteger)[i] = pFrom + anInteger[i];
-	};
-	return 0;
-}'
-]
-
-{ #category : #'tests-inline-builtins' }
-SlangBasicTranslationTest >> testInlineMethodSumArgumentsWithAnnotationsNoPrepare [
-	| tMethod translation |
-
-	tMethod := (self getTMethodFrom: #methodSumParametersWithAnnotations:to:with:).
-	generator doBasicInlining: true.
-	
-	translation := self translate: tMethod.
-	translation := translation trimBoth.
-	self
-		assert: translation
-		equals: '/* SlangBasicTranslationTestClass>>#methodSumParametersWithAnnotations:to:with: */
-static sqInt
-methodSumParametersWithAnnotationstowith(unsigned int *pFrom, unsigned int *pTo, sqInt anInteger)
-{
-	sqInt i;
-	unsigned int *pFrom1;
 	unsigned int *pTo1;
 
 	/* begin methodFromWithAnnotations:to:len: */
-	pFrom1 = pFrom + anInteger;
-	pTo1 = pTo + anInteger;
-	for (i = 0, iLimiT = 5 - 1; i <= iLimiT; i += 1) {
-		pTo1[i] = pFrom1[i];
+	pTo1 = ((unsigned int *) (yourself(pTo)) );
+	for (i = 0; i < 5; i += 1) {
+		pTo1[i] = pFrom + anInteger[i];
 	};
 	return 0;
 }'
 ]
 
 { #category : #'tests-inline-builtins' }
-SlangBasicTranslationTest >> testInlineMethodSumArgumentsWithAnnotationsPrepared [
-	| tMethod translation |
+SlangBasicTranslationTest >> testInlineMethodSumArgumentsWithAnnotationsUseBuiltIn [
+	| tMethod translation codeGenerator inlinedMethod |
 
-	tMethod := (self getTMethodFrom: #methodSumParametersWithAnnotations:to:with:).
-	generator 
-		prepareMethods;
-		doBasicInlining: true.
+	tMethod := self getTMethodFrom: #methodUseParametersWithAnnotationsBuiltIn:to:with:.
+	inlinedMethod := ((SlangBasicTranslationTestClass >> #methodFromWithAnnotations:to:) asTranslationMethodOfClass: TMethod).
+	
+	codeGenerator := CCodeGeneratorGlobalStructure new.
+	codeGenerator vmMaker: VMMaker new.
+	codeGenerator vmMaker vmmakerConfiguration: VMMakerConfiguration.	
+	codeGenerator 
+		addMethod: tMethod;
+		addMethod: inlinedMethod;		
+		doInlining: true.
+	
+	self assert: (tMethod locals includesAll: inlinedMethod locals).
 
 	translation := self translate: tMethod.
 	translation := translation trimBoth.
-	self
+
+	self 
 		assert: translation
-		equals: '/* SlangBasicTranslationTestClass>>#methodSumParametersWithAnnotations:to:with: */
+		equals: '/* SlangBasicTranslationTestClass>>#methodUseParametersWithAnnotationsBuiltIn:to:with: */
 static sqInt
-methodSumParametersWithAnnotationstowith(unsigned int *pFrom, unsigned int *pTo, sqInt anInteger)
+methodUseParametersWithAnnotationsBuiltIntowith(unsigned int *pFrom, unsigned int *pTo, sqInt anInteger)
 {
 	sqInt i;
 	sqInt pFrom1;
 	sqInt pTo1;
 
-	/* begin methodFromWithAnnotations:to:len: */
-	for (i = 0; i < 5; i += 1) {
-		(pTo + anInteger)[i] = pFrom + anInteger[i];
+	/* begin methodFromWithAnnotations:to: */
+	pFrom1 = ((sqInt) (pFrom + anInteger) );
+	for (i = 0; i <= 10; i += 1) {
+		pTo[i] = pFrom1[i];
 	};
 	return 0;
 }'
-]
-
-{ #category : #'tests-inline-builtins' }
-SlangBasicTranslationTest >> testInlineMethodSumArgumentsWithLengthNoPrepare [
-	| translation codeGenerator inlinedMethod |
-
-	translation := self getTMethodFrom: #methodSumParameters:to:with:len:.
-	inlinedMethod := ((SlangBasicTranslationTestClass >> #methodFrom:to:len:) asTranslationMethodOfClass: TMethod).
-	
-	codeGenerator := CCodeGeneratorGlobalStructure new.
-	codeGenerator vmMaker: VMMaker new.
-	codeGenerator vmMaker vmmakerConfiguration: VMMakerConfiguration.	
-	codeGenerator 
-		addMethod: translation;
-		addMethod: inlinedMethod;
-		doInlining: true.
-
-	(translation asCASTIn: codeGenerator) asString.
-	(inlinedMethod asCASTIn: codeGenerator) asString.
-	
-	self assert: (translation locals includesAll: inlinedMethod locals)
-]
-
-{ #category : #'tests-inline-builtins' }
-SlangBasicTranslationTest >> testInlineMethodSumArgumentsWithLengthPrepared [
-	| translation codeGenerator inlinedMethod |
-
-	translation := self getTMethodFrom: #methodSumParameters:to:with:len:.
-	inlinedMethod := ((SlangBasicTranslationTestClass >> #methodFrom:to:len:) asTranslationMethodOfClass: TMethod).
-	
-	codeGenerator := CCodeGeneratorGlobalStructure new.
-	codeGenerator vmMaker: VMMaker new.
-	codeGenerator vmMaker vmmakerConfiguration: VMMakerConfiguration.	
-	codeGenerator 
-		addMethod: translation;
-		addMethod: inlinedMethod;
-		prepareMethods;
-		doInlining: true.
-
-	(translation asCASTIn: codeGenerator) asString.
-	(inlinedMethod asCASTIn: codeGenerator) asString.
-	
-	self assert: (translation locals includesAll: inlinedMethod locals)
 ]
 
 { #category : #'tests-inlinenode' }

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
@@ -73,6 +73,56 @@ SlangBasicTranslationTestClass >> methodDefiningSingleVariable [
 	| foo |
 ]
 
+{ #category : #'generation-targets' }
+SlangBasicTranslationTestClass >> methodFrom: pFrom to: pTo [
+
+	0 to: 5 do: [ : i | pTo at: i put: (pFrom at: i) ]
+]
+
+{ #category : #'generation-targets' }
+SlangBasicTranslationTestClass >> methodFrom: pFrom to: pTo len: sizeLen [
+
+	0 to: sizeLen - 1 do: [ : i | pTo at: i put: (pFrom at: i) ]
+]
+
+{ #category : #'generation-targets' }
+SlangBasicTranslationTestClass >> methodFromWithAnnotations: pFrom to: pTo len: len [
+	<var: #pTo type: #'unsigned int *'>
+	<var: #pFrom type: #'unsigned int *'>
+
+	0 to: len - 1 do: [ : i | pTo at: i put: (pFrom at: i) ].
+	^ 0
+]
+
+{ #category : #'generation-targets' }
+SlangBasicTranslationTestClass >> methodSumParameters: pFrom to: pTo with: anInteger [
+
+	self 
+		methodFrom: pFrom + anInteger 
+		to: pTo + anInteger
+]
+
+{ #category : #'generation-targets' }
+SlangBasicTranslationTestClass >> methodSumParameters: pFrom to: pTo with: anInteger len: sizeLen [
+
+	self 
+		methodFrom: pFrom + anInteger 
+		to: pTo + anInteger
+		len: sizeLen - 1
+]
+
+{ #category : #'generation-targets' }
+SlangBasicTranslationTestClass >> methodSumParametersWithAnnotations: pFrom to: pTo with: anInteger [
+
+	<var: #pTo type: #'unsigned int *'>
+	<var: #pFrom type: #'unsigned int *'>
+
+	^ self
+			methodFromWithAnnotations: pFrom + anInteger
+			to: pTo + anInteger
+			len: 5
+]
+
 { #category : #inline }
 SlangBasicTranslationTestClass >> methodUsingSingleArrayVariable [
 

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
@@ -74,15 +74,17 @@ SlangBasicTranslationTestClass >> methodDefiningSingleVariable [
 ]
 
 { #category : #'generation-targets' }
-SlangBasicTranslationTestClass >> methodFrom: pFrom to: pTo [
-
-	0 to: 5 do: [ : i | pTo at: i put: (pFrom at: i) ]
-]
-
-{ #category : #'generation-targets' }
 SlangBasicTranslationTestClass >> methodFrom: pFrom to: pTo len: sizeLen [
 
 	0 to: sizeLen - 1 do: [ : i | pTo at: i put: (pFrom at: i) ]
+]
+
+{ #category : #'generation-targets' }
+SlangBasicTranslationTestClass >> methodFromWithAnnotations: pFrom to: pTo [
+	<var: #pTo type: #'unsigned int *'>
+	<var: #pFrom type: #'unsigned int *'>
+
+	0 to: 10 do: [ : i | pTo at: i put: (pFrom at: i) ].
 ]
 
 { #category : #'generation-targets' }
@@ -95,32 +97,25 @@ SlangBasicTranslationTestClass >> methodFromWithAnnotations: pFrom to: pTo len: 
 ]
 
 { #category : #'generation-targets' }
-SlangBasicTranslationTestClass >> methodSumParameters: pFrom to: pTo with: anInteger [
-
-	self 
-		methodFrom: pFrom + anInteger 
-		to: pTo + anInteger
-]
-
-{ #category : #'generation-targets' }
-SlangBasicTranslationTestClass >> methodSumParameters: pFrom to: pTo with: anInteger len: sizeLen [
-
-	self 
-		methodFrom: pFrom + anInteger 
-		to: pTo + anInteger
-		len: sizeLen - 1
-]
-
-{ #category : #'generation-targets' }
-SlangBasicTranslationTestClass >> methodSumParametersWithAnnotations: pFrom to: pTo with: anInteger [
+SlangBasicTranslationTestClass >> methodUseParametersWithAnnotations: pFrom to: pTo with: anInteger [
 
 	<var: #pTo type: #'unsigned int *'>
 	<var: #pFrom type: #'unsigned int *'>
 
 	^ self
-			methodFromWithAnnotations: pFrom + anInteger
-			to: pTo + anInteger
+			methodFromWithAnnotations: pFrom + anInteger 
+			to: pTo yourself
 			len: 5
+]
+
+{ #category : #'generation-targets' }
+SlangBasicTranslationTestClass >> methodUseParametersWithAnnotationsBuiltIn: pFrom to: pTo with: anInteger [
+	<var: #pTo type: #'unsigned int *'>
+	<var: #pFrom type: #'unsigned int *'>
+
+	self
+		methodFromWithAnnotations: pFrom + anInteger 
+		to: pTo
 ]
 
 { #category : #inline }

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -1534,10 +1534,18 @@ CCodeGenerator >> generateCASTAt: tast [
 
 { #category : #'CAST translation' }
 CCodeGenerator >> generateCASTAtPut: tast [
+	" Add parentheses to lvalue to correctly generate C code for complex inlining cases. For example in:
+	
+	 '(pTo + anInteger)[i] = pFrom + anInteger[i]'
+	
+	instead of (without parentheses)
+	
+	'pTo + anInteger[i] = pFrom + anInteger[i]'
 
+	"
 	^ CAssignmentNode
 		  lvalue: (CArrayAccessNode
-				   array: (tast receiver asCASTExpressionIn: self)
+				   array: ((tast receiver asCASTExpressionIn: self) needsParentheses: true)
 				   index: (tast arguments first asCASTExpressionIn: self))
 		  operator: '='
 		  rvalue: (tast arguments last asCASTExpressionIn: self)


### PR DESCRIPTION
When the code in written to C from the CAST, a complex expression from an inlining case could be adding one variable to a anInteger. But this is invalid when the expression is found in a L-Value. In this case, the sum operation should be enclosed between parentheses (both TAST and CAST are not affected as they're correctly generated). For example in:
	
```c
	(pTo + anInteger)[i] = pFrom + anInteger[i]
```	

instead of (without parentheses)
	
```c
	pTo + anInteger[i] = pFrom + anInteger[i]
```

This PR includes a fix implemented in `CCodeGenerator>>generateCASTAtPut:` to add parentheses to the l-value.
It also includes test handling cases of annotated (with pragmas) and unannotated variables for inlinings.
Similarily, tests cases were added for generation of prepared (with prepareMethods) and unprepared methods are considered.

