### PR TITLE
C AST translation right side parenthesis in expression

### DIFF
--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -1178,6 +1178,35 @@ SlangBasicTranslationTest >> testGoto [
 	self assert: translation equals: 'goto lab'
 ]
 
+{ #category : #'tests-inlinemethod' }
+SlangBasicTranslationTest >> testInlineMethodIfExpressionWithShiftRight [
+
+	| translation codeGenerator inlinedMethod cast printedString |
+	translation := (self getTMethodFrom: #methodToBeTranslatedWithIfAndShiftRight).
+	inlinedMethod := ((SlangBasicTranslationTestClass >> #methodWithIfAndShiftRight:) asTranslationMethodOfClass: TMethod).
+	
+	codeGenerator := CCodeGeneratorGlobalStructure new.
+	codeGenerator 
+		addMethod: translation;
+		addMethod: inlinedMethod;
+		doInlining: true.
+	
+	cast := translation asCASTIn: codeGenerator.
+	printedString := String streamContents: [ :str | cast prettyPrintOn: str ].
+	self assert: cast isCompoundStatement.
+	self assert: printedString equals: '/* SlangBasicTranslationTestClass>>#methodToBeTranslatedWithIfAndShiftRight */
+static sqInt
+methodToBeTranslatedWithIfAndShiftRight(void)
+{
+	/* begin methodWithIfAndShiftRight: */
+	((usqInt) (((2 < 0)
+		 ? 0
+		 : 2)) ) >> ((2 - 1) * 32);
+	return 0;
+}
+'.
+]
+
 { #category : #'tests-inline-builtins' }
 SlangBasicTranslationTest >> testInlineMethodSumArgumentsWithAnnotations [
 	| tMethod translation |
@@ -1201,7 +1230,7 @@ methodUseParametersWithAnnotationstowith(unsigned int *pFrom, unsigned int *pTo,
 	/* begin methodFromWithAnnotations:to:len: */
 	pTo1 = ((unsigned int *) (yourself(pTo)) );
 	for (i = 0; i < 5; i += 1) {
-		pTo1[i] = pFrom + anInteger[i];
+		pTo1[i] = (pFrom + anInteger)[i];
 	};
 	return 0;
 }'
@@ -1244,35 +1273,6 @@ methodUseParametersWithAnnotationsBuiltIntowith(unsigned int *pFrom, unsigned in
 	};
 	return 0;
 }'
-]
-
-{ #category : #'tests-inlinemethod' }
-SlangBasicTranslationTest >> testInlineMethodIfExpressionWithShiftRight [
-
-	| translation codeGenerator inlinedMethod cast printedString |
-	translation := (self getTMethodFrom: #methodToBeTranslatedWithIfAndShiftRight).
-	inlinedMethod := ((SlangBasicTranslationTestClass >> #methodWithIfAndShiftRight:) asTranslationMethodOfClass: TMethod).
-	
-	codeGenerator := CCodeGeneratorGlobalStructure new.
-	codeGenerator 
-		addMethod: translation;
-		addMethod: inlinedMethod;
-		doInlining: true.
-	
-	cast := translation asCASTIn: codeGenerator.
-	printedString := String streamContents: [ :str | cast prettyPrintOn: str ].
-	self assert: cast isCompoundStatement.
-	self assert: printedString equals: '/* SlangBasicTranslationTestClass>>#methodToBeTranslatedWithIfAndShiftRight */
-static sqInt
-methodToBeTranslatedWithIfAndShiftRight(void)
-{
-	/* begin methodWithIfAndShiftRight: */
-	((usqInt) (((2 < 0)
-		 ? 0
-		 : 2)) ) >> ((2 - 1) * 32);
-	return 0;
-}
-'.
 ]
 
 { #category : #'tests-inlinenode' }

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
@@ -103,6 +103,12 @@ SlangBasicTranslationTestClass >> methodFromWithAnnotations: pFrom to: pTo len: 
 	^ 0
 ]
 
+{ #category : #inline }
+SlangBasicTranslationTestClass >> methodToBeTranslatedWithIfAndShiftRight [
+
+	self methodWithIfAndShiftRight: 2
+]
+
 { #category : #'generation-targets' }
 SlangBasicTranslationTestClass >> methodUseParametersWithAnnotations: pFrom to: pTo with: anInteger [
 
@@ -123,12 +129,6 @@ SlangBasicTranslationTestClass >> methodUseParametersWithAnnotationsBuiltIn: pFr
 	self
 		methodFromWithAnnotations: pFrom + anInteger 
 		to: pTo
-]
-
-{ #category : #inline }
-SlangBasicTranslationTestClass >> methodToBeTranslatedWithIfAndShiftRight [
-
-	self methodWithIfAndShiftRight: 2
 ]
 
 { #category : #inline }

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -1530,9 +1530,17 @@ CCodeGenerator >> generateCASTAsVoidPointer: tast [
 
 { #category : #'CAST translation' }
 CCodeGenerator >> generateCASTAt: tast [
+	"Add parentheses to r-value to correctly generate C code during complex inlining cases. For instance if the AST root is #at:, with a TSendNode(#+) as child, then we should generate: 
 
+	pTo1[i] = (pFrom + anInteger)[i];
+	
+	instead of the (incorrect):
+	
+	pTo1[i] = pFrom + anInteger[i];
+
+	"
 	^ CArrayAccessNode
-		  array: (tast receiver asCASTExpressionIn: self)
+		  array: ((tast receiver asCASTExpressionIn: self) needsParentheses: true)
 		  index: (tast arguments first asCASTExpressionIn: self)
 ]
 


### PR DESCRIPTION
This PR add parentheses to the r-value side of an expression, needed to correctly generate C code during complex inlining cases. For instance if the (T)AST root is #at:, with a TSendNode(#+) as child, then we should generate: 

```c
	pTo1[i] = (pFrom + anInteger)[i];
```
instead of the (incorrect):
```c	
	pTo1[i] = pFrom + anInteger[i];
```
Fix the test case.
