### PR TITLE
Execute quick primitives using primitive table entries in StackVM

### DIFF
--- a/smalltalksrc/VMMaker/CurrentImageCoInterpreterFacade.class.st
+++ b/smalltalksrc/VMMaker/CurrentImageCoInterpreterFacade.class.st
@@ -948,7 +948,7 @@ CurrentImageCoInterpreterFacade >> printNum: anInteger [
 
 { #category : #printing }
 CurrentImageCoInterpreterFacade >> printStringOf: anOop [
-	Transcript nextPutAll: (self objectForOop: anOop)
+	Transcript nextPutAll: (self objectForOop: anOop); flush
 ]
 
 { #category : #testing }

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -8187,7 +8187,7 @@ StackInterpreter >> isPrimitiveFunctionPointerAQuickPrimitive [
 		ifTrue: [ ^ true ].
 	primitiveFunctionPointer = #primitivePushTwo 
 		ifTrue: [ ^ true ].
-	^ true
+	^ false
 	
 ]
 

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -1279,14 +1279,14 @@ StackInterpreter class >> initializePrimitiveTable [
 		(255 primitiveFail)
 
 		"Quick Push Const Methods"
-		(256 nil) "primitivePushSelf"
-		(257 nil) "primitivePushTrue"
-		(258 nil) "primitivePushFalse"
-		(259 nil) "primitivePushNil"
-		(260 nil) "primitivePushMinusOne"
-		(261 nil) "primitivePushZero"
-		(262 nil) "primitivePushOne"
-		(263 nil) "primitivePushTwo"
+		(256 primitivePushSelf)
+		(257 primitivePushTrue)
+		(258 primitivePushFalse)
+		(259 primitivePushNil)
+		(260 primitivePushMinusOne)
+		(261 primitivePushZero)
+		(262 primitivePushOne)
+		(263 primitivePushTwo)
 
 		"Quick Push Inst Var Methods"
 		(264 519 nil) "primitiveLoadInstVar"
@@ -5411,10 +5411,6 @@ StackInterpreter >> executePrimitiveFromInterpreter: inInterpreter ifFail: aBloc
 
 	primitiveFunctionPointer ~= 0 ifTrue: [
 		| succeeded |
-		self isPrimitiveFunctionPointerAnIndex ifTrue: [
-			self executeQuickPrimitive.
-			self returnToExecutive: inInterpreter.
-			^ nil ].
 		"slowPrimitiveResponse may of course context-switch. 
 		If so we must reenter the new process appropriately, returning only if we've found an interpreter frame.
 		The instructionPointer tells us from whence we came."
@@ -8171,6 +8167,22 @@ StackInterpreter >> isOptimizedMethod: methodObj [
 StackInterpreter >> isOptimizedMethodHeader: header [
 	<option: #SistaVM>
 	^header anyMask: AlternateHeaderIsOptimizedFlag
+]
+
+{ #category : #'message sending' }
+StackInterpreter >> isPrimitiveFunctionPointerAQuickPrimitive [
+	"Answer <true> if the receiver's primitive function pointer is any of the quick primitive selectors"
+
+	^ #(
+		#primitivePushTrue
+		#primitivePushFalse
+		#primitivePushNil
+		#primitivePushMinusOne
+		#primitivePushZero
+		#primitivePushOne
+		#primitivePushTwo 
+		) includes: primitiveFunctionPointer
+	
 ]
 
 { #category : #'primitive support' }
@@ -14240,15 +14252,22 @@ StackInterpreter >> sizeOfSTArrayFromCPrimitive: cPtr [
 
 ]
 
-{ #category : #'primitive support' }
-StackInterpreter >> slowPrimitiveResponse [
-	"Invoke a normal (non-quick) primitive.
+{ #category : #'message sending' }
+StackInterpreter >> slowPrimitiveResponse [ 
+	"Invoke a primitive.
 	 Called under the assumption that primFunctionPointer has been preloaded."
+
 	| nArgs savedFramePointer savedStackPointer |
 	<inline: true>
 	<var: #savedFramePointer type: #'char *'>
 	<var: #savedStackPointer type: #'char *'>
 	"self assert: (objectMemory isOopForwarded: (self stackValue: argumentCount)) not."
+	
+	self isPrimitiveFunctionPointerAQuickPrimitive 
+		ifTrue: [ 
+			self dispatchFunctionPointer: primitiveFunctionPointer.
+			^ true ].
+
 	self assert: objectMemory remapBufferCount = 0.
 	FailImbalancedPrimitives ifTrue:
 		[nArgs := argumentCount.

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -8174,13 +8174,13 @@ StackInterpreter >> isPrimitiveFunctionPointerAQuickPrimitive [
 	"Answer <true> if the receiver's primitive function pointer is any of the quick primitive selectors"
 
 	^ #(
-		#primitivePushTrue
-		#primitivePushFalse
-		#primitivePushNil
-		#primitivePushMinusOne
-		#primitivePushZero
-		#primitivePushOne
-		#primitivePushTwo 
+		primitivePushTrue
+		primitivePushFalse
+		primitivePushNil
+		primitivePushMinusOne
+		primitivePushZero
+		primitivePushOne
+		primitivePushTwo 
 		) includes: primitiveFunctionPointer
 	
 ]

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -8173,15 +8173,21 @@ StackInterpreter >> isOptimizedMethodHeader: header [
 StackInterpreter >> isPrimitiveFunctionPointerAQuickPrimitive [
 	"Answer <true> if the receiver's primitive function pointer is any of the quick primitive selectors"
 
-	^ #(
-		primitivePushTrue
-		primitivePushFalse
-		primitivePushNil
-		primitivePushMinusOne
-		primitivePushZero
-		primitivePushOne
-		primitivePushTwo 
-		) includes: primitiveFunctionPointer
+	primitiveFunctionPointer = #primitivePushTrue
+		ifTrue: [ ^ true ].
+	primitiveFunctionPointer = #primitivePushFalse
+		ifTrue: [ ^ true ].
+	primitiveFunctionPointer = #primitivePushNil
+		ifTrue: [ ^ true ].
+	primitiveFunctionPointer = #primitivePushMinusOne
+		ifTrue: [ ^ true ].
+	primitiveFunctionPointer = #primitivePushZero
+		ifTrue: [ ^ true ].
+	primitiveFunctionPointer = #primitivePushOne
+		ifTrue: [ ^ true ].
+	primitiveFunctionPointer = #primitivePushTwo 
+		ifTrue: [ ^ true ].
+	^ true
 	
 ]
 

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -5456,6 +5456,28 @@ StackInterpreter >> executeQuickPrimitive [
 	^ true
 ]
 
+{ #category : #'primitive support' }
+StackInterpreter >> executeQuickReturn [
+	" Send a quick return.
+	 Called under the assumption that primFunctionPtr has been preloaded"
+
+	| localPrimIndex |
+
+	localPrimIndex := self
+		                  cCoerceSimple: primitiveFunctionPointer
+		                  to: #sqInt.
+	self assert: (localPrimIndex > 255 and: [ localPrimIndex < 520 ]).
+	"Quick return inst vars"
+	localPrimIndex >= 264 ifTrue: [ 
+		self stackTopPut: (objectMemory
+				 fetchPointer: localPrimIndex - 264
+				 ofObject: self stackTop).
+		^ true ].
+	"Quick return constants"
+	self stackTopPut: (objectMemory integerObjectOf: localPrimIndex - 261).
+	^ true
+]
+
 { #category : #'translation support' }
 StackInterpreter >> expandCases [
 	"For translation only; noop when running in Smalltalk.
@@ -14272,7 +14294,12 @@ StackInterpreter >> slowPrimitiveResponse [
 	self isPrimitiveFunctionPointerAQuickPrimitive 
 		ifTrue: [ 
 			self dispatchFunctionPointer: primitiveFunctionPointer.
-			^ true ].
+			^ true ]
+		ifFalse: [ 	
+				self isPrimitiveFunctionPointerAnIndex 
+					ifTrue: [ 
+						self executeQuickPrimitive.
+						^ true ] ].
 
 	self assert: objectMemory remapBufferCount = 0.
 	FailImbalancedPrimitives ifTrue:

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -5410,50 +5410,24 @@ StackInterpreter >> executePrimitiveFromInterpreter: inInterpreter ifFail: aBloc
 	 the machine code primitive, just evaluate primitiveFunctionPointer directly."
 
 	primitiveFunctionPointer ~= 0 ifTrue: [
-		| succeeded |
 		"slowPrimitiveResponse may of course context-switch. 
 		If so we must reenter the new process appropriately, returning only if we've found an interpreter frame.
 		The instructionPointer tells us from whence we came."
-		succeeded := self slowPrimitiveResponse.
-		succeeded ifTrue: [
-			self returnToExecutive: inInterpreter.
-			^ nil ] ].
+		self slowPrimitiveResponse
+			 ifTrue: [ ^ self returnToExecutive: inInterpreter ] ].
 
 	^ aBlock value
 ]
 
-{ #category : #'primitive support' }
-StackInterpreter >> executeQuickPrimitive [
+{ #category : #'message sending' }
+StackInterpreter >> executeQuick [
 
-	"Invoke a quick primitive.
-	 Called under the assumption that primFunctionPtr has been preloaded"
-
-	| localPrimIndex |
-	self assert: self isPrimitiveFunctionPointerAnIndex.
-	localPrimIndex := self
-		                  cCoerceSimple: primitiveFunctionPointer
-		                  to: #sqInt.
-	self assert: (localPrimIndex > 255 and: [ localPrimIndex < 520 ]).
-	"Quick return inst vars"
-	localPrimIndex >= 264 ifTrue: [ 
-		self stackTopPut: (objectMemory
-				 fetchPointer: localPrimIndex - 264
-				 ofObject: self stackTop).
-		^ true ].
-	"Quick return constants"
-	localPrimIndex = 256 ifTrue: [ ^ true "return self" ].
-	localPrimIndex = 257 ifTrue: [ 
-		self stackTopPut: objectMemory trueObject.
-		^ true ].
-	localPrimIndex = 258 ifTrue: [ 
-		self stackTopPut: objectMemory falseObject.
-		^ true ].
-	localPrimIndex = 259 ifTrue: [ 
-		self stackTopPut: objectMemory nilObject.
-		^ true ].
-	self stackTopPut:
-		(objectMemory integerObjectOf: localPrimIndex - 261).
-	^ true
+	"primFailCode := 0."
+	self isPrimitiveFunctionPointerAQuickPrimitive 
+		ifTrue: [ self dispatchFunctionPointer: primitiveFunctionPointer. ^ true ]
+		ifFalse: [ self isPrimitiveFunctionPointerAnIndex 
+			ifTrue: [ self executeQuickReturn. ^ true ] ].
+	^ false
 ]
 
 { #category : #'primitive support' }
@@ -14291,15 +14265,8 @@ StackInterpreter >> slowPrimitiveResponse [
 	<var: #savedStackPointer type: #'char *'>
 	"self assert: (objectMemory isOopForwarded: (self stackValue: argumentCount)) not."
 	
-	self isPrimitiveFunctionPointerAQuickPrimitive 
-		ifTrue: [ 
-			self dispatchFunctionPointer: primitiveFunctionPointer.
-			^ true ]
-		ifFalse: [ 	
-				self isPrimitiveFunctionPointerAnIndex 
-					ifTrue: [ 
-						self executeQuickPrimitive.
-						^ true ] ].
+	self executeQuick
+		ifTrue: [ ^ true ].
 
 	self assert: objectMemory remapBufferCount = 0.
 	FailImbalancedPrimitives ifTrue:

--- a/smalltalksrc/VMMaker/StackInterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreterPrimitives.class.st
@@ -2668,6 +2668,58 @@ StackInterpreterPrimitives >> primitivePin [
 	self pop: argumentCount + 1 thenPush: wasPinned
 ]
 
+{ #category : #'quick primitives' }
+StackInterpreterPrimitives >> primitivePushFalse [
+
+	self push: objectMemory falseObject.
+
+]
+
+{ #category : #'quick primitives' }
+StackInterpreterPrimitives >> primitivePushMinusOne [
+
+	self push: (objectMemory integerObjectOf: -1)
+]
+
+{ #category : #'quick primitives' }
+StackInterpreterPrimitives >> primitivePushNil [
+
+	self push: objectMemory nilObject.
+
+]
+
+{ #category : #'quick primitives' }
+StackInterpreterPrimitives >> primitivePushOne [
+
+	self push: (objectMemory integerObjectOf: 1) 
+]
+
+{ #category : #'quick primitives' }
+StackInterpreterPrimitives >> primitivePushSelf [
+	"do nothing"
+	
+	"self stackTopPut: self popStack."
+]
+
+{ #category : #'quick primitives' }
+StackInterpreterPrimitives >> primitivePushTrue [
+
+	self push: objectMemory trueObject.
+
+]
+
+{ #category : #'quick primitives' }
+StackInterpreterPrimitives >> primitivePushTwo [
+
+	self push: (objectMemory integerObjectOf: 2)
+]
+
+{ #category : #'quick primitives' }
+StackInterpreterPrimitives >> primitivePushZero [
+
+	self push: (objectMemory integerObjectOf: 0)
+]
+
 { #category : #ffi }
 StackInterpreterPrimitives >> primitiveSameThreadCallout [
 	"Because of Slang restrictions, making FFI optional requires cutting the primitive in two different methods. Otherwise slang will unconditionally do all local declarations which may refer to invalid types if FFI is not enabled.

--- a/smalltalksrc/VMMaker/StackInterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreterPrimitives.class.st
@@ -2678,27 +2678,27 @@ StackInterpreterPrimitives >> primitivePin [
 { #category : #'quick primitives' }
 StackInterpreterPrimitives >> primitivePushFalse [
 
-	self push: objectMemory falseObject.
+	self stackTopPut: objectMemory falseObject.
 
 ]
 
 { #category : #'quick primitives' }
 StackInterpreterPrimitives >> primitivePushMinusOne [
 
-	self push: (objectMemory integerObjectOf: -1)
+	self stackTopPut: (objectMemory integerObjectOf: -1)
 ]
 
 { #category : #'quick primitives' }
 StackInterpreterPrimitives >> primitivePushNil [
 
-	self push: objectMemory nilObject.
+	self stackTopPut: objectMemory nilObject.
 
 ]
 
 { #category : #'quick primitives' }
 StackInterpreterPrimitives >> primitivePushOne [
 
-	self push: (objectMemory integerObjectOf: 1) 
+	self stackTopPut: (objectMemory integerObjectOf: 1) 
 ]
 
 { #category : #'quick primitives' }
@@ -2711,20 +2711,20 @@ StackInterpreterPrimitives >> primitivePushSelf [
 { #category : #'quick primitives' }
 StackInterpreterPrimitives >> primitivePushTrue [
 
-	self push: objectMemory trueObject.
+	self stackTopPut: objectMemory trueObject.
 
 ]
 
 { #category : #'quick primitives' }
 StackInterpreterPrimitives >> primitivePushTwo [
 
-	self push: (objectMemory integerObjectOf: 2)
+	self stackTopPut: (objectMemory integerObjectOf: 2)
 ]
 
 { #category : #'quick primitives' }
 StackInterpreterPrimitives >> primitivePushZero [
 
-	self push: (objectMemory integerObjectOf: 0)
+	self stackTopPut: (objectMemory integerObjectOf: 0)
 ]
 
 { #category : #ffi }

--- a/smalltalksrc/VMMaker/StackInterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreterPrimitives.class.st
@@ -1137,10 +1137,17 @@ StackInterpreterPrimitives >> primitiveDoPrimitiveWithArgs [
 		[self push: (objectMemory fetchPointer: index - 1 ofObject: argumentArray).
 		 index := index + 1].
 
-	self isPrimitiveFunctionPointerAnIndex ifTrue:
-		[self executeQuickPrimitive.
-		 tempOop2 := 0.
-		^nil].
+	"Handle quick executions"
+	self isPrimitiveFunctionPointerAQuickPrimitive 
+		ifTrue: [ 
+			self dispatchFunctionPointer: primitiveFunctionPointer. 
+			 tempOop2 := 0.
+			^ nil ]
+		ifFalse: [ self isPrimitiveFunctionPointerAnIndex 
+			ifTrue: [ self executeQuickReturn. 
+				 tempOop2 := 0.
+				^ nil ] ].
+	
 	"We use tempOop instead of pushRemappableOop:/popRemappableOop here because in
 	 the Cogit primitiveEnterCriticalSection, primitiveSignal, primitiveResume et al longjmp back
 	 to either the interpreter or machine code, depending on the process activated.  So if we're

--- a/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
@@ -26,6 +26,23 @@ VMPrimitiveTest >> assert: anOop contentEquals: oopToCompare [
 	
 ]
 
+{ #category : #'tests - quick primitives' }
+VMPrimitiveTest >> assert: aBlock pushed: anOop [
+
+	| oldStackSize |
+
+	stackBuilder 
+		addNewFrame; 
+		buildStack.
+	oldStackSize := interpreter stackPointer.
+	aBlock value.
+	
+	self assert: interpreter stackPointer equals: oldStackSize - memory wordSize.
+	self assert: interpreter stackTop equals: anOop.
+	
+	
+]
+
 { #category : #'as yet unclassified' }
 VMPrimitiveTest >> fillNewSpace [
 
@@ -120,6 +137,17 @@ VMPrimitiveTest >> testPrimitiveAddFailsWithTypeErrorOnFirstOperand [
 	
 ]
 
+{ #category : #'tests - quick primitives' }
+VMPrimitiveTest >> testPrimitiveAddFailsWithTypeErrorOnFirstOperandQuick [
+
+	interpreter primitivePushTrue.
+	interpreter primitivePushTwo.
+	
+	interpreter primitiveAdd. 
+
+	self assert: interpreter failed.
+]
+
 { #category : #'tests - primitiveAdd' }
 VMPrimitiveTest >> testPrimitiveAddFailsWithTypeErrorOnSecondOperand [
 
@@ -131,6 +159,17 @@ VMPrimitiveTest >> testPrimitiveAddFailsWithTypeErrorOnSecondOperand [
 	self assert: interpreter failed.
 	
 	
+]
+
+{ #category : #'tests - quick primitives' }
+VMPrimitiveTest >> testPrimitiveAddFailsWithTypeErrorOnSecondOperandQuick [
+
+	interpreter primitivePushTwo.
+	interpreter primitivePushTrue.
+	
+	interpreter primitiveAdd. 
+
+	self assert: interpreter failed.
 ]
 
 { #category : #'tests - primitiveAdd' }
@@ -147,6 +186,20 @@ VMPrimitiveTest >> testPrimitiveAddFailsWithTypeErrorPreservesStack [
 	self assert: (interpreter stackValue: 1) equals: string. 
 	
 	
+]
+
+{ #category : #'tests - quick primitives' }
+VMPrimitiveTest >> testPrimitiveAddFailsWithTypeErrorPreservesStackQuick [
+	| string |
+	
+	string := self newString: '42'.
+	interpreter push: string. 
+	interpreter primitivePushTwo.
+	
+	interpreter primitiveAdd. 
+
+	self assert: interpreter stackTop equals: (memory integerObjectOf: 2).
+	self assert: (interpreter stackValue: 1) equals: string. 
 ]
 
 { #category : #'tests - primitiveAdd' }
@@ -177,6 +230,24 @@ VMPrimitiveTest >> testPrimitiveAddWithNoOverflowPopsOperands [
 	"The previous lines pop the result of primiviteAdd (1 2) for us to check that 1 and 2 were popped from the stack by checking that the next value is our marker, for instance 42"
 	
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 42). 
+	
+	
+]
+
+{ #category : #'tests - quick primitives' }
+VMPrimitiveTest >> testPrimitiveAddWithNoOverflowPopsOperandsQuick [
+
+	interpreter push: (memory integerObjectOf: 16rC0FFEE). "Marker"
+	interpreter primitivePushOne.
+	interpreter primitivePushTwo.
+	
+	interpreter primitiveAdd. 
+
+	"Pop the result of primiviteAdd (1 2)"
+	interpreter popStack. 
+
+	"Check that the next value is our marker"
+	self assert: interpreter stackTop equals: (memory integerObjectOf: 16rC0FFEE). 
 	
 	
 ]
@@ -3119,6 +3190,133 @@ VMPrimitiveTest >> testPrimitivePinReturnsBoolean [
 	
 ]
 
+{ #category : #'tests - quick primitives' }
+VMPrimitiveTest >> testPrimitivePushFalse [
+
+	self 
+		assert: [ interpreter primitivePushFalse ]
+		pushed: memory falseObject
+.
+]
+
+{ #category : #'tests - quick primitives' }
+VMPrimitiveTest >> testPrimitivePushMinusOne [
+
+	self 
+		assert: [ interpreter primitivePushMinusOne ]
+		pushed: (memory integerObjectOf: -1)
+
+]
+
+{ #category : #'tests - quick primitives' }
+VMPrimitiveTest >> testPrimitivePushNil [
+
+	self 
+		assert: [ interpreter primitivePushNil ]
+		pushed: memory nilObject
+ 	
+]
+
+{ #category : #'tests - quick primitives' }
+VMPrimitiveTest >> testPrimitivePushOne [
+
+	self 
+		assert: [ interpreter primitivePushOne ]
+		pushed: (memory integerObjectOf: 1)
+ 	
+]
+
+{ #category : #'tests - quick primitives' }
+VMPrimitiveTest >> testPrimitivePushOneAndAdd [
+
+	stackBuilder 
+		addNewFrame; 
+		buildStack.
+	interpreter primitivePushOne.
+	interpreter primitivePushOne.
+	interpreter primitiveAdd.
+
+	self deny: interpreter failed.
+	self assert: interpreter stackTop equals: (memory integerObjectOf: 2). 
+	
+	
+]
+
+{ #category : #'tests - quick primitives' }
+VMPrimitiveTest >> testPrimitivePushOnePreservesStackState [
+
+	stackBuilder 
+		addNewFrame; 
+		buildStack.
+
+	"Add markers"
+	interpreter push: 16rC0FFEE.
+	self 
+		assert: interpreter stackTop 
+		equals: 16rC0FFEE.
+		
+	interpreter push: 16rFAFAFA.
+	self 
+		assert: interpreter stackTop 
+		equals: 16rFAFAFA.
+
+	"Quick primitive operation"
+	interpreter primitivePushOne.
+	
+	"Check markers are still present after the quick operation"
+   self assert: (interpreter stackValue: 1) equals: 16rFAFAFA.
+   self assert: (interpreter stackValue: 2) equals: 16rC0FFEE
+
+]
+
+{ #category : #'tests - quick primitives' }
+VMPrimitiveTest >> testPrimitivePushTrue [
+
+	self 
+		assert: [ interpreter primitivePushTrue ]
+		pushed: memory trueObject
+	
+]
+
+{ #category : #'tests - quick primitives' }
+VMPrimitiveTest >> testPrimitivePushTwo [
+
+	self 
+		assert: [ interpreter primitivePushTwo ]
+		pushed: (memory integerObjectOf: 2)
+]
+
+{ #category : #'tests - quick primitives' }
+VMPrimitiveTest >> testPrimitivePushZero [
+
+	self 
+		assert: [ interpreter primitivePushZero ]
+		pushed: (memory integerObjectOf: 0)
+
+]
+
+{ #category : #'tests - quick primitives' }
+VMPrimitiveTest >> testPrimitivePushZeroPreservesStackState [
+
+	stackBuilder 
+		addNewFrame; 
+		buildStack.
+
+	"Add markers"
+	interpreter push: 16rC0FFEE.
+	interpreter push: 16rFAFAFA.
+	"Quick primitive operation"
+	interpreter primitivePushZero.
+	
+	"Check markers are still present after the quick operation"
+	self 
+		assert: interpreter stackTop 
+		equals: (memory integerObjectOf: 0).
+
+   self assert: (interpreter stackValue: 1) equals: 16rFAFAFA.
+   self assert: (interpreter stackValue: 2) equals: 16rC0FFEE
+]
+
 { #category : #'tests - primitiveQuo' }
 VMPrimitiveTest >> testPrimitiveQuo [
 
@@ -3198,11 +3396,33 @@ VMPrimitiveTest >> testPrimitiveQuoWith0DivisionOnFirstOperand [
 	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 0). 
 ]
 
+{ #category : #'tests - quick primitives' }
+VMPrimitiveTest >> testPrimitiveQuoWith0DivisionOnFirstOperandQuick [
+
+	interpreter primitivePushZero.
+	interpreter push: (memory integerObjectOf: 4).
+	
+	interpreter primitiveQuo. 
+	
+	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 0). 
+]
+
 { #category : #'tests - primitiveQuo' }
 VMPrimitiveTest >> testPrimitiveQuoWith0DivisionOnSecondOperand [
 	
 	interpreter push: (memory integerObjectOf: 4).
 	interpreter push: (memory integerObjectOf: 0).
+	
+	interpreter primitiveQuo. 
+	
+	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 0). 
+]
+
+{ #category : #'tests - quick primitives' }
+VMPrimitiveTest >> testPrimitiveQuoWith0DivisionOnSecondOperandQuick [
+	
+	interpreter push: (memory integerObjectOf: 4).
+	interpreter primitivePushZero.
 	
 	interpreter primitiveQuo. 
 	
@@ -3237,6 +3457,21 @@ VMPrimitiveTest >> testPrimitiveQuoWithNoErrorPopsOperands [
 	interpreter push: (memory integerObjectOf: 42). "Marker"
 	interpreter push: (memory integerObjectOf: 1).
 	interpreter push: (memory integerObjectOf: 2).
+	
+	interpreter primitiveQuo. 
+	
+	interpreter popStack. 
+	"The previous lines pop the result of primiviteAdd (1 2) for us to check that 1 and 2 were poped from the Stack by checking that the next value is our marker, for instance 42"
+	
+	self assert: interpreter stackTop equals: (memory integerObjectOf: 42). 
+]
+
+{ #category : #'tests - quick primitives' }
+VMPrimitiveTest >> testPrimitiveQuoWithNoErrorPopsOperandsQuick [
+	
+	interpreter push: (memory integerObjectOf: 42). "Marker"
+	interpreter primitivePushOne.
+	interpreter primitivePushTwo.
 	
 	interpreter primitiveQuo. 
 	
@@ -5119,6 +5354,35 @@ VMPrimitiveTest >> testPrimitiveSubtractWithOverflowPreservesStack [
 	self assert: (interpreter stackValue: 1) equals: minSmallInt.
 	
 	
+]
+
+{ #category : #'tests - quick primitives' }
+VMPrimitiveTest >> testPrimitiveSubtractWithOverflowPreservesStackQuick [
+
+	| minSmallInt |
+	
+	minSmallInt:= (memory integerObjectOf: memory minSmallInteger). 
+	
+	interpreter push: minSmallInt. 
+	interpreter primitivePushTwo.
+	
+	interpreter primitiveSubtract. 
+	
+	self assert: interpreter stackTop equals: (memory integerObjectOf: 2). 
+	self assert: (interpreter stackValue: 1) equals: minSmallInt.
+	
+	
+]
+
+{ #category : #'tests - quick primitives' }
+VMPrimitiveTest >> testPrimitiveSubtractWithOverflowQuick [
+
+	interpreter push: (memory integerObjectOf: memory minSmallInteger).
+	interpreter primitivePushTwo.
+	
+	interpreter primitiveSubtract. 
+	
+	self assert: interpreter failed.
 ]
 
 { #category : #'tests - primitiveVMParameter' }

--- a/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
@@ -27,20 +27,24 @@ VMPrimitiveTest >> assert: anOop contentEquals: oopToCompare [
 ]
 
 { #category : #'tests - quick primitives' }
-VMPrimitiveTest >> assert: aBlock pushed: anOop [
+VMPrimitiveTest >> assert: aBlock quickPushed: anOop [
 
-	| oldStackSize |
+	| oldStackSize oldFrameSize |
 
 	stackBuilder 
 		addNewFrame; 
 		buildStack.
 	oldStackSize := interpreter stackPointer.
+	oldFrameSize := stackBuilder frames size.
 	aBlock value.
 	
-	self assert: interpreter stackPointer equals: oldStackSize - memory wordSize.
+	"Check that we did not created a new frame for the quick stuff"
+	self assert: stackBuilder frames size equals: oldFrameSize.
+	"Check that the SP has the same size as before, since quicks replace the top of the stack"
+	self assert: interpreter stackPointer equals: oldStackSize.
+	"Check that the stack top now has the oop we pushed"
 	self assert: interpreter stackTop equals: anOop.
-	
-	
+
 ]
 
 { #category : #'as yet unclassified' }
@@ -194,12 +198,15 @@ VMPrimitiveTest >> testPrimitiveAddFailsWithTypeErrorPreservesStackQuick [
 	
 	string := self newString: '42'.
 	interpreter push: string. 
+	interpreter push: 0.
 	interpreter primitivePushTwo.
 	
 	interpreter primitiveAdd. 
 
+	self assert: interpreter failed.
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 2).
 	self assert: (interpreter stackValue: 1) equals: string. 
+
 ]
 
 { #category : #'tests - primitiveAdd' }
@@ -3195,7 +3202,7 @@ VMPrimitiveTest >> testPrimitivePushFalse [
 
 	self 
 		assert: [ interpreter primitivePushFalse ]
-		pushed: memory falseObject
+		quickPushed: memory falseObject
 .
 ]
 
@@ -3204,7 +3211,7 @@ VMPrimitiveTest >> testPrimitivePushMinusOne [
 
 	self 
 		assert: [ interpreter primitivePushMinusOne ]
-		pushed: (memory integerObjectOf: -1)
+		quickPushed: (memory integerObjectOf: -1)
 
 ]
 
@@ -3213,7 +3220,7 @@ VMPrimitiveTest >> testPrimitivePushNil [
 
 	self 
 		assert: [ interpreter primitivePushNil ]
-		pushed: memory nilObject
+		quickPushed: memory nilObject
  	
 ]
 
@@ -3222,7 +3229,7 @@ VMPrimitiveTest >> testPrimitivePushOne [
 
 	self 
 		assert: [ interpreter primitivePushOne ]
-		pushed: (memory integerObjectOf: 1)
+		quickPushed: (memory integerObjectOf: 1)
  	
 ]
 
@@ -3233,6 +3240,7 @@ VMPrimitiveTest >> testPrimitivePushOneAndAdd [
 		addNewFrame; 
 		buildStack.
 	interpreter primitivePushOne.
+	interpreter push: 0.
 	interpreter primitivePushOne.
 	interpreter primitiveAdd.
 
@@ -3274,7 +3282,7 @@ VMPrimitiveTest >> testPrimitivePushTrue [
 
 	self 
 		assert: [ interpreter primitivePushTrue ]
-		pushed: memory trueObject
+		quickPushed: memory trueObject
 	
 ]
 
@@ -3283,7 +3291,7 @@ VMPrimitiveTest >> testPrimitivePushTwo [
 
 	self 
 		assert: [ interpreter primitivePushTwo ]
-		pushed: (memory integerObjectOf: 2)
+		quickPushed: (memory integerObjectOf: 2)
 ]
 
 { #category : #'tests - quick primitives' }
@@ -3291,7 +3299,7 @@ VMPrimitiveTest >> testPrimitivePushZero [
 
 	self 
 		assert: [ interpreter primitivePushZero ]
-		pushed: (memory integerObjectOf: 0)
+		quickPushed: (memory integerObjectOf: 0)
 
 ]
 


### PR DESCRIPTION
This PR modifies the primitive table to enable quick primitive methods to be executed in the Stack VM conforming to the standard execution of primitives, and replacing the need to use executeQuickPrimitive method testing for multiple primitive numbers. So it makes the logic more consistent with primitive execution.

Add a basic set of tests which verifies the state of the execution stack before and after the usage of quick primitives.
