### PR TITLE
Use protocolNameOfSelector: in pharo-12

### DIFF
--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -1468,8 +1468,8 @@ StackInterpreter class >> isNonArgumentImplicitReceiverVariableName: aString [
 StackInterpreter class >> isObjectAccessor: selector [
 	"Answer if selector is one of fetchPointer:ofObject: storePointer:ofObject:withValue:
 	 et al."
-	^(InterpreterProxy whichCategoryIncludesSelector: selector) = #'object access'
-	 or: [(SpurMemoryManager whichCategoryIncludesSelector: selector) = #'object access']
+	^ (InterpreterProxy protocolNameOfSelector: selector) = #'object access'
+	 or: [(SpurMemoryManager protocolNameOfSelector: selector) = #'object access']
 
 	"This for checking.  The above two protocols are somewhat disjoint."
 	"(InterpreterProxy allMethodsInCategory: #'object access') copyWithoutAll: (SpurMemoryManager allMethodsInCategory: #'object access')"
@@ -1478,7 +1478,8 @@ StackInterpreter class >> isObjectAccessor: selector [
 
 { #category : #'spur compilation support' }
 StackInterpreter class >> isStackAccessor: selector [
-	^(StackInterpreter whichCategoryIncludesSelector: selector) = #'stack access'
+
+	^ (StackInterpreter protocolNameOfSelector: selector) = #'stack access'
 ]
 
 { #category : #translation }

--- a/smalltalksrc/VMMakerTests/VMStackInterpreterTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMStackInterpreterTest.class.st
@@ -1,0 +1,46 @@
+Class {
+	#name : #VMStackInterpreterTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'stackInterpreterClass'
+	],
+	#category : #'VMMakerTests-StackInterpreter'
+}
+
+{ #category : #running }
+VMStackInterpreterTest >> setUp [
+
+	super setUp.
+	stackInterpreterClass := StackInterpreter.
+]
+
+{ #category : #accessing }
+VMStackInterpreterTest >> stackInterpreterClass [
+
+	^ stackInterpreterClass
+]
+
+{ #category : #accessing }
+VMStackInterpreterTest >> stackInterpreterClass: anObject [
+
+	stackInterpreterClass := anObject
+]
+
+{ #category : #running }
+VMStackInterpreterTest >> testIsObjectAccessor [
+
+	self 
+		assert: (self stackInterpreterClass isObjectAccessor: #firstIndexableField:);
+		assert: (self stackInterpreterClass isObjectAccessor: #slotSizeOf:);
+		assert: (self stackInterpreterClass isObjectAccessor: #fetchClassOf:)
+]
+
+{ #category : #running }
+VMStackInterpreterTest >> testIsStackAccessor [
+
+	self 
+		assert: (self stackInterpreterClass isStackAccessor: #stackIntegerValue:);
+		assert: (self stackInterpreterClass isStackAccessor: #stackValue:)
+		
+
+]


### PR DESCRIPTION
This PR modified two methods to use #protocolNameOfSelector: to avoid the Deprecation debugger from opening to suggest an automatic deprecation code rewrite, i.e..:

The messages appearing were like: The method ClassDescription>>#whichCategoryIncludesSelector: called from StackInterpreter class>>#isStackAccessor: has been deprecated. Use #protocolNameOfSelector: instead.

Also add two tests for #isObjectAccessor: and #isStackAccessor:
