### PR TITLE
Fixes #14768: File class>>primFileAttributes😷 answers corrupted result

### DIFF
--- a/extracted/plugins/FileAttributesPlugin/src/unix/faSupport.c
+++ b/extracted/plugins/FileAttributesPlugin/src/unix/faSupport.c
@@ -478,8 +478,10 @@ char		targetFile[FA_PATH_MAX];
 		if (S_ISLNK(statBuf.st_mode)) {
 			/* This is a symbolic link, provide the target filename */
 			status = readlink(faGetPlatPath(aFaPath), targetFile, FA_PATH_MAX);
-			if (status >= 0)
-				targetOop = pathNameToOop(targetFile); } }
+			if (status >= 0) {
+				targetFile[status] = 0;
+				targetOop = pathNameToOop(targetFile); } } }
+			
 	else {
 		status = stat(faGetPlatPath(aFaPath), &statBuf);
 		if (status)


### PR DESCRIPTION
Set the null terminator in the targetFile buffer

Fixes: https://github.com/pharo-project/pharo/issues/14786