### PR TITLE
Fix and test for inlinings with If's and right shift not translated

### DIFF
--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -1176,6 +1176,36 @@ SlangBasicTranslationTest >> testGoto [
 	self assert: translation equals: 'goto lab'
 ]
 
+{ #category : #'tests-inlinemethod' }
+SlangBasicTranslationTest >> testInlineMethodIfExpressionWithShiftRight [
+
+	| translation codeGenerator inlinedMethod cast printedString |
+	translation := (self getTMethodFrom: #methodToBeTranslatedWithIfAndShiftRight).
+	inlinedMethod := ((SlangBasicTranslationTestClass >> #methodWithIfAndShiftRight:) asTranslationMethodOfClass: TMethod).
+	
+	codeGenerator := CCodeGeneratorGlobalStructure new.
+	codeGenerator 
+		addMethod: translation;
+		addMethod: inlinedMethod;
+		doInlining: true.
+	
+	cast := translation asCASTIn: codeGenerator.
+	printedString := String streamContents: [ :str | cast prettyPrintOn: str ].
+	self assert: cast isCompoundStatement.
+	self assert: printedString equals: '/* SlangBasicTranslationTestClass>>#methodToBeTranslatedWithIfAndShiftRight */
+static sqInt
+methodToBeTranslatedWithIfAndShiftRight(void)
+{
+	/* begin methodWithIfAndShiftRight: */
+	((usqInt) (((2 < 0)
+		 ? 0
+		 : 2)) ) >> ((2 - 1) * 32);
+	return 0;
+}
+'.
+
+]
+
 { #category : #'tests-inlinenode' }
 SlangBasicTranslationTest >> testInlineNodeDoesNotInitializeReadBeforeWrittenArrayTemp [
 

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
@@ -81,6 +81,12 @@ SlangBasicTranslationTestClass >> methodDefiningSingleVariable [
 ]
 
 { #category : #inline }
+SlangBasicTranslationTestClass >> methodToBeTranslatedWithIfAndShiftRight [
+
+	self methodWithIfAndShiftRight: 2
+]
+
+{ #category : #inline }
 SlangBasicTranslationTestClass >> methodUsingSingleArrayVariable [
 
 	<var: 'foo' type: #'int[17]' >
@@ -127,6 +133,14 @@ SlangBasicTranslationTestClass >> methodWithAnOptionPragma [
 ]
 
 { #category : #inline }
+SlangBasicTranslationTestClass >> methodWithIfAndShiftRight: var [
+
+	^ (var < 0
+		ifTrue:  [ 0 ]
+		ifFalse: [ var ]) >> (var - 1 * 32)
+]
+
+{ #category : #inline }
 SlangBasicTranslationTestClass >> methodWithInlinePragma [
 
 	<inline: true>
@@ -165,13 +179,13 @@ SlangBasicTranslationTestClass >> methodWithOptionPragma [
 	
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #inline }
 SlangBasicTranslationTestClass >> methodWithRepeatedCFunctionName [
 
 	^ true
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #inline }
 SlangBasicTranslationTestClass >> methodWithRepeatedCFunctionName: arg1 [
 
 	^ true

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -2585,7 +2585,7 @@ CCodeGenerator >> generateCASTShiftLeft: tast [
 CCodeGenerator >> generateCASTShiftRight: tast [
 
 	| type rcvr |
-	rcvr := tast receiver asCASTIn: self.
+	rcvr := tast receiver asCASTExpressionIn: self.
 	(self
 		 is64BitIntegralVariable: tast receiver
 		 typeInto: [ :t | type := t ])


### PR DESCRIPTION
This PR add a C code generator test and fix which involves inlinings with an if expression in the left side of a right shift operation. For example, Slang code like:

```smalltalk
methodWithIfAndShiftRight: var

	^ (var < 0
		ifTrue:  [ 0 ]
		ifFalse: [ var ]) >> (var - 1 * 32)
```

was causing any translation which uses a similar pattern to fail, because the CIfStatementNode was asserted to be an expression. In the fix (thanks to Guille), we pass a CTernaryNode representing the if instead to correctly generates the C code.