### PR TITLE
Add a palette with the C translation of any inspected C node

### DIFF
--- a/smalltalksrc/VMMaker-Tools/CGLRAbstractNode.extension.st
+++ b/smalltalksrc/VMMaker-Tools/CGLRAbstractNode.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #CGLRAbstractNode }
+
+{ #category : #'*VMMaker-Tools' }
+CGLRAbstractNode >> inspectNode: specBuilder [
+	<inspectorPresentationOrder: 910 title: 'C'>
+
+	^  SpTextPresenter new 
+		text: (String streamContents: [ : stream | self prettyPrintOn: stream ]);
+		yourself   
+]


### PR DESCRIPTION
This PR add an extension method to VMMaker-Tools to access a new tab with the C code translation of any inspected CGLRAbstractNode. See the following screenshots:

![Screenshot 2023-09-06 at 17 59 19](https://github.com/pharo-project/pharo-vm/assets/4825959/506fddb3-8e45-423e-a87b-7c955d87a3bd)

![Screenshot 2023-09-06 at 17 44 03](https://github.com/pharo-project/pharo-vm/assets/4825959/fd22f9ca-694c-4630-9475-ed8da0033763)

