### PR TITLE
Add C source code inspection tab for TParseNode

### DIFF
--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -229,6 +229,12 @@ SlangBasicTranslationTest >> testAssignementAsExpressionWithExpressionBlockWithL
 		equals: 'y = (foo(1, 2), foo(3, 4), foo(5, 6), a)'
 ]
 
+{ #category : #'tests-blocks' }
+SlangBasicTranslationTest >> testAssignmentNodeIsExpression [
+
+	self assert: TAssignmentNode new isExpression.
+]
+
 { #category : #'tests-inlinemethod' }
 SlangBasicTranslationTest >> testBasicInlineAsSpecified [
 	
@@ -1178,6 +1184,35 @@ SlangBasicTranslationTest >> testGoto [
 	self assert: translation equals: 'goto lab'
 ]
 
+{ #category : #'tests-inlinemethod' }
+SlangBasicTranslationTest >> testInlineMethodIfExpressionWithShiftRight [
+
+	| translation codeGenerator inlinedMethod cast printedString |
+	translation := (self getTMethodFrom: #methodToBeTranslatedWithIfAndShiftRight).
+	inlinedMethod := ((SlangBasicTranslationTestClass >> #methodWithIfAndShiftRight:) asTranslationMethodOfClass: TMethod).
+	
+	codeGenerator := CCodeGeneratorGlobalStructure new.
+	codeGenerator 
+		addMethod: translation;
+		addMethod: inlinedMethod;
+		doInlining: true.
+	
+	cast := translation asCASTIn: codeGenerator.
+	printedString := String streamContents: [ :str | cast prettyPrintOn: str ].
+	self assert: cast isCompoundStatement.
+	self assert: printedString equals: '/* SlangBasicTranslationTestClass>>#methodToBeTranslatedWithIfAndShiftRight */
+static sqInt
+methodToBeTranslatedWithIfAndShiftRight(void)
+{
+	/* begin methodWithIfAndShiftRight: */
+	((usqInt) (((2 < 0)
+		 ? 0
+		 : 2)) ) >> ((2 - 1) * 32);
+	return 0;
+}
+'.
+]
+
 { #category : #'tests-inline-builtins' }
 SlangBasicTranslationTest >> testInlineMethodSumArgumentsWithAnnotations [
 	| tMethod translation |
@@ -1244,35 +1279,6 @@ methodUseParametersWithAnnotationsBuiltIntowith(unsigned int *pFrom, unsigned in
 	};
 	return 0;
 }'
-]
-
-{ #category : #'tests-inlinemethod' }
-SlangBasicTranslationTest >> testInlineMethodIfExpressionWithShiftRight [
-
-	| translation codeGenerator inlinedMethod cast printedString |
-	translation := (self getTMethodFrom: #methodToBeTranslatedWithIfAndShiftRight).
-	inlinedMethod := ((SlangBasicTranslationTestClass >> #methodWithIfAndShiftRight:) asTranslationMethodOfClass: TMethod).
-	
-	codeGenerator := CCodeGeneratorGlobalStructure new.
-	codeGenerator 
-		addMethod: translation;
-		addMethod: inlinedMethod;
-		doInlining: true.
-	
-	cast := translation asCASTIn: codeGenerator.
-	printedString := String streamContents: [ :str | cast prettyPrintOn: str ].
-	self assert: cast isCompoundStatement.
-	self assert: printedString equals: '/* SlangBasicTranslationTestClass>>#methodToBeTranslatedWithIfAndShiftRight */
-static sqInt
-methodToBeTranslatedWithIfAndShiftRight(void)
-{
-	/* begin methodWithIfAndShiftRight: */
-	((usqInt) (((2 < 0)
-		 ? 0
-		 : 2)) ) >> ((2 - 1) * 32);
-	return 0;
-}
-'.
 ]
 
 { #category : #'tests-inlinenode' }
@@ -1939,6 +1945,23 @@ SlangBasicTranslationTest >> testNonContiguousCaseStatementWithSameBodyAreCollap
 	}
 	break;
 }'
+]
+
+{ #category : #tests }
+SlangBasicTranslationTest >> testParseNodeNotExpressions [
+
+	self deny: TBraceCaseNode new isExpression.
+	self deny: TConstantNode new isExpression.
+	self deny: TDefineNode new isExpression.
+	self deny: TGoToNode new isExpression.
+	self deny: TInlineNode new isExpression.
+
+	self deny: TLabeledCommentNode new isExpression.
+	self deny: TReturnNode new isExpression.
+	self deny: TVariableNode new isExpression.
+	self deny: TCaseStmtNode new isExpression.
+
+
 ]
 
 { #category : #'tests-blocks' }
@@ -4774,6 +4797,12 @@ SlangBasicTranslationTest >> testSendNoMask [
 	self assert: translation equals: '(a & 1) == 0'
 ]
 
+{ #category : #tests }
+SlangBasicTranslationTest >> testSendNodeIsExpression [
+
+	self assert: TSendNode new isExpression.
+]
+
 { #category : #'tests-builtins' }
 SlangBasicTranslationTest >> testSendNot [
 
@@ -6136,6 +6165,12 @@ SlangBasicTranslationTest >> testSendWordSize [
 	self assert: translation equals: 'BytesPerWord'
 ]
 
+{ #category : #tests }
+SlangBasicTranslationTest >> testStatementListNodeIsExpression [
+
+	self assert: TStatementListNode new isExpression.
+]
+
 { #category : #'tests-builtins' }
 SlangBasicTranslationTest >> testStructFieldIsRenamedWithReservedWord [
 	"Tests if the struct field is renamed when it's a reserved word"
@@ -6522,6 +6557,12 @@ SlangBasicTranslationTest >> testSwitchStatementWithNoDefaultStatement [
 	default:
 	error("Case not found and no otherwise clause");
 }'
+]
+
+{ #category : #tests }
+SlangBasicTranslationTest >> testSwitchStmtNodeIsExpression [
+
+	self assert: TSwitchStmtNode new isExpression.
 ]
 
 { #category : #'tests-assignment' }

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -229,12 +229,6 @@ SlangBasicTranslationTest >> testAssignementAsExpressionWithExpressionBlockWithL
 		equals: 'y = (foo(1, 2), foo(3, 4), foo(5, 6), a)'
 ]
 
-{ #category : #'tests-blocks' }
-SlangBasicTranslationTest >> testAssignmentNodeIsExpression [
-
-	self assert: TAssignmentNode new isExpression.
-]
-
 { #category : #'tests-inlinemethod' }
 SlangBasicTranslationTest >> testBasicInlineAsSpecified [
 	
@@ -1945,23 +1939,6 @@ SlangBasicTranslationTest >> testNonContiguousCaseStatementWithSameBodyAreCollap
 	}
 	break;
 }'
-]
-
-{ #category : #tests }
-SlangBasicTranslationTest >> testParseNodeNotExpressions [
-
-	self deny: TBraceCaseNode new isExpression.
-	self deny: TConstantNode new isExpression.
-	self deny: TDefineNode new isExpression.
-	self deny: TGoToNode new isExpression.
-	self deny: TInlineNode new isExpression.
-
-	self deny: TLabeledCommentNode new isExpression.
-	self deny: TReturnNode new isExpression.
-	self deny: TVariableNode new isExpression.
-	self deny: TCaseStmtNode new isExpression.
-
-
 ]
 
 { #category : #'tests-blocks' }
@@ -4797,12 +4774,6 @@ SlangBasicTranslationTest >> testSendNoMask [
 	self assert: translation equals: '(a & 1) == 0'
 ]
 
-{ #category : #tests }
-SlangBasicTranslationTest >> testSendNodeIsExpression [
-
-	self assert: TSendNode new isExpression.
-]
-
 { #category : #'tests-builtins' }
 SlangBasicTranslationTest >> testSendNot [
 
@@ -6165,12 +6136,6 @@ SlangBasicTranslationTest >> testSendWordSize [
 	self assert: translation equals: 'BytesPerWord'
 ]
 
-{ #category : #tests }
-SlangBasicTranslationTest >> testStatementListNodeIsExpression [
-
-	self assert: TStatementListNode new isExpression.
-]
-
 { #category : #'tests-builtins' }
 SlangBasicTranslationTest >> testStructFieldIsRenamedWithReservedWord [
 	"Tests if the struct field is renamed when it's a reserved word"
@@ -6557,12 +6522,6 @@ SlangBasicTranslationTest >> testSwitchStatementWithNoDefaultStatement [
 	default:
 	error("Case not found and no otherwise clause");
 }'
-]
-
-{ #category : #tests }
-SlangBasicTranslationTest >> testSwitchStmtNodeIsExpression [
-
-	self assert: TSwitchStmtNode new isExpression.
 ]
 
 { #category : #'tests-assignment' }

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
@@ -103,6 +103,12 @@ SlangBasicTranslationTestClass >> methodFromWithAnnotations: pFrom to: pTo len: 
 	^ 0
 ]
 
+{ #category : #inline }
+SlangBasicTranslationTestClass >> methodToBeTranslatedWithIfAndShiftRight [
+
+	self methodWithIfAndShiftRight: 2
+]
+
 { #category : #'generation-targets' }
 SlangBasicTranslationTestClass >> methodUseParametersWithAnnotations: pFrom to: pTo with: anInteger [
 
@@ -123,12 +129,6 @@ SlangBasicTranslationTestClass >> methodUseParametersWithAnnotationsBuiltIn: pFr
 	self
 		methodFromWithAnnotations: pFrom + anInteger 
 		to: pTo
-]
-
-{ #category : #inline }
-SlangBasicTranslationTestClass >> methodToBeTranslatedWithIfAndShiftRight [
-
-	self methodWithIfAndShiftRight: 2
 ]
 
 { #category : #inline }

--- a/smalltalksrc/Slang/TAssignmentNode.class.st
+++ b/smalltalksrc/Slang/TAssignmentNode.class.st
@@ -204,6 +204,12 @@ TAssignmentNode >> isAssignment [
 ]
 
 { #category : #testing }
+TAssignmentNode >> isExpression [
+
+	^ true
+]
+
+{ #category : #testing }
 TAssignmentNode >> isSameAs: aTParseNode [
 	^aTParseNode isAssignment
 	 and: [(variable isSameAs: aTParseNode variable)

--- a/smalltalksrc/Slang/TParseNode.class.st
+++ b/smalltalksrc/Slang/TParseNode.class.st
@@ -241,6 +241,12 @@ TParseNode >> isDefine [
 ]
 
 { #category : #testing }
+TParseNode >> isExpression [
+
+	^ false
+]
+
+{ #category : #testing }
 TParseNode >> isGoTo [
 
 	^false

--- a/smalltalksrc/Slang/TSendNode.class.st
+++ b/smalltalksrc/Slang/TSendNode.class.st
@@ -353,6 +353,12 @@ TSendNode >> isConditionalSend [
 ]
 
 { #category : #testing }
+TSendNode >> isExpression [
+
+	^ true
+]
+
+{ #category : #testing }
 TSendNode >> isLiteralArrayDeclaration [
 	^selector == #cCoerce:to:
 	  and: [arguments first isConstant

--- a/smalltalksrc/Slang/TStatementListNode.class.st
+++ b/smalltalksrc/Slang/TStatementListNode.class.st
@@ -370,6 +370,12 @@ TStatementListNode >> initialize [
 ]
 
 { #category : #testing }
+TStatementListNode >> isExpression [
+
+	^ true
+]
+
+{ #category : #testing }
 TStatementListNode >> isNilStmtListNode [
 
 	|stmt|

--- a/smalltalksrc/Slang/TSwitchStmtNode.class.st
+++ b/smalltalksrc/Slang/TSwitchStmtNode.class.st
@@ -294,6 +294,12 @@ TSwitchStmtNode >> expression: expr cases: aTBraceNode otherwiseOrNil: otherwise
 	self otherwiseOrNil: otherwiseOrNilNode
 ]
 
+{ #category : #testing }
+TSwitchStmtNode >> isExpression [
+
+	^ true
+]
+
 { #category : #comparing }
 TSwitchStmtNode >> isSameAs: anotherNode [
 

--- a/smalltalksrc/VMMaker-Tools/TParseNode.extension.st
+++ b/smalltalksrc/VMMaker-Tools/TParseNode.extension.st
@@ -1,8 +1,8 @@
 Extension { #name : #TParseNode }
 
 { #category : #'*VMMaker-Tools' }
-TParseNode >> inspectNode: specBuilder [
-	<inspectorPresentationOrder: 910 title: 'C'>
+TParseNode >> inspectNode [
+	<inspectorPresentationOrder: 912 title: 'C (AST)'>
 
 	^  SpTextPresenter new 
 		text: (String streamContents: [ : stream | 
@@ -15,10 +15,27 @@ TParseNode >> inspectNode: specBuilder [
 					definingClass: self class;
 					yourself).
 			cg pushScope: TStatementListNode new.
-			(self respondsTo: #expression)
-				ifTrue: [ (self asCASTExpressionIn: cg) prettyPrintOn: stream ]
-				ifFalse: [ (self asCASTIn: cg) prettyPrintOn: stream ] ]);
-		yourself   
+			(self asCASTIn: cg) prettyPrintOn: stream ]);
+		yourself
+]
+
+{ #category : #'*VMMaker-Tools' }
+TParseNode >> inspectNodeExpression [
+	<inspectorPresentationOrder: 910 title: 'C (AST Expr)'>
+
+	^  SpTextPresenter new 
+		text: (String streamContents: [ : stream | 
+			| cg |
+			cg := MLVMCCodeGenerator new.
+			cg vmMaker: VMMaker new.
+			cg vmMaker vmmakerConfiguration: VMMakerConfiguration.
+			cg currentMethod: (TMethod new
+					labels: Set new;
+					definingClass: self class;
+					yourself).
+			cg pushScope: TStatementListNode new.
+			(self asCASTExpressionIn: cg) prettyPrintOn: stream ]);
+		yourself
 ]
 
 { #category : #'*VMMaker-Tools' }

--- a/smalltalksrc/VMMaker-Tools/TParseNode.extension.st
+++ b/smalltalksrc/VMMaker-Tools/TParseNode.extension.st
@@ -1,6 +1,27 @@
 Extension { #name : #TParseNode }
 
 { #category : #'*VMMaker-Tools' }
+TParseNode >> inspectNode: specBuilder [
+	<inspectorPresentationOrder: 910 title: 'C'>
+
+	^  SpTextPresenter new 
+		text: (String streamContents: [ : stream | 
+			| cg |
+			cg := MLVMCCodeGenerator new.
+			cg vmMaker: VMMaker new.
+			cg vmMaker vmmakerConfiguration: VMMakerConfiguration.
+			cg currentMethod: (TMethod new
+					labels: Set new;
+					definingClass: self class;
+					yourself).
+			cg pushScope: TStatementListNode new.
+			(self respondsTo: #expression)
+				ifTrue: [ (self asCASTExpressionIn: cg) prettyPrintOn: stream ]
+				ifFalse: [ (self asCASTIn: cg) prettyPrintOn: stream ] ]);
+		yourself   
+]
+
+{ #category : #'*VMMaker-Tools' }
 TParseNode >> inspectionTree [
 	<inspectorPresentationOrder: 35 title: 'Tree'>
 

--- a/smalltalksrc/VMMaker-Tools/TParseNode.extension.st
+++ b/smalltalksrc/VMMaker-Tools/TParseNode.extension.st
@@ -2,7 +2,7 @@ Extension { #name : #TParseNode }
 
 { #category : #'*VMMaker-Tools' }
 TParseNode >> inspectNode [
-	<inspectorPresentationOrder: 912 title: 'C (AST)'>
+	<inspectorPresentationOrder: 912 title: 'C (Not Expr)'>
 
 	^  SpTextPresenter new 
 		text: (String streamContents: [ : stream | 
@@ -11,13 +11,31 @@ TParseNode >> inspectNode [
 ]
 
 { #category : #'*VMMaker-Tools' }
+TParseNode >> inspectNodeContext: aContext [
+
+	aContext active: self isExpression not.
+	aContext 
+		title: 'C';
+		withoutEvaluator
+]
+
+{ #category : #'*VMMaker-Tools' }
 TParseNode >> inspectNodeExpression [
-	<inspectorPresentationOrder: 910 title: 'C (AST Expr)'>
+	<inspectorPresentationOrder: 912 title: 'C (Expression)'>
 
 	^  SpTextPresenter new 
 		text: (String streamContents: [ : stream | 
 			(self asCASTExpressionIn: self newCodeGeneratorForInspection) prettyPrintOn: stream ]);
 		yourself
+]
+
+{ #category : #'*VMMaker-Tools' }
+TParseNode >> inspectNodeExpressionContext: aContext [
+
+	aContext active: self isExpression.
+	aContext 
+		title: 'C (Expr)';
+		withoutEvaluator
 ]
 
 { #category : #'*VMMaker-Tools' }

--- a/smalltalksrc/VMMaker-Tools/TParseNode.extension.st
+++ b/smalltalksrc/VMMaker-Tools/TParseNode.extension.st
@@ -6,16 +6,7 @@ TParseNode >> inspectNode [
 
 	^  SpTextPresenter new 
 		text: (String streamContents: [ : stream | 
-			| cg |
-			cg := MLVMCCodeGenerator new.
-			cg vmMaker: VMMaker new.
-			cg vmMaker vmmakerConfiguration: VMMakerConfiguration.
-			cg currentMethod: (TMethod new
-					labels: Set new;
-					definingClass: self class;
-					yourself).
-			cg pushScope: TStatementListNode new.
-			(self asCASTIn: cg) prettyPrintOn: stream ]);
+			(self asCASTIn: self newCodeGeneratorForInspection) prettyPrintOn: stream ]);
 		yourself
 ]
 
@@ -25,16 +16,7 @@ TParseNode >> inspectNodeExpression [
 
 	^  SpTextPresenter new 
 		text: (String streamContents: [ : stream | 
-			| cg |
-			cg := MLVMCCodeGenerator new.
-			cg vmMaker: VMMaker new.
-			cg vmMaker vmmakerConfiguration: VMMakerConfiguration.
-			cg currentMethod: (TMethod new
-					labels: Set new;
-					definingClass: self class;
-					yourself).
-			cg pushScope: TStatementListNode new.
-			(self asCASTExpressionIn: cg) prettyPrintOn: stream ]);
+			(self asCASTExpressionIn: self newCodeGeneratorForInspection) prettyPrintOn: stream ]);
 		yourself
 ]
 
@@ -56,4 +38,19 @@ TParseNode >> inspectionTree [
 			 ] ];
 		expandAll;
 		yourself
+]
+
+{ #category : #'*VMMaker-Tools' }
+TParseNode >> newCodeGeneratorForInspection [
+
+	| cg |
+	cg := MLVMCCodeGenerator new.
+	cg vmMaker: VMMaker new.
+	cg vmMaker vmmakerConfiguration: VMMakerConfiguration.
+	cg currentMethod: (TMethod new
+			 labels: Set new;
+			 definingClass: self class;
+			 yourself).
+	cg pushScope: TStatementListNode new.
+	^ cg
 ]


### PR DESCRIPTION
This PR add an extension method to VMMaker-Tools to access a new tab with the C code translation of any inspected TParseNode. See the following screenshots:

<img width="870" alt="Screenshot 2023-09-06 at 21 03 26" src="https://github.com/pharo-project/pharo-vm/assets/4825959/2467549a-5a38-4fcd-8575-f1cdaee14532">
<img width="1051" alt="Screenshot 2023-09-06 at 21 05 43" src="https://github.com/pharo-project/pharo-vm/assets/4825959/dfebaa59-d1bc-482c-852b-b0c985f1b2fe">

To test it inspect the follwing nodes:

```smalltalk
TStatementListNode new
		              setArguments: #(  )
		              statements: { 
				              (TSendNode new
					               setSelector: #foo
					               receiver: (TConstantNode value: 1)
					               arguments: { (TConstantNode value: 2) }).
				              (TSendNode new
					               setSelector: #foo
					               receiver: (TConstantNode value: 3)
					               arguments: { (TConstantNode value: 4) }).
				              (TSendNode new
					               setSelector: #foo
					               receiver: (TConstantNode value: 5)
					               arguments: { (TConstantNode value: 6) }) }.
```