### PR TITLE
Updating to new tonel format [WIP]

### DIFF
--- a/smalltalksrc/VMMakerTests/Array.extension.st
+++ b/smalltalksrc/VMMakerTests/Array.extension.st
@@ -1,13 +1,13 @@
-Extension { #name : #Array }
+Extension { #name : 'Array' }
 
-{ #category : #'*VMMakerTests' }
+{ #category : '*VMMakerTests' }
 Array >> forMemory: aMemory inMethod: anObject [
 
 	^ aMemory newArrayWith: (self collect: [ :anElement | 
 			   anElement forMemory: aMemory inMethod: nil ])
 ]
 
-{ #category : #'*VMMakerTests' }
+{ #category : '*VMMakerTests' }
 Array >> forMethodBuilder: aBuilder [
 
 	^ self forMemory: aBuilder memory

--- a/smalltalksrc/VMMakerTests/ByteSymbol.extension.st
+++ b/smalltalksrc/VMMakerTests/ByteSymbol.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #ByteSymbol }
+Extension { #name : 'ByteSymbol' }
 
-{ #category : #'*VMMakerTests' }
+{ #category : '*VMMakerTests' }
 ByteSymbol >> forMemory: aMemory inMethod: anObject [ 
 
 	| vmString instSpec numSlots |
@@ -27,7 +27,7 @@ ByteSymbol >> forMemory: aMemory inMethod: anObject [
 	^ vmString
 ]
 
-{ #category : #'*VMMakerTests' }
+{ #category : '*VMMakerTests' }
 ByteSymbol >> forMethodBuilder: aBuilder [
 
 	^ self forMemory: aBuilder memory

--- a/smalltalksrc/VMMakerTests/Character.extension.st
+++ b/smalltalksrc/VMMakerTests/Character.extension.st
@@ -1,12 +1,12 @@
-Extension { #name : #Character }
+Extension { #name : 'Character' }
 
-{ #category : #'*VMMakerTests' }
+{ #category : '*VMMakerTests' }
 Character >> forMemory: memory [
 
 	^ memory characterObjectOf: self codePoint
 ]
 
-{ #category : #'*VMMakerTests' }
+{ #category : '*VMMakerTests' }
 Character >> forMethodBuilder: aBuilder [
 
 	^ self forMemory: aBuilder memory

--- a/smalltalksrc/VMMakerTests/Cogit.extension.st
+++ b/smalltalksrc/VMMakerTests/Cogit.extension.st
@@ -1,28 +1,28 @@
-Extension { #name : #Cogit }
+Extension { #name : 'Cogit' }
 
-{ #category : #'*VMMakerTests' }
+{ #category : '*VMMakerTests' }
 Cogit >> byte0: anInteger [
 
 	byte0 := anInteger
 ]
 
-{ #category : #'*VMMakerTests' }
+{ #category : '*VMMakerTests' }
 Cogit >> inBlock: anInteger [ 
 	inBlock := anInteger
 ]
 
-{ #category : #'*VMMakerTests' }
+{ #category : '*VMMakerTests' }
 Cogit >> methodOrBlockNumArgs: anInteger [ 
 	methodOrBlockNumArgs := anInteger
 ]
 
-{ #category : #'*VMMakerTests' }
+{ #category : '*VMMakerTests' }
 Cogit >> needsFrame [ 
 
 	^ true
 ]
 
-{ #category : #'*VMMakerTests' }
+{ #category : '*VMMakerTests' }
 Cogit >> needsFrame: aFalse [ 
 	needsFrame := aFalse
 ]

--- a/smalltalksrc/VMMakerTests/CompiledBlock.extension.st
+++ b/smalltalksrc/VMMakerTests/CompiledBlock.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #CompiledBlock }
+Extension { #name : 'CompiledBlock' }
 
-{ #category : #'*VMMakerTests' }
+{ #category : '*VMMakerTests' }
 CompiledBlock >> forMemory: memory inMethod: aMethodBuilder [ 
 
 	| methodBuilder |

--- a/smalltalksrc/VMMakerTests/DummyProcessor.class.st
+++ b/smalltalksrc/VMMakerTests/DummyProcessor.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #DummyProcessor,
-	#superclass : #Object,
+	#name : 'DummyProcessor',
+	#superclass : 'Object',
 	#instVars : [
 		'stackPointer',
 		'framePointer',
@@ -10,149 +10,151 @@ Class {
 		'linkRegisterValue',
 		'receiverRegisterValue'
 	],
-	#category : #'VMMakerTests-JitTests'
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DummyProcessor >> baseRegisterValue: anInteger [ 
 	
 	baseRegisterValue := anInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DummyProcessor >> cResultRegister [
 	
 	^ nil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DummyProcessor >> disassembler [
 	
 	^ LLVMDisassembler aarch64
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 DummyProcessor >> flushICacheFrom: anInteger to: anInteger2 [ 
 	
 	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DummyProcessor >> fp [
 	
 	^ framePointer 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DummyProcessor >> fp: anInteger [ 
 	
 	framePointer := anInteger 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DummyProcessor >> framePointerRegisterValue: anInteger [ 
 
 	framePointer := anInteger 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DummyProcessor >> hasLinkRegister [
 	
 	^ true
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 DummyProcessor >> initializeStackFor: aSimpleStackBasedCogit [ 
 
 	"We are dummy...."
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DummyProcessor >> instructionPointerRegisterValue [
 	
 	^ programCounter 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DummyProcessor >> integerRegisterState [
 	
 	^ #()
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DummyProcessor >> linkRegisterValue: anInteger [ 
 
 	linkRegisterValue := anInteger 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DummyProcessor >> machineSimulator [
 	
 	^ self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DummyProcessor >> memoryAt: anInteger write: aCollection size: anInteger3 [ 
 
 	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DummyProcessor >> pc [
 	
 	^ programCounter
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DummyProcessor >> pc: anInteger [ 
 	
 	programCounter := anInteger
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 DummyProcessor >> pushWord: anInteger [ 
 
 	stackPointer := stackPointer - 8
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DummyProcessor >> receiverRegisterValue: anInteger [ 
 
 	receiverRegisterValue := anInteger 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DummyProcessor >> runUntil: anInteger [ 
 	
 	programCounter := anInteger
 	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DummyProcessor >> setFramePointer: aFPValue stackPointer: aSPValue [
  
 	stackPointer := aSPValue.
 	framePointer := aFPValue 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DummyProcessor >> simulateLeafCallOf: anInteger nextpc: anInteger2 memory: anUndefinedObject [ 
 
 	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DummyProcessor >> smalltalkStackPointerRegisterValue [
 	^ smalltalkStackPointerRegisterValue
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DummyProcessor >> smalltalkStackPointerRegisterValue: anInteger [ 
 
 	smalltalkStackPointerRegisterValue := anInteger 	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 DummyProcessor >> sp [
 	
 	^ stackPointer 

--- a/smalltalksrc/VMMakerTests/ExitInterpreter.class.st
+++ b/smalltalksrc/VMMakerTests/ExitInterpreter.class.st
@@ -1,13 +1,14 @@
 Class {
-	#name : #ExitInterpreter,
-	#superclass : #Error,
+	#name : 'ExitInterpreter',
+	#superclass : 'Error',
 	#instVars : [
 		'returnValue'
 	],
-	#category : #VMMakerTests
+	#category : 'VMMakerTests',
+	#package : 'VMMakerTests'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ExitInterpreter >> returnValue: anInteger [ 
 	
 	returnValue := anInteger

--- a/smalltalksrc/VMMakerTests/LiteralVariable.extension.st
+++ b/smalltalksrc/VMMakerTests/LiteralVariable.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #LiteralVariable }
+Extension { #name : 'LiteralVariable' }
 
-{ #category : #'*VMMakerTests' }
+{ #category : '*VMMakerTests' }
 LiteralVariable >> forMemory: aMemory inMethod: anObject [
 
 	| aVariable |

--- a/smalltalksrc/VMMakerTests/ManifestVMMakerTests.class.st
+++ b/smalltalksrc/VMMakerTests/ManifestVMMakerTests.class.st
@@ -2,26 +2,28 @@
 I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
 "
 Class {
-	#name : #ManifestVMMakerTests,
-	#superclass : #PackageManifest,
-	#category : #'VMMakerTests-Manifest'
+	#name : 'ManifestVMMakerTests',
+	#superclass : 'PackageManifest',
+	#category : 'VMMakerTests-Manifest',
+	#package : 'VMMakerTests',
+	#tag : 'Manifest'
 }
 
-{ #category : #'code-critics' }
+{ #category : 'code-critics' }
 ManifestVMMakerTests class >> ruleBadMessageRule2V1FalsePositive [
 
 	<ignoreForCoverage>
 	^ #(#(#(#RGMethodDefinition #(#UnicornARMv8Simulator #smashCallerSavedRegistersWithValuesFrom:by:in: #false)) #'2023-05-12T09:19:16.384586+02:00') #(#(#RGMethodDefinition #(#UnicornARMv8Simulator #postCallArgumentsNumArgs:in: #false)) #'2023-05-12T09:20:41.357283+02:00') #(#(#RGMethodDefinition #(#ProcessorSimulator #smashRegistersWithValuesFrom:by: #false)) #'2023-05-12T09:25:17.137958+02:00') )
 ]
 
-{ #category : #'code-critics' }
+{ #category : 'code-critics' }
 ManifestVMMakerTests class >> rulePrecedenceRuleV1FalsePositive [
 
 	<ignoreForCoverage>
 	^ #(#(#(#RGPackageDefinition #(#VMMakerTests)) #'2023-05-12T09:19:42.605517+02:00') )
 ]
 
-{ #category : #'code-critics' }
+{ #category : 'code-critics' }
 ManifestVMMakerTests class >> ruleUncommonMessageSendRuleV1FalsePositive [
 	^ #(#(#(#RGPackageDefinition #(#VMMakerTests)) #'2020-07-24T12:05:44.86595+02:00') )
 ]

--- a/smalltalksrc/VMMakerTests/MethodBuilderTest.class.st
+++ b/smalltalksrc/VMMakerTests/MethodBuilderTest.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #MethodBuilderTest,
-	#superclass : #VMInterpreterTests,
+	#name : 'MethodBuilderTest',
+	#superclass : 'VMInterpreterTests',
 	#instVars : [
 		'literals',
 		'numberOfArguments',
@@ -11,17 +11,19 @@ Class {
 		'methodHeader',
 		'method'
 	],
-	#category : #'VMMakerTests-InterpreterTests'
+	#category : 'VMMakerTests-InterpreterTests',
+	#package : 'VMMakerTests',
+	#tag : 'InterpreterTests'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 MethodBuilderTest >> testAddingBytecodesDoesntOverrideHeader [
 	method := methodBuilder newMethod buildMethod.
 	
 	self assert: methodBuilder buildMethodHeader equals: (memory integerValueOf: (memory fetchPointer: 0 ofObject: method)).
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 MethodBuilderTest >> testAllocatingMethodDoesntOverflows [
 	method := methodBuilder newMethod; buildMethod.
 
@@ -33,14 +35,14 @@ MethodBuilderTest >> testAllocatingMethodDoesntOverflows [
 	self shouldnt:[ methodBuilder newMethod; buildMethod ] raise: AssertionFailure
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 MethodBuilderTest >> testBuildEmptyMethodIsCompiledMethod [
 	"checking the format"
 	method := methodBuilder newMethod; buildMethod.
 	self assert: (memory isCompiledMethod: method)
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 MethodBuilderTest >> testBytecodeAtForMethodWithNoLiteral [
 	| bytecodeAddress |
 	literals := { }.
@@ -54,7 +56,7 @@ MethodBuilderTest >> testBytecodeAtForMethodWithNoLiteral [
 	self assert: (memory byteAt: bytecodeAddress) equals: 1
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 MethodBuilderTest >> testBytecodeAtForMethodWithOneLiteral [
 
 	| bytecodeAddress |
@@ -69,7 +71,7 @@ MethodBuilderTest >> testBytecodeAtForMethodWithOneLiteral [
 	self assert: (memory byteAt: bytecodeAddress) equals: 1
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 MethodBuilderTest >> testBytecodeAtForMethodWithTwoLiteral [
 
 	| bytecodeAddress |
@@ -84,13 +86,13 @@ MethodBuilderTest >> testBytecodeAtForMethodWithTwoLiteral [
 	self assert: (memory byteAt: bytecodeAddress) equals: 1
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 MethodBuilderTest >> testClassOfCompiledMethodIsCompiledMethod [
 	
 	self assert: (memory fetchClassOf: methodBuilder newMethod buildMethod) equals: (memory splObj: 16).
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 MethodBuilderTest >> testGeneratingCompiledMethod [
 
 	method := methodBuilder newMethod
@@ -99,7 +101,7 @@ MethodBuilderTest >> testGeneratingCompiledMethod [
 	self assert: (memory isCompiledMethod: method)
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 MethodBuilderTest >> testInstanciateMethodShouldTakeOneSlotForEightBytecodes [
 
 	| numberOfByteCode |
@@ -114,7 +116,7 @@ MethodBuilderTest >> testInstanciateMethodShouldTakeOneSlotForEightBytecodes [
 		equals: 1 + (numberOfByteCode / wordSize) ceiling
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 MethodBuilderTest >> testInstanciateMethodShouldTakeTwoSlotForNineBytecodes [
 
 	| numberOfByteCode |
@@ -129,7 +131,7 @@ MethodBuilderTest >> testInstanciateMethodShouldTakeTwoSlotForNineBytecodes [
 		equals: 1 + (numberOfByteCode / wordSize) ceiling
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 MethodBuilderTest >> testSecondBytecodeAtForMethodWithOneLiteral [
 
 	| bytecodeAddress |

--- a/smalltalksrc/VMMakerTests/MockVMStructWithReservedWords.class.st
+++ b/smalltalksrc/VMMakerTests/MockVMStructWithReservedWords.class.st
@@ -1,27 +1,28 @@
 Class {
-	#name : #MockVMStructWithReservedWords,
-	#superclass : #VMStructType,
+	#name : 'MockVMStructWithReservedWords',
+	#superclass : 'VMStructType',
 	#instVars : [
 		'foo',
 		'case'
 	],
-	#category : #VMMakerTests
+	#category : 'VMMakerTests',
+	#package : 'VMMakerTests'
 }
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 MockVMStructWithReservedWords class >> instVarNamesAndTypesForTranslationDo: aBinaryBlock [
 	
 	aBinaryBlock value: 'foo' value: 'char *'.
 	aBinaryBlock value: 'case' value: 'char *'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MockVMStructWithReservedWords >> case [
 
 	^ case
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MockVMStructWithReservedWords >> case: anObject [
 
 	case := anObject

--- a/smalltalksrc/VMMakerTests/MockVMStructWithoutTypeDeclarations.class.st
+++ b/smalltalksrc/VMMakerTests/MockVMStructWithoutTypeDeclarations.class.st
@@ -1,14 +1,15 @@
 Class {
-	#name : #MockVMStructWithoutTypeDeclarations,
-	#superclass : #VMStructType,
+	#name : 'MockVMStructWithoutTypeDeclarations',
+	#superclass : 'VMStructType',
 	#instVars : [
 		'foo',
 		'bar'
 	],
-	#category : #VMMakerTests
+	#category : 'VMMakerTests',
+	#package : 'VMMakerTests'
 }
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 MockVMStructWithoutTypeDeclarations class >> instVarNamesAndTypesForTranslationDo: aBinaryBlock [
 	"Missing the bar type declaration"
 	

--- a/smalltalksrc/VMMakerTests/ParametrizedTestMatrix.extension.st
+++ b/smalltalksrc/VMMakerTests/ParametrizedTestMatrix.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #ParametrizedTestMatrix }
+Extension { #name : 'ParametrizedTestMatrix' }
 
-{ #category : #'*VMMakerTests' }
+{ #category : '*VMMakerTests' }
 ParametrizedTestMatrix >> + aParametrizedTestMatrix [
 
 	| newMatrix |

--- a/smalltalksrc/VMMakerTests/ProcessorSimulator.class.st
+++ b/smalltalksrc/VMMakerTests/ProcessorSimulator.class.st
@@ -1,46 +1,48 @@
 Class {
-	#name : #ProcessorSimulator,
-	#superclass : #Object,
+	#name : 'ProcessorSimulator',
+	#superclass : 'Object',
 	#instVars : [
 		'simulator',
 		'registerAliases',
 		'registerSmalltalkAliases',
 		'memory'
 	],
-	#category : #'VMMakerTests-Unicorn'
+	#category : 'VMMakerTests-Unicorn',
+	#package : 'VMMakerTests',
+	#tag : 'Unicorn'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ProcessorSimulator class >> ARMv5 [
 
 	^ UnicornARMv5Simulator new
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ProcessorSimulator class >> ARMv8 [
 
 	^ UnicornARMv8Simulator new
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ProcessorSimulator class >> IA32 [
 
 	^ UnicornI386Simulator new
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ProcessorSimulator class >> X64 [
 
 	^ UnicornX64Simulator new
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ProcessorSimulator class >> aarch64 [
 
 	^ UnicornARMv8Simulator new
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ProcessorSimulator class >> riscv64 [
 
 	"TODO: Add riscv32 and possibly two subclasses for the RISCV simulator"
@@ -48,203 +50,203 @@ ProcessorSimulator class >> riscv64 [
 	"^ SpikeRISCVSimulator new"
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 ProcessorSimulator class >> simulatorFor: isa [
 
 	^ (self subclasses detect: [ :each | each supportsISA: isa ]) perform: isa asSymbol
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessorSimulator >> aliasForRegister: aRegisterName [
 
 	^ registerAliases at: aRegisterName ifAbsent: [ '' ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessorSimulator >> aliasSmalltalkForRegister: aRegisterName [
 
 	^ registerSmalltalkAliases at: aRegisterName ifAbsent: [ '' ]
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> arg0Register [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> arg0RegisterValue [
 
 	^ self readRegister: self arg0Register
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> arg0RegisterValue: aValue [
 
 	^ self writeRegister: self arg0Register value: aValue
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> arg1Register [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> arg1RegisterValue [
 
 	^ self readRegister: self arg1Register
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> arg1RegisterValue: aValue [
 
 	^ self writeRegister: self arg1Register value: aValue
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> baseRegister [
 
 	self subclassResponsibility
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> baseRegisterValue [
 
 	^ self readRegister: self baseRegister
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> baseRegisterValue: aValue [
 
 	^ self writeRegister: self baseRegister value: aValue
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 ProcessorSimulator >> cResultRegister [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 ProcessorSimulator >> cResultRegisterValue [
 
 	^ self readRegister: self cResultRegister
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 ProcessorSimulator >> cResultRegisterValue: aValue [
 
 	self writeRegister: self cResultRegister value: aValue
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 ProcessorSimulator >> carg0 [
 
 	"By default fetch values from registers, override in platforms that don't (e.g. IA32)"
 	^ self carg0RegisterValue
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 ProcessorSimulator >> carg0Register [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 ProcessorSimulator >> carg0RegisterValue [
 
 	^ self readRegister: self carg0Register
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 ProcessorSimulator >> carg1 [
 
 	"By default fetch values from registers, override in platforms that don't (e.g. IA32)"
 	^ self carg1RegisterValue
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 ProcessorSimulator >> carg1Register [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 ProcessorSimulator >> carg1RegisterValue [
 
 	^ self readRegister: self carg1Register
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 ProcessorSimulator >> carg2 [
 
 	"By default fetch values from registers, override in platforms that don't (e.g. IA32)"
 	^ self carg2RegisterValue
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 ProcessorSimulator >> carg2Register [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 ProcessorSimulator >> carg2RegisterValue [
 
 	^ self readRegister: self carg2Register
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 ProcessorSimulator >> carg3 [
 
 	"By default fetch values from registers, override in platforms that don't (e.g. IA32)"
 	^ self carg3RegisterValue
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 ProcessorSimulator >> carg3Register [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 ProcessorSimulator >> carg3RegisterValue [
 
 	^ self readRegister: self carg3Register
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> classRegister [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> classRegisterValue [
 
 	^ self readRegister: self classRegister
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> classRegisterValue: aValue [
 
 	^ self writeRegister: self classRegister value: aValue
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessorSimulator >> cogit [
 
 	^ memory interpreter cogit
 ]
 
-{ #category : #disassembling }
+{ #category : 'disassembling' }
 ProcessorSimulator >> disassembleCurrentInstruction [
 
 	^ (self disassembleFrom: self instructionPointerRegisterValue opcodes: 1) first
 ]
 
-{ #category : #disassembling }
+{ #category : 'disassembling' }
 ProcessorSimulator >> disassembleFrom: anIndex opcodes: numberOfInstructions [
 
 	^ self disassembler
@@ -255,7 +257,7 @@ ProcessorSimulator >> disassembleFrom: anIndex opcodes: numberOfInstructions [
 		pc: self instructionPointerRegisterValue
 ]
 
-{ #category : #disassembling }
+{ #category : 'disassembling' }
 ProcessorSimulator >> disassembleFrom: start to: stop [
 
 	^ self disassembler
@@ -266,114 +268,114 @@ ProcessorSimulator >> disassembleFrom: start to: stop [
 		pc: self instructionPointerRegisterValue
 ]
 
-{ #category : #disassembling }
+{ #category : 'disassembling' }
 ProcessorSimulator >> disassembler [
 	self subclassResponsibility
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> doublePrecisionFloatingPointRegister0 [
 
 	self subclassResponsibility
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> doublePrecisionFloatingPointRegister0Value [
 
 	^ self readFloat64Register: self doublePrecisionFloatingPointRegister0
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> doublePrecisionFloatingPointRegister0Value: aValue [
 
 	^ self writeFloat64Register: self doublePrecisionFloatingPointRegister0 value: aValue
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> doublePrecisionFloatingPointRegister1 [
 
 	self subclassResponsibility
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> doublePrecisionFloatingPointRegister1Value [
 
 	^ self readFloat64Register: self doublePrecisionFloatingPointRegister1
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> doublePrecisionFloatingPointRegister1Value: aValue [
 
 	^ self writeFloat64Register: self doublePrecisionFloatingPointRegister1 value: aValue
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> doublePrecisionFloatingPointRegister2 [
 
 	self subclassResponsibility
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> doublePrecisionFloatingPointRegister2Value [
 
 	^ self readFloat64Register: self doublePrecisionFloatingPointRegister2
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> doublePrecisionFloatingPointRegister2Value: aValue [
 
 	^ self writeFloat64Register: self doublePrecisionFloatingPointRegister2 value: aValue
 ]
 
-{ #category : #disassembling }
+{ #category : 'disassembling' }
 ProcessorSimulator >> extractDestinationRegisterFromAssembly: aLLVMInstruction [
 
 	^  self subclassResponsibility
 ]
 
-{ #category : #memory }
+{ #category : 'memory' }
 ProcessorSimulator >> finishMappingMemory [
 
 	self subclassResponsibility
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> flushICacheFrom: startAddress to: endAddress [
 
 	simulator removeInstructionCacheFrom: startAddress to: endAddress
 ]
 
-{ #category : #'accessing-registers-shortcuts' }
+{ #category : 'accessing-registers-shortcuts' }
 ProcessorSimulator >> fp [
 
 	^ self framePointerRegisterValue
 ]
 
-{ #category : #'accessing-registers-shortcuts' }
+{ #category : 'accessing-registers-shortcuts' }
 ProcessorSimulator >> fp: aValue [
 
 	^ self framePointerRegisterValue: aValue
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> framePointerRegister [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> framePointerRegisterValue [
 
 	^ self readRegister: self framePointerRegister
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> framePointerRegisterValue: aValue [
 
 	self writeRegister: self framePointerRegister value: aValue
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessorSimulator >> getLastAddress: abstractInstructions [ 
 	
 	| last |
@@ -381,13 +383,13 @@ ProcessorSimulator >> getLastAddress: abstractInstructions [
 	^ last address + last machineCodeSize 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ProcessorSimulator >> hasLinkRegister [
 
 	^ false
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ProcessorSimulator >> initialize [ 
 
 	super initialize.
@@ -397,91 +399,91 @@ ProcessorSimulator >> initialize [
 	self initializeRegisterSmalltalkAliases.
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ProcessorSimulator >> initializeRegisterAliases [
 
 	"Hook for subclasses"
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ProcessorSimulator >> initializeRegisterSmalltalkAliases [
 
 	"Hook for subclasses"
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> instructionPointerRegister [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> instructionPointerRegisterValue [
 
 	^ self readRegister: self instructionPointerRegister
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> instructionPointerRegisterValue: aValue [
 
 	^ self writeRegister: self instructionPointerRegister value: aValue
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> integerRegisterState [
 
 	^ {  }
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessorSimulator >> lastExecutedInstructionAddress [
 
 	^ simulator lastExecutedInstructionAddress
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessorSimulator >> lastExecutedInstructionSize [
 
 	^ simulator lastExecutedInstructionSize
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessorSimulator >> lastInstructionCount [
 
 	^ simulator lastInstructionCount
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> linkRegister [
 
 	self subclassResponsibility
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> linkRegisterValue [
 
 	^ self readRegister: self linkRegister
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> linkRegisterValue: aValue [
 
 	^ self writeRegister: self linkRegister value: aValue
 ]
 
-{ #category : #'accessing-registers-shortcuts' }
+{ #category : 'accessing-registers-shortcuts' }
 ProcessorSimulator >> lr [
 
 	^ self linkRegisterValue
 ]
 
-{ #category : #'accessing-registers-shortcuts' }
+{ #category : 'accessing-registers-shortcuts' }
 ProcessorSimulator >> lr: aValue [
 
 	^ self linkRegisterValue: aValue
 ]
 
-{ #category : #memory }
+{ #category : 'memory' }
 ProcessorSimulator >> mapMemory: aMemory at: anAddress [
 
 	simulator
@@ -490,7 +492,7 @@ ProcessorSimulator >> mapMemory: aMemory at: anAddress [
 		withPermissions: UnicornConstants permissionAll.
 ]
 
-{ #category : #memory }
+{ #category : 'memory' }
 ProcessorSimulator >> mapMemoryInManager: aSlangMemoryManager [
 
 	aSlangMemoryManager regionsDo: [ :startAddress :region |
@@ -500,42 +502,42 @@ ProcessorSimulator >> mapMemoryInManager: aSlangMemoryManager [
 	self finishMappingMemory.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessorSimulator >> memory [
 	^ memory
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessorSimulator >> memory: aSpur64BitMMLECoSimulator [
 
 	memory := aSpur64BitMMLECoSimulator
 ]
 
-{ #category : #memory }
+{ #category : 'memory' }
 ProcessorSimulator >> memoryAt: address readNext: byteSize [
 
 	^ simulator memoryAt: address readNext: byteSize
 ]
 
-{ #category : #memory }
+{ #category : 'memory' }
 ProcessorSimulator >> memoryAt: address write: bytes size: size [
 
 	simulator memoryAt: address write: bytes size: size
 ]
 
-{ #category : #'accessing-registers-shortcuts' }
+{ #category : 'accessing-registers-shortcuts' }
 ProcessorSimulator >> pc [
 
 	^ self instructionPointerRegisterValue
 ]
 
-{ #category : #'accessing-registers-shortcuts' }
+{ #category : 'accessing-registers-shortcuts' }
 ProcessorSimulator >> pc: aValue [
 
 	^ self instructionPointerRegisterValue: aValue
 ]
 
-{ #category : #'accessing-stack' }
+{ #category : 'accessing-stack' }
 ProcessorSimulator >> peek [
 
 	| stackAddressIntegerValue peekedByteArray |
@@ -549,13 +551,13 @@ ProcessorSimulator >> peek [
 	^ peekedByteArray
 ]
 
-{ #category : #'accessing-stack' }
+{ #category : 'accessing-stack' }
 ProcessorSimulator >> peekAddress [
 
 	^ self peek integerAt: 1 size: self wordSize signed: false
 ]
 
-{ #category : #'accessing-stack' }
+{ #category : 'accessing-stack' }
 ProcessorSimulator >> popBytes [
 
 	| stackAddressIntegerValue aByteArray |
@@ -572,7 +574,7 @@ ProcessorSimulator >> popBytes [
 	^ aByteArray
 ]
 
-{ #category : #'accessing-stack' }
+{ #category : 'accessing-stack' }
 ProcessorSimulator >> popWord [
 
 	| aByteArray |
@@ -580,7 +582,7 @@ ProcessorSimulator >> popWord [
 	^ aByteArray integerAt: 1 size: self wordSize signed: false.
 ]
 
-{ #category : #'accessing-stack' }
+{ #category : 'accessing-stack' }
 ProcessorSimulator >> pushBytes: aByteArray [
 
 	| stackAddressIntegerValue |
@@ -601,7 +603,7 @@ ProcessorSimulator >> pushBytes: aByteArray [
 
 ]
 
-{ #category : #'accessing-stack' }
+{ #category : 'accessing-stack' }
 ProcessorSimulator >> pushWord: anInteger [
 
 	| aByteArray |
@@ -610,7 +612,7 @@ ProcessorSimulator >> pushWord: anInteger [
 	self pushBytes: aByteArray
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> readFloat64Register: aRegisterID [
 
 	| registerValue |
@@ -620,7 +622,7 @@ ProcessorSimulator >> readFloat64Register: aRegisterID [
 	^ registerValue doubleAt: 1
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> readRawRegister: aRegisterID size: aSize [
 
 	| registerValue |
@@ -629,7 +631,7 @@ ProcessorSimulator >> readRawRegister: aRegisterID size: aSize [
 	^ registerValue
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> readRegister: aRegisterID [
 
 	| registerValue size |
@@ -638,37 +640,37 @@ ProcessorSimulator >> readRegister: aRegisterID [
 	^ registerValue integerAt: 1 size: size signed: false
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> receiverRegister [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> receiverRegisterValue [
 
 	^ self readRegister: self receiverRegister
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> receiverRegisterValue: anInteger [
 
 	self writeRegister: self receiverRegister value: anInteger
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> register: anIndex readInto: aByteArray [
 
 	simulator register: anIndex readInto: aByteArray
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> registerAliases [
 
 	^ registerAliases
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> registerDescriptors [
 
 	^ self registerList collect: [ :reg |
@@ -680,98 +682,98 @@ ProcessorSimulator >> registerDescriptors [
 			yourself ]
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> registerList [
 
 	self subclassResponsibility
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> sendNumberOfArgumentsRegister [
 
 	self subclassResponsibility
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> sendNumberOfArgumentsRegisterValue [
 
 	^ self readRegister: self sendNumberOfArgumentsRegister
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> sendNumberOfArgumentsRegisterValue: aValue [
 
 	^ self writeRegister: self sendNumberOfArgumentsRegister value: aValue
 ]
 
-{ #category : #'simulation-support' }
+{ #category : 'simulation-support' }
 ProcessorSimulator >> simulateLeafCallOf: address nextpc: nextpc memory: aMemory [
 
 	self subclassResponsibility
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> smalltalkStackPointerRegister [
 	"By default they are the same"
 	^ self stackPointerRegister
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> smalltalkStackPointerRegisterValue [
 
 	^ self readRegister: self smalltalkStackPointerRegister
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> smalltalkStackPointerRegisterValue: aValue [
 
 	self writeRegister: self smalltalkStackPointerRegister value: aValue
 ]
 
-{ #category : #'simulation-support' }
+{ #category : 'simulation-support' }
 ProcessorSimulator >> smashRegisterAccessors [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> smashRegistersWithValuesFrom: base by: step [
 
 	self smashRegisterAccessors withIndexDo: [:accessor :index|
 		self perform: accessor with: index - 1 * step + base]
 ]
 
-{ #category : #'accessing-registers-shortcuts' }
+{ #category : 'accessing-registers-shortcuts' }
 ProcessorSimulator >> sp [
 
 	^ self stackPointerRegisterValue
 ]
 
-{ #category : #'accessing-registers-shortcuts' }
+{ #category : 'accessing-registers-shortcuts' }
 ProcessorSimulator >> sp: aValue [
 
 	^ self stackPointerRegisterValue: aValue
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> stackPointerRegister [
 
 	self subclassResponsibility
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> stackPointerRegisterValue [
 
 	^ self readRegister: self stackPointerRegister
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> stackPointerRegisterValue: aValue [
 
 	self writeRegister: self stackPointerRegister value: aValue
 ]
 
-{ #category : #'accessing-stack' }
+{ #category : 'accessing-stack' }
 ProcessorSimulator >> stackValueAt: anInteger [
 
 	"Get a value from the stack at a 0-base position"
@@ -780,7 +782,7 @@ ProcessorSimulator >> stackValueAt: anInteger [
 	^ aByteArray integerAt: 1 size: self wordSize signed: false
 ]
 
-{ #category : #'accessing-stack' }
+{ #category : 'accessing-stack' }
 ProcessorSimulator >> stackValueBytesAt: position [
 
 	"Get the bytes from the stack at a 0-base position"
@@ -798,7 +800,7 @@ ProcessorSimulator >> stackValueBytesAt: position [
 	^ aByteArray
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessorSimulator >> stackValues [
 
 	| initialValue |
@@ -809,14 +811,14 @@ ProcessorSimulator >> stackValues [
 	]
 ]
 
-{ #category : #'simulation-support' }
+{ #category : 'simulation-support' }
 ProcessorSimulator >> startAt: begin until: until timeout: timeout count: count [
 
 	self subclassResponsibility
 
 ]
 
-{ #category : #'simulation-support' }
+{ #category : 'simulation-support' }
 ProcessorSimulator >> step [
 
 	self
@@ -826,36 +828,36 @@ ProcessorSimulator >> step [
 		count: 1
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> temporaryRegister [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> temporaryRegisterValue [
 
 	^ self readRegister: self temporaryRegister
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> temporaryRegisterValue: anInteger [
 
 	^ self writeRegister: self temporaryRegister value: anInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessorSimulator >> wordAt: anInteger [
 
 	^ memory longAt: anInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ProcessorSimulator >> wordSize [
 	self subclassResponsibility
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> writeFloat64Register: aRegister value: aDouble [
 
 	| value |
@@ -865,7 +867,7 @@ ProcessorSimulator >> writeFloat64Register: aRegister value: aDouble [
 
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 ProcessorSimulator >> writeRegister: aRegister value: anInteger [
 
 	| value |

--- a/smalltalksrc/VMMakerTests/RegisterDescriptor.class.st
+++ b/smalltalksrc/VMMakerTests/RegisterDescriptor.class.st
@@ -1,49 +1,50 @@
 Class {
-	#name : #RegisterDescriptor,
-	#superclass : #Object,
+	#name : 'RegisterDescriptor',
+	#superclass : 'Object',
 	#instVars : [
 		'simulator',
 		'name',
 		'alias',
 		'smalltalkAlias'
 	],
-	#category : #VMMakerTests
+	#category : 'VMMakerTests',
+	#package : 'VMMakerTests'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RegisterDescriptor >> alias [
 	^ alias
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RegisterDescriptor >> alias: aString [ 
 	
 	alias := aString
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 RegisterDescriptor >> copyValueToClipboard [
 	
 	Clipboard clipboardText: self value hex
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 RegisterDescriptor >> inspectValue [
 
 	self value inspect
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RegisterDescriptor >> name [
 	^ name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RegisterDescriptor >> name: anObject [
 	name := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RegisterDescriptor >> printOn: aStream [
 
 	(self value isKindOf: Boolean )
@@ -53,35 +54,35 @@ RegisterDescriptor >> printOn: aStream [
 
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 RegisterDescriptor >> printValue [
 
 	simulator memory interpreter longPrintOop: self value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RegisterDescriptor >> simulator [
 	^ simulator
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RegisterDescriptor >> simulator: anObject [
 	simulator := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RegisterDescriptor >> smalltalkAlias [
 	
 	^ smalltalkAlias
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RegisterDescriptor >> smalltalkAlias: aString [ 
 	
 	smalltalkAlias := aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RegisterDescriptor >> value [
 
 	^ simulator perform: name

--- a/smalltalksrc/VMMakerTests/SmallInteger.extension.st
+++ b/smalltalksrc/VMMakerTests/SmallInteger.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #SmallInteger }
+Extension { #name : 'SmallInteger' }
 
-{ #category : #'*VMMakerTests' }
+{ #category : '*VMMakerTests' }
 SmallInteger >> forMemory: aMemory inMethod: anObject [
 	
 	(self > aMemory maxSmallInteger or: [ self < aMemory minSmallInteger ]) ifTrue: [ self halt ].

--- a/smalltalksrc/VMMakerTests/SpurMemoryManager.extension.st
+++ b/smalltalksrc/VMMakerTests/SpurMemoryManager.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #SpurMemoryManager }
+Extension { #name : 'SpurMemoryManager' }
 
-{ #category : #'*VMMakerTests' }
+{ #category : '*VMMakerTests' }
 SpurMemoryManager >> hiddenRootsObject: anInteger [ 
 	
 	hiddenRootsObj := anInteger

--- a/smalltalksrc/VMMakerTests/StackBuilderTest.class.st
+++ b/smalltalksrc/VMMakerTests/StackBuilderTest.class.st
@@ -15,8 +15,8 @@ temp2
 method
 "
 Class {
-	#name : #StackBuilderTest,
-	#superclass : #VMInterpreterTests,
+	#name : 'StackBuilderTest',
+	#superclass : 'VMInterpreterTests',
 	#instVars : [
 		'stackElement1',
 		'stackElement2',
@@ -32,10 +32,12 @@ Class {
 	#pools : [
 		'VMStackFrameOffsets'
 	],
-	#category : #'VMMakerTests-InterpreterTests'
+	#category : 'VMMakerTests-InterpreterTests',
+	#package : 'VMMakerTests',
+	#tag : 'InterpreterTests'
 }
 
-{ #category : #offset }
+{ #category : 'offset' }
 StackBuilderTest >> addFullFrame [
 
 	| frame |
@@ -69,78 +71,78 @@ StackBuilderTest >> addFullFrame [
 	^ frame
 ]
 
-{ #category : #offset }
+{ #category : 'offset' }
 StackBuilderTest >> offsetArgument1 [
 	^ self offsetArgument2 + 1
 ]
 
-{ #category : #offset }
+{ #category : 'offset' }
 StackBuilderTest >> offsetArgument1FromBaseFP [
 	^ self offsetArgument2FromBaseFP + 1
 ]
 
-{ #category : #offset }
+{ #category : 'offset' }
 StackBuilderTest >> offsetArgument2 [
 	"we skip the frame pointer"
 	^ self offsetMethod + 2
 ]
 
-{ #category : #offset }
+{ #category : 'offset' }
 StackBuilderTest >> offsetArgument2FromBaseFP [
 	^ 2
 ]
 
-{ #category : #offset }
+{ #category : 'offset' }
 StackBuilderTest >> offsetCallerFP [
 	^ self offsetMethod + 1
 ]
 
-{ #category : #offset }
+{ #category : 'offset' }
 StackBuilderTest >> offsetContext [ 
 	^ self offsetFlags + 1
 ]
 
-{ #category : #offset }
+{ #category : 'offset' }
 StackBuilderTest >> offsetFlags [
 	^ self offsetReceiver + 1
 ]
 
-{ #category : #offset }
+{ #category : 'offset' }
 StackBuilderTest >> offsetInstructionPointer [
 	^ 0
 ]
 
-{ #category : #offset }
+{ #category : 'offset' }
 StackBuilderTest >> offsetMethod [
 	^ self offsetContext + 1
 ]
 
-{ #category : #offset }
+{ #category : 'offset' }
 StackBuilderTest >> offsetReceiver [
 	^ self offsetTemp1 + 1 
 ]
 
-{ #category : #offset }
+{ #category : 'offset' }
 StackBuilderTest >> offsetStackElement1 [
 	^ self offsetStackElement2 + 1
 ]
 
-{ #category : #offset }
+{ #category : 'offset' }
 StackBuilderTest >> offsetStackElement2 [
 	^ self offsetInstructionPointer + 1
 ]
 
-{ #category : #offset }
+{ #category : 'offset' }
 StackBuilderTest >> offsetTemp1 [
 	^ self offsetTemp2 + 1
 ]
 
-{ #category : #offset }
+{ #category : 'offset' }
 StackBuilderTest >> offsetTemp2 [
 	^ self offsetStackElement1 + 1
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 StackBuilderTest >> setUp [
 	super setUp.
 	
@@ -155,14 +157,14 @@ StackBuilderTest >> setUp [
 
 ]
 
-{ #category : #'test-VMstate' }
+{ #category : 'test-VMstate' }
 StackBuilderTest >> testCallerFrameOfTopFrameShouldBeSecondFrameBuilderObject [
 	"For debug purpose, we added a link to the caller frame in the current frame."
 	self assert: (stackBuilder topFrame callerFrame) 
 		equals: (stackBuilder frames nextToLast)
 ]
 
-{ #category : #'test-VMstate' }
+{ #category : 'test-VMstate' }
 StackBuilderTest >> testCallerInstructionPointerIsPushedInStack [
 	"We have 3 frames. 
 	The caller of the caller of the top frame is the first one, which is the base"
@@ -170,7 +172,7 @@ StackBuilderTest >> testCallerInstructionPointerIsPushedInStack [
 		equals: stackBuilder frames second instructionPointer.
 ]
 
-{ #category : #'test-setFromMethod' }
+{ #category : 'test-setFromMethod' }
 StackBuilderTest >> testFrameHasMoreArgumentsThanMethodShouldFail [
 
 	| frame |
@@ -185,7 +187,7 @@ StackBuilderTest >> testFrameHasMoreArgumentsThanMethodShouldFail [
 	self should: [ stackBuilder buildStack ] raise: Error
 ]
 
-{ #category : #'test-setFromMethod' }
+{ #category : 'test-setFromMethod' }
 StackBuilderTest >> testFrameHasMoreTemporariesThanMethodShouldFail [
 
 	| frame |
@@ -200,7 +202,7 @@ StackBuilderTest >> testFrameHasMoreTemporariesThanMethodShouldFail [
 	self should: [ stackBuilder buildStack ] raise: Error
 ]
 
-{ #category : #'test-VMstate' }
+{ #category : 'test-VMstate' }
 StackBuilderTest >> testHeadFramePointerCallerCallerIsBaseFramePointer [
 	"We have 3 frames. 
 	The caller of the caller of the top frame is the first one, which is the base"
@@ -208,7 +210,7 @@ StackBuilderTest >> testHeadFramePointerCallerCallerIsBaseFramePointer [
 		equals: stackBuilder page baseFP
 ]
 
-{ #category : #'test-VMstate' }
+{ #category : 'test-VMstate' }
 StackBuilderTest >> testHeadFramePointerCallerIsNotBaseFramePointer [
 	"We have 3 frames. 
 	The caller of the top frame should be the middle one"
@@ -216,7 +218,7 @@ StackBuilderTest >> testHeadFramePointerCallerIsNotBaseFramePointer [
 		equals: stackBuilder page baseFP
 ]
 
-{ #category : #'test-setFromMethod' }
+{ #category : 'test-setFromMethod' }
 StackBuilderTest >> testInstructionPointerIsSetBeforeFirstBytecodeOfLastMethodPushed [
 
 	method := methodBuilder newMethod buildMethod.
@@ -228,7 +230,7 @@ StackBuilderTest >> testInstructionPointerIsSetBeforeFirstBytecodeOfLastMethodPu
 		equals: (methodBuilder bytecodeAt: 0 forMethod: method)
 ]
 
-{ #category : #'test-setFromMethod' }
+{ #category : 'test-setFromMethod' }
 StackBuilderTest >> testMethodHasMoreArgumentsThanFrameShouldUpdateFrame [
 
 	| frame argNum |
@@ -247,7 +249,7 @@ StackBuilderTest >> testMethodHasMoreArgumentsThanFrameShouldUpdateFrame [
 	self assert: frame argumentSize equals: argNum
 ]
 
-{ #category : #'test-setFromMethod' }
+{ #category : 'test-setFromMethod' }
 StackBuilderTest >> testMethodHasMoreTemporariesThanFrameShouldUpdateFrame [
 
 	| frame tempNum |
@@ -268,37 +270,37 @@ StackBuilderTest >> testMethodHasMoreTemporariesThanFrameShouldUpdateFrame [
 		equals: (OrderedCollection new: tempNum withAll: memory nilObject)
 ]
 
-{ #category : #'test-order' }
+{ #category : 'test-order' }
 StackBuilderTest >> testOrderArgument1InBaseFrame [
 	self assert: (interpreter stackPages unsignedLongAt: interpreter stackPage baseFP + (self offsetArgument1FromBaseFP * memory bytesPerOop))
 		equals: argument1
 ]
 
-{ #category : #'test-order' }
+{ #category : 'test-order' }
 StackBuilderTest >> testOrderArgument2InBaseFrame [
 	self assert: (interpreter stackPages unsignedLongAt: interpreter stackPage baseFP + (self offsetArgument2FromBaseFP * memory bytesPerOop))
 		equals: argument2
 ]
 
-{ #category : #'test-order' }
+{ #category : 'test-order' }
 StackBuilderTest >> testOrderContext [
 	self assert: (interpreter stackValue: self offsetContext)
 		equals: context
 ]
 
-{ #category : #'test-order' }
+{ #category : 'test-order' }
 StackBuilderTest >> testOrderMethod [
 	self assert: (interpreter stackValue: self offsetMethod)
 		equals: method
 ]
 
-{ #category : #'test-order' }
+{ #category : 'test-order' }
 StackBuilderTest >> testOrderReceiver [
 	self assert: (interpreter stackValue: self offsetReceiver)
 		equals: receiver
 ]
 
-{ #category : #'test-order' }
+{ #category : 'test-order' }
 StackBuilderTest >> testOrderStackElementIsReversed [
 	self assert: (interpreter stackValue: self offsetStackElement1)
 		equals: stackElement1.
@@ -306,7 +308,7 @@ StackBuilderTest >> testOrderStackElementIsReversed [
 		equals: stackElement2.
 ]
 
-{ #category : #'test-order' }
+{ #category : 'test-order' }
 StackBuilderTest >> testOrderStackTopOfSuspendedProcessIsInstructionPointer [
 	"When a process is suspended, the Instruction Pointer is pushed on the stack of the frame.
 	It should be the last thing pushed, and therefore, be at the top. "
@@ -314,7 +316,7 @@ StackBuilderTest >> testOrderStackTopOfSuspendedProcessIsInstructionPointer [
 		equals: instructionPointer.
 ]
 
-{ #category : #'test-order' }
+{ #category : 'test-order' }
 StackBuilderTest >> testOrderTempIsReversed [
 	self assert: (interpreter stackValue: self offsetTemp1)
 		equals: temp1.
@@ -322,7 +324,7 @@ StackBuilderTest >> testOrderTempIsReversed [
 		equals: temp2.
 ]
 
-{ #category : #'test-VMstate' }
+{ #category : 'test-VMstate' }
 StackBuilderTest >> testPageHeadFPIsLastFrameFP [
 	"The FramePointer of the interpreter should be the FramePointer of the current process last pushed frame."
 	self assert: interpreter framePointer

--- a/smalltalksrc/VMMakerTests/StackToRegisterMappingCogit.extension.st
+++ b/smalltalksrc/VMMakerTests/StackToRegisterMappingCogit.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #StackToRegisterMappingCogit }
+Extension { #name : 'StackToRegisterMappingCogit' }
 
-{ #category : #'*VMMakerTests' }
+{ #category : '*VMMakerTests' }
 StackToRegisterMappingCogit >> methodOrBlockNumTemps: anInteger [ 
 
 	methodOrBlockNumTemps := anInteger

--- a/smalltalksrc/VMMakerTests/UndefinedObject.extension.st
+++ b/smalltalksrc/VMMakerTests/UndefinedObject.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #UndefinedObject }
+Extension { #name : 'UndefinedObject' }
 
-{ #category : #'*VMMakerTests' }
+{ #category : '*VMMakerTests' }
 UndefinedObject >> forMemory: aMemory inMethod: anObject [
 
 	^ aMemory nilObject

--- a/smalltalksrc/VMMakerTests/UnicornARMv5Simulator.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornARMv5Simulator.class.st
@@ -1,64 +1,66 @@
 Class {
-	#name : #UnicornARMv5Simulator,
-	#superclass : #UnicornSimulator,
-	#category : #'VMMakerTests-Unicorn'
+	#name : 'UnicornARMv5Simulator',
+	#superclass : 'UnicornSimulator',
+	#category : 'VMMakerTests-Unicorn',
+	#package : 'VMMakerTests',
+	#tag : 'Unicorn'
 }
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> arg0Register [
 	
 	^ UcARMRegisters r3
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> arg1Register [
 
 	^ UcARMRegisters r4
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> baseRegister [
 
 	^ UcARMRegisters r10
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 UnicornARMv5Simulator >> cResultRegister [
 	
 	^ UcARMRegisters r0
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 UnicornARMv5Simulator >> carg0Register [
 	
 	^ UcARMRegisters r0
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 UnicornARMv5Simulator >> carg1Register [
 	
 	^ UcARMRegisters r1
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 UnicornARMv5Simulator >> carg2Register [
 	
 	^ UcARMRegisters r2
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 UnicornARMv5Simulator >> carg3Register [
 	
 	^ UcARMRegisters r3
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> classRegister [
 	
 	^ UcARMRegisters r8
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornARMv5Simulator >> convertIntegerToInternal: anInteger [ 
 
 	anInteger < 0 ifFalse: [ ^ anInteger ].
@@ -66,7 +68,7 @@ UnicornARMv5Simulator >> convertIntegerToInternal: anInteger [
 	^ 16rFFFFFFFF - anInteger abs + 1
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornARMv5Simulator >> convertInternalToInteger: aTwoComplementNumber [
 
 	(aTwoComplementNumber bitAnd: 1 << 31) = 0 ifTrue: [ 
@@ -75,7 +77,7 @@ UnicornARMv5Simulator >> convertInternalToInteger: aTwoComplementNumber [
 	^ aTwoComplementNumber - 16rFFFFFFFF - 1
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornARMv5Simulator >> createUnicorn [
 
 	"Enable Floating Point...
@@ -112,13 +114,13 @@ UnicornARMv5Simulator >> createUnicorn [
 	^ simulator
 ]
 
-{ #category : #disassembling }
+{ #category : 'disassembling' }
 UnicornARMv5Simulator >> disassembler [
 	
 	^ LLVMARMDisassembler armv7
 ]
 
-{ #category : #executing }
+{ #category : 'executing' }
 UnicornARMv5Simulator >> doStartAt: startAddress until: until timeout: timeout count: count [
 
 	| actualCount result error startTime remainingTimeout currentTime |
@@ -174,25 +176,25 @@ UnicornARMv5Simulator >> doStartAt: startAddress until: until timeout: timeout c
 			self instructionPointerRegisterValue = until ifTrue: [ ^ result ]]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornARMv5Simulator >> doublePrecisionFloatingPointRegister0 [
 
 	^ UcARMRegisters d0
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornARMv5Simulator >> doublePrecisionFloatingPointRegister1 [
 
 	^ UcARMRegisters d1
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornARMv5Simulator >> doublePrecisionFloatingPointRegister2 [
 
 	^ UcARMRegisters d2
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornARMv5Simulator >> extractDestinationRegisterFromAssembly: aLLVMInstruction [ 
 	
 	"In ARM, instructions are usually encoded asSpotterCandidateLink 
@@ -203,42 +205,42 @@ UnicornARMv5Simulator >> extractDestinationRegisterFromAssembly: aLLVMInstructio
 	^ (aLLVMInstruction assemblyCodeString substrings: String tab, ',') second trimBoth.
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> framePointerRegister [
 	
 	^ UcARMRegisters fp
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornARMv5Simulator >> getReturnAddress [
 	
 	^ self linkRegisterValue
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 UnicornARMv5Simulator >> hasLinkRegister [
 	^ true
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> instructionPointerRegister [
 
 	^ UcARMRegisters pc
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornARMv5Simulator >> integerRegisterState [
 	
 	^ #()
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> linkRegister [
 	
 	^ UcARMRegisters lr
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornARMv5Simulator >> postCallArgumentsNumArgs: numArgs in: aMemory [ 
 	"Answer an argument vector of the requested size after a vanilla
 	 ABI call. For ARM the Procedure Calling Specification can be found in IHI0042D_aapcs.pdf.
@@ -253,177 +255,177 @@ UnicornARMv5Simulator >> postCallArgumentsNumArgs: numArgs in: aMemory [
 			ifFalse: [memory unsignedLongAt: self sp + (i-5)*4 bigEndian: false]].	
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> r0 [
 	^ self readRegister: UcARMRegisters r0
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> r0: anInteger [ 
 	
 	^ self writeRegister: UcARMRegisters r0 value: anInteger
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> r1 [
 	^ self readRegister: UcARMRegisters r1
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> r10 [
 	^ self readRegister: UcARMRegisters r10
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> r10: anInteger [ 
 	
 	^ self writeRegister: UcARMRegisters r10 value: anInteger
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> r11: anInteger [ 
 	
 	^ self writeRegister: UcARMRegisters r11 value: anInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornARMv5Simulator >> r12 [
 	
 	^ self readRegister: UcARMRegisters r12
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> r12: anInteger [ 
 
 	self writeRegister: UcARMRegisters r12 value: anInteger
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> r1: anInteger [ 
 	
 	^ self writeRegister: UcARMRegisters r1 value: anInteger
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> r2 [
 	^ self readRegister: UcARMRegisters r2
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> r2: anInteger [ 
 	
 	^ self writeRegister: UcARMRegisters r2 value: anInteger
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> r3 [
 	^ self readRegister: UcARMRegisters r3
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> r3: anInteger [ 
 	
 	^ self writeRegister: UcARMRegisters r3 value: anInteger
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> r4 [
 	^ self readRegister: UcARMRegisters r4
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> r4: anInteger [ 
 	
 	^ self writeRegister: UcARMRegisters r4 value: anInteger
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> r5 [
 	^ self readRegister: UcARMRegisters r5
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> r5: anInteger [ 
 	
 	^ self writeRegister: UcARMRegisters r5 value: anInteger
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> r6 [
 	^ self readRegister: UcARMRegisters r6
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> r6: anInteger [ 
 	
 	^ self writeRegister: UcARMRegisters r6 value: anInteger
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> r7 [
 	^ self readRegister: UcARMRegisters r7
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> r7: anInteger [ 
 	
 	^ self writeRegister: UcARMRegisters r7 value: anInteger
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> r8 [
 	^ self readRegister: UcARMRegisters r8
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> r8: anInteger [ 
 	
 	^ self writeRegister: UcARMRegisters r8 value: anInteger
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> r9 [
 	^ self readRegister: UcARMRegisters r9
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> r9: anInteger [ 
 	
 	^ self writeRegister: UcARMRegisters r9 value: anInteger
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> receiverRegister [
 	
 	^ UcARMRegisters r5
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornARMv5Simulator >> registerList [
 
 	^ #(lr pc sp fp r0 r1 r2 r3 r4 r5 r6 r7 r8 r9)
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornARMv5Simulator >> registerStateGetters [
 	
 	^#(r0 r1 r2 r3 r4)
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornARMv5Simulator >> retpcIn: aMemory [ 
 	"The return address is on the stack, having been pushed by either
 	 simulateCallOf:nextpc:memory: or simulateJumpCallOf:memory:"
 	^memory longAt: self fp + 4
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> sendNumberOfArgumentsRegister [
 	
 	^ UcARMRegisters r6
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornARMv5Simulator >> simulateJumpCallOf: address memory: aMemory [
 	"Simulate a frame-building jump of address.  Build a frame since
 	a) this is used for calls into the run-time which are unlikely to be leaf-calls"
@@ -438,40 +440,40 @@ UnicornARMv5Simulator >> simulateJumpCallOf: address memory: aMemory [
 	self pc: address
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornARMv5Simulator >> simulateLeafCallOf: address nextpc: nextpc memory: aMemory [
 
 	self lr: nextpc.
 	self pc: address
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornARMv5Simulator >> simulateReturnIn: aSpurSimulatedMemory [
 
 	self fp: self popWord.
 	self pc: self popWord
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornARMv5Simulator >> smashCallerSavedRegistersWithValuesFrom: base by: step in: aMemory [
 	#(r0: r1: r2: r3: r9: r12: lr:) withIndexDo:
 		[:accessor :index|
 		self perform: accessor with: index - 1 * step + base]
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> smashRegisterAccessors [
 
 	^ #(r0: r1: r2: r3:)
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> stackPointerRegister [
 	
 	^ UcARMRegisters sp
 ]
 
-{ #category : #executing }
+{ #category : 'executing' }
 UnicornARMv5Simulator >> startAt: begin until: until timeout: timeout count: count [
 
 	begin == until ifTrue: [ ^ self ].
@@ -479,13 +481,13 @@ UnicornARMv5Simulator >> startAt: begin until: until timeout: timeout count: cou
 
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornARMv5Simulator >> temporaryRegister [
 	
 	^ UcARMRegisters r2
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornARMv5Simulator >> wordSize [
 	^ 4
 ]

--- a/smalltalksrc/VMMakerTests/UnicornARMv8Simulator.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornARMv8Simulator.class.st
@@ -1,94 +1,96 @@
 Class {
-	#name : #UnicornARMv8Simulator,
-	#superclass : #UnicornSimulator,
-	#category : #'VMMakerTests-Unicorn'
+	#name : 'UnicornARMv8Simulator',
+	#superclass : 'UnicornSimulator',
+	#category : 'VMMakerTests-Unicorn',
+	#package : 'VMMakerTests',
+	#tag : 'Unicorn'
 }
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 UnicornARMv8Simulator >> arg0Register [
 	
 	^ UcARM64Registers x3
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 UnicornARMv8Simulator >> arg1Register [
 	
 	^ UcARM64Registers x1
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 UnicornARMv8Simulator >> arg2Register [
 	
 	^ UcARM64Registers x2
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 UnicornARMv8Simulator >> arg3Register [
 	
 	^ UcARM64Registers x3
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 UnicornARMv8Simulator >> baseRegister [
 
 	^ UcARM64Registers x24
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 UnicornARMv8Simulator >> cResultRegister [
 	
 	^ UcARM64Registers x0
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 UnicornARMv8Simulator >> carg0Register [
 	
 	^ UcARM64Registers x0
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 UnicornARMv8Simulator >> carg1Register [
 	
 	^ UcARM64Registers x1
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 UnicornARMv8Simulator >> carg2Register [
 	
 	^ UcARM64Registers x2
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 UnicornARMv8Simulator >> carg3Register [
 	
 	^ UcARM64Registers x3
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> carry [
 
 	^ (self nzcv bitAnd: (1<<29))~= 0
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 UnicornARMv8Simulator >> classRegister [
 	
 	^ UcARM64Registers x22
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> cpacr_el1 [
 	
 	^ self readRegister: UcARM64Registers cpacr_el1
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> cpacr_el1: anInteger [ 
 	
 	self writeRegister: UcARM64Registers cpacr_el1 value: anInteger
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 UnicornARMv8Simulator >> createUnicorn [
 
 	simulator := Unicorn arm64.
@@ -97,31 +99,31 @@ UnicornARMv8Simulator >> createUnicorn [
 	^ simulator
 ]
 
-{ #category : #disassembling }
+{ #category : 'disassembling' }
 UnicornARMv8Simulator >> disassembler [
 	
 	^ LLVMARMDisassembler aarch64
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 UnicornARMv8Simulator >> doublePrecisionFloatingPointRegister0 [
 
 	^ UcARM64Registers d0
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 UnicornARMv8Simulator >> doublePrecisionFloatingPointRegister1 [
 
 	^ UcARM64Registers d1
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 UnicornARMv8Simulator >> doublePrecisionFloatingPointRegister2 [
 
 	^ UcARM64Registers d2
 ]
 
-{ #category : #disassembling }
+{ #category : 'disassembling' }
 UnicornARMv8Simulator >> extractDestinationRegisterFromAssembly: aLLVMInstruction [ 
 	
 	"In ARM, instructions are usually encoded asSpotterCandidateLink 
@@ -132,24 +134,24 @@ UnicornARMv8Simulator >> extractDestinationRegisterFromAssembly: aLLVMInstructio
 	^ (aLLVMInstruction assemblyCodeString substrings: String tab, ',') second trimBoth.
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 UnicornARMv8Simulator >> framePointerRegister [
 	
 	^ UcARM64Registers fp
 ]
 
-{ #category : #'simulation-support' }
+{ #category : 'simulation-support' }
 UnicornARMv8Simulator >> getReturnAddress [
 	
 	^ self linkRegisterValue
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 UnicornARMv8Simulator >> hasLinkRegister [
 	^ true
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 UnicornARMv8Simulator >> initializeRegisterAliases [
 
 	registerAliases
@@ -162,37 +164,37 @@ UnicornARMv8Simulator >> initializeRegisterAliases [
 		at: #x30 put: #linkRegister
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 UnicornARMv8Simulator >> instructionPointerRegister [
 
 	^ UcARM64Registers pc
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 UnicornARMv8Simulator >> linkRegister [
 	
 	^ UcARM64Registers x30
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> negative [
 
 	^ (self nzcv bitAnd: (1<<31))~= 0
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> nzcv [
 
 	^ self readRegister: UcARM64Registers nzcv 
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> overflow [
 
 	^ (self nzcv bitAnd: (1<<28)) ~= 0
 ]
 
-{ #category : #'simulation-support' }
+{ #category : 'simulation-support' }
 UnicornARMv8Simulator >> postCallArgumentsNumArgs: numArgs "<Integer>" in: aMemory [ "<ByteArray|Bitmap>"
 	"Answer an argument vector of the requested size after a vanilla
 	 ABI call. For ARM the Procedure Calling Specification can be found in IHI0042D_aapcs.pdf.
@@ -206,37 +208,37 @@ UnicornARMv8Simulator >> postCallArgumentsNumArgs: numArgs "<Integer>" in: aMemo
 			ifFalse: [memory unsignedLongAt: self sp + (i-5)*4 bigEndian: false]].
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 UnicornARMv8Simulator >> receiverRegister [
 	
 	^ UcARM64Registers x23
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornARMv8Simulator >> registerList [
 
 	^ #(lr pc sp fp x28 x0 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x16 x19 x20 x22 x23 x24 x25 zero negative carry overflow v0 v1 v2)
 ]
 
-{ #category : #'simulation-support' }
+{ #category : 'simulation-support' }
 UnicornARMv8Simulator >> registerStateGetters [
 
 	^#(	x0 x1 x2 x3 x4 x5 x6 x7 x8 x9 x12 sp lr pc)
 ]
 
-{ #category : #'simulation-support' }
+{ #category : 'simulation-support' }
 UnicornARMv8Simulator >> retpcIn: aMemory [ 
 
 	^ memory longAt: self fp + 8
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 UnicornARMv8Simulator >> sendNumberOfArgumentsRegister [
 	
 	^ UcARM64Registers x25
 ]
 
-{ #category : #'simulation-support' }
+{ #category : 'simulation-support' }
 UnicornARMv8Simulator >> simulateJumpCallOf: address memory: aMemory [
 	"Simulate a frame-building jump of address.  Build a frame since
 	a) this is used for calls into the run-time which are unlikely to be leaf-calls"
@@ -253,14 +255,14 @@ UnicornARMv8Simulator >> simulateJumpCallOf: address memory: aMemory [
 	self instructionPointerRegisterValue: address
 ]
 
-{ #category : #'simulation-support' }
+{ #category : 'simulation-support' }
 UnicornARMv8Simulator >> simulateLeafCallOf: address nextpc: nextpc memory: aMemory [
 	
 	self lr: nextpc.
 	self pc: address
 ]
 
-{ #category : #'simulation-support' }
+{ #category : 'simulation-support' }
 UnicornARMv8Simulator >> simulateReturnIn: aSpurSimulatedMemory [ 
 
 	self framePointerRegisterValue: self popWord.
@@ -270,13 +272,13 @@ UnicornARMv8Simulator >> simulateReturnIn: aSpurSimulatedMemory [
 
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 UnicornARMv8Simulator >> smalltalkStackPointerRegister [
 	"Internally to execute Smalltalk code we use X28 as the stack pointer register"
 	^ UcARM64Registers x28
 ]
 
-{ #category : #'simulation-support' }
+{ #category : 'simulation-support' }
 UnicornARMv8Simulator >> smashCallerSavedRegistersWithValuesFrom: base by: step in: aMemory [
 
 	#(x0: x1: x2: x3: x4: x5: lr:) withIndexDo:
@@ -284,373 +286,373 @@ UnicornARMv8Simulator >> smashCallerSavedRegistersWithValuesFrom: base by: step 
 		self perform: accessor with: index - 1 * step + base]
 ]
 
-{ #category : #'simulation-support' }
+{ #category : 'simulation-support' }
 UnicornARMv8Simulator >> smashRegisterAccessors [
 	
 	"Caller saved registers to smash"
 	^#( x0: x1: x2: x3: x4: x5: x6: x7: x8: x9: x10: x11: x12: )
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 UnicornARMv8Simulator >> stackPointerRegister [
 	
 	^ UcARM64Registers sp
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 UnicornARMv8Simulator >> temporaryRegister [
 
 	^ UcARM64Registers x1
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> v0 [
 
 	^ self readRawRegister: UcARM64Registers v0 size: 16
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> v1 [
 
 	^ self readRawRegister: UcARM64Registers v1 size: 16
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> v2 [
 
 	^ self readRawRegister: UcARM64Registers v2 size: 16
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 UnicornARMv8Simulator >> vectorRegister0Value [
 
 	^ simulator readRegisterId: UcARM64Registers v0 size:  16
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 UnicornARMv8Simulator >> vectorRegister1Value [
 
 	^ simulator readRegisterId: UcARM64Registers v1 size:  16
 ]
 
-{ #category : #'accessing-registers-abstract' }
+{ #category : 'accessing-registers-abstract' }
 UnicornARMv8Simulator >> vectorRegister2Value [
 
 	^ simulator readRegisterId: UcARM64Registers v2 size:  16
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> w25: anInteger [ 
 
 	self writeRegister: UcARM64Registers w25 value: anInteger
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> w6: anInteger [ 
 
 	self writeRegister: UcARM64Registers w6 value: anInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornARMv8Simulator >> wordSize [
 	^ 8
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x0 [
 
 	^ self readRegister: UcARM64Registers x0
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x0: anInteger [ 
 	
 	self writeRegister: UcARM64Registers x0 value: anInteger 
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x1 [
 
 	^ self readRegister: UcARM64Registers x1
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x10 [
 
 	^ self readRegister: UcARM64Registers x10
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x10: anInteger [ 
 
 	^ self writeRegister: UcARM64Registers x10 value: anInteger
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x11 [
 
 	^ self readRegister: UcARM64Registers x11
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x11: anInteger [ 
 
 	^ self writeRegister: UcARM64Registers x11 value: anInteger
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x12 [
 
 	^ self readRegister: UcARM64Registers x12
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x12: anInteger [ 
 
 	^ self writeRegister: UcARM64Registers x12 value: anInteger
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x13: anInteger [ 
 	
 	self writeRegister: UcARM64Registers x13 value: anInteger
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x14: anInteger [ 
 
 	self writeRegister: UcARM64Registers x14 value: anInteger
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x15: anInteger [ 
 
 	self writeRegister: UcARM64Registers x15 value: anInteger
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x16 [
 	
 	^ self readRegister: UcARM64Registers x16
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x16: anInteger [ 
 	
 	self writeRegister: UcARM64Registers x16 value: anInteger
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x17: anInteger [ 
 
 	self writeRegister: UcARM64Registers x17 value: anInteger
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x18: anInteger [ 
 
 	self writeRegister: UcARM64Registers x18 value: anInteger
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x19 [
 	
 	^ self readRegister: UcARM64Registers x19
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x19: anInteger [ 
 	
 	self writeRegister: UcARM64Registers x19 value: anInteger
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x1: anInteger [ 
 
 	^ self writeRegister: UcARM64Registers x1 value: anInteger
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x2 [
 
 	^ self readRegister: UcARM64Registers x2
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x20 [
 	
 	^ self readRegister: UcARM64Registers x20
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x22 [
 	
 	^ self readRegister: UcARM64Registers x22
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x23 [
 
 	^ self readRegister: UcARM64Registers x23
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x23: anInteger [ 
 	
 	self writeRegister: UcARM64Registers x23 value: anInteger
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x24 [
 
 	^ self readRegister: UcARM64Registers x24
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x24: anInteger [ 
 	
 	self writeRegister: UcARM64Registers x24 value: anInteger
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x25 [
 
 	^ self readRegister: UcARM64Registers x25
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x25: anInteger [ 
 	
 	self writeRegister: UcARM64Registers x25 value: anInteger
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x28 [
 
 	^ self readRegister: UcARM64Registers x28
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x28: anInteger [ 
 	
 	self writeRegister: UcARM64Registers x28 value: anInteger
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x29: anInteger [ 
 	
 	^ self writeRegister: UcARM64Registers x29 value: anInteger
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x2: anInteger [ 
 
 	^ self writeRegister: UcARM64Registers x2 value: anInteger
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x3 [
 
 	^ self readRegister: UcARM64Registers x3
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x30: anInteger [ 
 	
 	self writeRegister: UcARM64Registers x30 value: anInteger
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x3: anInteger [ 
 
 	^ self writeRegister: UcARM64Registers x3 value: anInteger
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x4 [
 
 	^ self readRegister: UcARM64Registers x4
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x4: anInteger [ 
 
 	^ self writeRegister: UcARM64Registers x4 value: anInteger
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x5 [
 
 	^ self readRegister: UcARM64Registers x5
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x5: anInteger [ 
 
 	^ self writeRegister: UcARM64Registers x5 value: anInteger
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x6 [
 
 	^ self readRegister: UcARM64Registers x6
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x6: anInteger [ 
 
 	^ self writeRegister: UcARM64Registers x6 value: anInteger
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x7 [
 
 	^ self readRegister: UcARM64Registers x7
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x7: anInteger [ 
 
 	^ self writeRegister: UcARM64Registers x7 value: anInteger
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x8 [
 
 	^ self readRegister: UcARM64Registers x8
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x8: anInteger [ 
 
 	^ self writeRegister: UcARM64Registers x8 value: anInteger
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x9 [
 
 	^ self readRegister: UcARM64Registers x9
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> x9: anInteger [ 
 
 	^ self writeRegister: UcARM64Registers x9 value: anInteger
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> xzr [
 	
 	^ self readRegister: UcARM64Registers xzr
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> xzr: anInteger [ 
 
 	^ self writeRegister: UcARM64Registers xzr value: anInteger
 ]
 
-{ #category : #'accessing-registers-physical' }
+{ #category : 'accessing-registers-physical' }
 UnicornARMv8Simulator >> zero [
 
 	^ (self nzcv bitAnd: (1<<30)) ~= 0

--- a/smalltalksrc/VMMakerTests/UnicornI386Simulator.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornI386Simulator.class.st
@@ -1,191 +1,193 @@
 Class {
-	#name : #UnicornI386Simulator,
-	#superclass : #UnicornSimulator,
-	#category : #'VMMakerTests-Unicorn'
+	#name : 'UnicornI386Simulator',
+	#superclass : 'UnicornSimulator',
+	#category : 'VMMakerTests-Unicorn',
+	#package : 'VMMakerTests',
+	#tag : 'Unicorn'
 }
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornI386Simulator >> arg0Register [
 	
 	^ UcX86Registers esi
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornI386Simulator >> baseRegister [
 
 	^ UcX86Registers ebx
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornI386Simulator >> cResultRegister [
 
 	^ UcX86Registers eax
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 UnicornI386Simulator >> carg0 [
 
 	"Stack value 0 is return address"
 	^ self stackValueAt: 1
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 UnicornI386Simulator >> carg1 [
 
 	"Stack value 0 is return address"
 	^ self stackValueAt: 2
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 UnicornI386Simulator >> carg2 [
 
 	"Stack value 0 is return address"
 	^ self stackValueAt: 3
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 UnicornI386Simulator >> carg3 [
 
 	"Stack value 0 is return address"
 	^ self stackValueAt: 4
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornI386Simulator >> classRegister [
 
 	^ UcX86Registers ecx
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornI386Simulator >> createUnicorn [
 
 	^ Unicorn x86
 ]
 
-{ #category : #disassembling }
+{ #category : 'disassembling' }
 UnicornI386Simulator >> disassembler [
 	
 	^ LLVMDisassembler i386
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornI386Simulator >> doublePrecisionFloatingPointRegister0 [
 
 	^ UcX86Registers xmm0
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornI386Simulator >> eax [
 	
 	^ self readRegister: UcX86Registers eax
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornI386Simulator >> eax: anInteger [ 
 
 	self writeRegister: UcX86Registers eax value: anInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornI386Simulator >> ebp [
 	^ self readRegister: UcX86Registers ebp
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornI386Simulator >> ebp: anInteger [ 
 	
 	self framePointerRegisterValue: anInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornI386Simulator >> ebx [
 	
 	^ self readRegister: UcX86Registers ebx
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornI386Simulator >> ebx: anInteger [ 
 
 	self writeRegister: UcX86Registers ebx value: anInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornI386Simulator >> ecx [
 	^ self readRegister: UcX86Registers ecx
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornI386Simulator >> ecx: anInteger [ 
 
 	self writeRegister: UcX86Registers ecx value: anInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornI386Simulator >> edi [
 	
 	^ self readRegister: UcX86Registers edi
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornI386Simulator >> edi: anInteger [ 
 	
 	self writeRegister: UcX86Registers edi value: anInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornI386Simulator >> edx [
 	^ self readRegister: UcX86Registers edx
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornI386Simulator >> edx: anInteger [ 
 	
 	^ self writeRegister: UcX86Registers edx value: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornI386Simulator >> eflags [
 	
 	^ self readRegister: UcX86Registers eflags
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornI386Simulator >> eip [
 	
 	^ self readRegister: UcX86Registers eip
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornI386Simulator >> eip: anInteger [ 
 	
 	self writeRegister: UcX86Registers eip value: anInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornI386Simulator >> esi [
 	
 	^ self readRegister: UcX86Registers esi
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornI386Simulator >> esi: anInteger [ 
 	
 	self writeRegister: UcX86Registers esi value: anInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornI386Simulator >> esp [
 	
 	^ self readRegister: UcX86Registers esp
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornI386Simulator >> esp: anInteger [ 
 	
 	self stackPointerRegisterValue: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornI386Simulator >> extractDestinationRegisterFromAssembly: aLLVMInstruction [ 
 	
 	| registerName |
@@ -195,38 +197,38 @@ UnicornI386Simulator >> extractDestinationRegisterFromAssembly: aLLVMInstruction
 	^ registerName
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornI386Simulator >> framePointerRegister [
 	
 	^ UcX86Registers ebp
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornI386Simulator >> getReturnAddress [
 	
 	^ self peekAddress
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornI386Simulator >> hasLinkRegister [ 
 
 	^ false
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornI386Simulator >> instructionPointerRegister [
 	
 	^ UcX86Registers eip
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornI386Simulator >> integerRegisterState [
 
 	^{	self eax. self ebx. self ecx. self edx. self esp. self ebp. self esi. self edi.
 		self eip. self eflags }
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornI386Simulator >> postCallArgumentsNumArgs: numArgs in: aMemory [
 	"Answer an argument vector of the requested size after a vanilla
 	 ABI call.  On IA32 this typically means accessing stacked arguments
@@ -237,31 +239,31 @@ UnicornI386Simulator >> postCallArgumentsNumArgs: numArgs in: aMemory [
 		  memory longAt: self ebp + i ]
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornI386Simulator >> receiverRegister [
 	
 	^ UcX86Registers edx
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornI386Simulator >> registerList [
 	
 	^ #(eip eax ebx ecx edx esp ebp esi edi)
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornI386Simulator >> retpcIn: aMemory [
 
 	^ memory longAt: self ebp + 4
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornI386Simulator >> sendNumberOfArgumentsRegister [
 
 	^ UcX86Registers ebx
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornI386Simulator >> simulateJumpCallOf: address memory: aMemory [
 	"Simulate a frame-building jump call of address (i.e. do not push the return pc
 	 as this has already been done).  Build a frame since
@@ -273,21 +275,21 @@ UnicornI386Simulator >> simulateJumpCallOf: address memory: aMemory [
 	self eip: address
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornI386Simulator >> simulateLeafCallOf: address nextpc: nextpc memory: aMemory [
 
 	self pushWord: nextpc.
 	self eip: address
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornI386Simulator >> simulateReturnIn: aMemory [
 
 	self ebp: self popWord.
 	self eip: self popWord
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornI386Simulator >> smashCallerSavedRegistersWithValuesFrom: base by: step in: aMemory [
 	#(eax: ecx: edx:)
 	   withIndexDo:
@@ -295,26 +297,26 @@ UnicornI386Simulator >> smashCallerSavedRegistersWithValuesFrom: base by: step i
 		self perform: accessor with: index - 1 * step + base]
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornI386Simulator >> smashRegisterAccessors [
 
 	^#(eax: ebx: ecx: edx: esi: edi:)
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornI386Simulator >> stackPointerRegister [
 	
 	^ UcX86Registers esp
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornI386Simulator >> temporaryRegister [
 	
 	"Assume SysV"
 	^ UcX86Registers eax
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornI386Simulator >> wordSize [
 	
 	^ 4

--- a/smalltalksrc/VMMakerTests/UnicornInvalidMemoryAccess.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornInvalidMemoryAccess.class.st
@@ -1,63 +1,65 @@
 Class {
-	#name : #UnicornInvalidMemoryAccess,
-	#superclass : #Error,
+	#name : 'UnicornInvalidMemoryAccess',
+	#superclass : 'Error',
 	#instVars : [
 		'type',
 		'address',
 		'size',
 		'value'
 	],
-	#category : #'VMMakerTests-Unicorn'
+	#category : 'VMMakerTests-Unicorn',
+	#package : 'VMMakerTests',
+	#tag : 'Unicorn'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornInvalidMemoryAccess >> address [
 	^ address
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornInvalidMemoryAccess >> address: anObject [
 	address := anObject
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 UnicornInvalidMemoryAccess >> isFetch [
 	
 	^ self type value anyMask: UcMemoryAccessType UC_MEM_FETCH value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornInvalidMemoryAccess >> messageText [
 
 	^ type item asString, ' at ', address hex
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornInvalidMemoryAccess >> size [
 	^ size
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornInvalidMemoryAccess >> size: anObject [
 	size := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornInvalidMemoryAccess >> type [
 	^ type
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornInvalidMemoryAccess >> type: anObject [
 	type := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornInvalidMemoryAccess >> value [
 	^ value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornInvalidMemoryAccess >> value: anObject [
 	value := anObject
 ]

--- a/smalltalksrc/VMMakerTests/UnicornProcessor.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornProcessor.class.st
@@ -1,104 +1,106 @@
 Class {
-	#name : #UnicornProcessor,
-	#superclass : #Object,
+	#name : 'UnicornProcessor',
+	#superclass : 'Object',
 	#instVars : [
 		'machineSimulator'
 	],
-	#category : #'VMMakerTests-Unicorn'
+	#category : 'VMMakerTests-Unicorn',
+	#package : 'VMMakerTests',
+	#tag : 'Unicorn'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> cResultRegister [
 	
 	^ machineSimulator cResultRegisterValue
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> cResultRegister: anInteger [ 
 	
 	machineSimulator cResultRegisterValue: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> convertIntegerToInternal: anInteger [ 
 	
 	^ machineSimulator convertIntegerToInternal: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> convertInternalToInteger: anInteger [ 
 
 	^ machineSimulator convertInternalToInteger: anInteger 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> eax: anInteger [ 
 	
 	machineSimulator eax: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> ebp: anInteger [ 
 	
 	machineSimulator ebp: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> ebx: anInteger [ 
 
 	machineSimulator ebx: anInteger 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> ecx: anInteger [ 
 
 	machineSimulator ecx: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> edi: anInteger [ 
 	
 	machineSimulator edi: anInteger
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornProcessor >> edx: anInteger [ 
 	
 	^ machineSimulator edx: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> esp: anInteger [ 
 	
 	machineSimulator esp: anInteger
 ]
 
-{ #category : #caching }
+{ #category : 'caching' }
 UnicornProcessor >> flushICacheFrom: startAddress to: endAddress [
 
 	"Do nothing for now..."
 	machineSimulator flushICacheFrom: startAddress to: endAddress
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornProcessor >> fp [
 	
 	^ machineSimulator framePointerRegisterValue
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornProcessor >> fp: aValue [
 
 	^ machineSimulator framePointerRegisterValue: aValue
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> hasLinkRegister [
 	
 	^ machineSimulator hasLinkRegister 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> initializeStackFor: aCompiler [
 	
 	"Initialize the machine code simulator"
@@ -109,192 +111,192 @@ UnicornProcessor >> initializeStackFor: aCompiler [
 	aCompiler backend configureStackAlignment
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> integerRegisterState [
 	
 	^ machineSimulator integerRegisterState 
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornProcessor >> linkRegisterValue [
 	
 	^ machineSimulator linkRegisterValue 
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornProcessor >> lr: anInteger [ 
 
 	machineSimulator lr: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> machineSimulator [
 	^ machineSimulator
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornProcessor >> machineSimulator: aMachineSimulator [
 	
 	machineSimulator := aMachineSimulator
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornProcessor >> pc [
 	
 	^ machineSimulator instructionPointerRegisterValue
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornProcessor >> pc: anInteger [ 
 	
 	^ machineSimulator instructionPointerRegisterValue: anInteger
 ]
 
-{ #category : #'stack-management' }
+{ #category : 'stack-management' }
 UnicornProcessor >> popWord [
 	
 	^ machineSimulator popWord
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> postCallArgumentsNumArgs: anInteger in: aSpurSimulatedMemory [ 
 	
 	^ machineSimulator postCallArgumentsNumArgs: anInteger in: aSpurSimulatedMemory
 ]
 
-{ #category : #'stack-management' }
+{ #category : 'stack-management' }
 UnicornProcessor >> pushWord: anInteger [ 
 	
 	machineSimulator pushWord: anInteger
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornProcessor >> r0: anInteger [ 
 
 	^ machineSimulator r0: anInteger
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornProcessor >> r10: anInteger [ 
 	
 	machineSimulator r10: anInteger
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornProcessor >> r11: anInteger [ 
 	
 	machineSimulator r11: anInteger
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornProcessor >> r1: anInteger [ 
 	
 	^ machineSimulator r1: anInteger 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornProcessor >> r2: anInteger [ 
 	
 	machineSimulator r2: anInteger 
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornProcessor >> r3: anInteger [ 
 	
 	machineSimulator r3: anInteger 
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornProcessor >> r4: anInteger [ 
 	
 	machineSimulator r4: anInteger 
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornProcessor >> r5: anInteger [ 
 
 	machineSimulator r5: anInteger 
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornProcessor >> r6: anInteger [ 
 	
 	machineSimulator r6: anInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornProcessor >> r8 [
 
 	^ machineSimulator r8
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornProcessor >> r8: anInteger [ 
 	
 	machineSimulator r8: anInteger 
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornProcessor >> r9: anInteger [
 	
 	machineSimulator r9: anInteger
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornProcessor >> r9b: anInteger [ 
 
 	machineSimulator r9b: anInteger
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornProcessor >> rax: anInteger [ 
 	
 	machineSimulator rax: anInteger
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornProcessor >> rbp: anInteger [ 
 	
 	machineSimulator rbp: anInteger
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornProcessor >> rcx: anInteger [ 
 	
 	machineSimulator rcx: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> rdi: anInteger [ 
 
 	machineSimulator rdi: anInteger 
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornProcessor >> rdx: anInteger [ 
 	
 	machineSimulator rdx: anInteger
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornProcessor >> retpcIn: aSpurSimulatedMemory [ 
 
 	^ machineSimulator retpcIn: aSpurSimulatedMemory 
 ]
 
-{ #category : #'accessing registers' }
+{ #category : 'accessing registers' }
 UnicornProcessor >> rsi: anInteger [ 
 	
 	^ machineSimulator rsi: anInteger
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornProcessor >> rsp: anInteger [ 
 	
 	machineSimulator rsp: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> runInMemory: aMemory minimumAddress: minimumAddress readOnlyBelow: minimumWritableAddress [
 
 
@@ -304,7 +306,7 @@ UnicornProcessor >> runInMemory: aMemory minimumAddress: minimumAddress readOnly
 		count: 0
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> runUntil: anAddress [
 
 	^ machineSimulator startAt: machineSimulator instructionPointerRegisterValue
@@ -313,165 +315,165 @@ UnicornProcessor >> runUntil: anAddress [
 		count: 0
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 UnicornProcessor >> setFramePointer: framePointer stackPointer: stackPointer [
 	
 	machineSimulator framePointerRegisterValue: framePointer.
 	machineSimulator stackPointerRegisterValue: stackPointer
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> simulateJumpCallOf: anInteger memory: aSpurSimulatedMemory [
 
 	machineSimulator simulateJumpCallOf: anInteger memory: aSpurSimulatedMemory
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> simulateLeafCallOf: address nextpc: nextpc memory: aMemory [
 
 	machineSimulator simulateLeafCallOf: address nextpc: nextpc memory: aMemory
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> simulateReturnIn: aSpurSimulatedMemory [ 
 
 	^ machineSimulator simulateReturnIn: aSpurSimulatedMemory 
 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> smashCallerSavedRegistersWithValuesFrom: anInteger by: anInteger2 in: aSpurSimulatedMemory [ 
 	
 	machineSimulator smashCallerSavedRegistersWithValuesFrom: anInteger by: anInteger2 in: aSpurSimulatedMemory 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> smashRegistersWithValuesFrom: base by: step [
 	
 	machineSimulator smashRegistersWithValuesFrom: base by: step
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornProcessor >> sp [
 	
 	^ machineSimulator stackPointerRegisterValue
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> sp: anInteger [ 
 	
 	machineSimulator stackPointerRegisterValue: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> w25: anInteger [ 
 	
 	machineSimulator w25: anInteger 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> w6: anInteger [ 
 	
 	machineSimulator w6: anInteger 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> x12: anInteger [ 
 	
 	machineSimulator x12: anInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornProcessor >> x16: anInteger [ 
 	
 	machineSimulator x16: anInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornProcessor >> x19: anInteger [ 
 
 	machineSimulator x19: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> x1: anInteger [ 
 
 	machineSimulator x1: anInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornProcessor >> x23: anInteger [ 
 	
 	machineSimulator x23: anInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornProcessor >> x24: anInteger [ 
 	
 	machineSimulator x24: anInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornProcessor >> x25: anInteger [ 
 	
 	machineSimulator x25: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> x28: anInteger [ 
 	
 	machineSimulator x28: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> x29: anInteger [ 
 	
 	machineSimulator x29: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> x30: anInteger [ 
 
 	machineSimulator x30: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> x3: anInteger [ 
 	
 	machineSimulator x3: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> x4: anInteger [ 
 
 	machineSimulator x4: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> x5: anInteger [ 
 	
 	machineSimulator x5: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> x6: anInteger [ 
 	
 	machineSimulator x6: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> x7: anInteger [ 
 	
 	machineSimulator x7: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> xzr [
 	
 	^ machineSimulator xzr
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornProcessor >> xzr: anInteger [ 
 	
 	machineSimulator xzr: anInteger

--- a/smalltalksrc/VMMakerTests/UnicornRISCVSimulator.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornRISCVSimulator.class.st
@@ -1,64 +1,66 @@
 Class {
-	#name : #UnicornRISCVSimulator,
-	#superclass : #UnicornSimulator,
-	#category : #'VMMakerTests-Unicorn'
+	#name : 'UnicornRISCVSimulator',
+	#superclass : 'UnicornSimulator',
+	#category : 'VMMakerTests-Unicorn',
+	#package : 'VMMakerTests',
+	#tag : 'Unicorn'
 }
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornRISCVSimulator >> arg0Register [
 
 	^ UcRISCVRegisters x10
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornRISCVSimulator >> arg1Register [
 
 	^ UcRISCVRegisters x11
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornRISCVSimulator >> baseRegister [
 
 	^ UcRISCVRegisters x26
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 UnicornRISCVSimulator >> cResultRegister [
 
 	^ UcRISCVRegisters x12
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 UnicornRISCVSimulator >> carg0Register [
 
 	^ UcRISCVRegisters x12
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 UnicornRISCVSimulator >> carg1Register [
 
 	^ UcRISCVRegisters x13
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 UnicornRISCVSimulator >> carg2Register [
 
 	^ UcRISCVRegisters x14
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 UnicornRISCVSimulator >> carg3Register [
 
 	^ UcRISCVRegisters x15
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornRISCVSimulator >> classRegister [
 
 	^ UcRISCVRegisters x23
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 UnicornRISCVSimulator >> createUnicorn [
 	
 	simulator := Unicorn riscv64.
@@ -67,290 +69,290 @@ UnicornRISCVSimulator >> createUnicorn [
 	^ simulator
 ]
 
-{ #category : #disassembling }
+{ #category : 'disassembling' }
 UnicornRISCVSimulator >> disassembler [ 
 
 	^ LLVMRV64Disassembler riscv64
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornRISCVSimulator >> doublePrecisionFloatingPointRegister0 [
 
 	^ UcRISCVRegisters f0
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornRISCVSimulator >> doublePrecisionFloatingPointRegister1 [
 
 	^ UcRISCVRegisters f1
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornRISCVSimulator >> doublePrecisionFloatingPointRegister2 [
 
 	^ UcRISCVRegisters f2
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> f0 [
 
 	^ self readRegister: UcRISCVRegisters f0
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> f1 [
 
 	^ self readRegister: UcRISCVRegisters f1
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> f10 [
 
 	^ self readRegister: UcRISCVRegisters f10
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> f11 [
 
 	^ self readRegister: UcRISCVRegisters f11
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> f12 [
 
 	^ self readRegister: UcRISCVRegisters f12
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> f13 [
 
 	^ self readRegister: UcRISCVRegisters f13
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> f14 [
 
 	^ self readRegister: UcRISCVRegisters f14
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> f15 [
 
 	^ self readRegister: UcRISCVRegisters f15
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> f16 [
 
 	^ self readRegister: UcRISCVRegisters f16
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> f17 [
 
 	^ self readRegister: UcRISCVRegisters f17
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> f18 [
 
 	^ self readRegister: UcRISCVRegisters f18
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> f19 [
 
 	^ self readRegister: UcRISCVRegisters f19
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> f2 [
 
 	^ self readRegister: UcRISCVRegisters f2
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> f20 [
 
 	^ self readRegister: UcRISCVRegisters f20
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> f21 [
 
 	^ self readRegister: UcRISCVRegisters f21
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> f22 [
 
 	^ self readRegister: UcRISCVRegisters f22
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> f23 [
 
 	^ self readRegister: UcRISCVRegisters f23
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> f24 [
 
 	^ self readRegister: UcRISCVRegisters f24
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> f25 [
 
 	^ self readRegister: UcRISCVRegisters f25
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> f26 [
 
 	^ self readRegister: UcRISCVRegisters f26
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> f27 [
 
 	^ self readRegister: UcRISCVRegisters f27
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> f28 [
 
 	^ self readRegister: UcRISCVRegisters f28
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> f29 [
 
 	^ self readRegister: UcRISCVRegisters f29
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> f3 [
 
 	^ self readRegister: UcRISCVRegisters f3
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> f30 [
 
 	^ self readRegister: UcRISCVRegisters f30
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> f31 [
 
 	^ self readRegister: UcRISCVRegisters f31
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> f4 [
 
 	^ self readRegister: UcRISCVRegisters f4
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> f5 [
 
 	^ self readRegister: UcRISCVRegisters f5
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> f6 [
 
 	^ self readRegister: UcRISCVRegisters f6
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> f7 [
 
 	^ self readRegister: UcRISCVRegisters f7
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> f8 [
 
 	^ self readRegister: UcRISCVRegisters f8
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> f9 [
 
 	^ self readRegister: UcRISCVRegisters f9
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 UnicornRISCVSimulator >> flagCarryRegister [
 
 	^ UcRISCVRegisters x31
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 UnicornRISCVSimulator >> flagCarryRegisterValue [
 
 	^ self readRegister: self flagCarryRegister
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 UnicornRISCVSimulator >> flagOverflowRegister [
 
 	^ UcRISCVRegisters x30
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 UnicornRISCVSimulator >> flagOverflowRegisterValue [
 
 	^ self readRegister: self flagOverflowRegister
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 UnicornRISCVSimulator >> flagSignRegister [
 
 	^ UcRISCVRegisters x29
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 UnicornRISCVSimulator >> flagSignRegisterValue [
 
 	^ self readRegister: self flagSignRegister
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 UnicornRISCVSimulator >> flagZeroRegister [
 
 	^ UcRISCVRegisters x28
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 UnicornRISCVSimulator >> flagZeroRegisterValue [
 
 	^ self readRegister: self flagZeroRegister
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornRISCVSimulator >> framePointerRegister [
 	
 	"Frame Pointer"
 	^ UcRISCVRegisters x8
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 UnicornRISCVSimulator >> getReturnAddress [
 	
 	^ self linkRegisterValue
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 UnicornRISCVSimulator >> hasLinkRegister [
 	
 	^ true
 ]
 
-{ #category : #disassembling }
+{ #category : 'disassembling' }
 UnicornRISCVSimulator >> initializeRegisterAliases [ 
 
 	registerAliases
@@ -396,7 +398,7 @@ UnicornRISCVSimulator >> initializeRegisterAliases [
 		at: #f7  put: #ft7
 ]
 
-{ #category : #disassembling }
+{ #category : 'disassembling' }
 UnicornRISCVSimulator >> initializeRegisterSmalltalkAliases [ 
 
 	registerSmalltalkAliases
@@ -425,43 +427,43 @@ UnicornRISCVSimulator >> initializeRegisterSmalltalkAliases [
 		at: #x31 put: #carry
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornRISCVSimulator >> instructionPointerRegister [
 
 	^ UcRISCVRegisters pc
 ]
 
-{ #category : #disassembling }
+{ #category : 'disassembling' }
 UnicornRISCVSimulator >> linkRegister [ 
 
 	^ UcRISCVRegisters x1
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 UnicornRISCVSimulator >> mstatus [
 
 	^ UcRISCVRegisters mstatus
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 UnicornRISCVSimulator >> mstatusRegisterValue [
 
 	^ self readRegister: self mstatus
 ]
 
-{ #category : #'c calling convention' }
+{ #category : 'c calling convention' }
 UnicornRISCVSimulator >> mstatusRegisterValue: aValue [
 
 	^ self writeRegister: self mstatus value: aValue
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornRISCVSimulator >> receiverRegister [
 	
 	^ UcRISCVRegisters x24
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornRISCVSimulator >> registerList [
 
 	^ #(lr pc sp fp 
@@ -470,375 +472,375 @@ UnicornRISCVSimulator >> registerList [
 		 f0 f1 f2 f3 f4 f5 f6 f7)
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> s0 [
 
 	^ self readRegister: UcRISCVRegisters s0
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> s0: aValue [
 
 	^ self writeRegister: UcRISCVRegisters s0 value: aValue
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> s2 [
 
 	^ self readRegister: UcRISCVRegisters s2
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> s2: aValue [
 
 	^ self writeRegister: UcRISCVRegisters s2 value: aValue
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> s7 [
 
 	^ self readRegister: UcRISCVRegisters s7
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> s7: aValue [
 
 	^ self writeRegister: UcRISCVRegisters s7 value: aValue
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> s8 [
 
 	^ self readRegister: UcRISCVRegisters s8
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> s8: aValue [
 
 	^ self writeRegister: UcRISCVRegisters s8 value: aValue
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> s9 [
 
 	^ self readRegister: UcRISCVRegisters s9
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> s9: aValue [
 
 	^ self writeRegister: UcRISCVRegisters s9 value: aValue
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornRISCVSimulator >> sendNumberOfArgumentsRegister [
 
 	^ UcRISCVRegisters x25
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornRISCVSimulator >> simulateLeafCallOf: destinationAddress nextpc: returnAddress memory: anUndefinedObject [ 
 
 	self linkRegisterValue: returnAddress.
 	self instructionPointerRegisterValue: destinationAddress
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornRISCVSimulator >> smashRegisterAccessors [
 	
 	"Caller saved registers to smash"
 	^#( x1: x5: x6: x7: x10: x11: x12: x13: x14: x15: x16: x17: x28: x29: x30: x31:)
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornRISCVSimulator >> stackPointerRegister [
 	
 	^ UcRISCVRegisters x2
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> t0 [
 
 	^ self readRegister: UcRISCVRegisters t0
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> t0: aValue [
 
 	^ self writeRegister: UcRISCVRegisters t0 value: aValue
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> t1 [
 
 	^ self readRegister: UcRISCVRegisters t1
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> t1: aValue [
 
 	^ self writeRegister: UcRISCVRegisters t1 value: aValue
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> t2 [
 
 	^ self readRegister: UcRISCVRegisters t2
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> t2: aValue [
 
 	^ self writeRegister: UcRISCVRegisters t2 value: aValue
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> t3 [
 
 	^ self readRegister: UcRISCVRegisters t3
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> t3: aValue [
 
 	^ self writeRegister: UcRISCVRegisters t3 value: aValue
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> t4 [
 
 	^ self readRegister: UcRISCVRegisters t4
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> t4: aValue [
 
 	^ self writeRegister: UcRISCVRegisters t4 value: aValue
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> t5 [
 
 	^ self readRegister: UcRISCVRegisters t5
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> t5: aValue [
 
 	^ self writeRegister: UcRISCVRegisters t5 value: aValue
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> t6 [
 
 	^ self readRegister: UcRISCVRegisters t6
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> t6: aValue [
 
 	^ self writeRegister: UcRISCVRegisters t6 value: aValue
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornRISCVSimulator >> temporaryRegister [
 
 	^ UcRISCVRegisters x22
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornRISCVSimulator >> wordSize [
 	
 	^ 8
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> x0 [
 
 	^ self readRegister: UcRISCVRegisters x0
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> x1 [
 
 	^ self readRegister: UcRISCVRegisters x1
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> x10 [
 
 	^ self readRegister: UcRISCVRegisters x10
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> x11 [
 
 	^ self readRegister: UcRISCVRegisters x11
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> x12 [
 
 	^ self readRegister: UcRISCVRegisters x12
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> x13 [
 
 	^ self readRegister: UcRISCVRegisters x13
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> x14 [
 
 	^ self readRegister: UcRISCVRegisters x14
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> x15 [
 
 	^ self readRegister: UcRISCVRegisters x15
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> x16 [
 
 	^ self readRegister: UcRISCVRegisters x16
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> x17 [
 
 	^ self readRegister: UcRISCVRegisters x17
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> x18 [
 
 	^ self readRegister: UcRISCVRegisters x18
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> x19 [
 
 	^ self readRegister: UcRISCVRegisters x19
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> x2 [
 
 	^ self readRegister: UcRISCVRegisters x2
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> x20 [
 
 	^ self readRegister: UcRISCVRegisters x20
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> x21 [
 
 	^ self readRegister: UcRISCVRegisters x21
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> x22 [
 
 	^ self readRegister: UcRISCVRegisters x22
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> x23 [
 
 	^ self readRegister: UcRISCVRegisters x23
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> x24 [
 
 	^ self readRegister: UcRISCVRegisters x24
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> x25 [
 
 	^ self readRegister: UcRISCVRegisters x25
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> x26 [
 
 	^ self readRegister: UcRISCVRegisters x26
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> x27 [
 
 	^ self readRegister: UcRISCVRegisters x27
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> x28 [
 
 	^ self readRegister: UcRISCVRegisters x28
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> x29 [
 
 	^ self readRegister: UcRISCVRegisters x29
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> x3 [
 
 	^ self readRegister: UcRISCVRegisters x3
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> x30 [
 
 	^ self readRegister: UcRISCVRegisters x30
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> x31 [
 
 	^ self readRegister: UcRISCVRegisters x31
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> x4 [
 
 	^ self readRegister: UcRISCVRegisters x4
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> x5 [
 
 	^ self readRegister: UcRISCVRegisters x5
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> x6 [
 
 	^ self readRegister: UcRISCVRegisters x6
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> x7 [
 
 	^ self readRegister: UcRISCVRegisters x7
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> x8 [
 
 	^ self readRegister: UcRISCVRegisters x8
 ]
 
-{ #category : #'machine registers' }
+{ #category : 'machine registers' }
 UnicornRISCVSimulator >> x9 [
 
 	^ self readRegister: UcRISCVRegisters x9

--- a/smalltalksrc/VMMakerTests/UnicornRegisterDescriptor.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornRegisterDescriptor.class.st
@@ -1,48 +1,50 @@
 Class {
-	#name : #UnicornRegisterDescriptor,
-	#superclass : #Object,
+	#name : 'UnicornRegisterDescriptor',
+	#superclass : 'Object',
 	#instVars : [
 		'simulator',
 		'name',
 		'alias'
 	],
-	#category : #'VMMakerTests-Unicorn'
+	#category : 'VMMakerTests-Unicorn',
+	#package : 'VMMakerTests',
+	#tag : 'Unicorn'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornRegisterDescriptor >> alias [
 	^ alias
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornRegisterDescriptor >> alias: aString [ 
 	
 	alias := aString
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 UnicornRegisterDescriptor >> copyValueToClipboard [
 	
 	Clipboard clipboardText: self value hex
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 UnicornRegisterDescriptor >> inspectValue [
 
 	self value inspect
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornRegisterDescriptor >> name [
 	^ name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornRegisterDescriptor >> name: anObject [
 	name := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornRegisterDescriptor >> printOn: aStream [
 
 	(self value isKindOf: Boolean )
@@ -52,23 +54,23 @@ UnicornRegisterDescriptor >> printOn: aStream [
 
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 UnicornRegisterDescriptor >> printValue [
 
 	simulator memory interpreter longPrintOop: self value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornRegisterDescriptor >> simulator [
 	^ simulator
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornRegisterDescriptor >> simulator: anObject [
 	simulator := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornRegisterDescriptor >> value [
 
 	^ simulator perform: name

--- a/smalltalksrc/VMMakerTests/UnicornSimulationTrap.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornSimulationTrap.class.st
@@ -1,14 +1,16 @@
 Class {
-	#name : #UnicornSimulationTrap,
-	#superclass : #Object,
+	#name : 'UnicornSimulationTrap',
+	#superclass : 'Object',
 	#instVars : [
 		'unicornInvalidAccess',
 		'simulator'
 	],
-	#category : #'VMMakerTests-Unicorn'
+	#category : 'VMMakerTests-Unicorn',
+	#package : 'VMMakerTests',
+	#tag : 'Unicorn'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 UnicornSimulationTrap class >> simulator: simulator error: anUnicornInvalidMemoryAccess [
 
 	^ self new
@@ -17,13 +19,13 @@ UnicornSimulationTrap class >> simulator: simulator error: anUnicornInvalidMemor
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornSimulationTrap >> address [
 	
 	^ unicornInvalidAccess address
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornSimulationTrap >> nextpc [
 	
 	| instruction |
@@ -31,7 +33,7 @@ UnicornSimulationTrap >> nextpc [
 	^ self simulator instructionPointerRegisterValue + instruction size
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornSimulationTrap >> registerAccessor [
 	
 	"Assume this is a read of a value into a register"
@@ -44,18 +46,18 @@ UnicornSimulationTrap >> registerAccessor [
 	^ (registerName , ':') asSymbol
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornSimulationTrap >> simulator [
 	
 	^ simulator
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornSimulationTrap >> simulator: anObject [
 	simulator := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornSimulationTrap >> type [
 	
 	unicornInvalidAccess type = UcMemoryAccessType UC_MEM_WRITE_UNMAPPED
@@ -68,12 +70,12 @@ UnicornSimulationTrap >> type [
 	self halt
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornSimulationTrap >> unicornInvalidAccess: anUnicornInvalidMemoryAccess [ 
 	unicornInvalidAccess := anUnicornInvalidMemoryAccess
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornSimulationTrap >> writtenValue [
 	"This is the value that was tried to be written but failed (if this is a failed write)"
 	^ unicornInvalidAccess value

--- a/smalltalksrc/VMMakerTests/UnicornSimulator.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornSimulator.class.st
@@ -1,26 +1,28 @@
 Class {
-	#name : #UnicornSimulator,
-	#superclass : #ProcessorSimulator,
+	#name : 'UnicornSimulator',
+	#superclass : 'ProcessorSimulator',
 	#instVars : [
 		'stopReason',
 		'invalidAccessHandler'
 	],
-	#category : #'VMMakerTests-Unicorn'
+	#category : 'VMMakerTests-Unicorn',
+	#package : 'VMMakerTests',
+	#tag : 'Unicorn'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 UnicornSimulator class >> supportsISA: isa [
 
 	^ #( #ARMv5 #ARMv8 #IA32 #X64 #aarch64 #riscv64 ) includes: isa
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 UnicornSimulator >> createUnicorn [
 
 	self subclassResponsibility
 ]
 
-{ #category : #executing }
+{ #category : 'executing' }
 UnicornSimulator >> doStartAt: startAddress until: until timeout: timeout count: count [
 
 	| result error startTime currentTime remainingTimeout remainingCount |
@@ -71,13 +73,13 @@ UnicornSimulator >> doStartAt: startAddress until: until timeout: timeout count:
 				ifTrue: [ ^ result ]]
 ]
 
-{ #category : #'stack-access' }
+{ #category : 'stack-access' }
 UnicornSimulator >> finishMappingMemory [
 
 	"Do nothing in the case of Unicorn, is useful if the simulator used has to map memory by hand"
 ]
 
-{ #category : #'handling invalid accesses' }
+{ #category : 'handling invalid accesses' }
 UnicornSimulator >> handleInvalidAccess: invalidAccess [
 
 	| previousInstructionPointer hasToContinue |
@@ -95,7 +97,7 @@ UnicornSimulator >> handleInvalidAccess: invalidAccess [
 	^ hasToContinue
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 UnicornSimulator >> initialize [
 
 	super initialize.
@@ -110,7 +112,7 @@ UnicornSimulator >> initialize [
 		true]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 UnicornSimulator >> initializeUnicorn [
 
 	simulator
@@ -126,12 +128,12 @@ UnicornSimulator >> initializeUnicorn [
 			false ]
 ]
 
-{ #category : #'handling invalid accesses' }
+{ #category : 'handling invalid accesses' }
 UnicornSimulator >> invalidAccessHandler: aFullBlockClosure [
 	invalidAccessHandler := aFullBlockClosure
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 UnicornSimulator >> registerHook: aBlock atAddress: anAddress [
 
 	simulator
@@ -140,7 +142,7 @@ UnicornSimulator >> registerHook: aBlock atAddress: anAddress [
 			address = anAddress ifTrue: [ aBlock value ] ]
 ]
 
-{ #category : #executing }
+{ #category : 'executing' }
 UnicornSimulator >> startAt: begin until: until timeout: timeout count: count [
 
 	^ self doStartAt: begin until: until timeout: timeout count: count.

--- a/smalltalksrc/VMMakerTests/UnicornTimeout.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornTimeout.class.st
@@ -1,18 +1,20 @@
 Class {
-	#name : #UnicornTimeout,
-	#superclass : #Error,
+	#name : 'UnicornTimeout',
+	#superclass : 'Error',
 	#instVars : [
 		'target'
 	],
-	#category : #'VMMakerTests-Unicorn'
+	#category : 'VMMakerTests-Unicorn',
+	#package : 'VMMakerTests',
+	#tag : 'Unicorn'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornTimeout >> target [
 	^ target
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornTimeout >> target: anObject [
 	target := anObject
 ]

--- a/smalltalksrc/VMMakerTests/UnicornX64Simulator.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornX64Simulator.class.st
@@ -1,98 +1,100 @@
 Class {
-	#name : #UnicornX64Simulator,
-	#superclass : #UnicornSimulator,
-	#category : #'VMMakerTests-Unicorn'
+	#name : 'UnicornX64Simulator',
+	#superclass : 'UnicornSimulator',
+	#category : 'VMMakerTests-Unicorn',
+	#package : 'VMMakerTests',
+	#tag : 'Unicorn'
 }
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornX64Simulator >> arg0Register [
 	
 	^ UcX86Registers rdi
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornX64Simulator >> arg1Register [
 	
 	^ UcX86Registers rsi
 ]
 
-{ #category : #'phisical-registers' }
+{ #category : 'phisical-registers' }
 UnicornX64Simulator >> baseRegister [
 
 	^ UcX86Registers rbx
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornX64Simulator >> cResultRegister [
 	
 	^ UcX86Registers rax
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornX64Simulator >> carg0Register [
 	
 	"Assume SysV"
 	^ UcX86Registers rdi
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornX64Simulator >> carg1Register [
 	
 	"Assume SysV"
 	^ UcX86Registers rsi
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornX64Simulator >> carg2Register [
 	
 	"Assume SysV"
 	^ UcX86Registers rdx
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornX64Simulator >> carg3Register [
 
 	"Assume SysV"
 	^ UcX86Registers rcx
 ]
 
-{ #category : #'virtual-registers' }
+{ #category : 'virtual-registers' }
 UnicornX64Simulator >> classRegister [
 	
 	^ UcX86Registers rcx
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornX64Simulator >> createUnicorn [
 
 	^ Unicorn x8664
 ]
 
-{ #category : #disassembling }
+{ #category : 'disassembling' }
 UnicornX64Simulator >> disassembler [
 	
 	^ LLVMDisassembler amd64
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornX64Simulator >> doublePrecisionFloatingPointRegister0 [
 
 	^ UcX86Registers xmm0
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornX64Simulator >> doublePrecisionFloatingPointRegister1 [
 
 	^ UcX86Registers xmm1
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornX64Simulator >> doublePrecisionFloatingPointRegister2 [
 
 	^ UcX86Registers xmm2
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornX64Simulator >> extractDestinationRegisterFromAssembly: aLLVMInstruction [ 
 	
 	| registerName |
@@ -102,25 +104,25 @@ UnicornX64Simulator >> extractDestinationRegisterFromAssembly: aLLVMInstruction 
 	^ registerName
 ]
 
-{ #category : #'virtual-registers' }
+{ #category : 'virtual-registers' }
 UnicornX64Simulator >> framePointerRegister [
 	
 	^ UcX86Registers rbp
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornX64Simulator >> getReturnAddress [
 	
 	^ self peekAddress 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 UnicornX64Simulator >> hasLinkRegister [
 
 	^ false
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 UnicornX64Simulator >> initializeRegisterAliases [
 
 	registerAliases
@@ -131,19 +133,19 @@ UnicornX64Simulator >> initializeRegisterAliases [
 		at: #rbp put: #framePointerRegister
 ]
 
-{ #category : #'virtual-registers' }
+{ #category : 'virtual-registers' }
 UnicornX64Simulator >> instructionPointerRegister [
 	
 	^ UcX86Registers rip
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornX64Simulator >> integerRegisterState [
 	
 	^ #()
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornX64Simulator >> postCallArgumentsNumArgs: numArgs in: aMemory [
 	"Answer an argument vector of the requested size after a Win64 or SysV
 	 ABI call.  On X64 this simply means accessing register arguments.
@@ -158,266 +160,266 @@ UnicornX64Simulator >> postCallArgumentsNumArgs: numArgs in: aMemory [
 		self perform: getter]
 ]
 
-{ #category : #'phisical-registers' }
+{ #category : 'phisical-registers' }
 UnicornX64Simulator >> r10 [
 
 	^ self readRegister: UcX86Registers r10
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornX64Simulator >> r10: anInteger [ 
 	
 	^ self writeRegister: UcX86Registers r10 value: anInteger
 ]
 
-{ #category : #'phisical-registers' }
+{ #category : 'phisical-registers' }
 UnicornX64Simulator >> r11 [
 
 	^ self readRegister: UcX86Registers r11
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornX64Simulator >> r11: anInteger [ 
 	
 	^ self writeRegister: UcX86Registers r11 value: anInteger
 ]
 
-{ #category : #'phisical-registers' }
+{ #category : 'phisical-registers' }
 UnicornX64Simulator >> r12 [
 
 	^ self readRegister: UcX86Registers r12
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornX64Simulator >> r12: anInteger [ 
 	
 	^ self writeRegister: UcX86Registers r12 value: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornX64Simulator >> r13: anInteger [ 
 	
 	self writeRegister: UcX86Registers r13 value: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornX64Simulator >> r14: anInteger [ 
 	
 	self writeRegister: UcX86Registers r14 value: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornX64Simulator >> r15: anInteger [ 
 	
 	self writeRegister: UcX86Registers r15 value: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornX64Simulator >> r1: anInteger [ 
 	
 	^ self writeRegister: UcX86Registers r1 value: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornX64Simulator >> r2: anInteger [ 
 	
 	^ self writeRegister: UcX86Registers r2 value: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornX64Simulator >> r3: anInteger [ 
 	
 	^ self writeRegister: UcX86Registers r3 value: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornX64Simulator >> r4: anInteger [ 
 	
 	^ self writeRegister: UcX86Registers r4 value: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornX64Simulator >> r5: anInteger [ 
 	
 	^ self writeRegister: UcX86Registers r5 value: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornX64Simulator >> r6: anInteger [ 
 	
 	^ self writeRegister: UcX86Registers r6 value: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornX64Simulator >> r7: anInteger [ 
 	
 	^ self writeRegister: UcX86Registers r7 value: anInteger
 ]
 
-{ #category : #'phisical-registers' }
+{ #category : 'phisical-registers' }
 UnicornX64Simulator >> r8 [
 
 	^ self readRegister: UcX86Registers r8
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornX64Simulator >> r8: anInteger [ 
 	
 	^ self writeRegister: UcX86Registers r8 value: anInteger
 ]
 
-{ #category : #'phisical-registers' }
+{ #category : 'phisical-registers' }
 UnicornX64Simulator >> r9 [
 
 	^ self readRegister: UcX86Registers r9
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornX64Simulator >> r9: anInteger [ 
 	
 	^ self writeRegister: UcX86Registers r9 value: anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornX64Simulator >> r9b: anInteger [ 
 
 	self writeRegister: UcX86Registers r9b value: anInteger 
 ]
 
-{ #category : #'phisical-registers' }
+{ #category : 'phisical-registers' }
 UnicornX64Simulator >> rax [
 
 	^ self readRegister: UcX86Registers rax
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornX64Simulator >> rax: anInteger [ 
 	
 	self writeRegister: UcX86Registers rax value: anInteger
 ]
 
-{ #category : #'phisical-registers' }
+{ #category : 'phisical-registers' }
 UnicornX64Simulator >> rbp [
 
 	^ self readRegister: UcX86Registers rbp
 ]
 
-{ #category : #'phisical-registers' }
+{ #category : 'phisical-registers' }
 UnicornX64Simulator >> rbp: anInteger [ 
 
 	^ self writeRegister: UcX86Registers rbp value: anInteger
 ]
 
-{ #category : #'phisical-registers' }
+{ #category : 'phisical-registers' }
 UnicornX64Simulator >> rbx [
 
 	^ self readRegister: UcX86Registers rbx
 ]
 
-{ #category : #'phisical-registers' }
+{ #category : 'phisical-registers' }
 UnicornX64Simulator >> rbx: aValue [
 
 	^ self writeRegister: UcX86Registers rbx value: aValue
 ]
 
-{ #category : #'phisical-registers' }
+{ #category : 'phisical-registers' }
 UnicornX64Simulator >> rcx [
 
 	^ self readRegister: UcX86Registers rcx
 ]
 
-{ #category : #'phisical-registers' }
+{ #category : 'phisical-registers' }
 UnicornX64Simulator >> rcx: anInteger [ 
 
 	^ self writeRegister: UcX86Registers rcx value: anInteger
 ]
 
-{ #category : #'phisical-registers' }
+{ #category : 'phisical-registers' }
 UnicornX64Simulator >> rdi [
 
 	^ self readRegister: UcX86Registers rdi
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornX64Simulator >> rdi: anInteger [ 
 	
 	self writeRegister: UcX86Registers rdi value: anInteger
 ]
 
-{ #category : #'phisical-registers' }
+{ #category : 'phisical-registers' }
 UnicornX64Simulator >> rdx [
 
 	^ self readRegister: UcX86Registers rdx
 ]
 
-{ #category : #'phisical-registers' }
+{ #category : 'phisical-registers' }
 UnicornX64Simulator >> rdx: anInteger [ 
 
 	^ self writeRegister: UcX86Registers rdx value: anInteger
 ]
 
-{ #category : #'virtual-registers' }
+{ #category : 'virtual-registers' }
 UnicornX64Simulator >> receiverRegister [
 	
 	^ UcX86Registers rdx
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornX64Simulator >> registerList [
 	
 	^ #(rip rax rbx rcx rdx rsp rbp r8 r9 r10 r11 r12 rsi rdi)
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornX64Simulator >> retpcIn: aSpurSimulatedMemory [ 
 
 	^ memory long64At: self rbp + 8	
 
 ]
 
-{ #category : #'phisical-registers' }
+{ #category : 'phisical-registers' }
 UnicornX64Simulator >> rip [
 
 	^ self readRegister: UcX86Registers rip
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornX64Simulator >> rip: anInteger [ 
 	
 	self writeRegister: UcX86Registers rip value: anInteger
 ]
 
-{ #category : #'phisical-registers' }
+{ #category : 'phisical-registers' }
 UnicornX64Simulator >> rsi [
 
 	^ self readRegister: UcX86Registers rsi
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornX64Simulator >> rsi: anInteger [ 
 	
 	self writeRegister: UcX86Registers rsi value: anInteger
 ]
 
-{ #category : #'phisical-registers' }
+{ #category : 'phisical-registers' }
 UnicornX64Simulator >> rsp [
 
 	^ self readRegister: UcX86Registers rsp
 ]
 
-{ #category : #'phisical-registers' }
+{ #category : 'phisical-registers' }
 UnicornX64Simulator >> rsp: anInteger [ 
 	
 	^ self writeRegister: UcX86Registers rsp value: anInteger
 ]
 
-{ #category : #'virtual-registers' }
+{ #category : 'virtual-registers' }
 UnicornX64Simulator >> sendNumberOfArgumentsRegister [
 	
 	^ UcX86Registers r9
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornX64Simulator >> simulateJumpCallOf: address memory: aMemory [
 	"Simulate a frame-building jump call of address (i.e. do not push the return pc
 	 as this has already been done).  Build a frame since
@@ -437,21 +439,21 @@ UnicornX64Simulator >> simulateJumpCallOf: address memory: aMemory [
 	self rip: address
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornX64Simulator >> simulateLeafCallOf: address nextpc: nextpc memory: aMemory [
 
 	self pushWord: nextpc.
 	self rip: address
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornX64Simulator >> simulateReturnIn: aMemory [
 
 	self rbp: (self popWord).
 	self rip: (self popWord)
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornX64Simulator >> smashCallerSavedRegistersWithValuesFrom: base by: step in: aMemory [
 	| volatileRegisters |
 	CogX64Compiler isSysV
@@ -469,50 +471,50 @@ UnicornX64Simulator >> smashCallerSavedRegistersWithValuesFrom: base by: step in
 		self perform: setter with: index - 1 * step + base]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 UnicornX64Simulator >> smashRegisterAccessors [
 
 	^#(rax: rbx: rcx: rdx: rsi: rdi: r8: r9: r10: r11: r12: r13: r14: r15:)
 ]
 
-{ #category : #'virtual-registers' }
+{ #category : 'virtual-registers' }
 UnicornX64Simulator >> stackPointerRegister [
 
 	^ UcX86Registers rsp
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornX64Simulator >> temporaryRegister [
 	
 	"Both in System V and Windows"
 	^ UcX86Registers rax
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornX64Simulator >> vectorRegister0Value [
 
 	^ simulator readRegisterId: UcX86Registers xmm0 size:  16
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornX64Simulator >> wordSize [
 	
 	^ 8
 ]
 
-{ #category : #'accessing - registers' }
+{ #category : 'accessing - registers' }
 UnicornX64Simulator >> xmm0 [
 	
 	^ simulator readRegisterId: UcX86Registers xmm0 size: 16
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 UnicornX64Simulator >> xmm1 [
 	
 	^ simulator readRegisterId: UcX86Registers xmm1 size: 16
 ]
 
-{ #category : #registers }
+{ #category : 'registers' }
 UnicornX64Simulator >> xmm2 [
 	
 	^ simulator readRegisterId: UcX86Registers xmm2 size: 16

--- a/smalltalksrc/VMMakerTests/VMARMStackAlignmentTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMARMStackAlignmentTest.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #VMARMStackAlignmentTest,
-	#superclass : #VMSimpleStackBasedCogitAbstractTest,
+	#name : 'VMARMStackAlignmentTest',
+	#superclass : 'VMSimpleStackBasedCogitAbstractTest',
 	#instVars : [
 		'instructions'
 	],
 	#pools : [
 		'CogAbstractRegisters'
 	],
-	#category : #'VMMakerTests-JitTests'
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #'building suites' }
+{ #category : 'building suites' }
 VMARMStackAlignmentTest class >> wordSizeParameters [
 
 	^ ParametrizedTestMatrix new
@@ -18,25 +20,25 @@ VMARMStackAlignmentTest class >> wordSizeParameters [
 		yourself
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMARMStackAlignmentTest >> addInstruction: anInstruction [ 
 
 	instructions add: anInstruction 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMARMStackAlignmentTest >> disassembleInstructions [
 
 	^ self disassembleFrom: cogInitialAddress opcodes: instructions size
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMARMStackAlignmentTest >> runInstructions [
 
 	^ self runFrom: cogInitialAddress until: cogInitialAddress + (instructions size * 4)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMARMStackAlignmentTest >> setUp [
 
 	super setUp.
@@ -45,7 +47,7 @@ VMARMStackAlignmentTest >> setUp [
 	machineSimulator stackPointerRegisterValue: interpreter rumpCStackAddress
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMARMStackAlignmentTest >> testUnAlignedStackWriteShouldGenerateError [
 	"To start the stack pointer should be aligned"
 
@@ -96,7 +98,7 @@ VMARMStackAlignmentTest >> testUnAlignedStackWriteShouldGenerateError [
 				equals: 'Unhandled CPU exception (UC_ERR_EXCEPTION)' ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMARMStackAlignmentTest >> testUnAlignedStackWriteShouldPass [
 
 	"To start the stack pointer should be aligned"	
@@ -135,7 +137,7 @@ VMARMStackAlignmentTest >> testUnAlignedStackWriteShouldPass [
 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMARMStackAlignmentTest >> writeInstructions [
 	
 	cogInitialAddress := cogit methodZone allocate: instructions size * 4 .

--- a/smalltalksrc/VMMakerTests/VMARMV8SIMDEncodingTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMARMV8SIMDEncodingTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #VMARMV8SIMDEncodingTest,
-	#superclass : #VMSimpleStackBasedCogitAbstractTest,
-	#category : #'VMMakerTests-JitTests'
+	#name : 'VMARMV8SIMDEncodingTest',
+	#superclass : 'VMSimpleStackBasedCogitAbstractTest',
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #'building suites' }
+{ #category : 'building suites' }
 VMARMV8SIMDEncodingTest class >> wordSizeParameters [
 
 	^ ParametrizedTestMatrix new
@@ -12,7 +14,7 @@ VMARMV8SIMDEncodingTest class >> wordSizeParameters [
 		yourself
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMARMV8SIMDEncodingTest >> armInstructionAt: index [
 
 	| addr inst |
@@ -22,20 +24,20 @@ VMARMV8SIMDEncodingTest >> armInstructionAt: index [
 	^ inst aarch64Disassembled
 ]
 
-{ #category : #configuration }
+{ #category : 'configuration' }
 VMARMV8SIMDEncodingTest >> generateCaptureCStackPointers [
 	
 	^ false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMARMV8SIMDEncodingTest >> initializationOptions [
 
 	^ super initializationOptions , { 
 		#ProcessorClass . DummyProcessor }
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMARMV8SIMDEncodingTest >> jitOptions [
 
 	^ super jitOptions
@@ -44,7 +46,7 @@ VMARMV8SIMDEncodingTest >> jitOptions [
 		  yourself
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMARMV8SIMDEncodingTest >> testEncodeDupWith64BitLanes [
 
 	self compile: [ cogit DupS: 64 R: 3 Vr: 0 ].
@@ -54,7 +56,7 @@ VMARMV8SIMDEncodingTest >> testEncodeDupWith64BitLanes [
 		equals: 'dup	v0.2d, x3'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMARMV8SIMDEncodingTest >> testEncodeFaddWith32BitLanes [
 
 	self compile: [ cogit FaddS: 32 Rv: 0 Rv: 1 Rv: 2 ].
@@ -64,7 +66,7 @@ VMARMV8SIMDEncodingTest >> testEncodeFaddWith32BitLanes [
 		equals: 'fadd	v2.4s, v0.4s, v1.4s'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMARMV8SIMDEncodingTest >> testEncodeFaddWith64BitLanes [
 
 	self compile: [ cogit FaddS: 64 Rv: 0 Rv: 1 Rv: 2 ].
@@ -74,7 +76,7 @@ VMARMV8SIMDEncodingTest >> testEncodeFaddWith64BitLanes [
 		equals: 'fadd	v2.2d, v0.2d, v1.2d'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMARMV8SIMDEncodingTest >> testEncodeFsubWith64BitLanes [
 
 	self compile: [ cogit FsubS: 64 Rv: 0 Rv: 1 Rv: 2 ].
@@ -84,7 +86,7 @@ VMARMV8SIMDEncodingTest >> testEncodeFsubWith64BitLanes [
 		equals: 'fsub	v2.2d, v0.2d, v1.2d'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMARMV8SIMDEncodingTest >> testEncodeLd1WithOne32BitLaneRegisterAndImmediateOffset [
 
 	self compile: [ cogit Ld1S: 32 Vr: 0 R: 1 Mw: 16 ].
@@ -94,7 +96,7 @@ VMARMV8SIMDEncodingTest >> testEncodeLd1WithOne32BitLaneRegisterAndImmediateOffs
 		equals: 'ld1	{ v0.4s }, [x1], #16'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMARMV8SIMDEncodingTest >> testEncodeLd1WithOne64BitLaneRegisterAndImmediateOffset [
 
 	self compile: [ cogit Ld1S: 64 Vr: 0 R: 1 Mw: 16 ].
@@ -104,7 +106,7 @@ VMARMV8SIMDEncodingTest >> testEncodeLd1WithOne64BitLaneRegisterAndImmediateOffs
 		equals: 'ld1	{ v0.2d }, [x1], #16'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMARMV8SIMDEncodingTest >> testEncodeLd1WithOne64BitLaneRegisterAndNoOffset [
 
 	self compile: [ cogit Ld1S: 64 Vr: 0 R: 1 Mw: 0 ].
@@ -114,7 +116,7 @@ VMARMV8SIMDEncodingTest >> testEncodeLd1WithOne64BitLaneRegisterAndNoOffset [
 		equals: 'ld1	{ v0.2d }, [x1]'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMARMV8SIMDEncodingTest >> testEncodeSt1WithOne32BitLaneRegisterAndImmediateOffset [
 
 	self compile: [ cogit St1S: 32 Vr: 0 R: 1 Mw: 16 ].
@@ -124,7 +126,7 @@ VMARMV8SIMDEncodingTest >> testEncodeSt1WithOne32BitLaneRegisterAndImmediateOffs
 		equals: 'st1	{ v0.4s }, [x1], #16'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMARMV8SIMDEncodingTest >> testEncodeSt1WithOne64BitLaneRegisterAndImmediateOffset [
 
 	self compile: [ cogit St1S: 64 Vr: 0 R: 1 Mw: 16 ].
@@ -134,7 +136,7 @@ VMARMV8SIMDEncodingTest >> testEncodeSt1WithOne64BitLaneRegisterAndImmediateOffs
 		equals: 'st1	{ v0.2d }, [x1], #16'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMARMV8SIMDEncodingTest >> testEncodeSt1WithOne64BitLaneRegisterAndNoOffset [
 
 	self compile: [ cogit St1S: 64 Vr: 0 R: 1 Mw: 0 ].

--- a/smalltalksrc/VMMakerTests/VMARMV8SpecificEncodingTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMARMV8SpecificEncodingTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #VMARMV8SpecificEncodingTest,
-	#superclass : #VMSimpleStackBasedCogitAbstractTest,
-	#category : #'VMMakerTests-JitTests'
+	#name : 'VMARMV8SpecificEncodingTest',
+	#superclass : 'VMSimpleStackBasedCogitAbstractTest',
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #'building suites' }
+{ #category : 'building suites' }
 VMARMV8SpecificEncodingTest class >> wordSizeParameters [
 
 	^ ParametrizedTestMatrix new
@@ -12,7 +14,7 @@ VMARMV8SpecificEncodingTest class >> wordSizeParameters [
 		yourself
 ]
 
-{ #category : #'tests - MoveRMwr' }
+{ #category : 'tests - MoveRMwr' }
 VMARMV8SpecificEncodingTest >> armInstructionAt: index [
 
 	| addr inst |
@@ -22,7 +24,7 @@ VMARMV8SpecificEncodingTest >> armInstructionAt: index [
 	^ inst aarch64Disassembled
 ]
 
-{ #category : #'tests - MoveMbrR' }
+{ #category : 'tests - MoveMbrR' }
 VMARMV8SpecificEncodingTest >> doTestEncodeMoveMbrR: constant [
 
 	| expectedAddress expectedValue |
@@ -46,7 +48,7 @@ VMARMV8SpecificEncodingTest >> doTestEncodeMoveMbrR: constant [
 
 ]
 
-{ #category : #'tests - MoveMwrR' }
+{ #category : 'tests - MoveMwrR' }
 VMARMV8SpecificEncodingTest >> doTestEncodeMoveMwrR: constant [
 
 	| expectedAddress expectedValue |
@@ -70,7 +72,7 @@ VMARMV8SpecificEncodingTest >> doTestEncodeMoveMwrR: constant [
 
 ]
 
-{ #category : #'tests - MoveRMwr' }
+{ #category : 'tests - MoveRMwr' }
 VMARMV8SpecificEncodingTest >> doTestEncodeMoveRMwr: constant [
 
 	| expectedAddress expectedValue |
@@ -92,7 +94,7 @@ VMARMV8SpecificEncodingTest >> doTestEncodeMoveRMwr: constant [
 
 ]
 
-{ #category : #'tests - cmpCqR' }
+{ #category : 'tests - cmpCqR' }
 VMARMV8SpecificEncodingTest >> testEncodeCmpCqRNonEncodeable12BitConstant [
 
 	| constant |
@@ -108,7 +110,7 @@ VMARMV8SpecificEncodingTest >> testEncodeCmpCqRNonEncodeable12BitConstant [
 	self assert: machineSimulator zero
 ]
 
-{ #category : #'tests - cmpCqR' }
+{ #category : 'tests - cmpCqR' }
 VMARMV8SpecificEncodingTest >> testEncodeCmpCqRWithNegative12BitConstant [
 
 	| negativeConstant12Bits |
@@ -123,7 +125,7 @@ VMARMV8SpecificEncodingTest >> testEncodeCmpCqRWithNegative12BitConstant [
 	self assert: machineSimulator zero
 ]
 
-{ #category : #'tests - cmpCqR' }
+{ #category : 'tests - cmpCqR' }
 VMARMV8SpecificEncodingTest >> testEncodeCmpCqRWithNegative12ShiftableBitConstant [
 
 	| negativeConstant12Bits |
@@ -138,7 +140,7 @@ VMARMV8SpecificEncodingTest >> testEncodeCmpCqRWithNegative12ShiftableBitConstan
 	self assert: machineSimulator zero
 ]
 
-{ #category : #'tests - cmpCqR' }
+{ #category : 'tests - cmpCqR' }
 VMARMV8SpecificEncodingTest >> testEncodeCmpCqRWithNegative13ShiftableBitConstant [
 
 	| negativeConstant12Bits |
@@ -153,7 +155,7 @@ VMARMV8SpecificEncodingTest >> testEncodeCmpCqRWithNegative13ShiftableBitConstan
 	self assert: machineSimulator zero
 ]
 
-{ #category : #'tests - cmpCqR' }
+{ #category : 'tests - cmpCqR' }
 VMARMV8SpecificEncodingTest >> testEncodeCmpCqRWithNegativeConstant [
 
 	| negativeConstant12Bits |
@@ -168,7 +170,7 @@ VMARMV8SpecificEncodingTest >> testEncodeCmpCqRWithNegativeConstant [
 	self assert: machineSimulator zero
 ]
 
-{ #category : #'tests - cmpCqR' }
+{ #category : 'tests - cmpCqR' }
 VMARMV8SpecificEncodingTest >> testEncodeCmpCqRWithPositive12BitConstant [
 
 	| positiveConstant12Bits |
@@ -183,7 +185,7 @@ VMARMV8SpecificEncodingTest >> testEncodeCmpCqRWithPositive12BitConstant [
 	self assert: machineSimulator zero
 ]
 
-{ #category : #'tests - cmpCqR' }
+{ #category : 'tests - cmpCqR' }
 VMARMV8SpecificEncodingTest >> testEncodeCmpCqRWithPositiveBigConstant [
 
 	| positiveConstant12Bits |
@@ -198,7 +200,7 @@ VMARMV8SpecificEncodingTest >> testEncodeCmpCqRWithPositiveBigConstant [
 	self assert: machineSimulator zero
 ]
 
-{ #category : #'tests - cmpCqR' }
+{ #category : 'tests - cmpCqR' }
 VMARMV8SpecificEncodingTest >> testEncodeCmpCqRWithPositiveShiftable12BitConstant [
 
 	| positiveConstant12Bits |
@@ -213,7 +215,7 @@ VMARMV8SpecificEncodingTest >> testEncodeCmpCqRWithPositiveShiftable12BitConstan
 	self assert: machineSimulator zero
 ]
 
-{ #category : #'tests - cmpCqR' }
+{ #category : 'tests - cmpCqR' }
 VMARMV8SpecificEncodingTest >> testEncodeCmpCqRWithPositiveShiftable13BitConstant [
 
 	| positiveConstant12Bits |
@@ -228,7 +230,7 @@ VMARMV8SpecificEncodingTest >> testEncodeCmpCqRWithPositiveShiftable13BitConstan
 	self assert: machineSimulator zero
 ]
 
-{ #category : #'tests - cmpCqR' }
+{ #category : 'tests - cmpCqR' }
 VMARMV8SpecificEncodingTest >> testEncodeMoveCqRWithEncodeableLargeNumber [
 
 
@@ -243,7 +245,7 @@ VMARMV8SpecificEncodingTest >> testEncodeMoveCqRWithEncodeableLargeNumber [
 	self assert: machineSimulator x24 equals: constantValue
 ]
 
-{ #category : #'tests - cmpCqR' }
+{ #category : 'tests - cmpCqR' }
 VMARMV8SpecificEncodingTest >> testEncodeMoveCqRWithLargeConstant [
 
 
@@ -258,7 +260,7 @@ VMARMV8SpecificEncodingTest >> testEncodeMoveCqRWithLargeConstant [
 	self assert: machineSimulator x24 equals: constantValue
 ]
 
-{ #category : #'tests - cmpCqR' }
+{ #category : 'tests - cmpCqR' }
 VMARMV8SpecificEncodingTest >> testEncodeMoveCqRWithNegativeLargeConstant [
 
 
@@ -275,7 +277,7 @@ VMARMV8SpecificEncodingTest >> testEncodeMoveCqRWithNegativeLargeConstant [
 	self assert: machineSimulator x24 hex equals: completementValue hex
 ]
 
-{ #category : #'tests - MoveMbrR' }
+{ #category : 'tests - MoveMbrR' }
 VMARMV8SpecificEncodingTest >> testEncodeMoveMbrRWithNegative9BitConstant [
 
 	self doTestEncodeMoveMbrR: -256.
@@ -283,7 +285,7 @@ VMARMV8SpecificEncodingTest >> testEncodeMoveMbrRWithNegative9BitConstant [
 
 ]
 
-{ #category : #'tests - MoveMbrR' }
+{ #category : 'tests - MoveMbrR' }
 VMARMV8SpecificEncodingTest >> testEncodeMoveMbrRWithNegativeNon9BitConstant [
 
 	self doTestEncodeMoveMbrR: -1024.
@@ -291,7 +293,7 @@ VMARMV8SpecificEncodingTest >> testEncodeMoveMbrRWithNegativeNon9BitConstant [
 
 ]
 
-{ #category : #'tests - MoveMbrR' }
+{ #category : 'tests - MoveMbrR' }
 VMARMV8SpecificEncodingTest >> testEncodeMoveMbrRWithPositive9BitConstant [
 
 	self doTestEncodeMoveMbrR: 255.
@@ -299,7 +301,7 @@ VMARMV8SpecificEncodingTest >> testEncodeMoveMbrRWithPositive9BitConstant [
 
 ]
 
-{ #category : #'tests - MoveMbrR' }
+{ #category : 'tests - MoveMbrR' }
 VMARMV8SpecificEncodingTest >> testEncodeMoveMbrRWithPositiveNon9BitConstant [
 
 	self doTestEncodeMoveMbrR: 1024.
@@ -307,35 +309,35 @@ VMARMV8SpecificEncodingTest >> testEncodeMoveMbrRWithPositiveNon9BitConstant [
 
 ]
 
-{ #category : #'tests - MoveMwrR' }
+{ #category : 'tests - MoveMwrR' }
 VMARMV8SpecificEncodingTest >> testEncodeMoveMwrRWithNegative9BitConstant [
 
 	self doTestEncodeMoveMwrR: -256
 	
 ]
 
-{ #category : #'tests - MoveMwrR' }
+{ #category : 'tests - MoveMwrR' }
 VMARMV8SpecificEncodingTest >> testEncodeMoveMwrRWithNegativeNon9BitConstant [
 
 	self doTestEncodeMoveMwrR: -20056
 	
 ]
 
-{ #category : #'tests - MoveMwrR' }
+{ #category : 'tests - MoveMwrR' }
 VMARMV8SpecificEncodingTest >> testEncodeMoveMwrRWithPositive12BitConstant [
 
 	self doTestEncodeMoveMwrR: 16r100
 	
 ]
 
-{ #category : #'tests - MoveMwrR' }
+{ #category : 'tests - MoveMwrR' }
 VMARMV8SpecificEncodingTest >> testEncodeMoveMwrRWithPositiveNon9BitConstant [
 
 	self doTestEncodeMoveMwrR: 20056
 	
 ]
 
-{ #category : #'tests - MoveRMwr' }
+{ #category : 'tests - MoveRMwr' }
 VMARMV8SpecificEncodingTest >> testEncodeMoveRMwrWithNegative9BitConstant [
 
 	self doTestEncodeMoveRMwr: -256.
@@ -346,28 +348,28 @@ VMARMV8SpecificEncodingTest >> testEncodeMoveRMwrWithNegative9BitConstant [
 		equals: 'stur	x23, [x3, #-256]'
 ]
 
-{ #category : #'tests - MoveRMwr' }
+{ #category : 'tests - MoveRMwr' }
 VMARMV8SpecificEncodingTest >> testEncodeMoveRMwrWithNon9BitButShiftableConstant [
 
 	self doTestEncodeMoveRMwr: 512
 
 ]
 
-{ #category : #'tests - MoveRMwr' }
+{ #category : 'tests - MoveRMwr' }
 VMARMV8SpecificEncodingTest >> testEncodeMoveRMwrWithNon9BitNegativeConstant [
 
 	self doTestEncodeMoveRMwr: -61440
 
 ]
 
-{ #category : #'tests - MoveRMwr' }
+{ #category : 'tests - MoveRMwr' }
 VMARMV8SpecificEncodingTest >> testEncodeMoveRMwrWithPositive9BitConstant [
 
 	self doTestEncodeMoveRMwr: 256
 
 ]
 
-{ #category : #'tests - cmpCqR' }
+{ #category : 'tests - cmpCqR' }
 VMARMV8SpecificEncodingTest >> testEncodeOrCqRWithEncodableConstant [
 
 	self compile: [
@@ -379,7 +381,7 @@ VMARMV8SpecificEncodingTest >> testEncodeOrCqRWithEncodableConstant [
 	self assert: machineSimulator receiverRegisterValue equals: 16r1FF
 ]
 
-{ #category : #'tests - cmpCqR' }
+{ #category : 'tests - cmpCqR' }
 VMARMV8SpecificEncodingTest >> testEncodeOrCqRWithLargeConstant [
 
 	self compile: [
@@ -391,7 +393,7 @@ VMARMV8SpecificEncodingTest >> testEncodeOrCqRWithLargeConstant [
 	self assert: machineSimulator receiverRegisterValue equals: (67108865 bitOr: 16r100)
 ]
 
-{ #category : #'tests - cmpCqR' }
+{ #category : 'tests - cmpCqR' }
 VMARMV8SpecificEncodingTest >> testEncodeOrCqRWithNonEncodableConstant [
 
 	self compile: [

--- a/smalltalksrc/VMMakerTests/VMAbstractBuilder.class.st
+++ b/smalltalksrc/VMMakerTests/VMAbstractBuilder.class.st
@@ -1,14 +1,16 @@
 Class {
-	#name : #VMAbstractBuilder,
-	#superclass : #Object,
+	#name : 'VMAbstractBuilder',
+	#superclass : 'Object',
 	#instVars : [
 		'interpreter',
 		'memory'
 	],
-	#category : #'VMMakerTests-Builders'
+	#category : 'VMMakerTests-Builders',
+	#package : 'VMMakerTests',
+	#tag : 'Builders'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMAbstractBuilder >> collection: aCollection at: anIndex put: anOop [
 	"convinience method to put an oop at a specific place
 	No need to take care of the size of the collection, I'm taking care of it!"
@@ -20,22 +22,22 @@ VMAbstractBuilder >> collection: aCollection at: anIndex put: anOop [
 	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMAbstractBuilder >> interpreter [
 	^ interpreter
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMAbstractBuilder >> interpreter: anObject [
 	interpreter := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMAbstractBuilder >> memory [
 	^ memory
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMAbstractBuilder >> memory: anObject [
 	memory := anObject
 ]

--- a/smalltalksrc/VMMakerTests/VMAbstractFFITest.class.st
+++ b/smalltalksrc/VMMakerTests/VMAbstractFFITest.class.st
@@ -1,13 +1,14 @@
 Class {
-	#name : #VMAbstractFFITest,
-	#superclass : #VMAbstractPrimitiveTest,
+	#name : 'VMAbstractFFITest',
+	#superclass : 'VMAbstractPrimitiveTest',
 	#pools : [
 		'LibFFIConstants'
 	],
-	#category : #VMMakerTests
+	#category : 'VMMakerTests',
+	#package : 'VMMakerTests'
 }
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMAbstractFFITest >> createExternalFunctionFor: aBlock withArgumentTypes: argumentTypes withReturnType: returnType [
 
 	| functionAddress tfExternalFunction functionExternalAddress tfFunctionDefinition cif cifExternalAddress |
@@ -31,7 +32,7 @@ VMAbstractFFITest >> createExternalFunctionFor: aBlock withArgumentTypes: argume
 	^ tfExternalFunction
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMAbstractFFITest >> createReturnFloatExternalFunctionFor: aBlock [
 
 	^ self
@@ -40,7 +41,7 @@ VMAbstractFFITest >> createReturnFloatExternalFunctionFor: aBlock [
 		withReturnType: interpreter libFFI float
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMAbstractFFITest >> createReturnFloatExternalFunctionFor: aBlock withArgumentTypes: argumentTypes [
 
 	^ self
@@ -49,20 +50,20 @@ VMAbstractFFITest >> createReturnFloatExternalFunctionFor: aBlock withArgumentTy
 		withReturnType: interpreter libFFI float
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMAbstractFFITest >> initializationOptions [
 
 	^ super initializationOptions , { 
 		#FEATURE_FFI . true }
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMAbstractFFITest >> interpreterClass [
 	
 	^ VMTestMockInterpreter
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMAbstractFFITest >> newExternalAddress: anInteger [
 
 	| anExternalAddress |
@@ -75,7 +76,7 @@ VMAbstractFFITest >> newExternalAddress: anInteger [
 	^ anExternalAddress
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMAbstractFFITest >> readyProcesses [
 	
 	| collection |
@@ -84,7 +85,7 @@ VMAbstractFFITest >> readyProcesses [
 	^ collection
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 VMAbstractFFITest >> setUp [ 
 
 	super setUp.

--- a/smalltalksrc/VMMakerTests/VMAbstractImageFormatTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMAbstractImageFormatTest.class.st
@@ -1,38 +1,40 @@
 Class {
-	#name : #VMAbstractImageFormatTest,
-	#superclass : #VMSpurInitializedOldSpaceTest,
+	#name : 'VMAbstractImageFormatTest',
+	#superclass : 'VMSpurInitializedOldSpaceTest',
 	#instVars : [
 		'imageReader'
 	],
-	#category : #'VMMakerTests-ImageFormat'
+	#category : 'VMMakerTests-ImageFormat',
+	#package : 'VMMakerTests',
+	#tag : 'ImageFormat'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMAbstractImageFormatTest >> defaultTimeLimit [
 
 	^ 30 seconds
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMAbstractImageFormatTest >> imageFileName [
 
 	^ 'lala.image'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMAbstractImageFormatTest >> readHeader [
 
 	^ imageReader readHeaderFromImage: self imageFileName
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 VMAbstractImageFormatTest >> saveImage [
 	
 	interpreter writeImageFileIO.
 
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMAbstractImageFormatTest >> setUp [
 
 	super setUp.
@@ -55,7 +57,7 @@ VMAbstractImageFormatTest >> setUp [
 
 ]
 
-{ #category : #ston }
+{ #category : 'ston' }
 VMAbstractImageFormatTest >> stonPretty: anObject [ 
 
 	^ String streamContents: [ :s |
@@ -66,7 +68,7 @@ VMAbstractImageFormatTest >> stonPretty: anObject [
 		 ]
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMAbstractImageFormatTest >> tearDown [
 
 	self imageFileName asFileReference ensureDeleteAll.

--- a/smalltalksrc/VMMakerTests/VMAbstractPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMAbstractPrimitiveTest.class.st
@@ -1,16 +1,17 @@
 Class {
-	#name : #VMAbstractPrimitiveTest,
-	#superclass : #VMSpurMemoryManagerTest,
+	#name : 'VMAbstractPrimitiveTest',
+	#superclass : 'VMSpurMemoryManagerTest',
 	#pools : [
 		'VMBasicConstants',
 		'VMBytecodeConstants',
 		'VMClassIndices',
 		'VMObjectIndices'
 	],
-	#category : #VMMakerTests
+	#category : 'VMMakerTests',
+	#package : 'VMMakerTests'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 VMAbstractPrimitiveTest >> createProcessFor: newMethod priority: aPriority [
 
 	| aProcess |
@@ -23,7 +24,7 @@ VMAbstractPrimitiveTest >> createProcessFor: newMethod priority: aPriority [
 	^ aProcess
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMAbstractPrimitiveTest >> createSuspendedProcessFor: newMethod priority: aPriority [
 
 	| suspendedContext aProcess |
@@ -45,7 +46,7 @@ VMAbstractPrimitiveTest >> createSuspendedProcessFor: newMethod priority: aPrior
 	^ aProcess
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMAbstractPrimitiveTest >> newArrayWith: aCollection [ 
 	| array |
 	array := self newObjectWithSlots: aCollection size format: memory arrayFormat classIndex: memory arrayClassIndexPun.
@@ -56,7 +57,7 @@ VMAbstractPrimitiveTest >> newArrayWith: aCollection [
 	
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMAbstractPrimitiveTest >> newMethodWithBytecodes: aCollection [
 
 	^ methodBuilder
@@ -65,7 +66,7 @@ VMAbstractPrimitiveTest >> newMethodWithBytecodes: aCollection [
 		  buildMethod
 ]
 
-{ #category : #'helpers - frames' }
+{ #category : 'helpers - frames' }
 VMAbstractPrimitiveTest >> newSmallContextReceiver: anOop method: aMethodOop arguments: aCollectionOfArgumentsOop temporaries: aCollectionOfTemporariesOop ip: anIp [
 
 	| newCtx numArgs numTemps |
@@ -114,7 +115,7 @@ VMAbstractPrimitiveTest >> newSmallContextReceiver: anOop method: aMethodOop arg
 	^ newCtx
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMAbstractPrimitiveTest >> setUp [
 	
 	"taken from VMSimpleStackBasedCogitBytecodeTest >> #setup"

--- a/smalltalksrc/VMMakerTests/VMBlockTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMBlockTest.class.st
@@ -1,24 +1,26 @@
 Class {
-	#name : #VMBlockTest,
-	#superclass : #VMInterpreterTests,
+	#name : 'VMBlockTest',
+	#superclass : 'VMInterpreterTests',
 	#pools : [
 		'VMClassIndices',
 		'VMObjectIndices'
 	],
-	#category : #'VMMakerTests-InterpreterTests'
+	#category : 'VMMakerTests-InterpreterTests',
+	#package : 'VMMakerTests',
+	#tag : 'InterpreterTests'
 }
 
-{ #category : #supports }
+{ #category : 'supports' }
 VMBlockTest >> anEmptyMethod [
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMBlockTest >> evaluatingABlock [
 
   [^1] value
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMBlockTest >> installFullBlockClosureClass [
 		| aClass |
 	aClass := self
@@ -32,14 +34,14 @@ VMBlockTest >> installFullBlockClosureClass [
 		withValue: aClass
 ]
 
-{ #category : #supports }
+{ #category : 'supports' }
 VMBlockTest >> methodReturningABlock [
 	<compilerOptions: #(- #optionConstantBlockClosure)>
 	^ []
 	
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMBlockTest >> methodReturningABlockInsideABlockWithLocal [
 
 	true ifTrue: [ 
@@ -48,14 +50,14 @@ VMBlockTest >> methodReturningABlockInsideABlockWithLocal [
 		^ [ anArgument ] ]
 ]
 
-{ #category : #supports }
+{ #category : 'supports' }
 VMBlockTest >> methodReturningABlockWithTwoArguments [
 	
 	^ [:a :b]
 	
 ]
 
-{ #category : #supports }
+{ #category : 'supports' }
 VMBlockTest >> methodWithLocalReturningABlock [
 
 	| a |
@@ -63,14 +65,14 @@ VMBlockTest >> methodWithLocalReturningABlock [
 	^ [ a ]
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMBlockTest >> setUp [
 
 	super setUp.
 	self initializeSpecialSelectors
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMBlockTest >> testCreatingABlockCapturesReceiver [
 
 	| methodReturning initialMethod |
@@ -95,7 +97,7 @@ VMBlockTest >> testCreatingABlockCapturesReceiver [
 	self assert: (memory fetchPointer: FullClosureReceiverIndex ofObject: interpreter stackTop) equals: memory trueObject
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 VMBlockTest >> testCreatingABlockClosureKnowsCompiledBlock [
 
 	| methodReturning initialMethod placeTakenByLiterals closure blockInitialPC compiledBlock |
@@ -132,7 +134,7 @@ VMBlockTest >> testCreatingABlockClosureKnowsCompiledBlock [
 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 VMBlockTest >> testCreatingABlockClosureShouldCopyUsedMethodVariable [
 
 	| methodReturning initialMethod |
@@ -159,7 +161,7 @@ VMBlockTest >> testCreatingABlockClosureShouldCopyUsedMethodVariable [
 		assert: (memory fetchPointer: FullClosureFirstCopiedValueIndex ofObject: interpreter stackTop) equals: (memory integerObjectOf: 2)
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 VMBlockTest >> testCreatingABlockClosureShouldHaveOuterContextObject [
 
 	| methodReturning initialMethod |
@@ -188,7 +190,7 @@ VMBlockTest >> testCreatingABlockClosureShouldHaveOuterContextObject [
 	self assert: (interpreter isWidowedContext: (memory outerContextOf: interpreter stackTop))
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMBlockTest >> testCreatingABlockInsideABlockClosureShouldCopyUsedBlockVariable [
 
 	| methodReturning initialMethod |
@@ -215,7 +217,7 @@ VMBlockTest >> testCreatingABlockInsideABlockClosureShouldCopyUsedBlockVariable 
 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 VMBlockTest >> testCreatingABlockWithoutArgumentsClosureShouldHaveNoArgument [
 
 	| methodReturning initialMethod |
@@ -242,7 +244,7 @@ VMBlockTest >> testCreatingABlockWithoutArgumentsClosureShouldHaveNoArgument [
 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMBlockTest >> testEvaluatingABlock [
 
 	| methodReturning initialMethod |
@@ -274,7 +276,7 @@ VMBlockTest >> testEvaluatingABlock [
 		equals: (memory classAtIndex: ClassFullBlockClosureCompactIndex)
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 VMBlockTest >> testPushClosureBytecodePushesClosure [
 
 	| methodReturning initialMethod |

--- a/smalltalksrc/VMMakerTests/VMByteCodesTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMByteCodesTest.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #VMByteCodesTest,
-	#superclass : #VMInterpreterTests,
+	#name : 'VMByteCodesTest',
+	#superclass : 'VMInterpreterTests',
 	#instVars : [
 		'contextOop',
 		'context',
 		'callingFrame',
 		'topFrame'
 	],
-	#category : #'VMMakerTests-InterpreterTests'
+	#category : 'VMMakerTests-InterpreterTests',
+	#package : 'VMMakerTests',
+	#tag : 'InterpreterTests'
 }
 
-{ #category : #'helper-assertions' }
+{ #category : 'helper-assertions' }
 VMByteCodesTest >> assert: aBlock pop: anOop intoTemporary: anIndex [
 	| oldStackSize |
 	oldStackSize := interpreter stackPointer.
@@ -21,7 +23,7 @@ VMByteCodesTest >> assert: aBlock pop: anOop intoTemporary: anIndex [
 	self assert: (interpreter temporary: anIndex in: interpreter framePointer) equals: anOop
 ]
 
-{ #category : #'helper-assertions' }
+{ #category : 'helper-assertions' }
 VMByteCodesTest >> assert: aBlock pushed: anOop [
 	| oldStackSize |
 	oldStackSize := interpreter stackPointer.
@@ -33,7 +35,7 @@ VMByteCodesTest >> assert: aBlock pushed: anOop [
 	
 ]
 
-{ #category : #'helper-assertions' }
+{ #category : 'helper-assertions' }
 VMByteCodesTest >> assert: aBlock returned: anOop [
 	| callerSP |
 	callerSP := interpreter frameCallerSP: interpreter framePointer.
@@ -45,7 +47,7 @@ VMByteCodesTest >> assert: aBlock returned: anOop [
 	
 ]
 
-{ #category : #'helper-assertions' }
+{ #category : 'helper-assertions' }
 VMByteCodesTest >> assertPopped: aBlock [
 	| oldStackSize |
 	oldStackSize := interpreter stackPointer.
@@ -56,24 +58,24 @@ VMByteCodesTest >> assertPopped: aBlock [
 	
 ]
 
-{ #category : #'helpers-bytecode-table' }
+{ #category : 'helpers-bytecode-table' }
 VMByteCodesTest >> firstPushTemporaryVariableBytecode [
 	"in v3 bytecode table"
 	^ 16
 ]
 
-{ #category : #'helpers-bytecode-table' }
+{ #category : 'helpers-bytecode-table' }
 VMByteCodesTest >> firstStoreAndPopTemporaryVariableBytecode [
 	^ 104
 ]
 
-{ #category : #'helper-interpret' }
+{ #category : 'helper-interpret' }
 VMByteCodesTest >> interpret: aBlock [
 
 	aBlock value
 ]
 
-{ #category : #'tests-simd' }
+{ #category : 'tests-simd' }
 VMByteCodesTest >> interpretNextBytecode [
 
 	| count |
@@ -83,7 +85,7 @@ VMByteCodesTest >> interpretNextBytecode [
 		count = 1 ]
 ]
 
-{ #category : #'tests-pushThisContext' }
+{ #category : 'tests-pushThisContext' }
 VMByteCodesTest >> interpretWithFrame: aBlock [
 
 	callingFrame := stackBuilder addNewFrame method:
@@ -95,7 +97,7 @@ VMByteCodesTest >> interpretWithFrame: aBlock [
 	self interpret: aBlock
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> pushTempTest: index [
 	
 	stackBuilder addNewFrame tempAt: index put: (memory integerObjectOf: 42).
@@ -109,13 +111,13 @@ VMByteCodesTest >> pushTempTest: index [
 
 ]
 
-{ #category : #'helpers-bytecode-table' }
+{ #category : 'helpers-bytecode-table' }
 VMByteCodesTest >> pushTemporaryVariableBytecodeAt: offset [
 	^ self firstPushTemporaryVariableBytecode + offset.
 	
 ]
 
-{ #category : #'tests-pushThisContext' }
+{ #category : 'tests-pushThisContext' }
 VMByteCodesTest >> pushThisContextTopFrame [
 
 	self interpretWithFrame: [ interpreter pushActiveContextBytecode ].
@@ -126,14 +128,14 @@ VMByteCodesTest >> pushThisContextTopFrame [
 		withInterpreter: interpreter
 ]
 
-{ #category : #'tests-simd' }
+{ #category : 'tests-simd' }
 VMByteCodesTest >> setUp [ 
 
 	super setUp.
 	self installFloat64RegisterClass
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> storeAndPopTemporaryIntoTempTest: index [
 	
 	stackBuilder addNewFrame
@@ -149,12 +151,12 @@ VMByteCodesTest >> storeAndPopTemporaryIntoTempTest: index [
 		intoTemporary: index
 ]
 
-{ #category : #'helpers-bytecode-table' }
+{ #category : 'helpers-bytecode-table' }
 VMByteCodesTest >> storeAndPopTemporaryVariableBytecodeAt: anInteger [ 
 	^ self firstStoreAndPopTemporaryVariableBytecode + anInteger
 ]
 
-{ #category : #'tests-pushThisContext' }
+{ #category : 'tests-pushThisContext' }
 VMByteCodesTest >> testAccessingSenderOfContextShouldReturnContextOfSender [
 	| oldMaybeSenderContext newMaybeSenderContext |
 	self interpretWithFrame: [ interpreter pushActiveContextBytecode. ].
@@ -164,7 +166,7 @@ VMByteCodesTest >> testAccessingSenderOfContextShouldReturnContextOfSender [
 	self assert: oldMaybeSenderContext equals: newMaybeSenderContext
 ]
 
-{ #category : #'tests-simd' }
+{ #category : 'tests-simd' }
 VMByteCodesTest >> testAddVectorBytecode [
 	| index v0 v1 result firstTerm size |
 	
@@ -191,7 +193,7 @@ VMByteCodesTest >> testAddVectorBytecode [
 	
 ]
 
-{ #category : #'tests-simd' }
+{ #category : 'tests-simd' }
 VMByteCodesTest >> testArraySumUsingVectorBytecode [
 	| cm x y result simulatedMethod z |
 
@@ -233,7 +235,7 @@ VMByteCodesTest >> testArraySumUsingVectorBytecode [
 	
 ]
 
-{ #category : #'tests-complex' }
+{ #category : 'tests-complex' }
 VMByteCodesTest >> testBytecodePopIntoReceiverWithReadOnlySendsAttemptToAssignMethod [
 
 	| class object objectToPutInSlot attemptToAssignMethod attemptToAssignSelector aMethodDictionary |
@@ -277,7 +279,7 @@ VMByteCodesTest >> testBytecodePopIntoReceiverWithReadOnlySendsAttemptToAssignMe
 	self assert: topFrame method equals: attemptToAssignMethod
 ]
 
-{ #category : #'tests-simd' }
+{ #category : 'tests-simd' }
 VMByteCodesTest >> testCallMappedInlinedPrimitiveBytecode [
 
 	| v0 v1 result method |
@@ -304,7 +306,7 @@ VMByteCodesTest >> testCallMappedInlinedPrimitiveBytecode [
 	self assert: (memory fetchFloat64: 1 ofObject: result) equals: 6.0
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> testDuplicateStackTop [
 
 	stackBuilder addNewFrame ; buildStack.
@@ -321,7 +323,7 @@ VMByteCodesTest >> testDuplicateStackTop [
 	
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> testPopStackTopBytecode [
 
 	stackBuilder addNewFrame ; buildStack.
@@ -337,7 +339,7 @@ VMByteCodesTest >> testPopStackTopBytecode [
 	
 ]
 
-{ #category : #'tests-simd' }
+{ #category : 'tests-simd' }
 VMByteCodesTest >> testPushArrayToRegisterBytecode [
 	| array index result |
 
@@ -362,7 +364,7 @@ VMByteCodesTest >> testPushArrayToRegisterBytecode [
 	
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> testPushConstantFalseBytecode [
 	stackBuilder addNewFrame ; buildStack.
 	self
@@ -370,7 +372,7 @@ VMByteCodesTest >> testPushConstantFalseBytecode [
 		pushed: memory falseObject
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> testPushConstantMinusOneBytecode [
 	stackBuilder addNewFrame ; buildStack.
 	self
@@ -378,7 +380,7 @@ VMByteCodesTest >> testPushConstantMinusOneBytecode [
 		pushed: (memory integerObjectOf: -1)
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> testPushConstantNilBytecode [
 	stackBuilder addNewFrame ; buildStack.
 	self
@@ -386,7 +388,7 @@ VMByteCodesTest >> testPushConstantNilBytecode [
 		pushed: memory nilObject
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> testPushConstantOneBytecode [
 	stackBuilder addNewFrame ; buildStack.
 	self
@@ -394,7 +396,7 @@ VMByteCodesTest >> testPushConstantOneBytecode [
 		pushed: (memory integerObjectOf: 1)
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> testPushConstantReceiverBytecode [
 	| intReceiver |
 	intReceiver := memory integerObjectOf: 42.
@@ -407,7 +409,7 @@ VMByteCodesTest >> testPushConstantReceiverBytecode [
 		pushed: intReceiver
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> testPushConstantTrueBytecode [
 	stackBuilder addNewFrame ; buildStack.
 	self
@@ -415,7 +417,7 @@ VMByteCodesTest >> testPushConstantTrueBytecode [
 		pushed: memory trueObject
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> testPushConstantTwoBytecode [
 	stackBuilder addNewFrame ; buildStack.
 	self
@@ -423,7 +425,7 @@ VMByteCodesTest >> testPushConstantTwoBytecode [
 		pushed: (memory integerObjectOf: 2)
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> testPushConstantZeroBytecode [
 	stackBuilder addNewFrame ; buildStack.
 	self
@@ -431,74 +433,74 @@ VMByteCodesTest >> testPushConstantZeroBytecode [
 		pushed: (memory integerObjectOf: 0)
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> testPushTemp0 [
 	self pushTempTest: 0
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> testPushTemp1 [
 	self pushTempTest: 1
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> testPushTemp10 [
 	self pushTempTest: 10
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> testPushTemp11 [
 	self pushTempTest: 11
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> testPushTemp2 [
 	self pushTempTest: 2
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> testPushTemp3 [
 	self pushTempTest: 3
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> testPushTemp4 [
 	self pushTempTest: 4
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> testPushTemp5 [
 	self pushTempTest: 5
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> testPushTemp6 [
 	self pushTempTest: 6
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> testPushTemp7 [
 	self pushTempTest: 7
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> testPushTemp8 [
 	self pushTempTest: 8
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> testPushTemp9 [
 	self pushTempTest: 9
 ]
 
-{ #category : #'tests-pushThisContext' }
+{ #category : 'tests-pushThisContext' }
 VMByteCodesTest >> testPushThisContextIsContext [
 
 	self pushThisContextTopFrame.
 	self assert: (memory isContext: interpreter stackTop).
 ]
 
-{ #category : #'tests-pushThisContext' }
+{ #category : 'tests-pushThisContext' }
 VMByteCodesTest >> testPushThisContextPushesValidInstructionPointer [
 
 	self pushThisContextTopFrame.
@@ -508,7 +510,7 @@ VMByteCodesTest >> testPushThisContextPushesValidInstructionPointer [
 		equals: (interpreter frameCallerFP: interpreter framePointer)
 ]
 
-{ #category : #'tests-pushThisContext' }
+{ #category : 'tests-pushThisContext' }
 VMByteCodesTest >> testPushThisContextPushesValidPointerToTheFramePointer [
 	
 	self pushThisContextTopFrame.
@@ -519,28 +521,28 @@ VMByteCodesTest >> testPushThisContextPushesValidPointerToTheFramePointer [
 		equals: interpreter framePointer
 ]
 
-{ #category : #'tests-pushThisContext' }
+{ #category : 'tests-pushThisContext' }
 VMByteCodesTest >> testPushThisContextPushesValidReceiver [
 
 	self pushThisContextTopFrame.
 	self assert: topFrame receiver equals: context receiver
 ]
 
-{ #category : #'tests-pushThisContext' }
+{ #category : 'tests-pushThisContext' }
 VMByteCodesTest >> testPushThisContextSetContextToFrame [
 
 	self pushThisContextTopFrame.
 	self assert: (interpreter frameContext: interpreter framePointer) equals: interpreter stackTop.
 ]
 
-{ #category : #'tests-pushThisContext' }
+{ #category : 'tests-pushThisContext' }
 VMByteCodesTest >> testPushThisContextSetFlagContextToFrame [
 
 	self pushThisContextTopFrame.
 	self assert: (interpreter frameHasContext: interpreter framePointer).
 ]
 
-{ #category : #'tests-pushThisContext' }
+{ #category : 'tests-pushThisContext' }
 VMByteCodesTest >> testPushThisContextTwiceMarriesOnce [
 	| previousTop newTop |
 	self interpretWithFrame: [ 
@@ -552,7 +554,7 @@ VMByteCodesTest >> testPushThisContextTwiceMarriesOnce [
 	self assert: newTop equals: previousTop.
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> testReturnFalse [
 
 	"We need to return to a method.
@@ -568,7 +570,7 @@ VMByteCodesTest >> testReturnFalse [
 		returned: memory falseObject
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> testReturnTrue [
 
 	"We need to return to a method.
@@ -584,7 +586,7 @@ VMByteCodesTest >> testReturnTrue [
 		returned: memory trueObject
 ]
 
-{ #category : #'tests-pushThisContext' }
+{ #category : 'tests-pushThisContext' }
 VMByteCodesTest >> testReturnsMarriedFrameWidowsContext [
 	| topFrameContext |
 	self interpretWithFrame: [ 
@@ -598,7 +600,7 @@ VMByteCodesTest >> testReturnsMarriedFrameWidowsContext [
 	self assert: (interpreter isWidowedContext: topFrameContext)
 ]
 
-{ #category : #'tests-send' }
+{ #category : 'tests-send' }
 VMByteCodesTest >> testSendMessageWithTwoArgumentsMakeAFrame [
 
 	| selectorOop aMethod aMethodToActivate receiver receiverClass aMethodDictionary arg1 arg2 |
@@ -645,47 +647,47 @@ VMByteCodesTest >> testSendMessageWithTwoArgumentsMakeAFrame [
 	self assert: interpreter stackTop equals: receiver
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> testStoreAndPopTemporary0 [
 	self storeAndPopTemporaryIntoTempTest: 0
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> testStoreAndPopTemporary1 [
 	self storeAndPopTemporaryIntoTempTest: 1
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> testStoreAndPopTemporary2 [
 	self storeAndPopTemporaryIntoTempTest: 2
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> testStoreAndPopTemporary3 [
 	self storeAndPopTemporaryIntoTempTest: 3
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> testStoreAndPopTemporary4 [
 	self storeAndPopTemporaryIntoTempTest: 4
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> testStoreAndPopTemporary5 [
 	self storeAndPopTemporaryIntoTempTest: 5
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> testStoreAndPopTemporary6 [
 	self storeAndPopTemporaryIntoTempTest: 6
 ]
 
-{ #category : #'tests-push-simple' }
+{ #category : 'tests-push-simple' }
 VMByteCodesTest >> testStoreAndPopTemporary7 [
 	self storeAndPopTemporaryIntoTempTest: 7
 ]
 
-{ #category : #'tests-simd' }
+{ #category : 'tests-simd' }
 VMByteCodesTest >> testStoreRegisterIntoArrayBytecode [
 	| register index array result |
 	
@@ -716,7 +718,7 @@ VMByteCodesTest >> testStoreRegisterIntoArrayBytecode [
 	self assert: (memory fetchFloat64: 3 ofObject: array) equals: 6.0.
 ]
 
-{ #category : #'tests-simd' }
+{ #category : 'tests-simd' }
 VMByteCodesTest >> testSubVectorBytecode [
 	| index vector0 vector1 result |
 	

--- a/smalltalksrc/VMMakerTests/VMBytecodeMethod.class.st
+++ b/smalltalksrc/VMMakerTests/VMBytecodeMethod.class.st
@@ -1,14 +1,16 @@
 Class {
-	#name : #VMBytecodeMethod,
-	#superclass : #Object,
+	#name : 'VMBytecodeMethod',
+	#superclass : 'Object',
 	#instVars : [
 		'virtualMachine',
 		'methodOop'
 	],
-	#category : #'VMMakerTests-Visualisation'
+	#category : 'VMMakerTests-Visualisation',
+	#package : 'VMMakerTests',
+	#tag : 'Visualisation'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 VMBytecodeMethod class >> newOnInterpreter: virtualMachine methodOop: methodOop [
 	
 	^ self new
@@ -17,13 +19,13 @@ VMBytecodeMethod class >> newOnInterpreter: virtualMachine methodOop: methodOop 
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMBytecodeMethod >> at: index [
 
 	^ virtualMachine objectMemory fetchByte: index - 1 "0 based" ofObject: methodOop
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMBytecodeMethod >> disassemble [
 	| symbolicBytecodes |
 	symbolicBytecodes := SymbolicBytecodeBuilder decode: self.
@@ -31,52 +33,52 @@ VMBytecodeMethod >> disassemble [
 ' join: (symbolicBytecodes collect: [ :sbc | sbc description ])
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMBytecodeMethod >> encoderClass [
 	^ EncoderForSistaV1
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMBytecodeMethod >> endPC [
 	
 	^ virtualMachine objectMemory bytesInObject: methodOop
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMBytecodeMethod >> initialPC [
 	"Answer the program counter for the receiver's first bytecode."
 
 	^ (self numLiterals + 1) * virtualMachine objectMemory wordSize + 1
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMBytecodeMethod >> literalAt: anInteger [ 
 	
 	^ 'literal key' -> 'literal?'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMBytecodeMethod >> methodOop [
 	^ methodOop
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMBytecodeMethod >> methodOop: anObject [
 	methodOop := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMBytecodeMethod >> numLiterals [
 	
 	^ virtualMachine objectMemory literalCountOf: methodOop 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMBytecodeMethod >> virtualMachine [
 	^ virtualMachine
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMBytecodeMethod >> virtualMachine: anObject [
 	virtualMachine := anObject
 ]

--- a/smalltalksrc/VMMakerTests/VMCodeCompactionTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMCodeCompactionTest.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #VMCodeCompactionTest,
-	#superclass : #VMPrimitiveCallAbstractTest,
+	#name : 'VMCodeCompactionTest',
+	#superclass : 'VMPrimitiveCallAbstractTest',
 	#pools : [
 		'CogRTLOpcodes'
 	],
-	#category : #'VMMakerTests-JitTests'
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMCodeCompactionTest >> createBaseFrameWithMachineCodeMethod: aMachineCodeMethod [
 
 	"Create the root context with a valid method"
@@ -32,7 +34,7 @@ VMCodeCompactionTest >> createBaseFrameWithMachineCodeMethod: aMachineCodeMethod
 
 ]
 
-{ #category : #utils }
+{ #category : 'utils' }
 VMCodeCompactionTest >> createFillingMethods: anInteger [ 
 
 	| firstMethod |
@@ -45,7 +47,7 @@ VMCodeCompactionTest >> createFillingMethods: anInteger [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMCodeCompactionTest >> fillCodeZone [
 
 	| aMethod |
@@ -61,13 +63,13 @@ VMCodeCompactionTest >> fillCodeZone [
 
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMCodeCompactionTest >> initialCodeSize [
 
 	^ 16 * 1024
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMCodeCompactionTest >> testCompactDuringInterpreterPrimitiveThatMovesCurrentMethodWhenShouldNotCrashFromMachineCodeMethod [
 
 	| firstMethod compactMethod callerMethod |
@@ -110,7 +112,7 @@ VMCodeCompactionTest >> testCompactDuringInterpreterPrimitiveThatMovesCurrentMet
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMCodeCompactionTest >> testCompactDuringInterpreterPrimitiveThatMovesCurrentMethodWhenUsingPrimCallMayCallBackShouldNotCrashFromMachineCodeMethod [
 
 	| firstMethod compactMethod callerMethod |
@@ -149,7 +151,7 @@ VMCodeCompactionTest >> testCompactDuringInterpreterPrimitiveThatMovesCurrentMet
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMCodeCompactionTest >> testCompactingAnUnusedMethodCompactsRemainingMethodToTheBeginning [
 
 	| firstMethod compactMethod methodOop |
@@ -172,7 +174,7 @@ VMCodeCompactionTest >> testCompactingAnUnusedMethodCompactsRemainingMethodToThe
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMCodeCompactionTest >> testCompactingShouldRelocateInSendsLiterals [
 
 	| firstMethod cogMethod methodOop |
@@ -206,7 +208,7 @@ VMCodeCompactionTest >> testCompactingShouldRelocateInSendsLiterals [
 		equals: memory nilObject
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMCodeCompactionTest >> testCompactingShouldRelocateLiterals [
 
 	| firstMethod cogMethod methodOop |
@@ -239,7 +241,7 @@ VMCodeCompactionTest >> testCompactingShouldRelocateLiterals [
 		equals: memory nilObject
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMCodeCompactionTest >> testCompactingShouldRelocateMethodReference [
 
 	| firstMethod cogMethod methodOop |
@@ -272,7 +274,7 @@ VMCodeCompactionTest >> testCompactingShouldRelocateMethodReference [
 		equals: (interpreter cogMethodOf: methodOop)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMCodeCompactionTest >> testCompactingShouldRelocateMonomorphicCallsite [
 
 	| firstMethod callerMethodOop calleeCogMethod selector callerCogMethod calleeMethodOop |
@@ -322,7 +324,7 @@ VMCodeCompactionTest >> testCompactingShouldRelocateMonomorphicCallsite [
 		equals: (interpreter cogMethodOf: calleeMethodOop) asInteger + cogit entryOffset
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMCodeCompactionTest >> testCompactingShouldRelocatePolymorphicPICCallsite [
 
 	"This method sets up a method A that is linked to a polymorphic PIC linked to B and C.
@@ -419,7 +421,7 @@ VMCodeCompactionTest >> testCompactingShouldRelocatePolymorphicPICCallsite [
 		equals: cogit ceCPICMissTrampoline
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMCodeCompactionTest >> testCompactingShouldRelocatePolymorphicPICInterpreterAbortCallsite [
 
 	"This method sets up a method A that is linked to a polymorphic PIC linked to B and C.
@@ -509,7 +511,7 @@ VMCodeCompactionTest >> testCompactingShouldRelocatePolymorphicPICInterpreterAbo
 		equals: cogit cePICAbortTrampoline
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMCodeCompactionTest >> testCompactingShouldRelocatePolymorphicPICMNUAbortCallsite [
 
 	"This method sets up a method A that is linked to a polymorphic PIC linked to B and C.
@@ -583,7 +585,7 @@ VMCodeCompactionTest >> testCompactingShouldRelocatePolymorphicPICMNUAbortCallsi
 		equals: cogit cePICAbortTrampoline
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMCodeCompactionTest >> testRelocatingAMethodDoesNotAffectTheFrameCreationPushes [
 
 	| firstMethod compactMethod methodOop readOnlyObject |

--- a/smalltalksrc/VMMakerTests/VMCogitHelpersTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMCogitHelpersTest.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #VMCogitHelpersTest,
-	#superclass : #VMSimpleStackBasedCogitAbstractTest,
+	#name : 'VMCogitHelpersTest',
+	#superclass : 'VMSimpleStackBasedCogitAbstractTest',
 	#instVars : [
 		'checkIsSmallInteger',
 		'checkNotSmallInteger'
@@ -9,10 +9,12 @@ Class {
 		'CogAbstractRegisters',
 		'CogRTLOpcodes'
 	],
-	#category : #'VMMakerTests-JitTests'
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMCogitHelpersTest >> assertIsInSmallIntegerRange: anInteger [
 
 	machineSimulator classRegisterValue: anInteger.
@@ -22,7 +24,7 @@ VMCogitHelpersTest >> assertIsInSmallIntegerRange: anInteger [
 	self assert: machineSimulator classRegisterValue equals: 0
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMCogitHelpersTest >> assertNotInSmallIntegerRange: anInteger [
 
 	machineSimulator classRegisterValue: anInteger.
@@ -32,7 +34,7 @@ VMCogitHelpersTest >> assertNotInSmallIntegerRange: anInteger [
 	self assert: machineSimulator classRegisterValue equals: 0
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMCogitHelpersTest >> denyIsInSmallIntegerRange: anInteger [
 
 	machineSimulator classRegisterValue: anInteger.
@@ -42,7 +44,7 @@ VMCogitHelpersTest >> denyIsInSmallIntegerRange: anInteger [
 	self assert: machineSimulator classRegisterValue equals: 1
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMCogitHelpersTest >> denyIsNotInSmallIntegerRange: anInteger [
 
 	machineSimulator classRegisterValue: anInteger.
@@ -52,14 +54,14 @@ VMCogitHelpersTest >> denyIsNotInSmallIntegerRange: anInteger [
 	self assert: machineSimulator classRegisterValue equals: 1
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMCogitHelpersTest >> runUntilReturnFrom: anAddress [
 	
 	self prepareCall.
 	super runUntilReturnFrom: anAddress
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMCogitHelpersTest >> setUp [
 
 	super setUp.
@@ -90,7 +92,7 @@ VMCogitHelpersTest >> setUp [
 	].
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMCogitHelpersTest >> testCheckNotSmallIntegerWithNonValidSmallIntegers [
 
 	self assertNotInSmallIntegerRange: memory maxSmallInteger + 1.
@@ -101,14 +103,14 @@ VMCogitHelpersTest >> testCheckNotSmallIntegerWithNonValidSmallIntegers [
 	]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMCogitHelpersTest >> testCheckNotSmallIntegerWithValidSmallIntegers [
 
 	self denyIsNotInSmallIntegerRange: 0.
 	self denyIsNotInSmallIntegerRange: memory maxSmallInteger.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMCogitHelpersTest >> testCheckSmallIntegerWithNonValidSmallIntegers [
 
 	self denyIsInSmallIntegerRange: memory maxSmallInteger + 1.
@@ -119,7 +121,7 @@ VMCogitHelpersTest >> testCheckSmallIntegerWithNonValidSmallIntegers [
 	]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMCogitHelpersTest >> testCheckSmallIntegerWithValidSmallIntegers [
 
 	self assertIsInSmallIntegerRange: 0.

--- a/smalltalksrc/VMMakerTests/VMCompiledCodeBuilder.class.st
+++ b/smalltalksrc/VMMakerTests/VMCompiledCodeBuilder.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #VMCompiledCodeBuilder,
-	#superclass : #VMAbstractBuilder,
+	#name : 'VMCompiledCodeBuilder',
+	#superclass : 'VMAbstractBuilder',
 	#instVars : [
 		'slotSize',
 		'numberOfTemporaries',
@@ -15,16 +15,18 @@ Class {
 	#pools : [
 		'VMObjectIndices'
 	],
-	#category : #'VMMakerTests-Builders'
+	#category : 'VMMakerTests-Builders',
+	#package : 'VMMakerTests',
+	#tag : 'Builders'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMCompiledCodeBuilder >> address [
 	
 	^ method
 ]
 
-{ #category : #deprecated }
+{ #category : 'deprecated' }
 VMCompiledCodeBuilder >> build [
 
 	self
@@ -34,14 +36,14 @@ VMCompiledCodeBuilder >> build [
 	^ self buildMethod
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 VMCompiledCodeBuilder >> buildMethod [
 	self instantiateMethod.
 	self fillMethod.
 	^ method
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 VMCompiledCodeBuilder >> buildMethodHeader [
 
 	^  (numberOfArguments bitShift: 24)
@@ -51,7 +53,7 @@ VMCompiledCodeBuilder >> buildMethodHeader [
 		+ (isPrimitive asBit << 16)
 ]
 
-{ #category : #helper }
+{ #category : 'helper' }
 VMCompiledCodeBuilder >> bytecodeAt: anIndex forMethod: aMethodOop [
 	| methodHeader |
 	"1 based"
@@ -61,17 +63,17 @@ VMCompiledCodeBuilder >> bytecodeAt: anIndex forMethod: aMethodOop [
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMCompiledCodeBuilder >> bytecodes [
 	^ bytecodes
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMCompiledCodeBuilder >> bytecodes: anObject [
 	bytecodes := anObject
 ]
 
-{ #category : #filling }
+{ #category : 'filling' }
 VMCompiledCodeBuilder >> classIndexToUse [
 	| newClass |
 	memory nilObject = (memory splObj: 16) ifTrue: [
@@ -88,7 +90,7 @@ VMCompiledCodeBuilder >> classIndexToUse [
 	^ memory classTagForClass: (memory splObj: 16)
 ]
 
-{ #category : #filling }
+{ #category : 'filling' }
 VMCompiledCodeBuilder >> fillFromPharoMethod: aCompiledMethod [
 
 	self newMethod.
@@ -99,7 +101,7 @@ VMCompiledCodeBuilder >> fillFromPharoMethod: aCompiledMethod [
 	self fillLiteralsFromPharo: aCompiledMethod allLiterals
 ]
 
-{ #category : #filling }
+{ #category : 'filling' }
 VMCompiledCodeBuilder >> fillLiteralsFromPharo: pharoLiterals [
 
 	originalLiterals := pharoLiterals copy.
@@ -107,14 +109,14 @@ VMCompiledCodeBuilder >> fillLiteralsFromPharo: pharoLiterals [
 
 ]
 
-{ #category : #filling }
+{ #category : 'filling' }
 VMCompiledCodeBuilder >> fillMethod [
 	self putHeaderInMethod.
 	self putLiteralInMethod.
 	self putBytecodesInMethod.
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 VMCompiledCodeBuilder >> initialize [
 	bytecodes := #[1 2 3 4 5 6 7 8 9 0].
 	literals := OrderedCollection new. 
@@ -129,7 +131,7 @@ VMCompiledCodeBuilder >> initialize [
 	slotSize := nil.
 ]
 
-{ #category : #inspecting }
+{ #category : 'inspecting' }
 VMCompiledCodeBuilder >> inspectMethodIn: aBuilder [
 	<inspectorPresentationOrder: 0 title: 'Items'> 
 
@@ -157,7 +159,7 @@ VMCompiledCodeBuilder >> inspectMethodIn: aBuilder [
 		yourself
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 VMCompiledCodeBuilder >> instantiateMethod [
 	slotSize := literals size 
 			+ (bytecodes size / memory wordSize) ceiling
@@ -170,73 +172,73 @@ VMCompiledCodeBuilder >> instantiateMethod [
 	method ifNotNil: [ memory fillObj: method numSlots: slotSize with: memory nilObject ].
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMCompiledCodeBuilder >> isPrimitive [
 	^ isPrimitive
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMCompiledCodeBuilder >> isPrimitive: anObject [
 	isPrimitive := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMCompiledCodeBuilder >> isSmall [
 	^ isSmall
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMCompiledCodeBuilder >> isSmall: anObject [
 	isSmall := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMCompiledCodeBuilder >> literalAt: anIndex put: anOop [
 	self collection: literals at: anIndex put: anOop
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMCompiledCodeBuilder >> literals [
 	^ literals
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMCompiledCodeBuilder >> literals: anObject [
 	literals := anObject.
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMCompiledCodeBuilder >> method [
 	^ method
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 VMCompiledCodeBuilder >> newMethod [
 	self initialize.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMCompiledCodeBuilder >> numberOfArguments [
 	^ numberOfArguments
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMCompiledCodeBuilder >> numberOfArguments: anObject [
 	numberOfArguments := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMCompiledCodeBuilder >> numberOfTemporaries [
 	^ numberOfTemporaries
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMCompiledCodeBuilder >> numberOfTemporaries: anObject [
 	numberOfTemporaries := anObject
 ]
 
-{ #category : #filling }
+{ #category : 'filling' }
 VMCompiledCodeBuilder >> putBytecodesInMethod [
 	bytecodes doWithIndex:[ :aBytecode :anIndex | 
 		memory storeByte: 
@@ -249,7 +251,7 @@ VMCompiledCodeBuilder >> putBytecodesInMethod [
 		]
 ]
 
-{ #category : #filling }
+{ #category : 'filling' }
 VMCompiledCodeBuilder >> putHeaderInMethod [
 	memory storePointer: 0 
 		ofObject: method
@@ -257,7 +259,7 @@ VMCompiledCodeBuilder >> putHeaderInMethod [
 
 ]
 
-{ #category : #filling }
+{ #category : 'filling' }
 VMCompiledCodeBuilder >> putLiteralInMethod [
 
 	originalLiterals doWithIndex: [ :aLiteral :anIndex | 
@@ -275,7 +277,7 @@ VMCompiledCodeBuilder >> putLiteralInMethod [
 		memory storePointer: anIndex ofObject: method withValue: aLiteral ]
 ]
 
-{ #category : #filling }
+{ #category : 'filling' }
 VMCompiledCodeBuilder >> setOuterCode: aVMCompiledCodeBuilder [ 
 
 	"In the case of CompiledBlocks we need to put the outerCode object (the last literal).
@@ -284,7 +286,7 @@ VMCompiledCodeBuilder >> setOuterCode: aVMCompiledCodeBuilder [
 	literals at: literals size put: aVMCompiledCodeBuilder address
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMCompiledCodeBuilder >> slotSize [
 	"Do not set by hand !"
 	^ slotSize

--- a/smalltalksrc/VMMakerTests/VMContext.class.st
+++ b/smalltalksrc/VMMakerTests/VMContext.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #VMContext,
-	#superclass : #Object,
+	#name : 'VMContext',
+	#superclass : 'Object',
 	#instVars : [
 		'contextOop',
 		'interpreter'
@@ -8,10 +8,12 @@ Class {
 	#pools : [
 		'VMObjectIndices'
 	],
-	#category : #'VMMakerTests-Visualisation'
+	#category : 'VMMakerTests-Visualisation',
+	#package : 'VMMakerTests',
+	#tag : 'Visualisation'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 VMContext class >> newOnContext: anInteger withInterpreter: aStackInterpreterSimulatorLSB [
 	^ self new
 		contextOop: anInteger;
@@ -19,7 +21,7 @@ VMContext class >> newOnContext: anInteger withInterpreter: aStackInterpreterSim
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMContext >> caller [
 	| senderContext |
 
@@ -35,12 +37,12 @@ VMContext >> caller [
 	^ VMContext newOnContext: senderContext withInterpreter: interpreter
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMContext >> contextOop: anInteger [ 
 	contextOop := anInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMContext >> description [
 	| homeContextOop method selector |
 	homeContextOop := interpreter findHomeForContext: contextOop.
@@ -50,32 +52,32 @@ VMContext >> description [
 	^ interpreter stringOf: selector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMContext >> instructionPointer [
 	^interpreter objectMemory fetchPointer: InstructionPointerIndex ofObject: contextOop.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMContext >> interpreter: aStackInterpreterSimulatorLSB [ 
 	interpreter := aStackInterpreterSimulatorLSB
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 VMContext >> isMarried [
 	^interpreter isStillMarriedContext: contextOop.
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 VMContext >> isNilObject [
 	^interpreter objectMemory nilObject = contextOop.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMContext >> receiver [
 	^interpreter objectMemory fetchPointer: ReceiverIndex ofObject: contextOop
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMContext >> sender [
 	^interpreter objectMemory fetchPointer: SenderIndex ofObject: contextOop.
 ]

--- a/smalltalksrc/VMMakerTests/VMContextAccessTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMContextAccessTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #VMContextAccessTest,
-	#superclass : #VMSimpleStackBasedCogitAbstractTest,
-	#category : #'VMMakerTests-JitTests'
+	#name : 'VMContextAccessTest',
+	#superclass : 'VMSimpleStackBasedCogitAbstractTest',
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMContextAccessTest >> assertContext: newContext equals: contextOop onInstVar: anIndex [ 
 
 	| originalPC copiedPC |
@@ -17,7 +19,7 @@ VMContextAccessTest >> assertContext: newContext equals: contextOop onInstVar: a
 	self assert: copiedPC  equals: originalPC
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMContextAccessTest >> pushActiveContext [
 
 	interpreter pushActiveContextBytecode.
@@ -25,7 +27,7 @@ VMContextAccessTest >> pushActiveContext [
 	^ interpreter stackTop
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMContextAccessTest >> setUp [
 
 	"taken from VMSimpleStackBasedCogitBytecodeTest >> #setup"
@@ -59,7 +61,7 @@ VMContextAccessTest >> setUp [
 	self initializeOldSpaceForFullGC
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMContextAccessTest >> testCloningTopContextHasCorrectPC [
 		
 	| contextOop newContext |
@@ -73,7 +75,7 @@ VMContextAccessTest >> testCloningTopContextHasCorrectPC [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMContextAccessTest >> testCloningTopContextHasCorrectPCAfterFullGC [
 		
 	| contextOop newContext |
@@ -91,7 +93,7 @@ VMContextAccessTest >> testCloningTopContextHasCorrectPCAfterFullGC [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMContextAccessTest >> testCloningTopContextHasCorrectReceiver [
 		
 	| contextOop newContext |
@@ -106,7 +108,7 @@ VMContextAccessTest >> testCloningTopContextHasCorrectReceiver [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMContextAccessTest >> testCloningTopContextHasCorrectSenderWhenItIsNil [
 		
 	| contextOop newContext |

--- a/smalltalksrc/VMMakerTests/VMDivisionInstructionTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMDivisionInstructionTest.class.st
@@ -1,14 +1,16 @@
 Class {
-	#name : #VMDivisionInstructionTest,
-	#superclass : #VMSimpleStackBasedCogitAbstractTest,
+	#name : 'VMDivisionInstructionTest',
+	#superclass : 'VMSimpleStackBasedCogitAbstractTest',
 	#pools : [
 		'CogAbstractRegisters',
 		'CogRTLOpcodes'
 	],
-	#category : #'VMMakerTests-JitTests'
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMDivisionInstructionTest >> testDivide: numerator by: divisor quotient: quotient remainer: remainer [
 
 	| expectedQuotient expectedRemainer |
@@ -30,63 +32,63 @@ VMDivisionInstructionTest >> testDivide: numerator by: divisor quotient: quotien
 	self assert: machineSimulator classRegisterValue equals: expectedRemainer
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMDivisionInstructionTest >> testDivisionWithNegativeDividentWithRemainerReturnsCorrectQuotientAndRemainder [
 
 	self testDivide: -10 by: 7 quotient: -1 remainer: -3.
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMDivisionInstructionTest >> testDivisionWithNegativeDivisorAndDividentWithRemainerReturnsCorrectQuotientAndRemainder [
 
 	self testDivide: -10 by: -7 quotient: 1 remainer: -3.
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMDivisionInstructionTest >> testDivisionWithNegativeDivisorWithRemainerReturnsCorrectQuotientAndRemainder [
 
 	self testDivide: 10 by: -7 quotient: -1 remainer: 3.
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMDivisionInstructionTest >> testDivisionWithRemainerReturnsCorrectQuotientAndRemainder [
 
 	self testDivide: 10 by: 7 quotient: 1 remainer: 3.
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMDivisionInstructionTest >> testIntegerDivisionReturnsCorrectQuotientAndRemainder [
 
 	self testDivide: 10 by: 2 quotient: 5 remainer: 0.
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMDivisionInstructionTest >> testIntegerDivisionWithNegativeDivisorReturnsCorrectQuotientAndRemainder [
 
 	self testDivide: 10 by: -2 quotient: -5 remainer: 0.
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMDivisionInstructionTest >> testIntegerDivisionWithNegativeNumeratorAndDivisorReturnsCorrectQuotientAndRemainder [
 
 	self testDivide: -10 by: -2 quotient: 5 remainer: 0.
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMDivisionInstructionTest >> testIntegerDivisionWithNegativeNumeratorReturnsCorrectQuotientAndRemainder [
 
 	self testDivide: -10 by: 2 quotient: -5 remainer: 0.
 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMDivisionInstructionTest >> twoComplementOf: anInteger [
 
 	^ self wordSize = 8

--- a/smalltalksrc/VMMakerTests/VMFFIArgumentMarshallingTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMFFIArgumentMarshallingTest.class.st
@@ -1,28 +1,29 @@
 Class {
-	#name : #VMFFIArgumentMarshallingTest,
-	#superclass : #VMAbstractFFITest,
-	#category : #VMMakerTests
+	#name : 'VMFFIArgumentMarshallingTest',
+	#superclass : 'VMAbstractFFITest',
+	#category : 'VMMakerTests',
+	#package : 'VMMakerTests'
 }
 
-{ #category : #private }
+{ #category : 'private' }
 VMFFIArgumentMarshallingTest class >> isAbstract [
 	
 	^ self == VMFFIArgumentMarshallingTest
 ]
 
-{ #category : #implementation }
+{ #category : 'implementation' }
 VMFFIArgumentMarshallingTest >> doTestFuntionWithArgumentType: argumentType smalltalkValue: smalltalkValue expectedValue: expectedValue [
 
 	self subclassResponsibility 
 ]
 
-{ #category : #implementation }
+{ #category : 'implementation' }
 VMFFIArgumentMarshallingTest >> doTestFuntionWithArgumentType: argumentType smalltalkValue: smalltalkValue failsWith: expectedErrorCode [
 
 	self subclassResponsibility 
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> newLargeIntegerForValue: aValue [
 
 	| newLargeInteger byteSize class |
@@ -43,7 +44,7 @@ VMFFIArgumentMarshallingTest >> newLargeIntegerForValue: aValue [
 	^ newLargeInteger
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithCharacterArgumentIsMarshalledCorrectly [
 
 	self
@@ -52,7 +53,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithCharacterArgumentIsMarshalledCorr
 		expectedValue: 17
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithDoubleArgumentIsMarshalledCorrectly [
 
 	self
@@ -61,7 +62,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithDoubleArgumentIsMarshalledCorrect
 		expectedValue: 17.0
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithFloatArgumentIsMarshalledCorrectly [
 
 	self
@@ -70,7 +71,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithFloatArgumentIsMarshalledCorrectl
 		expectedValue: 17.0
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithPointerArgumentIsMarshalledCorrectly [
 
 	self
@@ -79,7 +80,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithPointerArgumentIsMarshalledCorrec
 		expectedValue: 17
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithSINT16ArgumentWithNegativeValueIsMarshalledCorrectly [
 
 	self
@@ -88,7 +89,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithSINT16ArgumentWithNegativeValueIs
 		expectedValue: -42
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithSINT16ArgumentWithPositiveValueIsMarshalledCorrectly [
 
 	self
@@ -97,7 +98,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithSINT16ArgumentWithPositiveValueIs
 		expectedValue: 42
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithSINT16NegativeOutOfRangeProducesBadArgument [
 
 	self
@@ -107,7 +108,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithSINT16NegativeOutOfRangeProducesB
 
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithSINT16PositiveOutOfRangeProducesBadArgument [
 
 	self
@@ -117,7 +118,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithSINT16PositiveOutOfRangeProducesB
 
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithSINT32ArgumentWithLargeNegativeValueIsMarshalledCorrectly [
 
 	| aValue aValueToStore |
@@ -134,7 +135,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithSINT32ArgumentWithLargeNegativeVa
 		expectedValue: aValue
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithSINT32ArgumentWithLargePositiveHigherThan4BytesFails [
 
 	| aValue |
@@ -149,7 +150,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithSINT32ArgumentWithLargePositiveHi
 		failsWith: PrimErrBadArgument
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithSINT32ArgumentWithNegativeValueIsMarshalledCorrectly [
 
 	self
@@ -158,7 +159,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithSINT32ArgumentWithNegativeValueIs
 		expectedValue: -42
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithSINT32ArgumentWithPositiveValueIsMarshalledCorrectly [
 
 	self
@@ -167,7 +168,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithSINT32ArgumentWithPositiveValueIs
 		expectedValue: 42
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithSINT32NegativeOutOfRangeProducesBadArgument [
 
 	| valueToStore |
@@ -183,7 +184,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithSINT32NegativeOutOfRangeProducesB
 
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithSINT32PositiveOutOfRangeProducesBadArgument [
 
 	self
@@ -193,7 +194,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithSINT32PositiveOutOfRangeProducesB
 
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithSINT64ArgumentWithLargeNegativeValueIsMarshalledCorrectly [
 
 	| aValue |
@@ -205,7 +206,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithSINT64ArgumentWithLargeNegativeVa
 		expectedValue: aValue
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithSINT64ArgumentWithLargePositiveHigherThan8BytesFails [
 
 	| aValue newLargeInteger |
@@ -224,7 +225,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithSINT64ArgumentWithLargePositiveHi
 		failsWith: PrimErrBadArgument
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithSINT64ArgumentWithLargePositiveValueIsMarshalledCorrectly [
 
 	| aValue |
@@ -237,7 +238,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithSINT64ArgumentWithLargePositiveVa
 
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithSINT64ArgumentWithNegativeValueIsMarshalledCorrectly [
 
 	self
@@ -246,7 +247,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithSINT64ArgumentWithNegativeValueIs
 		expectedValue: -42
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithSINT64ArgumentWithPositiveValueIsMarshalledCorrectly [
 
 	self
@@ -255,7 +256,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithSINT64ArgumentWithPositiveValueIs
 		expectedValue: 42
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithSINT8ArgumentWithNegativeValueIsMarshalledCorrectly [
 
 	self
@@ -264,7 +265,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithSINT8ArgumentWithNegativeValueIsM
 		expectedValue: -42
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithSINT8ArgumentWithPositiveValueIsMarshalledCorrectly [
 
 	self
@@ -273,7 +274,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithSINT8ArgumentWithPositiveValueIsM
 		expectedValue: 42
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithSINT8NegativeOutOfRangeProducesBadArgument [
 
 	self
@@ -283,7 +284,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithSINT8NegativeOutOfRangeProducesBa
 
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithSINT8PositiveOutOfRangeProducesBadArgument [
 
 	self
@@ -293,7 +294,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithSINT8PositiveOutOfRangeProducesBa
 
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithStructByteArrayArgumentIsMarshalledCorrectly [
 
 	| oop ptr storedValue |
@@ -310,7 +311,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithStructByteArrayArgumentIsMarshall
 		expectedValue: storedValue
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithStructPointerArgumentIsMarshalledCorrectly [
 
 	| oop ptr storedValue |
@@ -327,7 +328,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithStructPointerArgumentIsMarshalled
 		expectedValue: storedValue
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithUINT16ArgumentWithNegatieValueFails [
 
 	self
@@ -336,7 +337,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithUINT16ArgumentWithNegatieValueFai
 		failsWith: PrimErrBadArgument
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithUINT16ArgumentWithPositiveValueIsMarshalledCorrectly [
 
 	self
@@ -345,7 +346,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithUINT16ArgumentWithPositiveValueIs
 		expectedValue: 8
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithUINT16WithPositiveOutOfRangeFailsWithPrimErrBadArgument [
 
 	self
@@ -354,7 +355,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithUINT16WithPositiveOutOfRangeFails
 		failsWith: PrimErrBadArgument
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithUINT32ArgumentWithLargePositiveHigherThan4BytesFails [
 
 	| aValue |
@@ -369,7 +370,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithUINT32ArgumentWithLargePositiveHi
 		failsWith: PrimErrBadArgument
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithUINT32ArgumentWithLargePositiveValueIsMarshalledCorrectly [
 
 	| aValue |
@@ -384,7 +385,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithUINT32ArgumentWithLargePositiveVa
 		expectedValue: 16r3FFFFFFF + 2
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithUINT32ArgumentWithNegatieValueFails [
 
 	self
@@ -393,7 +394,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithUINT32ArgumentWithNegatieValueFai
 		failsWith: PrimErrBadArgument
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithUINT32ArgumentWithPositiveValueIsMarshalledCorrectly [
 
 	self
@@ -402,7 +403,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithUINT32ArgumentWithPositiveValueIs
 		expectedValue: 42
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithUINT32WithPositiveOutOfRangeFailsWithPrimErrBadArgument [
 
 	| valueToStore |
@@ -417,7 +418,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithUINT32WithPositiveOutOfRangeFails
 		failsWith: PrimErrBadArgument
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithUINT64ArgumentWithLargePositiveHigherThan8BytesFails [
 
 	| aValue newLargeInteger |
@@ -436,7 +437,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithUINT64ArgumentWithLargePositiveHi
 		failsWith: PrimErrBadArgument
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithUINT64ArgumentWithLargePositiveValueIsMarshalledCorrectly [
 
 	| aValue |
@@ -448,7 +449,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithUINT64ArgumentWithLargePositiveVa
 		expectedValue: aValue
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithUINT64ArgumentWithNegatieValueFails [
 
 	self
@@ -457,7 +458,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithUINT64ArgumentWithNegatieValueFai
 		failsWith: PrimErrBadArgument
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithUINT64ArgumentWithPositiveValueIsMarshalledCorrectly [
 
 	self
@@ -466,7 +467,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithUINT64ArgumentWithPositiveValueIs
 		expectedValue: 42
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithUINT8ArgumentWithNegatieValueFails [
 
 	self
@@ -475,7 +476,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithUINT8ArgumentWithNegatieValueFail
 		failsWith: PrimErrBadArgument
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithUINT8ArgumentWithPositiveValueIsMarshalledCorrectly [
 
 	self
@@ -484,7 +485,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithUINT8ArgumentWithPositiveValueIsM
 		expectedValue: 8
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFIArgumentMarshallingTest >> testCalloutWithUINT8WithPositiveOutOfRangeFailsWithPrimErrBadArgument [
 
 	self

--- a/smalltalksrc/VMMakerTests/VMFFICallbacksTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMFFICallbacksTest.class.st
@@ -1,10 +1,11 @@
 Class {
-	#name : #VMFFICallbacksTest,
-	#superclass : #VMAbstractFFITest,
-	#category : #VMMakerTests
+	#name : 'VMFFICallbacksTest',
+	#superclass : 'VMAbstractFFITest',
+	#category : 'VMMakerTests',
+	#package : 'VMMakerTests'
 }
 
-{ #category : #'tests - callbacks' }
+{ #category : 'tests - callbacks' }
 VMFFICallbacksTest >> doCallout: tfExternalFunction with: parametersArray [
 	
 	interpreter push: memory nilObject.
@@ -16,7 +17,7 @@ VMFFICallbacksTest >> doCallout: tfExternalFunction with: parametersArray [
 
 ]
 
-{ #category : #'tests - callbacks' }
+{ #category : 'tests - callbacks' }
 VMFFICallbacksTest >> testPrimitiveSameThreadCallbackInCalloutSuspendsActiveProcess [
 
 	| parametersArray tfExternalFunction oldActiveProcess callbackContext |
@@ -51,7 +52,7 @@ VMFFICallbacksTest >> testPrimitiveSameThreadCallbackInCalloutSuspendsActiveProc
 	interpreter primitiveSameThreadCallout.
 ]
 
-{ #category : #'tests - callbacks' }
+{ #category : 'tests - callbacks' }
 VMFFICallbacksTest >> testPrimitiveSameThreadCallbackReturnKeepsAllOtherProcessesInReady [
 
 	| parametersArray tfExternalFunction callbackContext processBefore |
@@ -77,7 +78,7 @@ VMFFICallbacksTest >> testPrimitiveSameThreadCallbackReturnKeepsAllOtherProcesse
 	self assertCollection: self readyProcesses hasSameElements: processBefore
 ]
 
-{ #category : #'tests - callbacks' }
+{ #category : 'tests - callbacks' }
 VMFFICallbacksTest >> testPrimitiveSameThreadCallbackReturnResumesCalloutProcess [
 
 	| parametersArray tfExternalFunction oldActiveProcess callbackContext |
@@ -104,7 +105,7 @@ VMFFICallbacksTest >> testPrimitiveSameThreadCallbackReturnResumesCalloutProcess
 	self assert: interpreter activeProcess equals: oldActiveProcess.
 ]
 
-{ #category : #'tests - callbacks' }
+{ #category : 'tests - callbacks' }
 VMFFICallbacksTest >> testPrimitiveSameThreadReentrantCallbackRestoresCalloutProcess [
 
 	| parametersArray tfExternalFunction oldActiveProcess callbackContext numberOfCallbacks innerCallbackContext tfExternalFunction2 |

--- a/smalltalksrc/VMMakerTests/VMFFIHelpersTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMFFIHelpersTest.class.st
@@ -1,10 +1,11 @@
 Class {
-	#name : #VMFFIHelpersTest,
-	#superclass : #VMAbstractFFITest,
-	#category : #VMMakerTests
+	#name : 'VMFFIHelpersTest',
+	#superclass : 'VMAbstractFFITest',
+	#category : 'VMMakerTests',
+	#package : 'VMMakerTests'
 }
 
-{ #category : #'tests - helpers' }
+{ #category : 'tests - helpers' }
 VMFFIHelpersTest >> assertPopInEmptyStackFails [
 
 	[ interpreter popSameThreadCalloutSuspendedProcess.
@@ -15,7 +16,7 @@ VMFFIHelpersTest >> assertPopInEmptyStackFails [
 				equals: 'SameThreadCalloutSuspendedProcessStack is empty' ]
 ]
 
-{ #category : #'tests - helpers' }
+{ #category : 'tests - helpers' }
 VMFFIHelpersTest >> testPopSameThreadCalloutSuspendedProcessInEmptyStackRaisesError [
 
  	self assert: (memory splObj: SuspendedProcessInCallout) equals: memory nilObject.	
@@ -23,7 +24,7 @@ VMFFIHelpersTest >> testPopSameThreadCalloutSuspendedProcessInEmptyStackRaisesEr
 	self assertPopInEmptyStackFails
 ]
 
-{ #category : #'tests - helpers' }
+{ #category : 'tests - helpers' }
 VMFFIHelpersTest >> testPushPushThenPopPopSameThreadCalloutSuspendedProcessInEmptyStackReturnsFirstPushedProcess [
 
  	| aProcess anotherProcess |
@@ -41,7 +42,7 @@ VMFFIHelpersTest >> testPushPushThenPopPopSameThreadCalloutSuspendedProcessInEmp
 
 ]
 
-{ #category : #'tests - helpers' }
+{ #category : 'tests - helpers' }
 VMFFIHelpersTest >> testPushPushThenPopPopSameThreadCalloutSuspendedProcessInEmptyStackReturnsFirstPushedProcessWithNilNextLink [
 
  	| aProcess anotherProcess |
@@ -59,7 +60,7 @@ VMFFIHelpersTest >> testPushPushThenPopPopSameThreadCalloutSuspendedProcessInEmp
 
 ]
 
-{ #category : #'tests - helpers' }
+{ #category : 'tests - helpers' }
 VMFFIHelpersTest >> testPushPushThenPopSameThreadCalloutSuspendedProcessInEmptyStackReturnsLastPushedProcess [
 
  	| aProcess anotherProcess |
@@ -75,7 +76,7 @@ VMFFIHelpersTest >> testPushPushThenPopSameThreadCalloutSuspendedProcessInEmptyS
 
 ]
 
-{ #category : #'tests - helpers' }
+{ #category : 'tests - helpers' }
 VMFFIHelpersTest >> testPushPushThenPopSameThreadCalloutSuspendedProcessInEmptyStackReturnsLastPushedProcessWithNilNextLink [
 
  	| aProcess anotherProcess |
@@ -91,7 +92,7 @@ VMFFIHelpersTest >> testPushPushThenPopSameThreadCalloutSuspendedProcessInEmptyS
 
 ]
 
-{ #category : #'tests - helpers' }
+{ #category : 'tests - helpers' }
 VMFFIHelpersTest >> testPushSameThreadCalloutSuspendedProcessInEmptyStackStoresThePassedProcess [
 
  	| aProcess |
@@ -104,7 +105,7 @@ VMFFIHelpersTest >> testPushSameThreadCalloutSuspendedProcessInEmptyStackStoresT
 
 ]
 
-{ #category : #'tests - helpers' }
+{ #category : 'tests - helpers' }
 VMFFIHelpersTest >> testPushSameThreadCalloutSuspendedProcessInEmptyStackUpdatesNextLinkWithNil [
 
  	| aProcess |
@@ -117,7 +118,7 @@ VMFFIHelpersTest >> testPushSameThreadCalloutSuspendedProcessInEmptyStackUpdates
 
 ]
 
-{ #category : #'tests - helpers' }
+{ #category : 'tests - helpers' }
 VMFFIHelpersTest >> testPushThenPopPopSameThreadCalloutSuspendedProcessInEmptyStackFails [
 
  	| aProcess |
@@ -132,7 +133,7 @@ VMFFIHelpersTest >> testPushThenPopPopSameThreadCalloutSuspendedProcessInEmptySt
 
 ]
 
-{ #category : #'tests - helpers' }
+{ #category : 'tests - helpers' }
 VMFFIHelpersTest >> testPushThenPopSameThreadCalloutSuspendedProcessInEmptyStackReturnsProcessWithNilInNextLink [
 
  	| aProcess |
@@ -145,7 +146,7 @@ VMFFIHelpersTest >> testPushThenPopSameThreadCalloutSuspendedProcessInEmptyStack
 
 ]
 
-{ #category : #'tests - helpers' }
+{ #category : 'tests - helpers' }
 VMFFIHelpersTest >> testPushThenPopSameThreadCalloutSuspendedProcessInEmptyStackReturnsPushedProcess [
 
  	| aProcess |
@@ -158,7 +159,7 @@ VMFFIHelpersTest >> testPushThenPopSameThreadCalloutSuspendedProcessInEmptyStack
 
 ]
 
-{ #category : #'tests - helpers' }
+{ #category : 'tests - helpers' }
 VMFFIHelpersTest >> testReadAddressReadsTheValidAddressValue [
 
 	| anExternalAddress |

--- a/smalltalksrc/VMMakerTests/VMFFIReturnMarshallingTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMFFIReturnMarshallingTest.class.st
@@ -1,22 +1,23 @@
 Class {
-	#name : #VMFFIReturnMarshallingTest,
-	#superclass : #VMAbstractFFITest,
-	#category : #VMMakerTests
+	#name : 'VMFFIReturnMarshallingTest',
+	#superclass : 'VMAbstractFFITest',
+	#category : 'VMMakerTests',
+	#package : 'VMMakerTests'
 }
 
-{ #category : #private }
+{ #category : 'private' }
 VMFFIReturnMarshallingTest class >> isAbstract [ 
 
 	^ self = VMFFIReturnMarshallingTest
 ]
 
-{ #category : #'tests - marshalling return' }
+{ #category : 'tests - marshalling return' }
 VMFFIReturnMarshallingTest >> doTestCalloutWithReturnType: aLibFFIType returnValue: valueToReturn asserting: aBlock [
 	
 	self subclassResponsibility
 ]
 
-{ #category : #utils }
+{ #category : 'utils' }
 VMFFIReturnMarshallingTest >> doTestCalloutWithReturnType: aLibFFIType returnValue: valueToReturn expectedLargeIntegerValue: expectedValue [ 
 
 	self
@@ -36,7 +37,7 @@ VMFFIReturnMarshallingTest >> doTestCalloutWithReturnType: aLibFFIType returnVal
 
 ]
 
-{ #category : #'tests - marshalling return' }
+{ #category : 'tests - marshalling return' }
 VMFFIReturnMarshallingTest >> doTestCalloutWithReturnType: aLibFFIType returnValue: valueToReturn expectedSmalltalkValue: expectedValue [
 
 	self
@@ -50,7 +51,7 @@ VMFFIReturnMarshallingTest >> doTestCalloutWithReturnType: aLibFFIType returnVal
 
 ]
 
-{ #category : #'tests - marshalling return' }
+{ #category : 'tests - marshalling return' }
 VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningAnStructPushesAByteArray [
 
 	| valueToReturn |
@@ -72,7 +73,7 @@ VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningAnStructPushesAByteAr
 		
 ]
 
-{ #category : #'tests - marshalling return' }
+{ #category : 'tests - marshalling return' }
 VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningDoublePushSmallFloatInStack [
 
 	self
@@ -84,7 +85,7 @@ VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningDoublePushSmallFloatI
 
 ]
 
-{ #category : #'tests - marshalling return' }
+{ #category : 'tests - marshalling return' }
 VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningFloatPushSmallFloatInStack [
 
 	self
@@ -96,7 +97,7 @@ VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningFloatPushSmallFloatIn
 
 ]
 
-{ #category : #'tests - marshalling return' }
+{ #category : 'tests - marshalling return' }
 VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningPointerPushesAnExternalAddress [
 
 
@@ -110,7 +111,7 @@ VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningPointerPushesAnExtern
 
 ]
 
-{ #category : #'tests - marshalling return' }
+{ #category : 'tests - marshalling return' }
 VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningSINT16PushSmallInteger [
 
 	self
@@ -119,7 +120,7 @@ VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningSINT16PushSmallIntege
 		expectedSmalltalkValue: INT16_MAX - 1
 ]
 
-{ #category : #'tests - marshalling return' }
+{ #category : 'tests - marshalling return' }
 VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningSINT32PushLargeInteger [
 
 	| value |
@@ -131,7 +132,7 @@ VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningSINT32PushLargeIntege
 		expectedLargeIntegerValue: INT32_MAX - 1
 ]
 
-{ #category : #'tests - marshalling return' }
+{ #category : 'tests - marshalling return' }
 VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningSINT32PushSmallInteger [
 
 	| value |
@@ -145,7 +146,7 @@ VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningSINT32PushSmallIntege
 		expectedSmalltalkValue: value
 ]
 
-{ #category : #'tests - marshalling return' }
+{ #category : 'tests - marshalling return' }
 VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningSINT64PushLargeInteger [
 
 	self
@@ -154,7 +155,7 @@ VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningSINT64PushLargeIntege
 		expectedLargeIntegerValue: INT64_MAX - 1
 ]
 
-{ #category : #'tests - marshalling return' }
+{ #category : 'tests - marshalling return' }
 VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningSINT64PushSmallInteger [
 
 	self
@@ -163,7 +164,7 @@ VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningSINT64PushSmallIntege
 		expectedSmalltalkValue: memory maxSmallInteger
 ]
 
-{ #category : #'tests - marshalling return' }
+{ #category : 'tests - marshalling return' }
 VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningSINT8PushSmallInteger [
 
 	self
@@ -172,7 +173,7 @@ VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningSINT8PushSmallInteger
 		expectedSmalltalkValue: INT8_MAX - 1
 ]
 
-{ #category : #'tests - marshalling return' }
+{ #category : 'tests - marshalling return' }
 VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningUINT16PushSmallInteger [
 
 	self
@@ -181,7 +182,7 @@ VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningUINT16PushSmallIntege
 		expectedSmalltalkValue: INT16_MAX - 1
 ]
 
-{ #category : #'tests - marshalling return' }
+{ #category : 'tests - marshalling return' }
 VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningUINT32PushLargeInteger [
 
 	| value |
@@ -193,7 +194,7 @@ VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningUINT32PushLargeIntege
 		expectedLargeIntegerValue: INT32_MAX - 1
 ]
 
-{ #category : #'tests - marshalling return' }
+{ #category : 'tests - marshalling return' }
 VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningUINT32PushSmallInteger [
 
 	| value |
@@ -207,7 +208,7 @@ VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningUINT32PushSmallIntege
 		expectedSmalltalkValue: value
 ]
 
-{ #category : #'tests - marshalling return' }
+{ #category : 'tests - marshalling return' }
 VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningUINT64PushLargeInteger [
 
 	self
@@ -216,7 +217,7 @@ VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningUINT64PushLargeIntege
 		expectedLargeIntegerValue:  INT64_MAX 
 ]
 
-{ #category : #'tests - marshalling return' }
+{ #category : 'tests - marshalling return' }
 VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningUINT64PushSmallInteger [
 
 	self
@@ -225,7 +226,7 @@ VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningUINT64PushSmallIntege
 		expectedSmalltalkValue:  memory maxSmallInteger 
 ]
 
-{ #category : #'tests - marshalling return' }
+{ #category : 'tests - marshalling return' }
 VMFFIReturnMarshallingTest >> testPrimitiveCalloutReturningUINT8PushSmallInteger [
 
 	self

--- a/smalltalksrc/VMMakerTests/VMFFISameThreadArgumentMarshallingTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMFFISameThreadArgumentMarshallingTest.class.st
@@ -1,10 +1,11 @@
 Class {
-	#name : #VMFFISameThreadArgumentMarshallingTest,
-	#superclass : #VMFFIArgumentMarshallingTest,
-	#category : #VMMakerTests
+	#name : 'VMFFISameThreadArgumentMarshallingTest',
+	#superclass : 'VMFFIArgumentMarshallingTest',
+	#category : 'VMMakerTests',
+	#package : 'VMMakerTests'
 }
 
-{ #category : #implementation }
+{ #category : 'implementation' }
 VMFFISameThreadArgumentMarshallingTest >> doTestFuntionWithArgumentType: argumentType smalltalkValue: smalltalkValue expectedValue: expectedValue [
 
 	| parametersArray tfExternalFunction savedValue |
@@ -28,7 +29,7 @@ VMFFISameThreadArgumentMarshallingTest >> doTestFuntionWithArgumentType: argumen
 	self assert: savedValue equals: expectedValue.
 ]
 
-{ #category : #implementation }
+{ #category : 'implementation' }
 VMFFISameThreadArgumentMarshallingTest >> doTestFuntionWithArgumentType: argumentType smalltalkValue: smalltalkValue failsWith: expectedErrorCode [
 
 	| parametersArray tfExternalFunction savedValue |
@@ -52,7 +53,7 @@ VMFFISameThreadArgumentMarshallingTest >> doTestFuntionWithArgumentType: argumen
 	self assert: interpreter primFailCode equals: expectedErrorCode.
 ]
 
-{ #category : #'tests - parameters marshalling' }
+{ #category : 'tests - parameters marshalling' }
 VMFFISameThreadArgumentMarshallingTest >> testCalloutWithoutArgumentsMarshallsCorrectly [
 
 	| parametersArray tfExternalFunction functionCalled |

--- a/smalltalksrc/VMMakerTests/VMFFISameThreadCalloutTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMFFISameThreadCalloutTest.class.st
@@ -1,10 +1,11 @@
 Class {
-	#name : #VMFFISameThreadCalloutTest,
-	#superclass : #VMAbstractFFITest,
-	#category : #VMMakerTests
+	#name : 'VMFFISameThreadCalloutTest',
+	#superclass : 'VMAbstractFFITest',
+	#category : 'VMMakerTests',
+	#package : 'VMMakerTests'
 }
 
-{ #category : #'tests - callouts' }
+{ #category : 'tests - callouts' }
 VMFFISameThreadCalloutTest >> testPrimitiveSameThreadCalloutMaintainsActiveProcess [
 
 	| parametersArray tfExternalFunction oldActiveProcess |
@@ -24,7 +25,7 @@ VMFFISameThreadCalloutTest >> testPrimitiveSameThreadCalloutMaintainsActiveProce
 	self assert: interpreter activeProcess equals: oldActiveProcess
 ]
 
-{ #category : #'tests - callouts' }
+{ #category : 'tests - callouts' }
 VMFFISameThreadCalloutTest >> testPrimitiveSameThreadCalloutShouldKeepTheNewMethodVariable [
 
 	| parametersArray tfExternalFunction oldActiveProcess callbackContext |

--- a/smalltalksrc/VMMakerTests/VMFFISameThreadReturnMarshallingTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMFFISameThreadReturnMarshallingTest.class.st
@@ -1,10 +1,11 @@
 Class {
-	#name : #VMFFISameThreadReturnMarshallingTest,
-	#superclass : #VMFFIReturnMarshallingTest,
-	#category : #VMMakerTests
+	#name : 'VMFFISameThreadReturnMarshallingTest',
+	#superclass : 'VMFFIReturnMarshallingTest',
+	#category : 'VMMakerTests',
+	#package : 'VMMakerTests'
 }
 
-{ #category : #'tests - marshalling return' }
+{ #category : 'tests - marshalling return' }
 VMFFISameThreadReturnMarshallingTest >> doTestCalloutWithReturnType: aLibFFIType returnValue: valueToReturn asserting: aBlock [
 
 	| parametersArray tfExternalFunction |
@@ -26,7 +27,7 @@ VMFFISameThreadReturnMarshallingTest >> doTestCalloutWithReturnType: aLibFFIType
 	aBlock value
 ]
 
-{ #category : #'tests - marshalling return' }
+{ #category : 'tests - marshalling return' }
 VMFFISameThreadReturnMarshallingTest >> testPrimitiveCalloutReturningVoidPushesTheReceiver [
 
 	self 

--- a/smalltalksrc/VMMakerTests/VMFFIWorkerArgumentMarshallingTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMFFIWorkerArgumentMarshallingTest.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #VMFFIWorkerArgumentMarshallingTest,
-	#superclass : #VMFFIArgumentMarshallingTest,
+	#name : 'VMFFIWorkerArgumentMarshallingTest',
+	#superclass : 'VMFFIArgumentMarshallingTest',
 	#instVars : [
 		'aFunctionBlock',
 		'tfExternalFunction',
@@ -11,10 +11,11 @@ Class {
 		'task',
 		'savedValue'
 	],
-	#category : #VMMakerTests
+	#category : 'VMMakerTests',
+	#package : 'VMMakerTests'
 }
 
-{ #category : #implementation }
+{ #category : 'implementation' }
 VMFFIWorkerArgumentMarshallingTest >> doTestFuntionWithArgumentType: argumentType smalltalkValue: smalltalkValue expectedValue: expectedValue [
 
 	self doWorkerCallWithValue: smalltalkValue ofType: argumentType.
@@ -32,7 +33,7 @@ VMFFIWorkerArgumentMarshallingTest >> doTestFuntionWithArgumentType: argumentTyp
 	self assert: savedValue equals: expectedValue
 ]
 
-{ #category : #implementation }
+{ #category : 'implementation' }
 VMFFIWorkerArgumentMarshallingTest >> doTestFuntionWithArgumentType: argumentType smalltalkValue: smalltalkValue failsWith: expectedErrorCode [
 
 	self doWorkerCallWithValue: smalltalkValue ofType: argumentType.
@@ -41,7 +42,7 @@ VMFFIWorkerArgumentMarshallingTest >> doTestFuntionWithArgumentType: argumentTyp
 	self assert: interpreter primFailCode equals: expectedErrorCode.
 ]
 
-{ #category : #implementation }
+{ #category : 'implementation' }
 VMFFIWorkerArgumentMarshallingTest >> doWorkerCallWithValue: smalltalkValue ofType: argumentType [
 
 	aFunctionBlock := [ :anArgument | self fail: 'It should enqueue it, not execute it' ].
@@ -77,21 +78,21 @@ VMFFIWorkerArgumentMarshallingTest >> doWorkerCallWithValue: smalltalkValue ofTy
 	interpreter primitiveWorkerCallout
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMFFIWorkerArgumentMarshallingTest >> initializationOptions [
 
 	^ super initializationOptions , { 
 		#FEATURE_THREADED_FFI . true }
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMFFIWorkerArgumentMarshallingTest >> setUp [ 
 
 	super setUp.
 	interpreter libFFI testWorker clear
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMFFIWorkerArgumentMarshallingTest >> testCalloutWithoutArgumentsMarshallsCorrectly [
 
 	aFunctionBlock := [ :anArgument | self fail: 'It should enqueue it, not execute it' ].

--- a/smalltalksrc/VMMakerTests/VMFFIWorkerCalloutTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMFFIWorkerCalloutTest.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #VMFFIWorkerCalloutTest,
-	#superclass : #VMAbstractFFITest,
+	#name : 'VMFFIWorkerCalloutTest',
+	#superclass : 'VMAbstractFFITest',
 	#instVars : [
 		'aFunctionBlock',
 		'tfExternalFunction',
@@ -9,16 +9,17 @@ Class {
 		'workerOop',
 		'semaphoreIndex'
 	],
-	#category : #VMMakerTests
+	#category : 'VMMakerTests',
+	#package : 'VMMakerTests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMFFIWorkerCalloutTest >> doWorkerCallWithArguments: smalltalkValues ofTypes: argumentTypes [
 
 	^ self doWorkerCallWithArguments: smalltalkValues ofTypes: argumentTypes returnType: interpreter libFFI void
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMFFIWorkerCalloutTest >> doWorkerCallWithArguments: smalltalkValues ofTypes: argumentTypes returnType: returnType [
 
 	aFunctionBlock := [ self fail: 'It should enqueue it, not execute it' ].
@@ -49,21 +50,21 @@ VMFFIWorkerCalloutTest >> doWorkerCallWithArguments: smalltalkValues ofTypes: ar
 	interpreter primitiveWorkerCallout
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMFFIWorkerCalloutTest >> initializationOptions [
 
 	^ super initializationOptions , { 
 		#FEATURE_THREADED_FFI . true }
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMFFIWorkerCalloutTest >> testPrimitiveWorkerCalloutEnqueuesOnlyOneTask [
 
 	self doWorkerCallWithArguments: {} ofTypes: {}.
 	self assert: interpreter libFFI testWorker tasks size equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMFFIWorkerCalloutTest >> testPrimitiveWorkerCalloutReleasesAllAllocatedMemoryIfPrimitiveFails [
 
 	| previous |
@@ -86,7 +87,7 @@ VMFFIWorkerCalloutTest >> testPrimitiveWorkerCalloutReleasesAllAllocatedMemoryIf
 	self assert: interpreter allocatedElements size equals: previous.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMFFIWorkerCalloutTest >> testPrimitiveWorkerCalloutReturningVoidDoesNotAllocateReturnHolder [
 
 	self doWorkerCallWithArguments: {} ofTypes: {}.
@@ -94,7 +95,7 @@ VMFFIWorkerCalloutTest >> testPrimitiveWorkerCalloutReturningVoidDoesNotAllocate
 	self assert: interpreter libFFI testWorker tasks first returnHolderAddress isNil
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMFFIWorkerCalloutTest >> testPrimitiveWorkerCalloutWithParametersAllocatesArgumentHoldersAndReturnHolderInCHeap [
 
 	| previous |
@@ -116,7 +117,7 @@ VMFFIWorkerCalloutTest >> testPrimitiveWorkerCalloutWithParametersAllocatesArgum
 	self assert: interpreter allocatedElements size equals: previous + 7.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMFFIWorkerCalloutTest >> testPrimitiveWorkerCalloutWithoutParametersAndWithReturnAllocateJustOne [
 
 	| previous |
@@ -127,7 +128,7 @@ VMFFIWorkerCalloutTest >> testPrimitiveWorkerCalloutWithoutParametersAndWithRetu
 	self assert: interpreter allocatedElements size equals: previous + 1.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMFFIWorkerCalloutTest >> testPrimitiveWorkerCalloutWithoutParametersAndWithoutReturnDoesNotAllocate [
 
 	| previous |
@@ -138,7 +139,7 @@ VMFFIWorkerCalloutTest >> testPrimitiveWorkerCalloutWithoutParametersAndWithoutR
 	self assert: interpreter allocatedElements size equals: previous.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMFFIWorkerCalloutTest >> testPrimitiveWorkerCalloutWithoutParametersHasNilAsParametersPointer [
 
 	self doWorkerCallWithArguments: {} ofTypes: {}.

--- a/smalltalksrc/VMMakerTests/VMFFIWorkerReturnMarshallingTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMFFIWorkerReturnMarshallingTest.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #VMFFIWorkerReturnMarshallingTest,
-	#superclass : #VMFFIReturnMarshallingTest,
+	#name : 'VMFFIWorkerReturnMarshallingTest',
+	#superclass : 'VMFFIReturnMarshallingTest',
 	#instVars : [
 		'tfExternalFunction',
 		'returnHolder',
@@ -12,10 +12,11 @@ Class {
 		'worker',
 		'workerOop'
 	],
-	#category : #VMMakerTests
+	#category : 'VMMakerTests',
+	#package : 'VMMakerTests'
 }
 
-{ #category : #'tests - marshalling return' }
+{ #category : 'tests - marshalling return' }
 VMFFIWorkerReturnMarshallingTest >> doTestCalloutWithReturnType: aLibFFIType returnValue: valueToReturn asserting: aBlock [
 
 	tfExternalFunction := self
@@ -54,14 +55,14 @@ VMFFIWorkerReturnMarshallingTest >> doTestCalloutWithReturnType: aLibFFIType ret
 	aBlock value.
 ]
 
-{ #category : #'tests - marshalling return' }
+{ #category : 'tests - marshalling return' }
 VMFFIWorkerReturnMarshallingTest >> initializationOptions [
 
 	^ super initializationOptions , { 
 		#FEATURE_THREADED_FFI . true }
 ]
 
-{ #category : #'tests - marshalling return' }
+{ #category : 'tests - marshalling return' }
 VMFFIWorkerReturnMarshallingTest >> testPrimitiveCalloutReturningVoidPushesTheReceiver [
 
 	self 

--- a/smalltalksrc/VMMakerTests/VMForwardLiteralInMachineMethodTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMForwardLiteralInMachineMethodTest.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #VMForwardLiteralInMachineMethodTest,
-	#superclass : #VMPrimitiveCallAbstractTest,
+	#name : 'VMForwardLiteralInMachineMethodTest',
+	#superclass : 'VMPrimitiveCallAbstractTest',
 	#pools : [
 		'CogRTLOpcodes'
 	],
-	#category : #'VMMakerTests-JitTests'
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMForwardLiteralInMachineMethodTest >> initStack [
 
 	self createBaseFrame.
@@ -22,13 +24,13 @@ VMForwardLiteralInMachineMethodTest >> initStack [
 
 ]
 
-{ #category : #'methods under test' }
+{ #category : 'methods under test' }
 VMForwardLiteralInMachineMethodTest >> methodWithGlobal [
 
 	^ Smalltalk
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMForwardLiteralInMachineMethodTest >> testForwardLiteralInMethod [
 
 	| machineCodeMethod literal methodOop array literalValue selector associationClass valueClass literalKey |

--- a/smalltalksrc/VMMakerTests/VMFrameBuilder.class.st
+++ b/smalltalksrc/VMMakerTests/VMFrameBuilder.class.st
@@ -42,8 +42,8 @@ Configuring of the frame.
 			When it links them, it gives the last frame the previous caller Frame, for debug purpose.
 "
 Class {
-	#name : #VMFrameBuilder,
-	#superclass : #VMAbstractBuilder,
+	#name : 'VMFrameBuilder',
+	#superclass : 'VMAbstractBuilder',
 	#instVars : [
 		'method',
 		'context',
@@ -61,10 +61,12 @@ Class {
 		'methodBuilder',
 		'isSuspended'
 	],
-	#category : #'VMMakerTests-Builders'
+	#category : 'VMMakerTests-Builders',
+	#package : 'VMMakerTests',
+	#tag : 'Builders'
 }
 
-{ #category : #inspect }
+{ #category : 'inspect' }
 VMFrameBuilder >> adaptAddressToMemory: anInteger [
 	anInteger = memory nilObject ifTrue: [ ^ #nilObject ].
 	anInteger = memory trueObject ifTrue: [ ^ #trueObject ].
@@ -73,70 +75,70 @@ VMFrameBuilder >> adaptAddressToMemory: anInteger [
 	"^ memory integerObjectOf: anInteger"
 ]
 
-{ #category : #inspect }
+{ #category : 'inspect' }
 VMFrameBuilder >> adaptAddressToMemoryIfInteger: anAssociation [	
 	anAssociation value isInteger
 	ifTrue: [ anAssociation value: (self adaptAddressToMemory: anAssociation value) ]
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMFrameBuilder >> argumentSize [
 	^ argumentSize
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMFrameBuilder >> argumentSize: anObject [
 	argumentSize := anObject
 ]
 
-{ #category : #configuring }
+{ #category : 'configuring' }
 VMFrameBuilder >> beSuspended [
 	isSuspended := true
 ]
 
-{ #category : #configuring }
+{ #category : 'configuring' }
 VMFrameBuilder >> beSuspendedAt: anInstructionPointer [
 	instructionPointer := anInstructionPointer.
 	self beSuspended
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMFrameBuilder >> callerFrame [
 	^ callerFrame
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMFrameBuilder >> callerFrame: aFrame [ 
 	callerFrame := aFrame
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMFrameBuilder >> context [
 	^ context
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMFrameBuilder >> context: anObject [
 	context := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMFrameBuilder >> flags [
 	^ flags
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMFrameBuilder >> flags: anObject [
 	flags := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMFrameBuilder >> framePointer [
 	^ myFramePointer
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 VMFrameBuilder >> initializeWithInterpreter: anInterpreter andMemory: aMemory andMethodBuilder: aMethodBuilder [
 	memory := aMemory.
 	interpreter := anInterpreter. "allow to not care if it's for a cog or stack interpreter"
@@ -153,7 +155,7 @@ VMFrameBuilder >> initializeWithInterpreter: anInterpreter andMemory: aMemory an
 	argumentSize := 0.
 ]
 
-{ #category : #inspect }
+{ #category : 'inspect' }
 VMFrameBuilder >> inspectFrameIn: aBuilder [
 	<inspectorPresentationOrder: 0 title: 'Items'> 
 
@@ -184,12 +186,12 @@ VMFrameBuilder >> inspectFrameIn: aBuilder [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMFrameBuilder >> instructionPointer [
 	^ instructionPointer
 ]
 
-{ #category : #context }
+{ #category : 'context' }
 VMFrameBuilder >> isMarried [
 	| contextOop |
 	contextOop := interpreter frameContext: myFramePointer.
@@ -198,7 +200,7 @@ VMFrameBuilder >> isMarried [
 		ifFalse: [ interpreter isStillMarriedContext: contextOop ]
 ]
 
-{ #category : #context }
+{ #category : 'context' }
 VMFrameBuilder >> isSingle [
 	| contextOop |
 	contextOop := interpreter frameContext: myFramePointer.
@@ -209,43 +211,43 @@ VMFrameBuilder >> isSingle [
 			interpreter isSingleContext: contextOop ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 VMFrameBuilder >> isSuspended [
 	^ isSuspended
 ]
 
-{ #category : #context }
+{ #category : 'context' }
 VMFrameBuilder >> marryToContext [
 	interpreter ensureFrameIsMarried: myFramePointer SP: myStackPointer
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMFrameBuilder >> method [
 	^ method
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMFrameBuilder >> method: anOop [
 	method := anOop
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMFrameBuilder >> previousFrameArgsSize [
 	^ previousFrameArgsSize
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMFrameBuilder >> previousFrameArgsSize: anObject [
 	previousFrameArgsSize := anObject
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 VMFrameBuilder >> pushCurrentFramesStack [
 	"push to the stack all objects in the frame stack"
 	stack do: [ :oop | interpreter push: oop ].	
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 VMFrameBuilder >> pushFlags [
 	"Flags: this stack frame is single. I.e., it has no context object.
 	Otherwise GC fails with an assertion looking for it in the heap"
@@ -256,14 +258,14 @@ VMFrameBuilder >> pushFlags [
 	interpreter push: flags
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 VMFrameBuilder >> pushFrame [
 	interpreter push: receiver.
 	
 	temps do: [ :oop |  interpreter push: oop ].
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 VMFrameBuilder >> pushYourself [
 	self setVariablesFromCompiledMethod.
 
@@ -286,17 +288,17 @@ VMFrameBuilder >> pushYourself [
 	^ myFramePointer
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMFrameBuilder >> receiver [
 	^ receiver
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMFrameBuilder >> receiver: anObject [
 	receiver := anObject
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 VMFrameBuilder >> setArgsFromMethod [
 	| argNumber |
 	argNumber := interpreter argumentCountOf: method.
@@ -307,7 +309,7 @@ VMFrameBuilder >> setArgsFromMethod [
 			ifFalse: [ self error: 'Set temporaries do not match the number of arguments from the method oop.' ]]
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 VMFrameBuilder >> setInstructionPointerBeforeFirstBytecode [
 
 	"If possible, setting IP to before the first bytecode, so it is ready for fetchNextBytecode"
@@ -317,7 +319,7 @@ VMFrameBuilder >> setInstructionPointerBeforeFirstBytecode [
 	interpreter instructionPointer: instructionPointer
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 VMFrameBuilder >> setTempsFromMethod [
 	| tempNumber |
 	tempNumber := interpreter tempCountOf: method.
@@ -328,7 +330,7 @@ VMFrameBuilder >> setTempsFromMethod [
 			ifFalse: [ self error: 'Set temporaries do not match the number of temporaries from the method oop.' ]]
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 VMFrameBuilder >> setVariablesFromCompiledMethod [
 	(memory isCompiledMethod: method) ifFalse: [ ^ self ].
 
@@ -337,43 +339,43 @@ VMFrameBuilder >> setVariablesFromCompiledMethod [
 	self setArgsFromMethod
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMFrameBuilder >> stack [
 	^ stack
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMFrameBuilder >> stack: anObject [
 	stack := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMFrameBuilder >> stackPointer [
 	^ myStackPointer
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMFrameBuilder >> tempAt: anIndex put: anOop [
 	self collection: temps at: anIndex put: anOop
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMFrameBuilder >> temps [
 	^ temps
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMFrameBuilder >> temps: anObject [
 	temps := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMFrameBuilder >> vmMethodBuilder [
 
 	^ vmMethodBuilder
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMFrameBuilder >> vmMethodBuilder: anObject [
 
 	vmMethodBuilder := anObject

--- a/smalltalksrc/VMMakerTests/VMImageHeaderWritingTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMImageHeaderWritingTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #VMImageHeaderWritingTest,
-	#superclass : #VMAbstractImageFormatTest,
-	#category : #'VMMakerTests-ImageFormat'
+	#name : 'VMImageHeaderWritingTest',
+	#superclass : 'VMAbstractImageFormatTest',
+	#category : 'VMMakerTests-ImageFormat',
+	#package : 'VMMakerTests',
+	#tag : 'ImageFormat'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 VMImageHeaderWritingTest >> setUp [
 
 	super setUp.
@@ -18,7 +20,7 @@ VMImageHeaderWritingTest >> setUp [
 	self saveImage.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMImageHeaderWritingTest >> testImageHeaderWithPermanentObjects [
 
 	| header permanentObject |
@@ -35,7 +37,7 @@ VMImageHeaderWritingTest >> testImageHeaderWithPermanentObjects [
 				+ (memory bytesInObject: permanentObject) + 16 "PermSpace has an empty object as first object.".
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMImageHeaderWritingTest >> testWritingImageWritesCorrectBaseAddress [
 
 	| header |
@@ -45,7 +47,7 @@ VMImageHeaderWritingTest >> testWritingImageWritesCorrectBaseAddress [
 	self assert: header oldBaseAddr equals: memory getMemoryMap oldSpaceStart
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMImageHeaderWritingTest >> testWritingImageWritesCorrectBytesLeftInOldSpace [
 
 	| header |
@@ -55,7 +57,7 @@ VMImageHeaderWritingTest >> testWritingImageWritesCorrectBytesLeftInOldSpace [
 	self assert: header freeOldSpaceInImage equals: memory bytesLeftInOldSpace
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMImageHeaderWritingTest >> testWritingImageWritesCorrectCodeSize [
 
 	| header |
@@ -65,7 +67,7 @@ VMImageHeaderWritingTest >> testWritingImageWritesCorrectCodeSize [
 	self assert: header hdrCogCodeSize equals: interpreter unknownShortOrCodeSizeInKs
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMImageHeaderWritingTest >> testWritingImageWritesCorrectDataSize [
 
 	| header |
@@ -75,7 +77,7 @@ VMImageHeaderWritingTest >> testWritingImageWritesCorrectDataSize [
 	self assert: header dataSize equals: memory imageSizeToWrite
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMImageHeaderWritingTest >> testWritingImageWritesCorrectDesiredEdenSize [
 
 	| header |
@@ -85,7 +87,7 @@ VMImageHeaderWritingTest >> testWritingImageWritesCorrectDesiredEdenSize [
 	self assert: header hdrEdenBytes equals: interpreter getDesiredEdenBytes
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMImageHeaderWritingTest >> testWritingImageWritesCorrectDesiredNumberStackPages [
 
 	| header |
@@ -95,7 +97,7 @@ VMImageHeaderWritingTest >> testWritingImageWritesCorrectDesiredNumberStackPages
 	self assert: header hdrNumStackPages equals: interpreter getDesiredNumStackPages
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMImageHeaderWritingTest >> testWritingImageWritesCorrectExternalSemaphoreTable [
 
 	| header |
@@ -105,7 +107,7 @@ VMImageHeaderWritingTest >> testWritingImageWritesCorrectExternalSemaphoreTable 
 	self assert: header hdrMaxExtSemTabSize equals: (interpreter getMaxExtSemTabSizeSet ifTrue: [interpreter ioGetMaxExtSemTableSize] ifFalse: [0])
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMImageHeaderWritingTest >> testWritingImageWritesCorrectExtraVMMemory [
 
 	| header |
@@ -115,7 +117,7 @@ VMImageHeaderWritingTest >> testWritingImageWritesCorrectExtraVMMemory [
 	self assert: header extraVMMemory equals: interpreter getExtraVMMemory
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMImageHeaderWritingTest >> testWritingImageWritesCorrectFirstSegmentSize [
 
 	| header |
@@ -125,7 +127,7 @@ VMImageHeaderWritingTest >> testWritingImageWritesCorrectFirstSegmentSize [
 	self assert: header firstSegSize equals: memory firstSegmentBytes
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMImageHeaderWritingTest >> testWritingImageWritesCorrectHeaderFlags [
 
 	| header |
@@ -135,7 +137,7 @@ VMImageHeaderWritingTest >> testWritingImageWritesCorrectHeaderFlags [
 	self assert: header headerFlags equals: interpreter getImageHeaderFlags
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMImageHeaderWritingTest >> testWritingImageWritesCorrectHeaderSize [
 
 	| header expectedHeaderSize |
@@ -147,7 +149,7 @@ VMImageHeaderWritingTest >> testWritingImageWritesCorrectHeaderSize [
 	self assert: header imageHeaderSize equals: expectedHeaderSize.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMImageHeaderWritingTest >> testWritingImageWritesCorrectImageFormat [
 
 	| header |
@@ -157,7 +159,7 @@ VMImageHeaderWritingTest >> testWritingImageWritesCorrectImageFormat [
 	self assert: header imageFormat equals: interpreter imageFormatVersion
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMImageHeaderWritingTest >> testWritingImageWritesCorrectImageVersion [
 
 	| header |
@@ -167,7 +169,7 @@ VMImageHeaderWritingTest >> testWritingImageWritesCorrectImageVersion [
 	self assert: header imageVersion equals: interpreter getImageVersion
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMImageHeaderWritingTest >> testWritingImageWritesCorrectNextObjectHash [
 
 	| header |
@@ -177,7 +179,7 @@ VMImageHeaderWritingTest >> testWritingImageWritesCorrectNextObjectHash [
 	self assert: header hdrLastHash equals: memory lastHash
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMImageHeaderWritingTest >> testWritingImageWritesCorrectSpecialObjectsArrayOop [
 
 	| header |
@@ -187,7 +189,7 @@ VMImageHeaderWritingTest >> testWritingImageWritesCorrectSpecialObjectsArrayOop 
 	self assert: header initialSpecialObjectsOop equals: memory specialObjectsOop
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMImageHeaderWritingTest >> testWritingSTONHeader [
 
 	| header readHeader |
@@ -201,7 +203,7 @@ VMImageHeaderWritingTest >> testWritingSTONHeader [
 	self assert: readHeader equals: (self stonPretty: header).
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMImageHeaderWritingTest >> testWritingSTONPermSpace [
 
 	| writtenMetadata expectedPermSpaceMetadata |
@@ -222,7 +224,7 @@ VMImageHeaderWritingTest >> testWritingSTONPermSpace [
 	self assert: writtenMetadata equals: (self stonPretty: expectedPermSpaceMetadata).
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMImageHeaderWritingTest >> testWritingSTONPermSpaceOnEmptySpace [
 
 	| writtenMetadata |
@@ -236,7 +238,7 @@ VMImageHeaderWritingTest >> testWritingSTONPermSpaceOnEmptySpace [
 	self assert: writtenMetadata equals: (self stonPretty: ComposedMetadataStruct new).
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMImageHeaderWritingTest >> testWritingSTONSegment [
 
 	| header writtenHeader segmentMetadata |

--- a/smalltalksrc/VMMakerTests/VMImageReadingTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMImageReadingTest.class.st
@@ -1,27 +1,29 @@
 Class {
-	#name : #VMImageReadingTest,
-	#superclass : #VMAbstractImageFormatTest,
+	#name : 'VMImageReadingTest',
+	#superclass : 'VMAbstractImageFormatTest',
 	#instVars : [
 		'originalNilObjectIdentityHash',
 		'permanentObject',
 		'originalPermanentObjectIdentityHash'
 	],
-	#category : #'VMMakerTests-ImageFormat'
+	#category : 'VMMakerTests-ImageFormat',
+	#package : 'VMMakerTests',
+	#tag : 'ImageFormat'
 }
 
-{ #category : #query }
+{ #category : 'query' }
 VMImageReadingTest >> dataFrom: fileName [
 
 	^ self imageFileName asFileReference / fileName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMImageReadingTest >> initializationOptions [
 
 	^ super initializationOptions , { #CloneOnGC. false. #CloneOnScavenge. false }
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 VMImageReadingTest >> loadImage [
 
 	environmentBuilder := VMSimulatedEnvironmentBuilder new.
@@ -40,7 +42,7 @@ VMImageReadingTest >> loadImage [
 
 ]
 
-{ #category : #query }
+{ #category : 'query' }
 VMImageReadingTest >> metadataFrom: fileName [
 
 	| writtenHeader |
@@ -48,7 +50,7 @@ VMImageReadingTest >> metadataFrom: fileName [
 	^ STON fromString: writtenHeader
 ]
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 VMImageReadingTest >> saveImage [
 
 	memory garbageCollectForSnapshot.
@@ -61,7 +63,7 @@ VMImageReadingTest >> saveImage [
 
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 VMImageReadingTest >> setUp [
 
 	super setUp.
@@ -74,7 +76,7 @@ VMImageReadingTest >> setUp [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMImageReadingTest >> testMovingObjectsToPermSpaceReduceOldSpace [
 
 	| obj magicNumber initSegmentSize initPermSpaceSize finalSegmentSize finalPermSpaceSize |
@@ -115,7 +117,7 @@ VMImageReadingTest >> testMovingObjectsToPermSpaceReduceOldSpace [
 	self assert: (self metadataFrom: 'permSpace.ston') dataSize equals: finalPermSpaceSize
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMImageReadingTest >> testReadingSTONHeader [
 
 	| headerStruct headerFile |
@@ -133,7 +135,7 @@ VMImageReadingTest >> testReadingSTONHeader [
 	self assert: (self stonPretty: headerStruct) equals: headerFile contents.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMImageReadingTest >> testSavedImageSavesObjectFromOldSpace [
 	
 	self saveImage.	
@@ -142,7 +144,7 @@ VMImageReadingTest >> testSavedImageSavesObjectFromOldSpace [
 	self assert: originalNilObjectIdentityHash equals: (memory hashBitsOf: memory nilObject).
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMImageReadingTest >> testSavedImageSavesObjectFromPermanentSpace [
 
 	"Only valid in the new format"
@@ -158,7 +160,7 @@ VMImageReadingTest >> testSavedImageSavesObjectFromPermanentSpace [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMImageReadingTest >> testSavingImageWithThreeSegmentsIsCorrectlySqueezed [
 	
 	| firstNewSegmentSize secondNewSegmentSize obj newObj originalObjHash |
@@ -190,7 +192,7 @@ VMImageReadingTest >> testSavingImageWithThreeSegmentsIsCorrectlySqueezed [
 	self assert: originalObjHash equals: (memory hashBitsOf: newObj).
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMImageReadingTest >> testSavingPermanentSpaceObjectsInSpurFormatFails [
 
 	imageWriterClass = SpurImageWriter ifFalse: [ ^ self skip ].

--- a/smalltalksrc/VMMakerTests/VMInterpreterTests.class.st
+++ b/smalltalksrc/VMMakerTests/VMInterpreterTests.class.st
@@ -1,14 +1,16 @@
 Class {
-	#name : #VMInterpreterTests,
-	#superclass : #VMSpurMemoryManagerTest,
+	#name : 'VMInterpreterTests',
+	#superclass : 'VMSpurMemoryManagerTest',
 	#pools : [
 		'VMClassIndices',
 		'VMObjectIndices'
 	],
-	#category : #'VMMakerTests-InterpreterTests'
+	#category : 'VMMakerTests-InterpreterTests',
+	#package : 'VMMakerTests',
+	#tag : 'InterpreterTests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMInterpreterTests >> installSelector: aSelectorOop method: aMethodOop inMethodDictionary: aMethodDictionary [
 	
 	| anArrayOfMethods |
@@ -23,7 +25,7 @@ VMInterpreterTests >> installSelector: aSelectorOop method: aMethodOop inMethodD
 		withValue: aMethodOop
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMInterpreterTests >> setUp [
 	
 	"taken from VMSimpleStackBasedCogitBytecodeTest >> #setup"
@@ -41,7 +43,7 @@ VMInterpreterTests >> setUp [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMInterpreterTests >> setUpMethodDictionaryIn: aClass [
 	"2 instances variables the array of methods and the tally
 	and 12 entries to put elemetns of the collection"

--- a/smalltalksrc/VMMakerTests/VMJITPrimitiveCallingTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJITPrimitiveCallingTest.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #VMJITPrimitiveCallingTest,
-	#superclass : #VMPrimitiveCallAbstractTest,
+	#name : 'VMJITPrimitiveCallingTest',
+	#superclass : 'VMPrimitiveCallAbstractTest',
 	#pools : [
 		'CogRTLOpcodes'
 	],
-	#category : #'VMMakerTests-JitTests'
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMJITPrimitiveCallingTest >> initStack [
 
 	self createBaseFrame.
@@ -19,7 +21,7 @@ VMJITPrimitiveCallingTest >> initStack [
 
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMJITPrimitiveCallingTest >> setUp [
 	super setUp.
 
@@ -34,7 +36,7 @@ VMJITPrimitiveCallingTest >> setUp [
 	self createActiveProcess
 ]
 
-{ #category : #'tests - with tracing' }
+{ #category : 'tests - with tracing' }
 VMJITPrimitiveCallingTest >> testCallingNamedPrimitiveTakingTracesWithInvalidNumbersExecutesFailbackCode [
 
 	| callingMethod |
@@ -54,7 +56,7 @@ VMJITPrimitiveCallingTest >> testCallingNamedPrimitiveTakingTracesWithInvalidNum
 
 ]
 
-{ #category : #'tests - with tracing' }
+{ #category : 'tests - with tracing' }
 VMJITPrimitiveCallingTest >> testCallingNamedPrimitivesTakingTracesHasATraceForThePrimitive [
 
 	| callingMethod |
@@ -74,7 +76,7 @@ VMJITPrimitiveCallingTest >> testCallingNamedPrimitivesTakingTracesHasATraceForT
 	self assert: (interpreter primTraceLog at: 1) equals: callingMethod selector
 ]
 
-{ #category : #'tests - with tracing' }
+{ #category : 'tests - with tracing' }
 VMJITPrimitiveCallingTest >> testCallingNamedPrimitivesTakingTracesReturnsValidResults [
 
 	| callingMethod |
@@ -94,7 +96,7 @@ VMJITPrimitiveCallingTest >> testCallingNamedPrimitivesTakingTracesReturnsValidR
 	self assert: machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 2)
 ]
 
-{ #category : #'tests - run on smalltalk stack' }
+{ #category : 'tests - run on smalltalk stack' }
 VMJITPrimitiveCallingTest >> testCallingPrimitiveInSmalltalkStackWithInvalidReceiverRunsFallbackCode [
 
 	| callingMethod |
@@ -114,7 +116,7 @@ VMJITPrimitiveCallingTest >> testCallingPrimitiveInSmalltalkStackWithInvalidRece
 
 ]
 
-{ #category : #'tests - run on smalltalk stack' }
+{ #category : 'tests - run on smalltalk stack' }
 VMJITPrimitiveCallingTest >> testCallingPrimitiveInSmalltalkStackWithLargeIntegerWillExecuteThePrimitiveAndReturnASmallInteger [
 
 	| callingMethod |
@@ -134,7 +136,7 @@ VMJITPrimitiveCallingTest >> testCallingPrimitiveInSmalltalkStackWithLargeIntege
 
 ]
 
-{ #category : #'tests - run on smalltalk stack' }
+{ #category : 'tests - run on smalltalk stack' }
 VMJITPrimitiveCallingTest >> testCallingPrimitiveInSmalltalkStackWithSmallIntegerReceiverReturnsSmallInteger [
 
 	| callingMethod |
@@ -154,7 +156,7 @@ VMJITPrimitiveCallingTest >> testCallingPrimitiveInSmalltalkStackWithSmallIntege
 
 ]
 
-{ #category : #'tests - with tracing' }
+{ #category : 'tests - with tracing' }
 VMJITPrimitiveCallingTest >> testCallingPrimitiveTakingTracesWithInvalidNumbersExecutesFailbackCode [
 
 	| callingMethod |
@@ -174,7 +176,7 @@ VMJITPrimitiveCallingTest >> testCallingPrimitiveTakingTracesWithInvalidNumbersE
 
 ]
 
-{ #category : #'tests - without tracing' }
+{ #category : 'tests - without tracing' }
 VMJITPrimitiveCallingTest >> testCallingPrimitiveWithoutTakingTracesReturnsValidResult [
 
 	| callingMethod |
@@ -194,7 +196,7 @@ VMJITPrimitiveCallingTest >> testCallingPrimitiveWithoutTakingTracesReturnsValid
 	self assert: machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 3)
 ]
 
-{ #category : #'tests - without tracing' }
+{ #category : 'tests - without tracing' }
 VMJITPrimitiveCallingTest >> testCallingPrimitiveWithoutTakingTracesWithInvalidNumbersExecutesFailbackCode [
 
 	| callingMethod |
@@ -216,7 +218,7 @@ VMJITPrimitiveCallingTest >> testCallingPrimitiveWithoutTakingTracesWithInvalidN
 
 ]
 
-{ #category : #'tests - with tracing' }
+{ #category : 'tests - with tracing' }
 VMJITPrimitiveCallingTest >> testCallingPrimitivesTakingTracesHasATraceForThePrimitive [
 
 	| callingMethod |
@@ -236,7 +238,7 @@ VMJITPrimitiveCallingTest >> testCallingPrimitivesTakingTracesHasATraceForThePri
 	self assert: (interpreter primTraceLog at: 1) equals: callingMethod selector
 ]
 
-{ #category : #'tests - with tracing' }
+{ #category : 'tests - with tracing' }
 VMJITPrimitiveCallingTest >> testCallingPrimitivesTakingTracesReturnsValidResults [
 
 	| callingMethod |
@@ -256,7 +258,7 @@ VMJITPrimitiveCallingTest >> testCallingPrimitivesTakingTracesReturnsValidResult
 	self assert: machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 3)
 ]
 
-{ #category : #'tests - newMethod' }
+{ #category : 'tests - newMethod' }
 VMJITPrimitiveCallingTest >> testNamedPrimitiveCallSetsNewMethod [
 
 	| callingMethod |
@@ -278,7 +280,7 @@ VMJITPrimitiveCallingTest >> testNamedPrimitiveCallSetsNewMethod [
 
 ]
 
-{ #category : #'tests - primitiveFunctionPointer' }
+{ #category : 'tests - primitiveFunctionPointer' }
 VMJITPrimitiveCallingTest >> testNamedPrimitiveCallSetsPrimitiveFunctionPointerWhenCallingCImplementation [
 
 	| callingMethod |
@@ -300,7 +302,7 @@ VMJITPrimitiveCallingTest >> testNamedPrimitiveCallSetsPrimitiveFunctionPointerW
 
 ]
 
-{ #category : #'tests - retry primitive' }
+{ #category : 'tests - retry primitive' }
 VMJITPrimitiveCallingTest >> testNamedPrimitiveFailingWithAccessorDepthWithForwardersDoesRetry [
 
 	| callingMethod forwarder receiver |
@@ -334,7 +336,7 @@ VMJITPrimitiveCallingTest >> testNamedPrimitiveFailingWithAccessorDepthWithForwa
 
 ]
 
-{ #category : #'tests - retry primitive' }
+{ #category : 'tests - retry primitive' }
 VMJITPrimitiveCallingTest >> testNamedPrimitiveFailingWithAccessorDepthWithoutForwardersDoNotRetry [
 
 	| callingMethod |
@@ -357,7 +359,7 @@ VMJITPrimitiveCallingTest >> testNamedPrimitiveFailingWithAccessorDepthWithoutFo
 
 ]
 
-{ #category : #'tests - retry primitive' }
+{ #category : 'tests - retry primitive' }
 VMJITPrimitiveCallingTest >> testNamedPrimitiveFailingWithAccessorDepthZeroWithForwardersDoesNotRetry [
 
 	| callingMethod forwarder receiver |
@@ -391,7 +393,7 @@ VMJITPrimitiveCallingTest >> testNamedPrimitiveFailingWithAccessorDepthZeroWithF
 
 ]
 
-{ #category : #'tests - retry primitive' }
+{ #category : 'tests - retry primitive' }
 VMJITPrimitiveCallingTest >> testNamedPrimitiveFailingWithAccessorDepthZeroWithoutForwardersDoNotRetry [
 
 	| callingMethod |
@@ -414,7 +416,7 @@ VMJITPrimitiveCallingTest >> testNamedPrimitiveFailingWithAccessorDepthZeroWitho
 
 ]
 
-{ #category : #'tests - retry primitive' }
+{ #category : 'tests - retry primitive' }
 VMJITPrimitiveCallingTest >> testNamedPrimitiveFailingWithNegativeAccessorDepthWithForwardersDoNotRetry [
 
 	| callingMethod forwarder receiver |
@@ -448,7 +450,7 @@ VMJITPrimitiveCallingTest >> testNamedPrimitiveFailingWithNegativeAccessorDepthW
 
 ]
 
-{ #category : #'tests - retry primitive' }
+{ #category : 'tests - retry primitive' }
 VMJITPrimitiveCallingTest >> testNamedPrimitiveFailingWithNegativeAccessorDepthWithoutForwardersDoNotRetry [
 
 	| callingMethod |
@@ -471,7 +473,7 @@ VMJITPrimitiveCallingTest >> testNamedPrimitiveFailingWithNegativeAccessorDepthW
 
 ]
 
-{ #category : #'tests - with tracing' }
+{ #category : 'tests - with tracing' }
 VMJITPrimitiveCallingTest >> testNamedPrimitiveIsNotTracedIfNotCalled [
 
 	| callingMethod |
@@ -488,7 +490,7 @@ VMJITPrimitiveCallingTest >> testNamedPrimitiveIsNotTracedIfNotCalled [
 
 ]
 
-{ #category : #'tests - newMethod' }
+{ #category : 'tests - newMethod' }
 VMJITPrimitiveCallingTest >> testPrimitiveCallSetsNewMethod [
 
 	| callingMethod |
@@ -510,7 +512,7 @@ VMJITPrimitiveCallingTest >> testPrimitiveCallSetsNewMethod [
 
 ]
 
-{ #category : #'tests - primitiveFunctionPointer' }
+{ #category : 'tests - primitiveFunctionPointer' }
 VMJITPrimitiveCallingTest >> testPrimitiveCallSetsPrimitiveFunctionPointerWhenCallingCImplementation [
 
 	| callingMethod |
@@ -532,7 +534,7 @@ VMJITPrimitiveCallingTest >> testPrimitiveCallSetsPrimitiveFunctionPointerWhenCa
 
 ]
 
-{ #category : #'tests - error code' }
+{ #category : 'tests - error code' }
 VMJITPrimitiveCallingTest >> testPrimitiveFailingDoesNotSetErrorCodeInOtherTemp [
 
 	"The method has two temporaries. The first one is the error code, the second one is a user defined temp."
@@ -571,7 +573,7 @@ VMJITPrimitiveCallingTest >> testPrimitiveFailingDoesNotSetErrorCodeInOtherTemp 
 	self assert: (interpreter temporary: 1 in: interpreter framePointer) equals: memory nilObject
 ]
 
-{ #category : #'tests - error code' }
+{ #category : 'tests - error code' }
 VMJITPrimitiveCallingTest >> testPrimitiveFailingSetsErrorCodeInCorrectTemp [
 
 	"The method has two temporaries. The first one is the error code, the second one is a user defined temp."
@@ -610,7 +612,7 @@ VMJITPrimitiveCallingTest >> testPrimitiveFailingSetsErrorCodeInCorrectTemp [
 	self assert: (interpreter temporary: 0 in: machineSimulator framePointerRegisterValue) equals: (memory integerObjectOf: -1)
 ]
 
-{ #category : #'tests - retry primitive' }
+{ #category : 'tests - retry primitive' }
 VMJITPrimitiveCallingTest >> testPrimitiveFailingWithAccessorDepthWithForwardersDoesRetry [
 
 	| callingMethod forwarder receiver |
@@ -646,7 +648,7 @@ VMJITPrimitiveCallingTest >> testPrimitiveFailingWithAccessorDepthWithForwarders
 
 ]
 
-{ #category : #'tests - retry primitive' }
+{ #category : 'tests - retry primitive' }
 VMJITPrimitiveCallingTest >> testPrimitiveFailingWithAccessorDepthWithoutForwardersDoNotRetry [
 
 	| callingMethod |
@@ -671,7 +673,7 @@ VMJITPrimitiveCallingTest >> testPrimitiveFailingWithAccessorDepthWithoutForward
 
 ]
 
-{ #category : #'tests - retry primitive' }
+{ #category : 'tests - retry primitive' }
 VMJITPrimitiveCallingTest >> testPrimitiveFailingWithAccessorDepthZeroWithForwardersDoesNotRetry [
 
 	| callingMethod forwarder receiver |
@@ -707,7 +709,7 @@ VMJITPrimitiveCallingTest >> testPrimitiveFailingWithAccessorDepthZeroWithForwar
 
 ]
 
-{ #category : #'tests - retry primitive' }
+{ #category : 'tests - retry primitive' }
 VMJITPrimitiveCallingTest >> testPrimitiveFailingWithAccessorDepthZeroWithoutForwardersDoNotRetry [
 
 	| callingMethod |
@@ -732,7 +734,7 @@ VMJITPrimitiveCallingTest >> testPrimitiveFailingWithAccessorDepthZeroWithoutFor
 
 ]
 
-{ #category : #'tests - retry primitive' }
+{ #category : 'tests - retry primitive' }
 VMJITPrimitiveCallingTest >> testPrimitiveFailingWithNegativeAccessorDepthWithForwardersDoNotRetry [
 
 	| callingMethod forwarder receiver |
@@ -768,7 +770,7 @@ VMJITPrimitiveCallingTest >> testPrimitiveFailingWithNegativeAccessorDepthWithFo
 
 ]
 
-{ #category : #'tests - retry primitive' }
+{ #category : 'tests - retry primitive' }
 VMJITPrimitiveCallingTest >> testPrimitiveFailingWithNegativeAccessorDepthWithoutForwardersDoNotRetry [
 
 	| callingMethod |
@@ -793,7 +795,7 @@ VMJITPrimitiveCallingTest >> testPrimitiveFailingWithNegativeAccessorDepthWithou
 
 ]
 
-{ #category : #'tests - with tracing' }
+{ #category : 'tests - with tracing' }
 VMJITPrimitiveCallingTest >> testPrimitiveIsNotTracedIfNotCalled [
 
 	| callingMethod |
@@ -810,7 +812,7 @@ VMJITPrimitiveCallingTest >> testPrimitiveIsNotTracedIfNotCalled [
 
 ]
 
-{ #category : #'tests - fail fast' }
+{ #category : 'tests - fail fast' }
 VMJITPrimitiveCallingTest >> testPrimitiveWithPrimitiveFailExecutesFallbackCode [
 
 	| callingMethod |
@@ -833,7 +835,7 @@ VMJITPrimitiveCallingTest >> testPrimitiveWithPrimitiveFailExecutesFallbackCode 
 
 ]
 
-{ #category : #'tests - profile sampling' }
+{ #category : 'tests - profile sampling' }
 VMJITPrimitiveCallingTest >> testPrimitiveWithProfileSemaphoreAndNextTickTakesSample [
 
 	| callingMethod |
@@ -859,7 +861,7 @@ VMJITPrimitiveCallingTest >> testPrimitiveWithProfileSemaphoreAndNextTickTakesSa
 	self assert: interpreter nextProfileTick equals: 0
 ]
 
-{ #category : #'tests - profile sampling' }
+{ #category : 'tests - profile sampling' }
 VMJITPrimitiveCallingTest >> testPrimitiveWithProfileSemaphoreButNotNextTickDoesNotTakeSample [
 
 	| callingMethod |
@@ -883,7 +885,7 @@ VMJITPrimitiveCallingTest >> testPrimitiveWithProfileSemaphoreButNotNextTickDoes
 	self assert: machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 42)
 ]
 
-{ #category : #'tests - fail fast' }
+{ #category : 'tests - fail fast' }
 VMJITPrimitiveCallingTest >> testPrimitiveWithoutFunctionExecutesFallbackCode [
 
 	| callingMethod |

--- a/smalltalksrc/VMMakerTests/VMJITVMPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJITVMPrimitiveTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #VMJITVMPrimitiveTest,
-	#superclass : #VMSimpleStackBasedCogitAbstractTest,
-	#category : #'VMMakerTests-JitTests'
+	#name : 'VMJITVMPrimitiveTest',
+	#superclass : 'VMSimpleStackBasedCogitAbstractTest',
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #'tests - primitiveMethodXray' }
+{ #category : 'tests - primitiveMethodXray' }
 VMJITVMPrimitiveTest >> setUp [
 
 	super setUp.
@@ -14,7 +16,7 @@ VMJITVMPrimitiveTest >> setUp [
 	self createBaseFrame
 ]
 
-{ #category : #'tests - primitiveMethodXray' }
+{ #category : 'tests - primitiveMethodXray' }
 VMJITVMPrimitiveTest >> testPrimitiveMethodXRayPreviouslyCompiledFramelessMethod [
 
 	| methodToXray target |
@@ -33,7 +35,7 @@ VMJITVMPrimitiveTest >> testPrimitiveMethodXRayPreviouslyCompiledFramelessMethod
 	self assert: ((memory integerValueOf: interpreter stackTop) anyMask: 2r0111)
 ]
 
-{ #category : #'tests - primitiveMethodXray' }
+{ #category : 'tests - primitiveMethodXray' }
 VMJITVMPrimitiveTest >> testPrimitiveMethodXRayShouldCompile [
 
 	| methodToXray target |
@@ -52,7 +54,7 @@ VMJITVMPrimitiveTest >> testPrimitiveMethodXRayShouldCompile [
 	self assert: ((memory integerValueOf: interpreter stackTop) anyMask: 2r0001)
 ]
 
-{ #category : #'tests - primitiveMethodXray' }
+{ #category : 'tests - primitiveMethodXray' }
 VMJITVMPrimitiveTest >> testPrimitiveMethodXRayShouldNotCompile [
 
 	| methodToXray target |
@@ -70,7 +72,7 @@ VMJITVMPrimitiveTest >> testPrimitiveMethodXRayShouldNotCompile [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 0)
 ]
 
-{ #category : #'tests - primitiveMethodXray' }
+{ #category : 'tests - primitiveMethodXray' }
 VMJITVMPrimitiveTest >> testPrimitiveMethodXRayWasCompiled [
 
 	| methodToXray target |
@@ -89,7 +91,7 @@ VMJITVMPrimitiveTest >> testPrimitiveMethodXRayWasCompiled [
 	self assert: ((memory integerValueOf: interpreter stackTop) anyMask: 2r0010)
 ]
 
-{ #category : #'tests - primitiveMethodXray' }
+{ #category : 'tests - primitiveMethodXray' }
 VMJITVMPrimitiveTest >> testPrimitiveMethodXRayWasNotCompiled [
 
 	| methodToXray target |

--- a/smalltalksrc/VMMakerTests/VMJistMethodTestObject.class.st
+++ b/smalltalksrc/VMMakerTests/VMJistMethodTestObject.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #VMJistMethodTestObject,
-	#superclass : #Object,
+	#name : 'VMJistMethodTestObject',
+	#superclass : 'Object',
 	#instVars : [
 		'var1',
 		'var2',
@@ -132,10 +132,12 @@ Class {
 		'var128',
 		'var129'
 	],
-	#category : #'VMMakerTests-JitTests'
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 VMJistMethodTestObject >> initialize [
     super initialize.
     var1 := Array new.

--- a/smalltalksrc/VMMakerTests/VMJitMethodTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJitMethodTest.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #VMJitMethodTest,
-	#superclass : #VMPrimitiveCallAbstractTest,
+	#name : 'VMJitMethodTest',
+	#superclass : 'VMPrimitiveCallAbstractTest',
 	#pools : [
 		'CogRTLOpcodes'
 	],
-	#category : #'VMMakerTests-JitTests'
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMJitMethodTest >> addVector: arg1 with: arg2 intoVector: arg3 [
 
 	| tmp1 tmp2 |
@@ -19,14 +21,14 @@ VMJitMethodTest >> addVector: arg1 with: arg2 intoVector: arg3 [
 	^ arg3
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMJitMethodTest >> comparingSmallIntegers: aBitmap [
 
 	aBitmap size = 32768 ifTrue: [ ^ 17 ].
 	^ 23
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMJitMethodTest >> initStack [
 
 	self createBaseFrame.
@@ -41,13 +43,13 @@ VMJitMethodTest >> initStack [
 
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMJitMethodTest >> initialCodeSize [
 
 	^ 16 * 1024
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMJitMethodTest >> setUp [ 
 
 	super setUp.
@@ -55,7 +57,7 @@ VMJitMethodTest >> setUp [
 	self installFloat64RegisterClass	
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMJitMethodTest >> setUpTrampolines [
 
 	super setUpTrampolines.
@@ -67,7 +69,7 @@ VMJitMethodTest >> setUpTrampolines [
 	cogit ceReturnToInterpreterTrampoline: (self compileTrampoline: [ cogit Stop ] named:#ceReturnToInterpreterTrampoline).
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMJitMethodTest >> testComparingSmallIntegersThatNotFit [
 	| callingMethod parameter aSize bytesPerSlot desiredByteSize numberOfWordSizeSlots padding |
 	
@@ -102,7 +104,7 @@ VMJitMethodTest >> testComparingSmallIntegersThatNotFit [
 		equals: 17
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMJitMethodTest >> testJitCompiledFloat32VectorAddition [
 
 	| callingMethod cm x y z |
@@ -176,7 +178,7 @@ VMJitMethodTest >> testJitCompiledFloat32VectorAddition [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMJitMethodTest >> testJitCompiledFloat64VectorAddition [
 
 	| callingMethod cm x y z firstTerm size |
@@ -248,7 +250,7 @@ VMJitMethodTest >> testJitCompiledFloat64VectorAddition [
 	self assert: (memory fetchFloat64: 1 ofObject: z) equals: 22.0
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMJitMethodTest >> testMixedInlinedLiteralsSmoteTest [
 	| callingMethod |
 	
@@ -257,7 +259,7 @@ VMJitMethodTest >> testMixedInlinedLiteralsSmoteTest [
 	self deny: callingMethod address equals: 0.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMJitMethodTest >> testOnStackReplacementForLongRunningVectorAddMethod [
 	| callingMethod cm x y z firstTerm size frame |
 	

--- a/smalltalksrc/VMMakerTests/VMJitMethodWithImmutabilityTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJitMethodWithImmutabilityTest.class.st
@@ -1,26 +1,28 @@
 Class {
-	#name : #VMJitMethodWithImmutabilityTest,
-	#superclass : #VMPrimitiveCallAbstractTest,
+	#name : 'VMJitMethodWithImmutabilityTest',
+	#superclass : 'VMPrimitiveCallAbstractTest',
 	#pools : [
 		'CogRTLOpcodes'
 	],
-	#category : #'VMMakerTests-JitTests'
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 VMJitMethodWithImmutabilityTest >> initialCodeSize [
 
 	^ 32 * 1024
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 VMJitMethodWithImmutabilityTest >> setUp [ 
 
 	super setUp.
 	self initializeSpecialSelectors
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 VMJitMethodWithImmutabilityTest >> setUpTrampolines [
 
 	super setUpTrampolines.
@@ -30,7 +32,7 @@ VMJitMethodWithImmutabilityTest >> setUpTrampolines [
 	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMJitMethodWithImmutabilityTest >> testCompileMethodWithALotOfAssignmentsToInstanceVariables [
 	| callingMethod |
 	

--- a/smalltalksrc/VMMakerTests/VMJitSimdBytecode.class.st
+++ b/smalltalksrc/VMMakerTests/VMJitSimdBytecode.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #VMJitSimdBytecode,
-	#superclass : #VMStackToRegisterMappingCogitTest,
-	#category : #'VMMakerTests-JitTests'
+	#name : 'VMJitSimdBytecode',
+	#superclass : 'VMStackToRegisterMappingCogitTest',
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMJitSimdBytecode class >> wordSizeParameters [ 
 
 	^ self wordSize64Parameters 
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMJitSimdBytecode >> jitOptions [
 
 	^ super jitOptions
@@ -18,7 +20,7 @@ VMJitSimdBytecode >> jitOptions [
 		  yourself
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMJitSimdBytecode >> testAddVector32CopiesArraySumIntoVectorRegister [
 
 	| endInstruction primitiveAddress array register |
@@ -60,7 +62,7 @@ VMJitSimdBytecode >> testAddVector32CopiesArraySumIntoVectorRegister [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMJitSimdBytecode >> testAddVectorCopiesArraySumIntoVectorRegister [
 
 	| endInstruction primitiveAddress array register |
@@ -95,7 +97,7 @@ VMJitSimdBytecode >> testAddVectorCopiesArraySumIntoVectorRegister [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMJitSimdBytecode >> testAddVectorPushesArraySumIntoSimulatedStack [
 
 	| endInstruction primitiveAddress array entry |
@@ -130,7 +132,7 @@ VMJitSimdBytecode >> testAddVectorPushesArraySumIntoSimulatedStack [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMJitSimdBytecode >> testPushArrayToRegisterCopiesArrayChunkIntoVectorRegister [
 
 	| endInstruction primitiveAddress array register |
@@ -161,7 +163,7 @@ VMJitSimdBytecode >> testPushArrayToRegisterCopiesArrayChunkIntoVectorRegister [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMJitSimdBytecode >> testPushArrayToRegisterPushesArrayChunkIntoSimulatedStack [
 
 	| endInstruction primitiveAddress array entry |
@@ -191,7 +193,7 @@ VMJitSimdBytecode >> testPushArrayToRegisterPushesArrayChunkIntoSimulatedStack [
 	self assert: (entry registerr) equals: 0.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMJitSimdBytecode >> testStoreRegisterIntoArrayReplacesArrayElementsWithRegisterContent [
 
 	| endInstruction primitiveAddress array |
@@ -222,7 +224,7 @@ VMJitSimdBytecode >> testStoreRegisterIntoArrayReplacesArrayElementsWithRegister
 	self assert: (memory fetchFloat64: 1 ofObject: array) equals: 4.0.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMJitSimdBytecode >> testSubVectorStoreResultIntoVectorRegister [
 
 	| endInstruction primitiveAddress array register |

--- a/smalltalksrc/VMMakerTests/VMJittedBoxFloatPrimitivesTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJittedBoxFloatPrimitivesTest.class.st
@@ -1,14 +1,16 @@
 Class {
-	#name : #VMJittedBoxFloatPrimitivesTest,
-	#superclass : #VMJittedPrimitivesTest,
+	#name : 'VMJittedBoxFloatPrimitivesTest',
+	#superclass : 'VMJittedPrimitivesTest',
 	#pools : [
 		'CogAbstractRegisters',
 		'CogRTLOpcodes'
 	],
-	#category : #'VMMakerTests-JitTests'
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMJittedBoxFloatPrimitivesTest >> setUp [
 
 	super setUp.
@@ -22,7 +24,7 @@ VMJittedBoxFloatPrimitivesTest >> setUp [
 				 named: 'ceCheckFeatures') ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMJittedBoxFloatPrimitivesTest >> testAsFloat [
 
 	cogit receiverTags: memory smallIntegerTag.
@@ -36,7 +38,7 @@ VMJittedBoxFloatPrimitivesTest >> testAsFloat [
 		equals: 27.0
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMJittedBoxFloatPrimitivesTest >> testAsFloatWhenThereIsNotSpaceFailsPrimitive [
 
 	| stop |

--- a/smalltalksrc/VMMakerTests/VMJittedByteArrayAccessPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJittedByteArrayAccessPrimitiveTest.class.st
@@ -1,20 +1,22 @@
 Class {
-	#name : #VMJittedByteArrayAccessPrimitiveTest,
-	#superclass : #VMJittedPrimitivesTest,
+	#name : 'VMJittedByteArrayAccessPrimitiveTest',
+	#superclass : 'VMJittedPrimitivesTest',
 	#instVars : [
 		'receiver',
 		'targetReceiver'
 	],
-	#category : #'VMMakerTests-JitTests'
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #'building suites' }
+{ #category : 'building suites' }
 VMJittedByteArrayAccessPrimitiveTest class >> wordSizeParameters [
 
 	^ self wordSize64Parameters 
 ]
 
-{ #category : #'tests - store integers' }
+{ #category : 'tests - store integers' }
 VMJittedByteArrayAccessPrimitiveTest >> assertEqualsTo: expectedValue bitSize: bitSize [
 
 	({ 8. 16. 32. 64 } includes: bitSize) ifFalse: [ self fail ].
@@ -42,7 +44,7 @@ VMJittedByteArrayAccessPrimitiveTest >> assertEqualsTo: expectedValue bitSize: b
 	
 ]
 
-{ #category : #utils }
+{ #category : 'utils' }
 VMJittedByteArrayAccessPrimitiveTest >> genPrimitive: aString [ 
 
 	| endPart |
@@ -54,7 +56,7 @@ VMJittedByteArrayAccessPrimitiveTest >> genPrimitive: aString [
 
 ]
 
-{ #category : #utils }
+{ #category : 'utils' }
 VMJittedByteArrayAccessPrimitiveTest >> newReceiver [
 	"In this case the target receiver is the same receiver"
 	
@@ -68,7 +70,7 @@ VMJittedByteArrayAccessPrimitiveTest >> newReceiver [
 	targetReceiver := receiver
 ]
 
-{ #category : #utils }
+{ #category : 'utils' }
 VMJittedByteArrayAccessPrimitiveTest >> newReceiverWithValue: aValue ofBitSize: bitSize [ 
 
 	| complementedValue |
@@ -90,7 +92,7 @@ VMJittedByteArrayAccessPrimitiveTest >> newReceiverWithValue: aValue ofBitSize: 
 		memory storeLong64: 0 ofObject: targetReceiver withValue: complementedValue ].	
 ]
 
-{ #category : #'tests - load booleans' }
+{ #category : 'tests - load booleans' }
 VMJittedByteArrayAccessPrimitiveTest >> testLoadBoolean8LoadsFalse [
 
 	| expectedValue |
@@ -111,7 +113,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testLoadBoolean8LoadsFalse [
 
 ]
 
-{ #category : #'tests - load booleans' }
+{ #category : 'tests - load booleans' }
 VMJittedByteArrayAccessPrimitiveTest >> testLoadBoolean8LoadsTrue [
 
 	| expectedValue |
@@ -132,7 +134,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testLoadBoolean8LoadsTrue [
 
 ]
 
-{ #category : #'tests - load chars' }
+{ #category : 'tests - load chars' }
 VMJittedByteArrayAccessPrimitiveTest >> testLoadChar16LoadsValue [
 
 	| expectedValue |
@@ -153,7 +155,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testLoadChar16LoadsValue [
 
 ]
 
-{ #category : #'tests - load chars' }
+{ #category : 'tests - load chars' }
 VMJittedByteArrayAccessPrimitiveTest >> testLoadChar32LoadsValue [
 
 	| expectedValue |
@@ -174,7 +176,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testLoadChar32LoadsValue [
 
 ]
 
-{ #category : #'tests - load chars' }
+{ #category : 'tests - load chars' }
 VMJittedByteArrayAccessPrimitiveTest >> testLoadChar8LoadsValue [
 
 	| expectedValue |
@@ -195,7 +197,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testLoadChar8LoadsValue [
 
 ]
 
-{ #category : #'tests - load floats' }
+{ #category : 'tests - load floats' }
 VMJittedByteArrayAccessPrimitiveTest >> testLoadFloat32LoadsValue [
 
 	| expectedValue |
@@ -216,7 +218,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testLoadFloat32LoadsValue [
 
 ]
 
-{ #category : #'tests - load floats' }
+{ #category : 'tests - load floats' }
 VMJittedByteArrayAccessPrimitiveTest >> testLoadFloat64LoadsBoxedValue [
 
 	| expectedValue |
@@ -237,7 +239,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testLoadFloat64LoadsBoxedValue [
 
 ]
 
-{ #category : #'tests - load floats' }
+{ #category : 'tests - load floats' }
 VMJittedByteArrayAccessPrimitiveTest >> testLoadFloat64LoadsValue [
 
 	| expectedValue |
@@ -258,7 +260,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testLoadFloat64LoadsValue [
 
 ]
 
-{ #category : #'tests - load integers' }
+{ #category : 'tests - load integers' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadInt16LoadsNegativeValue [
 
 	| expectedValue |
@@ -279,7 +281,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadInt16LoadsNegativeValue
 
 ]
 
-{ #category : #'tests - load integers' }
+{ #category : 'tests - load integers' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadInt16LoadsPositiveValue [
 
 	| expectedValue |
@@ -300,7 +302,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadInt16LoadsPositiveValue
 
 ]
 
-{ #category : #'tests - load integers' }
+{ #category : 'tests - load integers' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadInt32LoadsNegativeValue [
 
 	| expectedValue |
@@ -321,7 +323,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadInt32LoadsNegativeValue
 
 ]
 
-{ #category : #'tests - load integers' }
+{ #category : 'tests - load integers' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadInt32LoadsPositiveValue [
 
 	| expectedValue |
@@ -342,7 +344,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadInt32LoadsPositiveValue
 
 ]
 
-{ #category : #'tests - load integers' }
+{ #category : 'tests - load integers' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadInt64LoadsNegativeValue [
 
 	| expectedValue |
@@ -363,7 +365,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadInt64LoadsNegativeValue
 
 ]
 
-{ #category : #'tests - load integers' }
+{ #category : 'tests - load integers' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadInt64LoadsPositiveValue [
 
 	| expectedValue |
@@ -384,7 +386,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadInt64LoadsPositiveValue
 
 ]
 
-{ #category : #'tests - load integers' }
+{ #category : 'tests - load integers' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadInt8LoadsNegativeValue [
 
 	| expectedValue |
@@ -405,7 +407,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadInt8LoadsNegativeValue 
 
 ]
 
-{ #category : #'tests - load integers' }
+{ #category : 'tests - load integers' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadInt8LoadsPositiveValue [
 
 	| expectedValue |
@@ -426,7 +428,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadInt8LoadsPositiveValue 
 
 ]
 
-{ #category : #'tests - load integers' }
+{ #category : 'tests - load integers' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadPointerLoadsValue [
 
 	| expectedValue |
@@ -447,7 +449,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadPointerLoadsValue [
 
 ]
 
-{ #category : #'tests - load integers' }
+{ #category : 'tests - load integers' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadUInt16LoadsValue [
 
 	| expectedValue |
@@ -468,7 +470,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadUInt16LoadsValue [
 
 ]
 
-{ #category : #'tests - load integers' }
+{ #category : 'tests - load integers' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadUInt32LoadsValue [
 
 	| expectedValue |
@@ -489,7 +491,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadUInt32LoadsValue [
 
 ]
 
-{ #category : #'tests - load integers' }
+{ #category : 'tests - load integers' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadUInt64LoadsValue [
 
 	| expectedValue |
@@ -510,7 +512,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadUInt64LoadsValue [
 
 ]
 
-{ #category : #'tests - load integers' }
+{ #category : 'tests - load integers' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadUInt8LoadsValue [
 
 	| expectedValue |
@@ -531,7 +533,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadUInt8LoadsValue [
 
 ]
 
-{ #category : #'tests - store booleans' }
+{ #category : 'tests - store booleans' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreBoolean8StoresFalse [
 
 	self genPrimitive: #StoreBoolean8.
@@ -547,7 +549,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreBoolean8StoresFalse [
 
 ]
 
-{ #category : #'tests - store booleans' }
+{ #category : 'tests - store booleans' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreBoolean8StoresTrue [
 
 	self genPrimitive: #StoreBoolean8.
@@ -563,7 +565,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreBoolean8StoresTrue [
 
 ]
 
-{ #category : #'tests - store chars' }
+{ #category : 'tests - store chars' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreChar16StoresValue [
 
 	| expectedValue |
@@ -583,7 +585,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreChar16StoresValue [
 
 ]
 
-{ #category : #'tests - store chars' }
+{ #category : 'tests - store chars' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreChar32StoresValue [
 
 	| expectedValue |
@@ -603,7 +605,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreChar32StoresValue [
 
 ]
 
-{ #category : #'tests - store chars' }
+{ #category : 'tests - store chars' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreChar8StoresValue [
 
 	| expectedValue |
@@ -623,7 +625,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreChar8StoresValue [
 
 ]
 
-{ #category : #'tests - store floats' }
+{ #category : 'tests - store floats' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreFloat32StoresValue [
 
 	| expectedValue |
@@ -642,7 +644,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreFloat32StoresValue [
 
 ]
 
-{ #category : #'tests - store floats' }
+{ #category : 'tests - store floats' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreFloat32StoresValueDoNotOverwriteAfter [
 
 	| expectedValue |
@@ -661,7 +663,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreFloat32StoresValueDoNo
 		self assert: (memory fetchByte: i ofObject: targetReceiver) equals: 16r90 + i + 1. ].
 ]
 
-{ #category : #'tests - store floats' }
+{ #category : 'tests - store floats' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreFloat64StoresBoxedFloatValue [
 
 	| expectedValue |
@@ -680,7 +682,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreFloat64StoresBoxedFloa
 
 ]
 
-{ #category : #'tests - store floats' }
+{ #category : 'tests - store floats' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreFloat64StoresValue [
 
 	| expectedValue |
@@ -699,7 +701,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreFloat64StoresValue [
 
 ]
 
-{ #category : #'tests - store integers' }
+{ #category : 'tests - store integers' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreInt16StoresNegativeValue [
 
 	| expectedValue |
@@ -719,7 +721,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreInt16StoresNegativeVal
 
 ]
 
-{ #category : #'tests - store integers' }
+{ #category : 'tests - store integers' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreInt16StoresPositiveValue [
 
 	| expectedValue |
@@ -739,7 +741,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreInt16StoresPositiveVal
 
 ]
 
-{ #category : #'tests - store integers' }
+{ #category : 'tests - store integers' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreInt16StoresPositiveValueWithoutOverwritting [
 
 	| expectedValue |
@@ -761,7 +763,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreInt16StoresPositiveVal
 		self assert: (memory fetchByte: i ofObject: targetReceiver) equals: 16r90 + i + 1. ].
 ]
 
-{ #category : #'tests - store integers' }
+{ #category : 'tests - store integers' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreInt32StoresNegativeValue [
 
 	| expectedValue |
@@ -781,7 +783,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreInt32StoresNegativeVal
 
 ]
 
-{ #category : #'tests - store integers' }
+{ #category : 'tests - store integers' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreInt32StoresPositiveValue [
 
 	| expectedValue |
@@ -801,7 +803,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreInt32StoresPositiveVal
 
 ]
 
-{ #category : #'tests - store integers' }
+{ #category : 'tests - store integers' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreInt32StoresPositiveValueWithoutOverwriting [
 
 	| expectedValue |
@@ -821,7 +823,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreInt32StoresPositiveVal
 		self assert: (memory fetchByte: i ofObject: targetReceiver) equals: 16r90 + i + 1. ].
 ]
 
-{ #category : #'tests - store integers' }
+{ #category : 'tests - store integers' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreInt64StoresNegativeValue [
 
 	| expectedValue |
@@ -841,7 +843,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreInt64StoresNegativeVal
 
 ]
 
-{ #category : #'tests - store integers' }
+{ #category : 'tests - store integers' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreInt64StoresPositiveValue [
 
 	| expectedValue |
@@ -861,7 +863,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreInt64StoresPositiveVal
 
 ]
 
-{ #category : #'tests - store integers' }
+{ #category : 'tests - store integers' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreInt8StoresNegativeValue [
 
 	| expectedValue |
@@ -881,7 +883,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreInt8StoresNegativeValu
 
 ]
 
-{ #category : #'tests - store integers' }
+{ #category : 'tests - store integers' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreInt8StoresPositiveValue [
 
 	| expectedValue |
@@ -901,7 +903,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreInt8StoresPositiveValu
 
 ]
 
-{ #category : #'tests - store integers' }
+{ #category : 'tests - store integers' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreInt8StoresPositiveValueWithoutOverwritting [
 
 	| expectedValue |
@@ -923,7 +925,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreInt8StoresPositiveValu
 		self assert: (memory fetchByte: i ofObject: targetReceiver) equals: 16r90 + i + 1. ].
 ]
 
-{ #category : #'tests - store integers' }
+{ #category : 'tests - store integers' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStorePointerStoresValue [
 
 	| expectedValue |
@@ -943,7 +945,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStorePointerStoresValue [
 
 ]
 
-{ #category : #'tests - store integers' }
+{ #category : 'tests - store integers' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreUInt16StoresValue [
 
 	| expectedValue |
@@ -963,7 +965,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreUInt16StoresValue [
 
 ]
 
-{ #category : #'tests - store integers' }
+{ #category : 'tests - store integers' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreUInt32StoresValue [
 
 	| expectedValue |
@@ -983,7 +985,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreUInt32StoresValue [
 
 ]
 
-{ #category : #'tests - store integers' }
+{ #category : 'tests - store integers' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreUInt64StoresValue [
 
 	| expectedValue |
@@ -1004,7 +1006,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreUInt64StoresValue [
 
 ]
 
-{ #category : #'tests - store integers' }
+{ #category : 'tests - store integers' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreUInt8StoresValue [
 
 	| expectedValue |
@@ -1024,7 +1026,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreUInt8StoresValue [
 
 ]
 
-{ #category : #utils }
+{ #category : 'utils' }
 VMJittedByteArrayAccessPrimitiveTest >> trailingName [
 
 	^ 'Bytes'

--- a/smalltalksrc/VMMakerTests/VMJittedExternalAddressAccessPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJittedExternalAddressAccessPrimitiveTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #VMJittedExternalAddressAccessPrimitiveTest,
-	#superclass : #VMJittedByteArrayAccessPrimitiveTest,
-	#category : #'VMMakerTests-JitTests'
+	#name : 'VMJittedExternalAddressAccessPrimitiveTest',
+	#superclass : 'VMJittedByteArrayAccessPrimitiveTest',
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #utils }
+{ #category : 'utils' }
 VMJittedExternalAddressAccessPrimitiveTest >> newReceiver [
 	"In this case the target receiver is a byteArray and the receiver to the primitive is an external address pointing to it"
 
@@ -14,7 +16,7 @@ VMJittedExternalAddressAccessPrimitiveTest >> newReceiver [
 
 ]
 
-{ #category : #utils }
+{ #category : 'utils' }
 VMJittedExternalAddressAccessPrimitiveTest >> trailingName [
 
 	^ 'ExternalAddress'

--- a/smalltalksrc/VMMakerTests/VMJittedGeneralPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJittedGeneralPrimitiveTest.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #VMJittedGeneralPrimitiveTest,
-	#superclass : #VMJittedPrimitivesTest,
+	#name : 'VMJittedGeneralPrimitiveTest',
+	#superclass : 'VMJittedPrimitivesTest',
 	#pools : [
 		'CogRTLOpcodes'
 	],
-	#category : #'VMMakerTests-JitTests'
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMJittedGeneralPrimitiveTest >> lastObjectInNewSpace [
 
 	| lastOop |
@@ -15,7 +17,7 @@ VMJittedGeneralPrimitiveTest >> lastObjectInNewSpace [
 	^ lastOop
 ]
 
-{ #category : #'tests - support' }
+{ #category : 'tests - support' }
 VMJittedGeneralPrimitiveTest >> testCheckImmediateWhenImmediateFloat [
 
 	"32 bits images does not have SmallFloats"
@@ -40,7 +42,7 @@ VMJittedGeneralPrimitiveTest >> testCheckImmediateWhenImmediateFloat [
 	self assert: machineSimulator receiverRegisterValue equals: 1
 ]
 
-{ #category : #'tests - support' }
+{ #category : 'tests - support' }
 VMJittedGeneralPrimitiveTest >> testCheckImmediateWhenImmediateSmallInteger [
 		
 	self compile: [ | jump | 
@@ -60,7 +62,7 @@ VMJittedGeneralPrimitiveTest >> testCheckImmediateWhenImmediateSmallInteger [
 	self assert: machineSimulator receiverRegisterValue equals: 1
 ]
 
-{ #category : #'tests - support' }
+{ #category : 'tests - support' }
 VMJittedGeneralPrimitiveTest >> testCheckImmediateWhenNonImmediate [
 		
 	self compile: [ | jump | 
@@ -80,7 +82,7 @@ VMJittedGeneralPrimitiveTest >> testCheckImmediateWhenNonImmediate [
 	self assert: machineSimulator receiverRegisterValue equals: 0
 ]
 
-{ #category : #'tests - equals comparison' }
+{ #category : 'tests - equals comparison' }
 VMJittedGeneralPrimitiveTest >> testCompareSmallIntegerEqualsToBoxedFloat [
 
 	self compile: [ | jump | 
@@ -96,7 +98,7 @@ VMJittedGeneralPrimitiveTest >> testCompareSmallIntegerEqualsToBoxedFloat [
 	self assert: machineSimulator receiverRegisterValue equals: self memory trueObject
 ]
 
-{ #category : #'tests - equals comparison' }
+{ #category : 'tests - equals comparison' }
 VMJittedGeneralPrimitiveTest >> testCompareSmallIntegerEqualsToSmallInteger [
 
 	self compile: [ | jump | 
@@ -112,7 +114,7 @@ VMJittedGeneralPrimitiveTest >> testCompareSmallIntegerEqualsToSmallInteger [
 	self assert: machineSimulator receiverRegisterValue equals: self memory trueObject
 ]
 
-{ #category : #'tests - greater or equal than comparison' }
+{ #category : 'tests - greater or equal than comparison' }
 VMJittedGeneralPrimitiveTest >> testCompareSmallIntegerGreaterOrEqualThanEqualBoxedFloat [
 
 	self compile: [ | jump | 
@@ -128,7 +130,7 @@ VMJittedGeneralPrimitiveTest >> testCompareSmallIntegerGreaterOrEqualThanEqualBo
 	self assert: machineSimulator receiverRegisterValue equals: self memory trueObject
 ]
 
-{ #category : #'tests - greater or equal than comparison' }
+{ #category : 'tests - greater or equal than comparison' }
 VMJittedGeneralPrimitiveTest >> testCompareSmallIntegerGreaterOrEqualThanEqualSmallInteger [
 
 	self compile: [ | jump | 
@@ -144,7 +146,7 @@ VMJittedGeneralPrimitiveTest >> testCompareSmallIntegerGreaterOrEqualThanEqualSm
 	self assert: machineSimulator receiverRegisterValue equals: self memory trueObject
 ]
 
-{ #category : #'tests - greater or equal than comparison' }
+{ #category : 'tests - greater or equal than comparison' }
 VMJittedGeneralPrimitiveTest >> testCompareSmallIntegerGreaterOrEqualThanGreaterBoxedFloat [
 
 	self compile: [ | jump | 
@@ -160,7 +162,7 @@ VMJittedGeneralPrimitiveTest >> testCompareSmallIntegerGreaterOrEqualThanGreater
 	self assert: machineSimulator receiverRegisterValue equals: self memory falseObject
 ]
 
-{ #category : #'tests - greater or equal than comparison' }
+{ #category : 'tests - greater or equal than comparison' }
 VMJittedGeneralPrimitiveTest >> testCompareSmallIntegerGreaterOrEqualThanGreaterSmallInteger [
 
 	self compile: [ | jump | 
@@ -176,7 +178,7 @@ VMJittedGeneralPrimitiveTest >> testCompareSmallIntegerGreaterOrEqualThanGreater
 	self assert: machineSimulator receiverRegisterValue equals: self memory falseObject
 ]
 
-{ #category : #'tests - greater or equal than comparison' }
+{ #category : 'tests - greater or equal than comparison' }
 VMJittedGeneralPrimitiveTest >> testCompareSmallIntegerGreaterOrEqualThanSmallerBoxedFloat [
 
 	self compile: [ | jump | 
@@ -192,7 +194,7 @@ VMJittedGeneralPrimitiveTest >> testCompareSmallIntegerGreaterOrEqualThanSmaller
 	self assert: machineSimulator receiverRegisterValue equals: self memory trueObject
 ]
 
-{ #category : #'tests - greater or equal than comparison' }
+{ #category : 'tests - greater or equal than comparison' }
 VMJittedGeneralPrimitiveTest >> testCompareSmallIntegerGreaterOrEqualThanSmallerSmallInteger [
 
 	self compile: [ | jump | 
@@ -208,7 +210,7 @@ VMJittedGeneralPrimitiveTest >> testCompareSmallIntegerGreaterOrEqualThanSmaller
 	self assert: machineSimulator receiverRegisterValue equals: self memory trueObject
 ]
 
-{ #category : #'tests - greater than comparison' }
+{ #category : 'tests - greater than comparison' }
 VMJittedGeneralPrimitiveTest >> testCompareSmallIntegerGreaterThanBoxedFloat [
 
 	self compile: [ | jump | 
@@ -224,7 +226,7 @@ VMJittedGeneralPrimitiveTest >> testCompareSmallIntegerGreaterThanBoxedFloat [
 	self assert: machineSimulator receiverRegisterValue equals: self memory trueObject
 ]
 
-{ #category : #'tests - greater than comparison' }
+{ #category : 'tests - greater than comparison' }
 VMJittedGeneralPrimitiveTest >> testCompareSmallIntegerGreaterThanSmallInteger [
 
 	self compile: [ | jump | 
@@ -240,7 +242,7 @@ VMJittedGeneralPrimitiveTest >> testCompareSmallIntegerGreaterThanSmallInteger [
 	self assert: machineSimulator receiverRegisterValue equals: self memory trueObject
 ]
 
-{ #category : #'tests - equals comparison' }
+{ #category : 'tests - equals comparison' }
 VMJittedGeneralPrimitiveTest >> testCompareSmallIntegerNotEqualsToBoxedFloat [
 
 	self compile: [ | jump | 
@@ -256,7 +258,7 @@ VMJittedGeneralPrimitiveTest >> testCompareSmallIntegerNotEqualsToBoxedFloat [
 	self assert: machineSimulator receiverRegisterValue equals: self memory falseObject
 ]
 
-{ #category : #'tests - equals comparison' }
+{ #category : 'tests - equals comparison' }
 VMJittedGeneralPrimitiveTest >> testCompareSmallIntegerNotEqualsToSmallInteger [
 
 	self compile: [ | jump | 
@@ -272,7 +274,7 @@ VMJittedGeneralPrimitiveTest >> testCompareSmallIntegerNotEqualsToSmallInteger [
 	self assert: machineSimulator receiverRegisterValue equals: self memory falseObject
 ]
 
-{ #category : #'tests - greater than comparison' }
+{ #category : 'tests - greater than comparison' }
 VMJittedGeneralPrimitiveTest >> testCompareSmallIntegerNotGreaterThanBoxedFloat [
 
 	self compile: [ | jump | 
@@ -288,7 +290,7 @@ VMJittedGeneralPrimitiveTest >> testCompareSmallIntegerNotGreaterThanBoxedFloat 
 	self assert: machineSimulator receiverRegisterValue equals: self memory falseObject
 ]
 
-{ #category : #'tests - greater than comparison' }
+{ #category : 'tests - greater than comparison' }
 VMJittedGeneralPrimitiveTest >> testCompareSmallIntegerNotGreaterThanSmallInteger [
 
 	self compile: [ | jump | 
@@ -304,7 +306,7 @@ VMJittedGeneralPrimitiveTest >> testCompareSmallIntegerNotGreaterThanSmallIntege
 	self assert: machineSimulator receiverRegisterValue equals: self memory falseObject
 ]
 
-{ #category : #'tests - support' }
+{ #category : 'tests - support' }
 VMJittedGeneralPrimitiveTest >> testConvertIntegerToSmallInteger [
 
 	self compile: [
@@ -317,7 +319,7 @@ VMJittedGeneralPrimitiveTest >> testConvertIntegerToSmallInteger [
 	self assert: machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 17).
 ]
 
-{ #category : #'tests - support' }
+{ #category : 'tests - support' }
 VMJittedGeneralPrimitiveTest >> testConvertSmallIntegerToInteger [
 
 	self compile: [ | jump | 
@@ -330,7 +332,7 @@ VMJittedGeneralPrimitiveTest >> testConvertSmallIntegerToInteger [
 	self assert: machineSimulator receiverRegisterValue equals: 17.
 ]
 
-{ #category : #'tests - support' }
+{ #category : 'tests - support' }
 VMJittedGeneralPrimitiveTest >> testGetClassIndexOfObjectObtainsClassIndex [
 
 	self compile: [ | jump | 
@@ -343,7 +345,7 @@ VMJittedGeneralPrimitiveTest >> testGetClassIndexOfObjectObtainsClassIndex [
 	self assert: machineSimulator receiverRegisterValue equals: (memory classIndexOf: memory falseObject)
 ]
 
-{ #category : #'tests - support' }
+{ #category : 'tests - support' }
 VMJittedGeneralPrimitiveTest >> testGetClassObjectOfClassIndex [
 
 	self compile: [
@@ -356,7 +358,7 @@ VMJittedGeneralPrimitiveTest >> testGetClassObjectOfClassIndex [
 	self assert: machineSimulator arg0RegisterValue equals: classFloat
 ]
 
-{ #category : #'tests - support' }
+{ #category : 'tests - support' }
 VMJittedGeneralPrimitiveTest >> testGetNumberOfSlotsOf16BitIndexable [
 
 	self compile: [
@@ -370,7 +372,7 @@ VMJittedGeneralPrimitiveTest >> testGetNumberOfSlotsOf16BitIndexable [
 	self assert: machineSimulator arg0RegisterValue equals: 8 * 2 "bytes" / self wordSize
 ]
 
-{ #category : #'tests - support' }
+{ #category : 'tests - support' }
 VMJittedGeneralPrimitiveTest >> testGetNumberOfSlotsOf16BitIndexableWithPadding [
 
 	self compile: [
@@ -384,7 +386,7 @@ VMJittedGeneralPrimitiveTest >> testGetNumberOfSlotsOf16BitIndexableWithPadding 
 	self assert: machineSimulator arg0RegisterValue equals: 8 * 2 "bytes" / self wordSize
 ]
 
-{ #category : #'tests - support' }
+{ #category : 'tests - support' }
 VMJittedGeneralPrimitiveTest >> testGetNumberOfSlotsOf32BitIndexable [
 
 	self compile: [
@@ -398,7 +400,7 @@ VMJittedGeneralPrimitiveTest >> testGetNumberOfSlotsOf32BitIndexable [
 	self assert: machineSimulator arg0RegisterValue equals: 8 * 4 "bytes" / self wordSize
 ]
 
-{ #category : #'tests - support' }
+{ #category : 'tests - support' }
 VMJittedGeneralPrimitiveTest >> testGetNumberOfSlotsOf32BitIndexableWithPadding [
 
 	self compile: [
@@ -412,7 +414,7 @@ VMJittedGeneralPrimitiveTest >> testGetNumberOfSlotsOf32BitIndexableWithPadding 
 	self assert: machineSimulator arg0RegisterValue equals: (7 * 4 roundUpTo: self wordSize) "bytes" / self wordSize
 ]
 
-{ #category : #'tests - support' }
+{ #category : 'tests - support' }
 VMJittedGeneralPrimitiveTest >> testGetNumberOfSlotsOf64BitIndexable [
 
 	| desiredSlots |
@@ -430,7 +432,7 @@ VMJittedGeneralPrimitiveTest >> testGetNumberOfSlotsOf64BitIndexable [
 	self assert: machineSimulator arg0RegisterValue equals: (desiredSlots * 8 / self wordSize)
 ]
 
-{ #category : #'tests - support' }
+{ #category : 'tests - support' }
 VMJittedGeneralPrimitiveTest >> testGetNumberOfSlotsOf8BitIndexable [
 
 	self compile: [
@@ -444,7 +446,7 @@ VMJittedGeneralPrimitiveTest >> testGetNumberOfSlotsOf8BitIndexable [
 	self assert: machineSimulator arg0RegisterValue equals: 8 "bytes" / self wordSize
 ]
 
-{ #category : #'tests - support' }
+{ #category : 'tests - support' }
 VMJittedGeneralPrimitiveTest >> testGetNumberOfSlotsOf8BitIndexableWithPadding [
 
 	self compile: [
@@ -458,7 +460,7 @@ VMJittedGeneralPrimitiveTest >> testGetNumberOfSlotsOf8BitIndexableWithPadding [
 	self assert: machineSimulator arg0RegisterValue equals: 8 "bytes" / self wordSize
 ]
 
-{ #category : #'tests - support' }
+{ #category : 'tests - support' }
 VMJittedGeneralPrimitiveTest >> testMoveFloatToFloatPointRegister [
 
 	self compile: [ | jump | 
@@ -473,7 +475,7 @@ VMJittedGeneralPrimitiveTest >> testMoveFloatToFloatPointRegister [
 	self assert: machineSimulator doublePrecisionFloatingPointRegister0Value equals: Float fmax.
 ]
 
-{ #category : #'tests - primitiveAdd' }
+{ #category : 'tests - primitiveAdd' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveAddDoesNotCompileIfReceiverTagIsNotSmallInteger [
 	
 	| result |
@@ -486,7 +488,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveAddDoesNotCompileIfReceiverTagIsNot
 	self assert: result equals: UnimplementedPrimitive.
 ]
 
-{ #category : #'tests - primitiveAdd' }
+{ #category : 'tests - primitiveAdd' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveAddFailsWhenArgumentIsNotSmallInteger [
 	
 	| endInstruction primitiveAddress |
@@ -503,7 +505,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveAddFailsWhenArgumentIsNotSmallInteg
 	self runFrom: primitiveAddress until: endInstruction address.
 ]
 
-{ #category : #'tests - primitiveAdd' }
+{ #category : 'tests - primitiveAdd' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveAddFailsWhenSumOverflows [
 	
 	| endInstruction primitiveAddress |
@@ -520,7 +522,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveAddFailsWhenSumOverflows [
 	self runFrom: primitiveAddress until: endInstruction address.
 ]
 
-{ #category : #'tests - primitiveAdd' }
+{ #category : 'tests - primitiveAdd' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveAddFailsWhenSumOverflowsWhenNegative [
 	
 	| endInstruction primitiveAddress |
@@ -537,7 +539,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveAddFailsWhenSumOverflowsWhenNegativ
 	self runFrom: primitiveAddress until: endInstruction address.
 ]
 
-{ #category : #'tests - primitiveAdd' }
+{ #category : 'tests - primitiveAdd' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveAddIsCompleteWhenReceiverTagIsSmallInteger [
 	
 	| result |
@@ -548,7 +550,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveAddIsCompleteWhenReceiverTagIsSmall
 	self assert: result equals: CompletePrimitive.
 ]
 
-{ #category : #'tests - primitiveAdd' }
+{ #category : 'tests - primitiveAdd' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveAddReturnsASmallInteger [
 	
 	| endInstruction primitiveAddress |
@@ -565,7 +567,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveAddReturnsASmallInteger [
 	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 94).
 ]
 
-{ #category : #'tests - primitiveAdd' }
+{ #category : 'tests - primitiveAdd' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveAddReturnsASmallIntegerWhenNegativeNumbers [
 	
 	| endInstruction primitiveAddress |
@@ -583,7 +585,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveAddReturnsASmallIntegerWhenNegative
 	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: -265).
 ]
 
-{ #category : #'tests - primitiveAsFloat' }
+{ #category : 'tests - primitiveAsFloat' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveAsFloatDoesNotCompileIfReceiverTagIsNotSmallInteger [
 	
 	| result |
@@ -596,7 +598,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveAsFloatDoesNotCompileIfReceiverTagI
 	self assert: result equals: UnimplementedPrimitive.
 ]
 
-{ #category : #'tests - primitiveAsFloat' }
+{ #category : 'tests - primitiveAsFloat' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveAsFloatIsCompleteWhenReceiverTagIsSmallInteger [
 	
 	| result |
@@ -609,7 +611,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveAsFloatIsCompleteWhenReceiverTagIsS
 	self assert: result equals: 0. "Incomplete Primitive, if the float cannot be allocated, it executes the C code"
 ]
 
-{ #category : #'tests - primitiveAsFloat' }
+{ #category : 'tests - primitiveAsFloat' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveAsFloatReturnsASmallFloat [
 	
 	| endInstruction primitiveAddress |
@@ -629,7 +631,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveAsFloatReturnsASmallFloat [
 	self assert: self machineSimulator receiverRegisterValue equals: (memory floatObjectOf: 42.0)
 ]
 
-{ #category : #'tests - primitiveAsFloat' }
+{ #category : 'tests - primitiveAsFloat' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveAsFloatWith64BitIntegerReturnsASmallFloat [
 	
 	| endInstruction primitiveAddress |
@@ -652,7 +654,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveAsFloatWith64BitIntegerReturnsASmal
 		equals: 8589934592 asFloat
 ]
 
-{ #category : #'tests - primitiveBitAnd/Or' }
+{ #category : 'tests - primitiveBitAnd/Or' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveBitAndDoesCompileForSmallIntegerReceiver [
 	
 	| result |
@@ -665,7 +667,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveBitAndDoesCompileForSmallIntegerRec
 	self assert: result equals: CompletePrimitive
 ]
 
-{ #category : #'tests - primitiveBitAnd/Or' }
+{ #category : 'tests - primitiveBitAnd/Or' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveBitAndDoesNotCompileForNonSmallIntegerReceiver [
 	
 	| result |
@@ -678,7 +680,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveBitAndDoesNotCompileForNonSmallInte
 	self assert: result equals: UnimplementedPrimitive
 ]
 
-{ #category : #'tests - primitiveBitAnd/Or' }
+{ #category : 'tests - primitiveBitAnd/Or' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveBitAndShouldFailWithNonSmallIntegerArgument [
 	
 	| primitiveAddress endInstruction |
@@ -694,7 +696,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveBitAndShouldFailWithNonSmallInteger
 	self runFrom: primitiveAddress until: endInstruction address.
 ]
 
-{ #category : #'tests - primitiveBitAnd/Or' }
+{ #category : 'tests - primitiveBitAnd/Or' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveBitAndShouldPreserveSmallIntegerTag [
 	
 	| primitiveAddress endInstruction |
@@ -712,7 +714,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveBitAndShouldPreserveSmallIntegerTag
 	self assert: machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 1)
 ]
 
-{ #category : #'tests - primitiveBitAnd/Or' }
+{ #category : 'tests - primitiveBitAnd/Or' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveBitOrDoesCompileForSmallIntegerReceiver [
 	
 	| result |
@@ -725,7 +727,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveBitOrDoesCompileForSmallIntegerRece
 	self assert: result equals: CompletePrimitive
 ]
 
-{ #category : #'tests - primitiveBitAnd/Or' }
+{ #category : 'tests - primitiveBitAnd/Or' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveBitOrDoesNotCompileForNonSmallIntegerReceiver [
 	
 	| result |
@@ -738,7 +740,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveBitOrDoesNotCompileForNonSmallInteg
 	self assert: result equals: UnimplementedPrimitive
 ]
 
-{ #category : #'tests - primitiveBitAnd/Or' }
+{ #category : 'tests - primitiveBitAnd/Or' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveBitOrShouldFailWithNonSmallIntegerArgument [
 	
 	| primitiveAddress endInstruction |
@@ -754,7 +756,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveBitOrShouldFailWithNonSmallIntegerA
 	self runFrom: primitiveAddress until: endInstruction address.
 ]
 
-{ #category : #'tests - primitiveBitAnd/Or' }
+{ #category : 'tests - primitiveBitAnd/Or' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveBitOrShouldPreserveSmallIntegerTag [
 	
 	| primitiveAddress endInstruction |
@@ -772,7 +774,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveBitOrShouldPreserveSmallIntegerTag 
 	self assert: machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 3)
 ]
 
-{ #category : #'tests - primitiveBitShift' }
+{ #category : 'tests - primitiveBitShift' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveBitShiftDoesCompileForSmallIntegerReceiver [
 	
 	| result |
@@ -785,7 +787,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveBitShiftDoesCompileForSmallIntegerR
 	self assert: result equals: CompletePrimitive
 ]
 
-{ #category : #'tests - primitiveBitShift' }
+{ #category : 'tests - primitiveBitShift' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveBitShiftDoesNotCompileForNonSmallIntegerReceiver [
 	
 	| result |
@@ -798,7 +800,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveBitShiftDoesNotCompileForNonSmallIn
 	self assert: result equals: UnimplementedPrimitive
 ]
 
-{ #category : #'tests - primitiveBitShift' }
+{ #category : 'tests - primitiveBitShift' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveBitShiftShouldFailWithArgumentBiggerThanSmallIntegerBits [
 	
 	| primitiveAddress endInstruction |
@@ -816,7 +818,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveBitShiftShouldFailWithArgumentBigge
 	self runFrom: primitiveAddress until: endInstruction address.
 ]
 
-{ #category : #'tests - primitiveBitShift' }
+{ #category : 'tests - primitiveBitShift' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveBitShiftShouldFailWithNonSmallIntegerArgument [
 	
 	| primitiveAddress endInstruction |
@@ -832,7 +834,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveBitShiftShouldFailWithNonSmallInteg
 	self runFrom: primitiveAddress until: endInstruction address.
 ]
 
-{ #category : #'tests - primitiveBitShift' }
+{ #category : 'tests - primitiveBitShift' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveBitShiftShouldFailWithOverflow [
 	
 	| primitiveAddress endInstruction |
@@ -850,7 +852,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveBitShiftShouldFailWithOverflow [
 	self runFrom: primitiveAddress until: endInstruction address.
 ]
 
-{ #category : #'tests - primitiveBitShift' }
+{ #category : 'tests - primitiveBitShift' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveBitShiftShouldReturnSmallInteger [
 	
 	| primitiveAddress endInstruction |
@@ -872,7 +874,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveBitShiftShouldReturnSmallInteger [
 		equals: (memory integerObjectOf: memory maxSmallInteger >> 1 << 1)
 ]
 
-{ #category : #'tests - primitiveBitShift' }
+{ #category : 'tests - primitiveBitShift' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveBitShiftShouldReturnSmallIntegerWithShiftRight [
 	
 	| primitiveAddress endInstruction |
@@ -894,7 +896,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveBitShiftShouldReturnSmallIntegerWit
 		equals: (memory integerObjectOf: 17)
 ]
 
-{ #category : #'tests - primitiveBitShift' }
+{ #category : 'tests - primitiveBitShift' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveBitShiftShouldReturnZeroIfShiftIsBiggerThanNumSmallIntegerBits [
 	
 	| primitiveAddress endInstruction |
@@ -916,7 +918,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveBitShiftShouldReturnZeroIfShiftIsBi
 		equals: (memory integerObjectOf: 0)
 ]
 
-{ #category : #'tests - primitiveBitXor' }
+{ #category : 'tests - primitiveBitXor' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveBitXorCompileWithNegativeSmallInt [
 	
 	| primitiveAddress endInstruction |
@@ -934,7 +936,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveBitXorCompileWithNegativeSmallInt [
 	self assert: machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 128)
 ]
 
-{ #category : #'tests - primitiveBitXor' }
+{ #category : 'tests - primitiveBitXor' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveBitXorDoesCompileForSmallIntegerReceiver [
 	
 	| result |
@@ -947,7 +949,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveBitXorDoesCompileForSmallIntegerRec
 	self assert: result equals: CompletePrimitive
 ]
 
-{ #category : #'tests - primitiveBitXor' }
+{ #category : 'tests - primitiveBitXor' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveBitXorDoesNotCompileForNonSmallIntegerReceiver [
 	
 	| result |
@@ -960,7 +962,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveBitXorDoesNotCompileForNonSmallInte
 	self assert: result equals: UnimplementedPrimitive
 ]
 
-{ #category : #'tests - primitiveBitXor' }
+{ #category : 'tests - primitiveBitXor' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveBitXorShouldFailWithNonSmallIntegerArgument [
 	
 	| primitiveAddress endInstruction |
@@ -976,7 +978,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveBitXorShouldFailWithNonSmallInteger
 	self runFrom: primitiveAddress until: endInstruction address.
 ]
 
-{ #category : #'tests - primitiveBitXor' }
+{ #category : 'tests - primitiveBitXor' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveBitXorShouldPreserveSmallIntegerTag [
 	
 	| primitiveAddress endInstruction |
@@ -994,7 +996,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveBitXorShouldPreserveSmallIntegerTag
 	self assert: machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 2)
 ]
 
-{ #category : #'tests - primitiveDiv' }
+{ #category : 'tests - primitiveDiv' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveDivCompilesOnFloatResult [
 	
 	| endInstruction primitiveAddress |
@@ -1012,7 +1014,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveDivCompilesOnFloatResult [
 	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 10).
 ]
 
-{ #category : #'tests - primitiveDiv' }
+{ #category : 'tests - primitiveDiv' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveDivCompilesWithNegativNumbers [
 	
 	| endInstruction primitiveAddress |
@@ -1029,7 +1031,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveDivCompilesWithNegativNumbers [
 	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: -3).
 ]
 
-{ #category : #'tests - primitiveDiv' }
+{ #category : 'tests - primitiveDiv' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveDivDoesNotCompileIfReceiverTagIsNotSmallInteger [
 	
 	| result |
@@ -1042,7 +1044,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveDivDoesNotCompileIfReceiverTagIsNot
 	self assert: result equals: UnimplementedPrimitive.
 ]
 
-{ #category : #'tests - primitiveDiv' }
+{ #category : 'tests - primitiveDiv' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveDivFailsWhenArgumentIsNotSmallInteger [
 	
 	| endInstruction primitiveAddress |
@@ -1059,7 +1061,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveDivFailsWhenArgumentIsNotSmallInteg
 	self runFrom: primitiveAddress until: endInstruction address.
 ]
 
-{ #category : #'tests - primitiveDiv' }
+{ #category : 'tests - primitiveDiv' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveDivFailsWithZeroDivision [
 	
 	| endInstruction primitiveAddress |
@@ -1076,7 +1078,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveDivFailsWithZeroDivision [
 	self runFrom: primitiveAddress until: endInstruction address.
 ]
 
-{ #category : #'tests - primitiveDiv' }
+{ #category : 'tests - primitiveDiv' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveDivIsCompleteWhenReceiverTagIsSmallInteger [
 	
 	| result |
@@ -1087,7 +1089,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveDivIsCompleteWhenReceiverTagIsSmall
 	self assert: result equals: CompletePrimitive.
 ]
 
-{ #category : #'tests - primitiveDiv' }
+{ #category : 'tests - primitiveDiv' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveDivReturnsASmallInteger [
 	
 	| endInstruction primitiveAddress |
@@ -1104,7 +1106,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveDivReturnsASmallInteger [
 	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 50).
 ]
 
-{ #category : #'tests - primitiveDiv' }
+{ #category : 'tests - primitiveDiv' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveDivReturnsASmallIntegerWhenNegativeNumbers [
 	
 	| endInstruction primitiveAddress |
@@ -1122,7 +1124,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveDivReturnsASmallIntegerWhenNegative
 	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 50).
 ]
 
-{ #category : #'tests - primitiveDiv' }
+{ #category : 'tests - primitiveDiv' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveDivReturnsZeroWithZeroReceiver [
 	
 	| endInstruction primitiveAddress |
@@ -1139,7 +1141,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveDivReturnsZeroWithZeroReceiver [
 	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 0).
 ]
 
-{ #category : #'tests - primitiveDivide' }
+{ #category : 'tests - primitiveDivide' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveDivideDoesNotCompileIfReceiverTagIsNotSmallInteger [
 	
 	| result |
@@ -1152,7 +1154,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveDivideDoesNotCompileIfReceiverTagIs
 	self assert: result equals: UnimplementedPrimitive.
 ]
 
-{ #category : #'tests - primitiveDivide' }
+{ #category : 'tests - primitiveDivide' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveDivideFailsOnNonIntegerResult [
 	
 	| endInstruction primitiveAddress |
@@ -1169,7 +1171,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveDivideFailsOnNonIntegerResult [
 	self runFrom: primitiveAddress until: endInstruction address.
 ]
 
-{ #category : #'tests - primitiveDivide' }
+{ #category : 'tests - primitiveDivide' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveDivideFailsWhenArgumentIsNotSmallInteger [
 	
 	| endInstruction primitiveAddress |
@@ -1186,7 +1188,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveDivideFailsWhenArgumentIsNotSmallIn
 	self runFrom: primitiveAddress until: endInstruction address.
 ]
 
-{ #category : #'tests - primitiveDivide' }
+{ #category : 'tests - primitiveDivide' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveDivideFailsWithZeroDivision [
 	
 	| endInstruction primitiveAddress |
@@ -1203,7 +1205,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveDivideFailsWithZeroDivision [
 	self runFrom: primitiveAddress until: endInstruction address.
 ]
 
-{ #category : #'tests - primitiveDivide' }
+{ #category : 'tests - primitiveDivide' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveDivideIsCompleteWhenReceiverTagIsSmallInteger [
 	
 	| result |
@@ -1214,7 +1216,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveDivideIsCompleteWhenReceiverTagIsSm
 	self assert: result equals: CompletePrimitive.
 ]
 
-{ #category : #'tests - primitiveDivide' }
+{ #category : 'tests - primitiveDivide' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveDivideReturnsASmallInteger [
 	
 	| endInstruction primitiveAddress |
@@ -1231,7 +1233,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveDivideReturnsASmallInteger [
 	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 50).
 ]
 
-{ #category : #'tests - primitiveDivide' }
+{ #category : 'tests - primitiveDivide' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveDivideReturnsASmallIntegerWhenNegativeNumbers [
 	
 	| endInstruction primitiveAddress |
@@ -1249,7 +1251,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveDivideReturnsASmallIntegerWhenNegat
 	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 50).
 ]
 
-{ #category : #'tests - primitiveDivide' }
+{ #category : 'tests - primitiveDivide' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveDivideReturnsZeroWithZeroReceiver [
 	
 	| endInstruction primitiveAddress |
@@ -1266,7 +1268,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveDivideReturnsZeroWithZeroReceiver [
 	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 0).
 ]
 
-{ #category : #'tests - primitiveEqual' }
+{ #category : 'tests - primitiveEqual' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveEqualDoesNotCompileIfReceiverTagIsNotSmallInteger [
 	
 	| result |
@@ -1279,7 +1281,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveEqualDoesNotCompileIfReceiverTagIsN
 	self assert: result equals: UnimplementedPrimitive.
 ]
 
-{ #category : #'tests - primitiveEqual' }
+{ #category : 'tests - primitiveEqual' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveEqualFailsWhenArgumentIsNotSmallInteger [
 	
 	| endInstruction primitiveAddress |
@@ -1296,7 +1298,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveEqualFailsWhenArgumentIsNotSmallInt
 	self runFrom: primitiveAddress until: endInstruction address.
 ]
 
-{ #category : #'tests - primitiveEqual' }
+{ #category : 'tests - primitiveEqual' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveEqualIsCompleteWhenReceiverTagIsSmallInteger [
 	
 	| result |
@@ -1307,7 +1309,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveEqualIsCompleteWhenReceiverTagIsSma
 	self assert: result equals: CompletePrimitive.
 ]
 
-{ #category : #'tests - primitiveEqual' }
+{ #category : 'tests - primitiveEqual' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveEqualReturnsABoolean [
 	
 	| endInstruction primitiveAddress |
@@ -1324,7 +1326,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveEqualReturnsABoolean [
 	self assert: self machineSimulator receiverRegisterValue equals: (memory trueObject).
 ]
 
-{ #category : #'tests - primitiveEqual' }
+{ #category : 'tests - primitiveEqual' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveEqualReturnsABooleanWhenNegativeNumbers [
 
 		| endInstruction primitiveAddress |
@@ -1342,7 +1344,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveEqualReturnsABooleanWhenNegativeNum
 	self assert: self machineSimulator receiverRegisterValue equals: (memory falseObject).
 ]
 
-{ #category : #'tests - primitiveGreaterOrEqual' }
+{ #category : 'tests - primitiveGreaterOrEqual' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveGreaterOrEqualDoesNotCompileIfReceiverTagIsNotSmallInteger [
 	
 	| result |
@@ -1355,7 +1357,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveGreaterOrEqualDoesNotCompileIfRecei
 	self assert: result equals: UnimplementedPrimitive.
 ]
 
-{ #category : #'tests - primitiveGreaterOrEqual' }
+{ #category : 'tests - primitiveGreaterOrEqual' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveGreaterOrEqualFailsWhenArgumentIsNotSmallInteger [
 	
 	| endInstruction primitiveAddress |
@@ -1372,7 +1374,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveGreaterOrEqualFailsWhenArgumentIsNo
 	self runFrom: primitiveAddress until: endInstruction address.
 ]
 
-{ #category : #'tests - primitiveGreaterOrEqual' }
+{ #category : 'tests - primitiveGreaterOrEqual' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveGreaterOrEqualIsCompleteWhenReceiverTagIsSmallInteger [
 	
 	| result |
@@ -1383,7 +1385,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveGreaterOrEqualIsCompleteWhenReceive
 	self assert: result equals: CompletePrimitive.
 ]
 
-{ #category : #'tests - primitiveGreaterOrEqual' }
+{ #category : 'tests - primitiveGreaterOrEqual' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveGreaterOrEqualReturnsABoolean [
 	
 	| endInstruction primitiveAddress |
@@ -1400,7 +1402,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveGreaterOrEqualReturnsABoolean [
 	self assert: self machineSimulator receiverRegisterValue equals: (memory trueObject).
 ]
 
-{ #category : #'tests - primitiveGreaterOrEqual' }
+{ #category : 'tests - primitiveGreaterOrEqual' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveGreaterOrEqualReturnsABooleanWhenNegativeNumbers [
 
 		| endInstruction primitiveAddress |
@@ -1418,7 +1420,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveGreaterOrEqualReturnsABooleanWhenNe
 	self assert: self machineSimulator receiverRegisterValue equals: (memory trueObject).
 ]
 
-{ #category : #'tests - primitiveGreaterThan' }
+{ #category : 'tests - primitiveGreaterThan' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveGreaterThanDoesNotCompileIfReceiverTagIsNotSmallInteger [
 	
 	| result |
@@ -1431,7 +1433,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveGreaterThanDoesNotCompileIfReceiver
 	self assert: result equals: UnimplementedPrimitive.
 ]
 
-{ #category : #'tests - primitiveGreaterThan' }
+{ #category : 'tests - primitiveGreaterThan' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveGreaterThanFailsWhenArgumentIsNotSmallInteger [
 	
 	| endInstruction primitiveAddress |
@@ -1448,7 +1450,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveGreaterThanFailsWhenArgumentIsNotSm
 	self runFrom: primitiveAddress until: endInstruction address.
 ]
 
-{ #category : #'tests - primitiveGreaterThan' }
+{ #category : 'tests - primitiveGreaterThan' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveGreaterThanIsCompleteWhenReceiverTagIsSmallInteger [
 	
 	| result |
@@ -1459,7 +1461,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveGreaterThanIsCompleteWhenReceiverTa
 	self assert: result equals: CompletePrimitive.
 ]
 
-{ #category : #'tests - primitiveGreaterThan' }
+{ #category : 'tests - primitiveGreaterThan' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveGreaterThanReturnsABoolean [
 	
 	| endInstruction primitiveAddress |
@@ -1476,7 +1478,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveGreaterThanReturnsABoolean [
 	self assert: self machineSimulator receiverRegisterValue equals: (memory falseObject).
 ]
 
-{ #category : #'tests - primitiveGreaterThan' }
+{ #category : 'tests - primitiveGreaterThan' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveGreaterThanReturnsABooleanWhenNegativeNumbers [
 	
 	| endInstruction primitiveAddress |
@@ -1494,7 +1496,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveGreaterThanReturnsABooleanWhenNegat
 	self assert: self machineSimulator receiverRegisterValue equals: (memory trueObject).
 ]
 
-{ #category : #'tests - primitiveHashMultiply' }
+{ #category : 'tests - primitiveHashMultiply' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveHashMultiplySmallIntegerReturnsHashMultiply [
 	
 	| result primitiveAddress |
@@ -1511,7 +1513,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveHashMultiplySmallIntegerReturnsHash
 	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 50 hashMultiply).
 ]
 
-{ #category : #'tests - primitiveLessOrEqual' }
+{ #category : 'tests - primitiveLessOrEqual' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveLessOrEqualDoesNotCompileIfReceiverTagIsNotSmallInteger [
 	
 	| result |
@@ -1524,7 +1526,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveLessOrEqualDoesNotCompileIfReceiver
 	self assert: result equals: UnimplementedPrimitive.
 ]
 
-{ #category : #'tests - primitiveLessOrEqual' }
+{ #category : 'tests - primitiveLessOrEqual' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveLessOrEqualFailsWhenArgumentIsNotSmallInteger [
 	
 	| endInstruction primitiveAddress |
@@ -1541,7 +1543,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveLessOrEqualFailsWhenArgumentIsNotSm
 	self runFrom: primitiveAddress until: endInstruction address.
 ]
 
-{ #category : #'tests - primitiveLessOrEqual' }
+{ #category : 'tests - primitiveLessOrEqual' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveLessOrEqualIsCompleteWhenReceiverTagIsSmallInteger [
 	
 	| result |
@@ -1552,7 +1554,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveLessOrEqualIsCompleteWhenReceiverTa
 	self assert: result equals: CompletePrimitive.
 ]
 
-{ #category : #'tests - primitiveLessOrEqual' }
+{ #category : 'tests - primitiveLessOrEqual' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveLessOrEqualReturnsABoolean [
 	
 	| endInstruction primitiveAddress |
@@ -1569,7 +1571,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveLessOrEqualReturnsABoolean [
 	self assert: self machineSimulator receiverRegisterValue equals: (memory trueObject).
 ]
 
-{ #category : #'tests - primitiveLessOrEqual' }
+{ #category : 'tests - primitiveLessOrEqual' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveLessOrEqualReturnsABooleanWhenNegativeNumbers [
 
 		| endInstruction primitiveAddress |
@@ -1587,7 +1589,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveLessOrEqualReturnsABooleanWhenNegat
 	self assert: self machineSimulator receiverRegisterValue equals: (memory falseObject).
 ]
 
-{ #category : #'tests - primitiveLessThan' }
+{ #category : 'tests - primitiveLessThan' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveLessThanDoesNotCompileIfReceiverTagIsNotSmallInteger [
 	
 	| result |
@@ -1600,7 +1602,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveLessThanDoesNotCompileIfReceiverTag
 	self assert: result equals: UnimplementedPrimitive.
 ]
 
-{ #category : #'tests - primitiveLessThan' }
+{ #category : 'tests - primitiveLessThan' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveLessThanFailsWhenArgumentIsNotSmallInteger [
 	
 	| endInstruction primitiveAddress |
@@ -1617,7 +1619,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveLessThanFailsWhenArgumentIsNotSmall
 	self runFrom: primitiveAddress until: endInstruction address.
 ]
 
-{ #category : #'tests - primitiveLessThan' }
+{ #category : 'tests - primitiveLessThan' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveLessThanIsCompleteWhenReceiverTagIsSmallInteger [
 	
 	| result |
@@ -1628,7 +1630,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveLessThanIsCompleteWhenReceiverTagIs
 	self assert: result equals: CompletePrimitive.
 ]
 
-{ #category : #'tests - primitiveLessThan' }
+{ #category : 'tests - primitiveLessThan' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveLessThanReturnsABoolean [
 	
 	| endInstruction primitiveAddress |
@@ -1645,7 +1647,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveLessThanReturnsABoolean [
 	self assert: self machineSimulator receiverRegisterValue equals: (memory trueObject).
 ]
 
-{ #category : #'tests - primitiveLessThan' }
+{ #category : 'tests - primitiveLessThan' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveLessThanReturnsABooleanWhenNegativeNumbers [
 
 		| endInstruction primitiveAddress |
@@ -1663,7 +1665,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveLessThanReturnsABooleanWhenNegative
 	self assert: self machineSimulator receiverRegisterValue equals: (memory falseObject).
 ]
 
-{ #category : #'tests - primitiveMultiply' }
+{ #category : 'tests - primitiveMultiply' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveMultiplyDoesNotCompileIfReceiverTagIsNotSmallInteger [
 	
 	| result |
@@ -1676,7 +1678,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveMultiplyDoesNotCompileIfReceiverTag
 	self assert: result equals: UnimplementedPrimitive.
 ]
 
-{ #category : #'tests - primitiveMultiply' }
+{ #category : 'tests - primitiveMultiply' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveMultiplyFailsWhenArgumentIsNotSmallInteger [
 	
 	| endInstruction primitiveAddress |
@@ -1693,7 +1695,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveMultiplyFailsWhenArgumentIsNotSmall
 	self runFrom: primitiveAddress until: endInstruction address.
 ]
 
-{ #category : #'tests - primitiveMultiply' }
+{ #category : 'tests - primitiveMultiply' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveMultiplyFailsWhenComputationOverflows [
 	
 	| endInstruction primitiveAddress |
@@ -1710,7 +1712,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveMultiplyFailsWhenComputationOverflo
 	self runFrom: primitiveAddress until: endInstruction address.
 ]
 
-{ #category : #'tests - primitiveMultiply' }
+{ #category : 'tests - primitiveMultiply' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveMultiplyFailsWhenNegativeOverflow [
 	
 	| endInstruction primitiveAddress |
@@ -1729,7 +1731,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveMultiplyFailsWhenNegativeOverflow [
 	self runFrom: primitiveAddress until: endInstruction address.
 ]
 
-{ #category : #'tests - primitiveMultiply' }
+{ #category : 'tests - primitiveMultiply' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveMultiplyFailsWhenPositiveOverflow [
 	
 	| endInstruction primitiveAddress |
@@ -1748,7 +1750,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveMultiplyFailsWhenPositiveOverflow [
 	self runFrom: primitiveAddress until: endInstruction address.
 ]
 
-{ #category : #'tests - primitiveMultiply' }
+{ #category : 'tests - primitiveMultiply' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveMultiplyFailsWhenSumOverflowsWhenNegative [
 	
 	| endInstruction primitiveAddress |
@@ -1765,7 +1767,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveMultiplyFailsWhenSumOverflowsWhenNe
 	self runFrom: primitiveAddress until: endInstruction address.
 ]
 
-{ #category : #'tests - primitiveMultiply' }
+{ #category : 'tests - primitiveMultiply' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveMultiplyIsCompleteWhenReceiverTagIsSmallInteger [
 	
 	| result |
@@ -1776,7 +1778,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveMultiplyIsCompleteWhenReceiverTagIs
 	self assert: result equals: CompletePrimitive.
 ]
 
-{ #category : #'tests - primitiveMultiply' }
+{ #category : 'tests - primitiveMultiply' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveMultiplyReturnsANegativeSmallInteger [
 	
 	| endInstruction primitiveAddress |
@@ -1793,7 +1795,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveMultiplyReturnsANegativeSmallIntege
 	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: -84).
 ]
 
-{ #category : #'tests - primitiveMultiply' }
+{ #category : 'tests - primitiveMultiply' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveMultiplyReturnsASmallInteger [
 	
 	| endInstruction primitiveAddress |
@@ -1810,7 +1812,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveMultiplyReturnsASmallInteger [
 	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 84).
 ]
 
-{ #category : #'tests - primitiveMultiply' }
+{ #category : 'tests - primitiveMultiply' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveMultiplyReturnsASmallIntegerWhenNegativeNumbers [
 	
 	| endInstruction primitiveAddress |
@@ -1828,7 +1830,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveMultiplyReturnsASmallIntegerWhenNeg
 	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 17424).
 ]
 
-{ #category : #'tests - primitiveMultiply' }
+{ #category : 'tests - primitiveMultiply' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveMultiplyReturnsZeroWithZeroOperand [
 	
 	| endInstruction primitiveAddress |
@@ -1846,7 +1848,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveMultiplyReturnsZeroWithZeroOperand 
 	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 0).
 ]
 
-{ #category : #'tests - primitiveNew' }
+{ #category : 'tests - primitiveNew' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveNewInitializesObjectCorrectly [
 
 	| endInstruction primitiveAddress class newOop instanceVariableCount |
@@ -1872,7 +1874,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveNewInitializesObjectCorrectly [
 			equals: memory nilObject ]
 ]
 
-{ #category : #'tests - primitiveNew' }
+{ #category : 'tests - primitiveNew' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveNewWithArgInitializesObjectCorrectly [
 
 	| endInstruction primitiveAddress class newOop arraySize |
@@ -1902,7 +1904,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveNewWithArgInitializesObjectCorrectl
 			equals: memory nilObject ]
 ]
 
-{ #category : #'tests - primitiveNew' }
+{ #category : 'tests - primitiveNew' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveNewWithArgInitializesObjectCorrectlyWhenNotAligned [
 
 	| endInstruction primitiveAddress class newOop arraySize |
@@ -1933,7 +1935,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveNewWithArgInitializesObjectCorrectl
 			equals: memory nilObject ]
 ]
 
-{ #category : #'tests - primitiveNotEqual' }
+{ #category : 'tests - primitiveNotEqual' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveNotEqualDoesNotCompileIfReceiverTagIsNotSmallInteger [
 	
 	| result |
@@ -1946,7 +1948,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveNotEqualDoesNotCompileIfReceiverTag
 	self assert: result equals: UnimplementedPrimitive.
 ]
 
-{ #category : #'tests - primitiveNotEqual' }
+{ #category : 'tests - primitiveNotEqual' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveNotEqualFailsWhenArgumentIsNotSmallInteger [
 	
 	| endInstruction primitiveAddress |
@@ -1963,7 +1965,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveNotEqualFailsWhenArgumentIsNotSmall
 	self runFrom: primitiveAddress until: endInstruction address.
 ]
 
-{ #category : #'tests - primitiveNotEqual' }
+{ #category : 'tests - primitiveNotEqual' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveNotEqualIsCompleteWhenReceiverTagIsSmallInteger [
 	
 	| result |
@@ -1974,7 +1976,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveNotEqualIsCompleteWhenReceiverTagIs
 	self assert: result equals: CompletePrimitive.
 ]
 
-{ #category : #'tests - primitiveNotEqual' }
+{ #category : 'tests - primitiveNotEqual' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveNotEqualReturnsABoolean [
 	
 	| endInstruction primitiveAddress |
@@ -1991,7 +1993,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveNotEqualReturnsABoolean [
 	self assert: self machineSimulator receiverRegisterValue equals: (memory falseObject).
 ]
 
-{ #category : #'tests - primitiveNotEqual' }
+{ #category : 'tests - primitiveNotEqual' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveNotEqualReturnsABooleanWhenNegativeNumbers [
 
 		| endInstruction primitiveAddress |
@@ -2009,7 +2011,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveNotEqualReturnsABooleanWhenNegative
 	self assert: self machineSimulator receiverRegisterValue equals: (memory trueObject).
 ]
 
-{ #category : #'tests - primitiveQuo' }
+{ #category : 'tests - primitiveQuo' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveQuoCompilesOnNonIntegerResult [
 	
 	| endInstruction primitiveAddress |
@@ -2027,7 +2029,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveQuoCompilesOnNonIntegerResult [
 	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 10).
 ]
 
-{ #category : #'tests - primitiveQuo' }
+{ #category : 'tests - primitiveQuo' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveQuoCompilesWithNegativNumbers [
 	
 	| endInstruction primitiveAddress |
@@ -2044,7 +2046,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveQuoCompilesWithNegativNumbers [
 	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: -2).
 ]
 
-{ #category : #'tests - primitiveQuo' }
+{ #category : 'tests - primitiveQuo' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveQuoDoesNotCompileIfReceiverTagIsNotSmallInteger [
 	
 	| result |
@@ -2057,7 +2059,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveQuoDoesNotCompileIfReceiverTagIsNot
 	self assert: result equals: UnimplementedPrimitive.
 ]
 
-{ #category : #'tests - primitiveQuo' }
+{ #category : 'tests - primitiveQuo' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveQuoFailsWhenArgumentIsNotSmallInteger [
 	
 	| endInstruction primitiveAddress |
@@ -2074,7 +2076,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveQuoFailsWhenArgumentIsNotSmallInteg
 	self runFrom: primitiveAddress until: endInstruction address.
 ]
 
-{ #category : #'tests - primitiveQuo' }
+{ #category : 'tests - primitiveQuo' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveQuoFailsWithZeroDivision [
 	
 	| endInstruction primitiveAddress |
@@ -2091,7 +2093,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveQuoFailsWithZeroDivision [
 	self runFrom: primitiveAddress until: endInstruction address.
 ]
 
-{ #category : #'tests - primitiveQuo' }
+{ #category : 'tests - primitiveQuo' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveQuoIsCompleteWhenReceiverTagIsSmallInteger [
 	
 	| result |
@@ -2102,7 +2104,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveQuoIsCompleteWhenReceiverTagIsSmall
 	self assert: result equals: CompletePrimitive.
 ]
 
-{ #category : #'tests - primitiveQuo' }
+{ #category : 'tests - primitiveQuo' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveQuoReturnsASmallInteger [
 	
 	| endInstruction primitiveAddress |
@@ -2119,7 +2121,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveQuoReturnsASmallInteger [
 	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 50).
 ]
 
-{ #category : #'tests - primitiveQuo' }
+{ #category : 'tests - primitiveQuo' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveQuoReturnsASmallIntegerWhenNegativeNumbers [
 	
 	| endInstruction primitiveAddress |
@@ -2137,7 +2139,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveQuoReturnsASmallIntegerWhenNegative
 	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 50).
 ]
 
-{ #category : #'tests - primitiveQuo' }
+{ #category : 'tests - primitiveQuo' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveQuoReturnsZeroWithZeroReceiver [
 	
 	| endInstruction primitiveAddress |
@@ -2154,7 +2156,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveQuoReturnsZeroWithZeroReceiver [
 	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 0).
 ]
 
-{ #category : #'tests - primitiveStringCompare' }
+{ #category : 'tests - primitiveStringCompare' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveStringCompareBigString [
 	
 
@@ -2173,7 +2175,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveStringCompareBigString [
 	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 0).
 ]
 
-{ #category : #'tests - primitiveStringCompare' }
+{ #category : 'tests - primitiveStringCompare' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveStringCompareWithHigherSymbol [
 	
 
@@ -2192,7 +2194,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveStringCompareWithHigherSymbol [
 	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 1).
 ]
 
-{ #category : #'tests - primitiveStringCompare' }
+{ #category : 'tests - primitiveStringCompare' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveStringCompareWithIsCaseSensitive [
 	
 
@@ -2211,7 +2213,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveStringCompareWithIsCaseSensitive [
 	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 32).
 ]
 
-{ #category : #'tests - primitiveStringCompare' }
+{ #category : 'tests - primitiveStringCompare' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveStringCompareWithLowerSymbol [
 	
 
@@ -2230,7 +2232,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveStringCompareWithLowerSymbol [
 	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: -1).
 ]
 
-{ #category : #'tests - primitiveStringCompare' }
+{ #category : 'tests - primitiveStringCompare' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveStringCompareWithSameSymbol [
 	
 
@@ -2248,7 +2250,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveStringCompareWithSameSymbol [
 	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 0).
 ]
 
-{ #category : #'tests - primitiveSubtract' }
+{ #category : 'tests - primitiveSubtract' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveSubtractDoesNotCompileIfReceiverTagIsNotSmallInteger [
 	
 	| result |
@@ -2261,7 +2263,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveSubtractDoesNotCompileIfReceiverTag
 	self assert: result equals: UnimplementedPrimitive.
 ]
 
-{ #category : #'tests - primitiveSubtract' }
+{ #category : 'tests - primitiveSubtract' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveSubtractFailsWhenArgumentIsNotSmallInteger [
 	
 	| endInstruction primitiveAddress |
@@ -2278,7 +2280,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveSubtractFailsWhenArgumentIsNotSmall
 	self runFrom: primitiveAddress until: endInstruction address.
 ]
 
-{ #category : #'tests - primitiveSubtract' }
+{ #category : 'tests - primitiveSubtract' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveSubtractFailsWhenSumOverflows [
 	
 	| endInstruction primitiveAddress |
@@ -2295,7 +2297,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveSubtractFailsWhenSumOverflows [
 	self runFrom: primitiveAddress until: endInstruction address.
 ]
 
-{ #category : #'tests - primitiveSubtract' }
+{ #category : 'tests - primitiveSubtract' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveSubtractFailsWhenSumOverflowsWhenNegative [
 	
 	| endInstruction primitiveAddress |
@@ -2312,7 +2314,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveSubtractFailsWhenSumOverflowsWhenNe
 	self runFrom: primitiveAddress until: endInstruction address.
 ]
 
-{ #category : #'tests - primitiveSubtract' }
+{ #category : 'tests - primitiveSubtract' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveSubtractIsCompleteWhenReceiverTagIsSmallInteger [
 	
 	| result |
@@ -2323,7 +2325,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveSubtractIsCompleteWhenReceiverTagIs
 	self assert: result equals: CompletePrimitive.
 ]
 
-{ #category : #'tests - primitiveSubtract' }
+{ #category : 'tests - primitiveSubtract' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveSubtractReturnsASmallInteger [
 	
 	| endInstruction primitiveAddress |
@@ -2340,7 +2342,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveSubtractReturnsASmallInteger [
 	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: -10).
 ]
 
-{ #category : #'tests - primitiveSubtract' }
+{ #category : 'tests - primitiveSubtract' }
 VMJittedGeneralPrimitiveTest >> testPrimitiveSubtractReturnsASmallIntegerWhenNegativeNumbers [
 	
 	| endInstruction primitiveAddress |
@@ -2358,7 +2360,7 @@ VMJittedGeneralPrimitiveTest >> testPrimitiveSubtractReturnsASmallIntegerWhenNeg
 	self assert: self machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 10).
 ]
 
-{ #category : #'tests - support' }
+{ #category : 'tests - support' }
 VMJittedGeneralPrimitiveTest >> testSmallIntegerLessShouldNotCompileForNonSmallIntegers [
 		
 	| result |
@@ -2370,7 +2372,7 @@ VMJittedGeneralPrimitiveTest >> testSmallIntegerLessShouldNotCompileForNonSmallI
 	self assert: result equals: UnimplementedPrimitive.
 ]
 
-{ #category : #'tests - support' }
+{ #category : 'tests - support' }
 VMJittedGeneralPrimitiveTest >> testSmallIntegerLessThanNonSmallIntegerArgumentDoesNotReturn [
 	
 	"If the argument is not an small integer, flow jumps and return does not (yet) happen"
@@ -2396,7 +2398,7 @@ VMJittedGeneralPrimitiveTest >> testSmallIntegerLessThanNonSmallIntegerArgumentD
 	self assert: machineSimulator arg0RegisterValue equals: self memory falseObject.
 ]
 
-{ #category : #'tests - support' }
+{ #category : 'tests - support' }
 VMJittedGeneralPrimitiveTest >> testSmallIntegerLessThanReturnsFalse [
 	
 	self compile: [ 
@@ -2418,7 +2420,7 @@ VMJittedGeneralPrimitiveTest >> testSmallIntegerLessThanReturnsFalse [
 	self assert: machineSimulator receiverRegisterValue equals: memory falseObject.
 ]
 
-{ #category : #'tests - support' }
+{ #category : 'tests - support' }
 VMJittedGeneralPrimitiveTest >> testSmallIntegerLessThanReturnsTrue [
 	
 	self compile: [ 

--- a/smalltalksrc/VMMakerTests/VMJittedLookupTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJittedLookupTest.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #VMJittedLookupTest,
-	#superclass : #VMSimpleStackBasedCogitAbstractTest,
+	#name : 'VMJittedLookupTest',
+	#superclass : 'VMSimpleStackBasedCogitAbstractTest',
 	#instVars : [
 		'methodOop',
 		'selectorOop',
 		'receiver',
 		'receiverClass'
 	],
-	#category : #'VMMakerTests-JitTests'
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMJittedLookupTest >> installSelector: aSelectorOop method: aMethodOop inMethodDictionary: aMethodDictionary [
 	
 	| anArrayOfMethods |
@@ -25,7 +27,7 @@ VMJittedLookupTest >> installSelector: aSelectorOop method: aMethodOop inMethodD
 		withValue: aMethodOop
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMJittedLookupTest >> setArrayClassIntoClassTable [
 	| aClass |
 	aClass := self
@@ -38,7 +40,7 @@ VMJittedLookupTest >> setArrayClassIntoClassTable [
 		withValue: aClass
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMJittedLookupTest >> setMessageClassIntoClassTable [
 	| aClass |
 	aClass := self
@@ -51,7 +53,7 @@ VMJittedLookupTest >> setMessageClassIntoClassTable [
 		withValue: aClass
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMJittedLookupTest >> setUpClassAndMethod [
 
 
@@ -63,7 +65,7 @@ VMJittedLookupTest >> setUpClassAndMethod [
 	receiverClass := self setSmallIntegerClassIntoClassTable
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMJittedLookupTest >> setUpMethodDictionaryIn: aClass [
 	"2 instances variables the array of methods and the tally
 	and 12 entries to put elemetns of the collection"
@@ -90,7 +92,7 @@ VMJittedLookupTest >> setUpMethodDictionaryIn: aClass [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMJittedLookupTest >> testLookUpMNUShouldJItCompile [
 
 	| superclass superclassMethodDictionary foundMethod |
@@ -123,7 +125,7 @@ VMJittedLookupTest >> testLookUpMNUShouldJItCompile [
 	self assert: foundMethod equals: methodOop
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMJittedLookupTest >> testLookUpMNUWithAnyNonMethodObjectShouldNotJItCompile [
 
 	| superclass superclassMethodDictionary foundMethod |

--- a/smalltalksrc/VMMakerTests/VMJittedPrimitiveAtPutTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJittedPrimitiveAtPutTest.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #VMJittedPrimitiveAtPutTest,
-	#superclass : #VMJittedPrimitivesTest,
+	#name : 'VMJittedPrimitiveAtPutTest',
+	#superclass : 'VMJittedPrimitivesTest',
 	#instVars : [
 		'stop'
 	],
-	#category : #'VMMakerTests-JitTests'
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 VMJittedPrimitiveAtPutTest >> setUp [
 
 	super setUp.
@@ -21,7 +23,7 @@ VMJittedPrimitiveAtPutTest >> setUp [
 		bytecodes: 10.
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMJittedPrimitiveAtPutTest >> setUpTrampolines [ 
 
 	super setUpTrampolines.
@@ -30,7 +32,7 @@ VMJittedPrimitiveAtPutTest >> setUpTrampolines [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMJittedPrimitiveAtPutTest >> testPrimitiveAtPut32bitIndexableWithLargeNumberShouldStoreValue [
 
 	| integerArray offset expectedValue |

--- a/smalltalksrc/VMMakerTests/VMJittedPrimitiveAtTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJittedPrimitiveAtTest.class.st
@@ -1,20 +1,22 @@
 Class {
-	#name : #VMJittedPrimitiveAtTest,
-	#superclass : #VMJittedPrimitivesTest,
+	#name : 'VMJittedPrimitiveAtTest',
+	#superclass : 'VMJittedPrimitivesTest',
 	#instVars : [
 		'stop'
 	],
-	#category : #'VMMakerTests-JitTests'
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMJittedPrimitiveAtTest >> assertFallsThrough [
 
 	self runFrom: cogInitialAddress until: stop address.
 	self assert: machineSimulator instructionPointerRegisterValue equals: stop address
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMJittedPrimitiveAtTest >> setUp [
 
 	super setUp.
@@ -25,7 +27,7 @@ VMJittedPrimitiveAtTest >> setUp [
 		bytecodes: 10.
 ]
 
-{ #category : #'tests - 16bit indexable' }
+{ #category : 'tests - 16bit indexable' }
 VMJittedPrimitiveAtTest >> testPrimitiveAt16bitIndexableFirstPaddingOutOfBoundsShouldFallThrough [
 
 	| integerArray offset |
@@ -41,7 +43,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAt16bitIndexableFirstPaddingOutOfBoundsS
 	self assertFallsThrough
 ]
 
-{ #category : #'tests - 16bit indexable' }
+{ #category : 'tests - 16bit indexable' }
 VMJittedPrimitiveAtTest >> testPrimitiveAt16bitIndexableOutOfBoundsShouldFallThrough [
 
 	| integerArray offset |
@@ -57,7 +59,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAt16bitIndexableOutOfBoundsShouldFallThr
 	self assertFallsThrough
 ]
 
-{ #category : #'tests - 16bit indexable' }
+{ #category : 'tests - 16bit indexable' }
 VMJittedPrimitiveAtTest >> testPrimitiveAt16bitIndexableSecondPaddingOutOfBoundsShouldFallThrough [
 
 	| integerArray offset |
@@ -73,7 +75,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAt16bitIndexableSecondPaddingOutOfBounds
 	self assertFallsThrough
 ]
 
-{ #category : #'tests - 16bit indexable' }
+{ #category : 'tests - 16bit indexable' }
 VMJittedPrimitiveAtTest >> testPrimitiveAt16bitIndexableShouldReturnValue [
 
 	| integerArray offset |
@@ -100,7 +102,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAt16bitIndexableShouldReturnValue [
 		equals: 17
 ]
 
-{ #category : #'tests - 16bit indexable' }
+{ #category : 'tests - 16bit indexable' }
 VMJittedPrimitiveAtTest >> testPrimitiveAt16bitIndexableThirdPaddingOutOfBoundsShouldFallThrough [
 
 	| integerArray offset |
@@ -116,7 +118,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAt16bitIndexableThirdPaddingOutOfBoundsS
 	self assertFallsThrough
 ]
 
-{ #category : #'tests - 16bit indexable' }
+{ #category : 'tests - 16bit indexable' }
 VMJittedPrimitiveAtTest >> testPrimitiveAt16bitIndexableWithLargeNumberShouldReturnValue [
 
 	| integerArray offset expectedValue |
@@ -142,7 +144,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAt16bitIndexableWithLargeNumberShouldRet
 		equals: expectedValue
 ]
 
-{ #category : #'tests - 32bit indexable' }
+{ #category : 'tests - 32bit indexable' }
 VMJittedPrimitiveAtTest >> testPrimitiveAt32bitIndexableOutOfBoundsAtPaddingShouldFallThrough [
 
 	| integerArray offset |
@@ -158,7 +160,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAt32bitIndexableOutOfBoundsAtPaddingShou
 	self assertFallsThrough
 ]
 
-{ #category : #'tests - 32bit indexable' }
+{ #category : 'tests - 32bit indexable' }
 VMJittedPrimitiveAtTest >> testPrimitiveAt32bitIndexableOutOfBoundsShouldFallThrough [
 
 	| integerArray offset |
@@ -174,7 +176,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAt32bitIndexableOutOfBoundsShouldFallThr
 	self assertFallsThrough
 ]
 
-{ #category : #'tests - 32bit indexable' }
+{ #category : 'tests - 32bit indexable' }
 VMJittedPrimitiveAtTest >> testPrimitiveAt32bitIndexableShouldReturnValue [
 
 	| integerArray offset |
@@ -199,7 +201,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAt32bitIndexableShouldReturnValue [
 		equals: 17
 ]
 
-{ #category : #'tests - 32bit indexable' }
+{ #category : 'tests - 32bit indexable' }
 VMJittedPrimitiveAtTest >> testPrimitiveAt32bitIndexableWithLargeNumberShouldReturnValue [
 
 	| integerArray offset expectedValue |
@@ -228,7 +230,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAt32bitIndexableWithLargeNumberShouldRet
 		equals: expectedValue
 ]
 
-{ #category : #'tests - 64bit indexable' }
+{ #category : 'tests - 64bit indexable' }
 VMJittedPrimitiveAtTest >> testPrimitiveAt64bitIndexableOutOfBoundsShouldFallThrough [
 
 	| integerArray offset |
@@ -244,7 +246,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAt64bitIndexableOutOfBoundsShouldFallThr
 	self assertFallsThrough
 ]
 
-{ #category : #'tests - 64bit indexable' }
+{ #category : 'tests - 64bit indexable' }
 VMJittedPrimitiveAtTest >> testPrimitiveAt64bitIndexableWithLargeIntegerIn32BitsShouldFallthrough [
 
 	| integerArray offset |
@@ -261,7 +263,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAt64bitIndexableWithLargeIntegerIn32Bits
 	self assertFallsThrough
 ]
 
-{ #category : #'tests - 64bit indexable' }
+{ #category : 'tests - 64bit indexable' }
 VMJittedPrimitiveAtTest >> testPrimitiveAt64bitIndexableWithLargeIntegerShouldReturnValue [
 
 	| integerArray offset |
@@ -288,7 +290,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAt64bitIndexableWithLargeIntegerShouldRe
 		equals: SmallInteger maxVal + 1
 ]
 
-{ #category : #'tests - 64bit indexable' }
+{ #category : 'tests - 64bit indexable' }
 VMJittedPrimitiveAtTest >> testPrimitiveAt64bitIndexableWithSmallIntegerShouldReturnValue [
 
 	| integerArray offset |
@@ -315,7 +317,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAt64bitIndexableWithSmallIntegerShouldRe
 		equals: (memory integerObjectOf: 17)
 ]
 
-{ #category : #'tests - 8bit indexable' }
+{ #category : 'tests - 8bit indexable' }
 VMJittedPrimitiveAtTest >> testPrimitiveAt8bitIndexableFifthPaddingOutOfBoundsShouldFallThrough [
 
 	| integerArray offset |
@@ -330,7 +332,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAt8bitIndexableFifthPaddingOutOfBoundsSh
 	self assertFallsThrough
 ]
 
-{ #category : #'tests - 8bit indexable' }
+{ #category : 'tests - 8bit indexable' }
 VMJittedPrimitiveAtTest >> testPrimitiveAt8bitIndexableFirstPaddingOutOfBoundsShouldFallThrough [
 
 	| integerArray offset |
@@ -345,7 +347,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAt8bitIndexableFirstPaddingOutOfBoundsSh
 	self assertFallsThrough
 ]
 
-{ #category : #'tests - 8bit indexable' }
+{ #category : 'tests - 8bit indexable' }
 VMJittedPrimitiveAtTest >> testPrimitiveAt8bitIndexableFourthPaddingOutOfBoundsShouldFallThrough [
 
 	| integerArray offset |
@@ -360,7 +362,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAt8bitIndexableFourthPaddingOutOfBoundsS
 	self assertFallsThrough
 ]
 
-{ #category : #'tests - 8bit indexable' }
+{ #category : 'tests - 8bit indexable' }
 VMJittedPrimitiveAtTest >> testPrimitiveAt8bitIndexableOutOfBoundsShouldFallThrough [
 
 	| integerArray offset |
@@ -375,7 +377,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAt8bitIndexableOutOfBoundsShouldFallThro
 	self assertFallsThrough
 ]
 
-{ #category : #'tests - 8bit indexable' }
+{ #category : 'tests - 8bit indexable' }
 VMJittedPrimitiveAtTest >> testPrimitiveAt8bitIndexableSecondPaddingOutOfBoundsShouldFallThrough [
 
 	| integerArray offset |
@@ -390,7 +392,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAt8bitIndexableSecondPaddingOutOfBoundsS
 	self assertFallsThrough
 ]
 
-{ #category : #'tests - 8bit indexable' }
+{ #category : 'tests - 8bit indexable' }
 VMJittedPrimitiveAtTest >> testPrimitiveAt8bitIndexableSeventhPaddingOutOfBoundsShouldFallThrough [
 
 	| integerArray offset |
@@ -405,7 +407,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAt8bitIndexableSeventhPaddingOutOfBounds
 	self assertFallsThrough
 ]
 
-{ #category : #'tests - 8bit indexable' }
+{ #category : 'tests - 8bit indexable' }
 VMJittedPrimitiveAtTest >> testPrimitiveAt8bitIndexableShouldReturnValue [
 
 	| integerArray offset |
@@ -431,7 +433,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAt8bitIndexableShouldReturnValue [
 		equals: 17
 ]
 
-{ #category : #'tests - 8bit indexable' }
+{ #category : 'tests - 8bit indexable' }
 VMJittedPrimitiveAtTest >> testPrimitiveAt8bitIndexableSixthPaddingOutOfBoundsShouldFallThrough [
 
 	| integerArray offset |
@@ -446,7 +448,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAt8bitIndexableSixthPaddingOutOfBoundsSh
 	self assertFallsThrough
 ]
 
-{ #category : #'tests - 8bit indexable' }
+{ #category : 'tests - 8bit indexable' }
 VMJittedPrimitiveAtTest >> testPrimitiveAt8bitIndexableThirdPaddingOutOfBoundsShouldFallThrough [
 
 	| integerArray offset |
@@ -461,7 +463,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAt8bitIndexableThirdPaddingOutOfBoundsSh
 	self assertFallsThrough
 ]
 
-{ #category : #'tests - 8bit indexable' }
+{ #category : 'tests - 8bit indexable' }
 VMJittedPrimitiveAtTest >> testPrimitiveAt8bitIndexableWithLargeNumberShouldReturnValue [
 
 	| integerArray offset expectedValue |
@@ -487,7 +489,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAt8bitIndexableWithLargeNumberShouldRetu
 		equals: expectedValue
 ]
 
-{ #category : #'tests - pointer indexable' }
+{ #category : 'tests - pointer indexable' }
 VMJittedPrimitiveAtTest >> testPrimitiveAtArrayOutOfBoundsShouldFallThrough [
 	
 	| offset array |
@@ -500,7 +502,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAtArrayOutOfBoundsShouldFallThrough [
 	self assertFallsThrough
 ]
 
-{ #category : #'tests - pointer indexable' }
+{ #category : 'tests - pointer indexable' }
 VMJittedPrimitiveAtTest >> testPrimitiveAtArrayShouldAccessValue [
 	
 	| offset array |
@@ -514,7 +516,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAtArrayShouldAccessValue [
 	self assert: machineSimulator receiverRegisterValue equals: memory falseObject
 ]
 
-{ #category : #'tests - fixed pointer layout' }
+{ #category : 'tests - fixed pointer layout' }
 VMJittedPrimitiveAtTest >> testPrimitiveAtFixedObjectWithInstanceVariablesShouldFallThrough [
 	
 	| objectWithInstanceVariables |
@@ -531,7 +533,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAtFixedObjectWithInstanceVariablesShould
 	self assertFallsThrough
 ]
 
-{ #category : #'tests - fixed pointer layout' }
+{ #category : 'tests - fixed pointer layout' }
 VMJittedPrimitiveAtTest >> testPrimitiveAtFixedObjectWithNoInstanceVariablesShouldFallThrough [
 	
 	| objectWithNoInstanceVariables |
@@ -546,7 +548,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAtFixedObjectWithNoInstanceVariablesShou
 	self assert: machineSimulator instructionPointerRegisterValue equals: stop address
 ]
 
-{ #category : #'tests - immediate' }
+{ #category : 'tests - immediate' }
 VMJittedPrimitiveAtTest >> testPrimitiveAtImmediateCharacterShouldFallThrough [
 	
 	machineSimulator receiverRegisterValue: (memory characterObjectOf: $a codePoint).
@@ -555,7 +557,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAtImmediateCharacterShouldFallThrough [
 	self assert: machineSimulator instructionPointerRegisterValue equals: stop address
 ]
 
-{ #category : #'tests - immediate' }
+{ #category : 'tests - immediate' }
 VMJittedPrimitiveAtTest >> testPrimitiveAtImmediateFloatShouldFallThrough [
 	
 	"Floats are not immediate in 32 bits"
@@ -567,7 +569,7 @@ VMJittedPrimitiveAtTest >> testPrimitiveAtImmediateFloatShouldFallThrough [
 	self assert: machineSimulator instructionPointerRegisterValue equals: stop address
 ]
 
-{ #category : #'tests - immediate' }
+{ #category : 'tests - immediate' }
 VMJittedPrimitiveAtTest >> testPrimitiveAtSmallIntegerShouldFallThrough [
 		
 	machineSimulator receiverRegisterValue: (memory integerObjectOf: 17).

--- a/smalltalksrc/VMMakerTests/VMJittedPrimitiveSizeTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJittedPrimitiveSizeTest.class.st
@@ -1,20 +1,22 @@
 Class {
-	#name : #VMJittedPrimitiveSizeTest,
-	#superclass : #VMJittedPrimitivesTest,
+	#name : 'VMJittedPrimitiveSizeTest',
+	#superclass : 'VMJittedPrimitivesTest',
 	#instVars : [
 		'stop'
 	],
-	#category : #'VMMakerTests-JitTests'
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMJittedPrimitiveSizeTest >> assertFallsThrough [
 
 	self runFrom: cogInitialAddress until: stop address.
 	self assert: machineSimulator instructionPointerRegisterValue equals: stop address
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMJittedPrimitiveSizeTest >> setUp [
 
 	super setUp.
@@ -25,7 +27,7 @@ VMJittedPrimitiveSizeTest >> setUp [
 		bytecodes: 10.
 ]
 
-{ #category : #'tests - bit indexable' }
+{ #category : 'tests - bit indexable' }
 VMJittedPrimitiveSizeTest >> testPrimitiveSize16bitIndexableShouldReturnNumberOf16bitSlots [
 
 	| integerArray |
@@ -41,7 +43,7 @@ VMJittedPrimitiveSizeTest >> testPrimitiveSize16bitIndexableShouldReturnNumberOf
 		equals: 7
 ]
 
-{ #category : #'tests - bit indexable' }
+{ #category : 'tests - bit indexable' }
 VMJittedPrimitiveSizeTest >> testPrimitiveSize32bitIndexableShouldReturnNumberOf32bitSlots [
 
 	| integerArray |
@@ -57,7 +59,7 @@ VMJittedPrimitiveSizeTest >> testPrimitiveSize32bitIndexableShouldReturnNumberOf
 		equals: 7
 ]
 
-{ #category : #'tests - bit indexable' }
+{ #category : 'tests - bit indexable' }
 VMJittedPrimitiveSizeTest >> testPrimitiveSize32bitIndexableWithExtraHeaderShouldReturnNumberOf32bitSlots [
 
 	| integerArray aSize bytesPerSlot desiredByteSize numberOfWordSizeSlots padding |
@@ -83,7 +85,7 @@ VMJittedPrimitiveSizeTest >> testPrimitiveSize32bitIndexableWithExtraHeaderShoul
 		equals: 32768
 ]
 
-{ #category : #'tests - bit indexable' }
+{ #category : 'tests - bit indexable' }
 VMJittedPrimitiveSizeTest >> testPrimitiveSize64bitIndexableShouldReturnNumberOf64bitSlots [
 
 	| integerArray |
@@ -99,7 +101,7 @@ VMJittedPrimitiveSizeTest >> testPrimitiveSize64bitIndexableShouldReturnNumberOf
 		equals: 7
 ]
 
-{ #category : #'tests - bit indexable' }
+{ #category : 'tests - bit indexable' }
 VMJittedPrimitiveSizeTest >> testPrimitiveSize8bitIndexableShouldReturnNumberOf8bitSlots [
 
 	| integerArray |
@@ -115,7 +117,7 @@ VMJittedPrimitiveSizeTest >> testPrimitiveSize8bitIndexableShouldReturnNumberOf8
 		equals: 7
 ]
 
-{ #category : #'tests - pointer indexable' }
+{ #category : 'tests - pointer indexable' }
 VMJittedPrimitiveSizeTest >> testPrimitiveSizeArrayShouldReturnPointerSizedSlots [
 	
 	| array |
@@ -129,7 +131,7 @@ VMJittedPrimitiveSizeTest >> testPrimitiveSizeArrayShouldReturnPointerSizedSlots
 	self assert: machineSimulator receiverRegisterValue equals: (memory integerObjectOf: 7)
 ]
 
-{ #category : #'tests - fixed pointer layout' }
+{ #category : 'tests - fixed pointer layout' }
 VMJittedPrimitiveSizeTest >> testPrimitiveSizeFixedObjectShouldFallThrough [
 	
 	| objectWithInstanceVariables |
@@ -144,7 +146,7 @@ VMJittedPrimitiveSizeTest >> testPrimitiveSizeFixedObjectShouldFallThrough [
 	self assertFallsThrough
 ]
 
-{ #category : #'tests - fixed pointer layout' }
+{ #category : 'tests - fixed pointer layout' }
 VMJittedPrimitiveSizeTest >> testPrimitiveSizeImmediateCharacterShouldFallThrough [
 	
 	self prepareStackForSendReceiver: (memory characterObjectOf: $a codePoint).
@@ -152,7 +154,7 @@ VMJittedPrimitiveSizeTest >> testPrimitiveSizeImmediateCharacterShouldFallThroug
 	self assertFallsThrough
 ]
 
-{ #category : #'tests - fixed pointer layout' }
+{ #category : 'tests - fixed pointer layout' }
 VMJittedPrimitiveSizeTest >> testPrimitiveSizeImmediateFloatShouldFallThrough [
 
 	"Floats are not immediate in 32 bits"
@@ -163,7 +165,7 @@ VMJittedPrimitiveSizeTest >> testPrimitiveSizeImmediateFloatShouldFallThrough [
 	self assertFallsThrough
 ]
 
-{ #category : #'tests - fixed pointer layout' }
+{ #category : 'tests - fixed pointer layout' }
 VMJittedPrimitiveSizeTest >> testPrimitiveSizeImmediateIntegerShouldFallThrough [
 	
 	self prepareStackForSendReceiver: (memory integerObjectOf: 17).

--- a/smalltalksrc/VMMakerTests/VMJittedPrimitivesTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJittedPrimitivesTest.class.st
@@ -1,21 +1,23 @@
 Class {
-	#name : #VMJittedPrimitivesTest,
-	#superclass : #VMSimpleStackBasedCogitAbstractTest,
+	#name : 'VMJittedPrimitivesTest',
+	#superclass : 'VMSimpleStackBasedCogitAbstractTest',
 	#instVars : [
 		'classFloat'
 	],
 	#pools : [
 		'CogRTLOpcodes'
 	],
-	#category : #'VMMakerTests-JitTests'
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #private }
+{ #category : 'private' }
 VMJittedPrimitivesTest class >> isAbstract [
 	^ self == VMJittedPrimitivesTest
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMJittedPrimitivesTest >> executePrimitiveWithReceiver: receiverOop [
 	
 	"Simulate a primitive execution having an object as receiver and a single argument
@@ -28,7 +30,7 @@ VMJittedPrimitivesTest >> executePrimitiveWithReceiver: receiverOop [
 
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMJittedPrimitivesTest >> executePrimitiveWithReceiver: receiverOop withArgument: argumentOop [
 	
 	"Simulate a primitive execution having an object as receiver and a single argument
@@ -41,7 +43,7 @@ VMJittedPrimitivesTest >> executePrimitiveWithReceiver: receiverOop withArgument
 
 ]
 
-{ #category : #utils }
+{ #category : 'utils' }
 VMJittedPrimitivesTest >> executePrimitiveWithReceiver: receiverOop withArgument: firstArgumentOop and: secondArgumentOop [ 
 
 	"Simulate a primitive execution having an object as receiver and a single argument
@@ -54,13 +56,13 @@ VMJittedPrimitivesTest >> executePrimitiveWithReceiver: receiverOop withArgument
 	self runUntilReturn
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMJittedPrimitivesTest >> prepareStackForSendReceiver: aReceiver [
 
 	self prepareStackForSendReceiver: aReceiver arguments: #()
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMJittedPrimitivesTest >> setUp [
 
 	super setUp.

--- a/smalltalksrc/VMMakerTests/VMJittedSmallFloatPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJittedSmallFloatPrimitiveTest.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #VMJittedSmallFloatPrimitiveTest,
-	#superclass : #VMJittedPrimitivesTest,
+	#name : 'VMJittedSmallFloatPrimitiveTest',
+	#superclass : 'VMJittedPrimitivesTest',
 	#pools : [
 		'CogRTLOpcodes'
 	],
-	#category : #'VMMakerTests-JitTests'
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #'building suites' }
+{ #category : 'building suites' }
 VMJittedSmallFloatPrimitiveTest class >> wordSizeParameters [
 
 	"SmallFloats only exist in 64bits systems"
@@ -15,7 +17,7 @@ VMJittedSmallFloatPrimitiveTest class >> wordSizeParameters [
 	^ self wordSize64Parameters
 ]
 
-{ #category : #'tests - primitiveAdd' }
+{ #category : 'tests - primitiveAdd' }
 VMJittedSmallFloatPrimitiveTest >> testPrimitiveAddTwoSmallFloatsReturnsASmallFloat [
 	
 	cogit receiverTags: memory smallFloatTag.
@@ -29,7 +31,7 @@ VMJittedSmallFloatPrimitiveTest >> testPrimitiveAddTwoSmallFloatsReturnsASmallFl
 	self assert: machineSimulator receiverRegisterValue equals: (self memory floatObjectOf: 3.0)
 ]
 
-{ #category : #'tests - primitiveDivide' }
+{ #category : 'tests - primitiveDivide' }
 VMJittedSmallFloatPrimitiveTest >> testPrimitiveDivideTwoSmallFloatsReturnsASmallFloat [
 	
 	cogit receiverTags: memory smallFloatTag.
@@ -45,7 +47,7 @@ VMJittedSmallFloatPrimitiveTest >> testPrimitiveDivideTwoSmallFloatsReturnsASmal
 		equals: 0.5
 ]
 
-{ #category : #'tests - primitiveEquals' }
+{ #category : 'tests - primitiveEquals' }
 VMJittedSmallFloatPrimitiveTest >> testPrimitiveEqualTwoSmallFloatsReturnsFalse [
 	
 	cogit receiverTags: memory smallFloatTag.
@@ -61,7 +63,7 @@ VMJittedSmallFloatPrimitiveTest >> testPrimitiveEqualTwoSmallFloatsReturnsFalse 
 		equals: memory falseObject
 ]
 
-{ #category : #'tests - primitiveEquals' }
+{ #category : 'tests - primitiveEquals' }
 VMJittedSmallFloatPrimitiveTest >> testPrimitiveEqualTwoSmallFloatsReturnsTrue [
 	
 	cogit receiverTags: memory smallFloatTag.
@@ -77,7 +79,7 @@ VMJittedSmallFloatPrimitiveTest >> testPrimitiveEqualTwoSmallFloatsReturnsTrue [
 		equals: memory trueObject
 ]
 
-{ #category : #'tests - primitiveGreaterThan' }
+{ #category : 'tests - primitiveGreaterThan' }
 VMJittedSmallFloatPrimitiveTest >> testPrimitiveGreaterOrEqualTwoSmallFloatsReturnsFalseWhenLower [
 	
 	cogit receiverTags: memory smallFloatTag.
@@ -93,7 +95,7 @@ VMJittedSmallFloatPrimitiveTest >> testPrimitiveGreaterOrEqualTwoSmallFloatsRetu
 		equals: memory falseObject
 ]
 
-{ #category : #'tests - primitiveGreaterThan' }
+{ #category : 'tests - primitiveGreaterThan' }
 VMJittedSmallFloatPrimitiveTest >> testPrimitiveGreaterOrEqualTwoSmallFloatsReturnsTrueWhenEquals [
 	
 	cogit receiverTags: memory smallFloatTag.
@@ -109,7 +111,7 @@ VMJittedSmallFloatPrimitiveTest >> testPrimitiveGreaterOrEqualTwoSmallFloatsRetu
 		equals: memory trueObject
 ]
 
-{ #category : #'tests - primitiveGreaterThan' }
+{ #category : 'tests - primitiveGreaterThan' }
 VMJittedSmallFloatPrimitiveTest >> testPrimitiveGreaterOrEqualTwoSmallFloatsReturnsTrueWhenGreater [
 	
 	cogit receiverTags: memory smallFloatTag.
@@ -125,7 +127,7 @@ VMJittedSmallFloatPrimitiveTest >> testPrimitiveGreaterOrEqualTwoSmallFloatsRetu
 		equals: memory trueObject
 ]
 
-{ #category : #'tests - primitiveGreaterThan' }
+{ #category : 'tests - primitiveGreaterThan' }
 VMJittedSmallFloatPrimitiveTest >> testPrimitiveGreaterThanTwoSmallFloatsReturnsFalseWhenEqual [
 	
 	cogit receiverTags: memory smallFloatTag.
@@ -141,7 +143,7 @@ VMJittedSmallFloatPrimitiveTest >> testPrimitiveGreaterThanTwoSmallFloatsReturns
 		equals: memory falseObject
 ]
 
-{ #category : #'tests - primitiveGreaterThan' }
+{ #category : 'tests - primitiveGreaterThan' }
 VMJittedSmallFloatPrimitiveTest >> testPrimitiveGreaterThanTwoSmallFloatsReturnsFalseWhenLower [
 	
 	cogit receiverTags: memory smallFloatTag.
@@ -157,7 +159,7 @@ VMJittedSmallFloatPrimitiveTest >> testPrimitiveGreaterThanTwoSmallFloatsReturns
 		equals: memory falseObject
 ]
 
-{ #category : #'tests - primitiveGreaterThan' }
+{ #category : 'tests - primitiveGreaterThan' }
 VMJittedSmallFloatPrimitiveTest >> testPrimitiveGreaterThanTwoSmallFloatsReturnsTrueWhenGreater [
 	
 	cogit receiverTags: memory smallFloatTag.
@@ -173,7 +175,7 @@ VMJittedSmallFloatPrimitiveTest >> testPrimitiveGreaterThanTwoSmallFloatsReturns
 		equals: memory trueObject
 ]
 
-{ #category : #'tests - primitiveLessThan' }
+{ #category : 'tests - primitiveLessThan' }
 VMJittedSmallFloatPrimitiveTest >> testPrimitiveLessOrEqualTwoSmallFloatsReturnsFalseWhenGreater [
 	
 	cogit receiverTags: memory smallFloatTag.
@@ -189,7 +191,7 @@ VMJittedSmallFloatPrimitiveTest >> testPrimitiveLessOrEqualTwoSmallFloatsReturns
 		equals: memory falseObject
 ]
 
-{ #category : #'tests - primitiveLessThan' }
+{ #category : 'tests - primitiveLessThan' }
 VMJittedSmallFloatPrimitiveTest >> testPrimitiveLessOrEqualTwoSmallFloatsReturnsTrueWhenEquals [
 	
 	cogit receiverTags: memory smallFloatTag.
@@ -205,7 +207,7 @@ VMJittedSmallFloatPrimitiveTest >> testPrimitiveLessOrEqualTwoSmallFloatsReturns
 		equals: memory trueObject
 ]
 
-{ #category : #'tests - primitiveLessThan' }
+{ #category : 'tests - primitiveLessThan' }
 VMJittedSmallFloatPrimitiveTest >> testPrimitiveLessOrEqualTwoSmallFloatsReturnsTrueWhenLower [
 	
 	cogit receiverTags: memory smallFloatTag.
@@ -221,7 +223,7 @@ VMJittedSmallFloatPrimitiveTest >> testPrimitiveLessOrEqualTwoSmallFloatsReturns
 		equals: memory trueObject
 ]
 
-{ #category : #'tests - primitiveLessThan' }
+{ #category : 'tests - primitiveLessThan' }
 VMJittedSmallFloatPrimitiveTest >> testPrimitiveLessThanTwoSmallFloatsReturnsFalseWhenEquals [
 	
 	cogit receiverTags: memory smallFloatTag.
@@ -237,7 +239,7 @@ VMJittedSmallFloatPrimitiveTest >> testPrimitiveLessThanTwoSmallFloatsReturnsFal
 		equals: memory falseObject
 ]
 
-{ #category : #'tests - primitiveLessThan' }
+{ #category : 'tests - primitiveLessThan' }
 VMJittedSmallFloatPrimitiveTest >> testPrimitiveLessThanTwoSmallFloatsReturnsFalseWhenGreater [
 	
 	cogit receiverTags: memory smallFloatTag.
@@ -253,7 +255,7 @@ VMJittedSmallFloatPrimitiveTest >> testPrimitiveLessThanTwoSmallFloatsReturnsFal
 		equals: memory falseObject
 ]
 
-{ #category : #'tests - primitiveLessThan' }
+{ #category : 'tests - primitiveLessThan' }
 VMJittedSmallFloatPrimitiveTest >> testPrimitiveLessThanTwoSmallFloatsReturnsTrueWhenLower [
 	
 	cogit receiverTags: memory smallFloatTag.
@@ -269,7 +271,7 @@ VMJittedSmallFloatPrimitiveTest >> testPrimitiveLessThanTwoSmallFloatsReturnsTru
 		equals: memory trueObject
 ]
 
-{ #category : #'tests - primitiveMultiply' }
+{ #category : 'tests - primitiveMultiply' }
 VMJittedSmallFloatPrimitiveTest >> testPrimitiveMultiplyTwoSmallFloatsReturnsASmallFloat [
 	
 	cogit receiverTags: memory smallFloatTag.
@@ -285,7 +287,7 @@ VMJittedSmallFloatPrimitiveTest >> testPrimitiveMultiplyTwoSmallFloatsReturnsASm
 		equals: 6.0
 ]
 
-{ #category : #'tests - primitiveEquals' }
+{ #category : 'tests - primitiveEquals' }
 VMJittedSmallFloatPrimitiveTest >> testPrimitiveNotEqualTwoSmallFloatsReturnsFalse [
 	
 	cogit receiverTags: memory smallFloatTag.
@@ -301,7 +303,7 @@ VMJittedSmallFloatPrimitiveTest >> testPrimitiveNotEqualTwoSmallFloatsReturnsFal
 		equals: memory falseObject
 ]
 
-{ #category : #'tests - primitiveEquals' }
+{ #category : 'tests - primitiveEquals' }
 VMJittedSmallFloatPrimitiveTest >> testPrimitiveNotEqualTwoSmallFloatsReturnsTrue [
 	
 	cogit receiverTags: memory smallFloatTag.
@@ -317,7 +319,7 @@ VMJittedSmallFloatPrimitiveTest >> testPrimitiveNotEqualTwoSmallFloatsReturnsTru
 		equals: memory trueObject
 ]
 
-{ #category : #'tests - primitiveSquareRoot' }
+{ #category : 'tests - primitiveSquareRoot' }
 VMJittedSmallFloatPrimitiveTest >> testPrimitiveSquareRootASmallFloatsReturnsASmallFloat [
 	
 	cogit receiverTags: memory smallFloatTag.
@@ -332,7 +334,7 @@ VMJittedSmallFloatPrimitiveTest >> testPrimitiveSquareRootASmallFloatsReturnsASm
 		equals: 2.0 sqrt
 ]
 
-{ #category : #'tests - primitiveSubtract' }
+{ #category : 'tests - primitiveSubtract' }
 VMJittedSmallFloatPrimitiveTest >> testPrimitiveSubtractTwoSmallFloatsReturnsASmallFloat [
 	
 	cogit receiverTags: memory smallFloatTag.

--- a/smalltalksrc/VMMakerTests/VMLiterRulesTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMLiterRulesTest.class.st
@@ -1,10 +1,11 @@
 Class {
-	#name : #VMLiterRulesTest,
-	#superclass : #TestCase,
-	#category : #VMMakerTests
+	#name : 'VMLiterRulesTest',
+	#superclass : 'TestCase',
+	#category : 'VMMakerTests',
+	#package : 'VMMakerTests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMLiterRulesTest >> testSlangRedundantTypeDeclaration [
 
 	| ast |
@@ -20,7 +21,7 @@ VMLiterRulesTest >> testSlangRedundantTypeDeclaration [
 			 ast pragmas first).
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMLiterRulesTest >> testSlangTypeDeclarationForArgument [
 
 	| ast |
@@ -31,7 +32,7 @@ VMLiterRulesTest >> testSlangTypeDeclarationForArgument [
 			 ast pragmas first)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMLiterRulesTest >> testSlangTypeDeclarationForVariable [
 
 	| ast |

--- a/smalltalksrc/VMMakerTests/VMLookUpTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMLookUpTest.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #VMLookUpTest,
-	#superclass : #VMInterpreterTests,
+	#name : 'VMLookUpTest',
+	#superclass : 'VMInterpreterTests',
 	#instVars : [
 		'methodOop',
 		'selectorOop',
@@ -14,10 +14,12 @@ Class {
 		'VMBasicConstants',
 		'VMBytecodeConstants'
 	],
-	#category : #'VMMakerTests-InterpreterTests'
+	#category : 'VMMakerTests-InterpreterTests',
+	#package : 'VMMakerTests',
+	#tag : 'InterpreterTests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMLookUpTest class >> testParameters [
 
 	^ super testParameters * (ParametrizedTestMatrix new
@@ -26,7 +28,7 @@ VMLookUpTest class >> testParameters [
 		   yourself)
 ]
 
-{ #category : #assertions }
+{ #category : 'assertions' }
 VMLookUpTest >> assertNonForwardedSelectorsIn: aMethodDictionary [
 
 	| length |
@@ -37,19 +39,19 @@ VMLookUpTest >> assertNonForwardedSelectorsIn: aMethodDictionary [
 		self deny: (memory isForwarded: selector) ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMLookUpTest >> linearSearchLimit [
 
 	^ linearSearchLimit
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMLookUpTest >> linearSearchLimit: anObject [
 
 	linearSearchLimit := anObject
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMLookUpTest >> setArrayClassIntoClassTable [
 	| aClass |
 	aClass := self
@@ -62,7 +64,7 @@ VMLookUpTest >> setArrayClassIntoClassTable [
 		withValue: aClass
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMLookUpTest >> setMessageClassIntoClassTable [
 	| aClass |
 	aClass := self
@@ -75,7 +77,7 @@ VMLookUpTest >> setMessageClassIntoClassTable [
 		withValue: aClass
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMLookUpTest >> setUp [
 
 	"taken from VMSimpleStackBasedCogitBytecodeTest >> #setup"
@@ -131,7 +133,7 @@ VMLookUpTest >> setUp [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMLookUpTest >> setUpClassAndMethod [
 
 
@@ -143,7 +145,7 @@ VMLookUpTest >> setUpClassAndMethod [
 	receiverClass := self setSmallIntegerClassIntoClassTable
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMLookUpTest >> testInstallSmallIntegerClassIntoClassTable [
 	"We set a smallInteger class into the classTable"
 
@@ -153,7 +155,7 @@ VMLookUpTest >> testInstallSmallIntegerClassIntoClassTable [
 		equals: receiverClass
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMLookUpTest >> testLookUpFindsForwardedMethod [
 
 	| aMethodDictionary |
@@ -169,7 +171,7 @@ VMLookUpTest >> testLookUpFindsForwardedMethod [
 	self assert: interpreter newMethod equals: methodOop.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMLookUpTest >> testLookUpFindsMethodInClass [
 	
 	| aMethodDictionary |
@@ -184,7 +186,7 @@ VMLookUpTest >> testLookUpFindsMethodInClass [
 	self assert: interpreter newMethod equals: methodOop
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMLookUpTest >> testLookUpFindsMethodInSuperclass [
 
 	| superclass superclassMethodDictionary |
@@ -209,7 +211,7 @@ VMLookUpTest >> testLookUpFindsMethodInSuperclass [
 	self assert: interpreter newMethod equals: methodOop
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMLookUpTest >> testLookUpFindsMethodWithForwardedSelector [
 
 	| aMethodDictionary |
@@ -226,7 +228,7 @@ VMLookUpTest >> testLookUpFindsMethodWithForwardedSelector [
 	self assertNonForwardedSelectorsIn: aMethodDictionary
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMLookUpTest >> testLookUpInDefiningClassCreatesANewEntryInCache [
 
 	| aMethodDictionary |
@@ -241,7 +243,7 @@ VMLookUpTest >> testLookUpInDefiningClassCreatesANewEntryInCache [
 	self assert: (interpreter lookupInMethodCacheSel: selectorOop classTag:memory smallIntegerTag).
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMLookUpTest >> testLookUpInFindsCannotInterpretCreatesANewEntryInCache [
 
 	| nonExistingSelector cannotInterpretMethodOop cannotInterpretSelectorOop superclass superclassMethodDictionary |
@@ -283,7 +285,7 @@ VMLookUpTest >> testLookUpInFindsCannotInterpretCreatesANewEntryInCache [
 			 classTag: memory smallIntegerTag)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMLookUpTest >> testLookUpInFindsDNUCreatesANewEntryInCache [
 
 	| nonExistingSelector dnuMethodOop dnuSelectorOop aMethodDictionary |
@@ -319,7 +321,7 @@ VMLookUpTest >> testLookUpInFindsDNUCreatesANewEntryInCache [
 			 classTag: memory smallIntegerTag)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMLookUpTest >> testLookUpInSuperclassCreatesANewEntryInCache [
 
 	| superclass superclassMethodDictionary |
@@ -341,7 +343,7 @@ VMLookUpTest >> testLookUpInSuperclassCreatesANewEntryInCache [
 	self assert: (interpreter lookupInMethodCacheSel: selectorOop classTag:memory smallIntegerTag).
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMLookUpTest >> testLookUpNonExistingCannotInterpretAnswersDNUMethod [
 
 	| nonExistingSelector superclass superclassMethodDictionary dnuMethodOop dnuSelectorOop |
@@ -379,7 +381,7 @@ VMLookUpTest >> testLookUpNonExistingCannotInterpretAnswersDNUMethod [
 	self assert: interpreter newMethod equals: dnuMethodOop
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMLookUpTest >> testLookUpNonExistingDNUThrowsRecursivelyDoesNotUnderstand [
 
 	| nonExistingSelector aMethodDictionary |
@@ -400,7 +402,7 @@ VMLookUpTest >> testLookUpNonExistingDNUThrowsRecursivelyDoesNotUnderstand [
 	self should: [interpreter lookupMethodInClass: receiverClass] raise: Error.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMLookUpTest >> testLookUpNonExistingSelectorAnswersDNUMethod [
 
 	| nonExistingSelector dnuMethodOop dnuSelectorOop aMethodDictionary |
@@ -434,7 +436,7 @@ VMLookUpTest >> testLookUpNonExistingSelectorAnswersDNUMethod [
 	self assert: interpreter newMethod equals: dnuMethodOop
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMLookUpTest >> testLookUpWithNilMethodDictionaryAndNilSuperclassFails [
 	"There is no superclass, so no cannotInterpret: to call"
 
@@ -456,7 +458,7 @@ VMLookUpTest >> testLookUpWithNilMethodDictionaryAndNilSuperclassFails [
 	self should: [ interpreter lookupMethodInClass: receiverClass ] raise: Error
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMLookUpTest >> testLookUpWithNilMethodDictionaryAndNoCannotInterpretAnswersDNUMethod [
 	"Class has a nil methodDictionary, so `cannotInterpret:` is send.
 	But superclass does not understand it, so `doesNotUnderstand:` is called instead."
@@ -502,7 +504,7 @@ VMLookUpTest >> testLookUpWithNilMethodDictionaryAndNoCannotInterpretAnswersDNUM
 	self assert: interpreter newMethod equals: dnuMethodOop
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMLookUpTest >> testLookUpWithNilMethodDictionaryFindsCannotInterpret [
 
 	| nonExistingSelector cannotInterpretMethodOop cannotInterpretSelectorOop superclass superclassMethodDictionary |
@@ -542,7 +544,7 @@ VMLookUpTest >> testLookUpWithNilMethodDictionaryFindsCannotInterpret [
 	self assert: interpreter newMethod equals: cannotInterpretMethodOop
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMLookUpTest >> testPrimitivePerformCreatesCorrectFrame [
 	| aMethodDictionary receiverOop frame |	
 	"Primitive perform sets everything up (frame, instruction pointer..) so next interpret loop will execute the first bytecode."
@@ -567,7 +569,7 @@ VMLookUpTest >> testPrimitivePerformCreatesCorrectFrame [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMLookUpTest >> testPrimitivePerformExecutes [
 	| aMethodDictionary receiverOop |
 	self setUpClassAndMethod.	
@@ -585,7 +587,7 @@ VMLookUpTest >> testPrimitivePerformExecutes [
 	self assert: interpreter stackTop equals: receiverOop
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMLookUpTest >> testPrimitivePerformFindsMethodOop [
 	| aMethodDictionary receiverOop |
 	self setUpClassAndMethod.	
@@ -606,7 +608,7 @@ VMLookUpTest >> testPrimitivePerformFindsMethodOop [
 	"(1) the Instruction Pointer is set to be just before the bytecode to execute, so fetchNextBytecode will fetch the first bytecode ( #justActivateNewMethod: )"
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMLookUpTest >> testPrimitivePerformSetsIPBeforeFirstBytecode [
 	| aMethodDictionary receiverOop |	
 	"Primitive perform sets everything up (frame, instruction pointer..) so next interpret loop will execute the first bytecode."

--- a/smalltalksrc/VMMakerTests/VMMASTTranslationTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMMASTTranslationTest.class.st
@@ -1,46 +1,47 @@
 Class {
-	#name : #VMMASTTranslationTest,
-	#superclass : #TestCase,
-	#category : #VMMakerTests
+	#name : 'VMMASTTranslationTest',
+	#superclass : 'TestCase',
+	#category : 'VMMakerTests',
+	#package : 'VMMakerTests'
 }
 
-{ #category : #'generation-targets' }
+{ #category : 'generation-targets' }
 VMMASTTranslationTest >> + arg [
 ]
 
-{ #category : #'generation-targets' }
+{ #category : 'generation-targets' }
 VMMASTTranslationTest >> emptyBlockHasSingleNilStatement [
 
 	[  ] value
 ]
 
-{ #category : #'generation-targets' }
+{ #category : 'generation-targets' }
 VMMASTTranslationTest >> inlineMethodWithLoop [
 
 	self methodWithLoop
 ]
 
-{ #category : #'generation-targets' }
+{ #category : 'generation-targets' }
 VMMASTTranslationTest >> inlineSecondLevelMethodWithLoop [
 
 	self inlineMethodWithLoop
 ]
 
-{ #category : #'generation-targets' }
+{ #category : 'generation-targets' }
 VMMASTTranslationTest >> inlineTwiceMethodWithLoop [
 
 	self methodWithLoop.
 	self methodWithLoop
 ]
 
-{ #category : #'generation-targets' }
+{ #category : 'generation-targets' }
 VMMASTTranslationTest >> inlineTwiceSecondLevelMethodWithLoop [
 
 	self inlineMethodWithLoop.
 	self inlineMethodWithLoop
 ]
 
-{ #category : #'generation-targets' }
+{ #category : 'generation-targets' }
 VMMASTTranslationTest >> inlinedMethodWithLocalWithSameName [
 
 	<inline:true>
@@ -50,17 +51,17 @@ VMMASTTranslationTest >> inlinedMethodWithLocalWithSameName [
 
 ]
 
-{ #category : #'generation-targets' }
+{ #category : 'generation-targets' }
 VMMASTTranslationTest >> methodWithArgument: anArgument [
 ]
 
-{ #category : #'generation-targets' }
+{ #category : 'generation-targets' }
 VMMASTTranslationTest >> methodWithExpressionInLoopCondition [
 
 	1 to: self something - 10 do: [ :i | self foo: i ]
 ]
 
-{ #category : #'generation-targets' }
+{ #category : 'generation-targets' }
 VMMASTTranslationTest >> methodWithIfNil [
 
 	self something
@@ -68,7 +69,7 @@ VMMASTTranslationTest >> methodWithIfNil [
 		ifNotNil: [ 2 ]
 ]
 
-{ #category : #'generation-targets' }
+{ #category : 'generation-targets' }
 VMMASTTranslationTest >> methodWithIfNilIfNotNil [
 
 	self something
@@ -77,7 +78,7 @@ VMMASTTranslationTest >> methodWithIfNilIfNotNil [
 
 ]
 
-{ #category : #'generation-targets' }
+{ #category : 'generation-targets' }
 VMMASTTranslationTest >> methodWithIfNilIfNotNilWithArgument [
 
 	self something
@@ -85,7 +86,7 @@ VMMASTTranslationTest >> methodWithIfNilIfNotNilWithArgument [
 		ifNotNil: [ :soSomething | self lala: soSomething ]
 ]
 
-{ #category : #'generation-targets' }
+{ #category : 'generation-targets' }
 VMMASTTranslationTest >> methodWithIfNotNilIfNil [
 
 	self something
@@ -93,7 +94,7 @@ VMMASTTranslationTest >> methodWithIfNotNilIfNil [
 		ifNil: [ 2 ]
 ]
 
-{ #category : #'generation-targets' }
+{ #category : 'generation-targets' }
 VMMASTTranslationTest >> methodWithIfNotNilIfNilWithArgument [
 
 	self something
@@ -101,14 +102,14 @@ VMMASTTranslationTest >> methodWithIfNotNilIfNilWithArgument [
 		ifNil: [ ]
 ]
 
-{ #category : #'generation-targets' }
+{ #category : 'generation-targets' }
 VMMASTTranslationTest >> methodWithIfNotNilWithArgument [
 
 	self something ifNotNil: [ :soSomething |
 		self lala: soSomething ]
 ]
 
-{ #category : #'generation-targets' }
+{ #category : 'generation-targets' }
 VMMASTTranslationTest >> methodWithLocalVarAndAndInlinedMethod [
 
 	<var: 'cond' type: 'pthread_cond_t'>
@@ -117,17 +118,17 @@ VMMASTTranslationTest >> methodWithLocalVarAndAndInlinedMethod [
 	self inlinedMethodWithLocalWithSameName.
 ]
 
-{ #category : #'generation-targets' }
+{ #category : 'generation-targets' }
 VMMASTTranslationTest >> methodWithLoop [
 
 	1 to: 10 do: [ :i | self foo: i ]
 ]
 
-{ #category : #'generation-targets' }
+{ #category : 'generation-targets' }
 VMMASTTranslationTest >> methodWithNoArguments [
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMMASTTranslationTest >> testArgumentIsNoTemp [
 
 	| translation method |
@@ -137,7 +138,7 @@ VMMASTTranslationTest >> testArgumentIsNoTemp [
 	self deny: (translation locals includes: method methodNode arguments first name)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMMASTTranslationTest >> testComplexIfNilIfNotNilWithArgument [
 
 	| translation method codeGenerator assignment conditional condition |
@@ -174,7 +175,7 @@ VMMASTTranslationTest >> testComplexIfNilIfNotNilWithArgument [
 	self assert: condition arguments first name equals: 'nil'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMMASTTranslationTest >> testComplexIfNotNilIfNilWithArgument [
 
 	| translation method codeGenerator assignment conditional condition |
@@ -211,7 +212,7 @@ VMMASTTranslationTest >> testComplexIfNotNilIfNilWithArgument [
 	self assert: condition arguments first name equals: 'nil'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMMASTTranslationTest >> testComplexIfNotNilWithArgument [
 
 	| translation method codeGenerator assignment conditional condition |
@@ -243,7 +244,7 @@ VMMASTTranslationTest >> testComplexIfNotNilWithArgument [
 	self assert: condition arguments first name equals: 'nil'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMMASTTranslationTest >> testEmptyBlockGeneratesSingleNilStatement [
 
 	| translation method codeGenerator block |
@@ -259,7 +260,7 @@ VMMASTTranslationTest >> testEmptyBlockGeneratesSingleNilStatement [
 	self assert: block statements first value equals: nil
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMMASTTranslationTest >> testIfNilIfNotNilBecomesIfTrueIfFalse [
 
 	| translation |
@@ -268,7 +269,7 @@ VMMASTTranslationTest >> testIfNilIfNotNilBecomesIfTrueIfFalse [
 	self assert: translation statements first selector equals: #ifTrue:ifFalse:
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMMASTTranslationTest >> testIfNilIfNotNilDoesNotInvertBlocks [
 
 	| translation |
@@ -288,7 +289,7 @@ VMMASTTranslationTest >> testIfNilIfNotNilDoesNotInvertBlocks [
 		equals: 2
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMMASTTranslationTest >> testIfNotNilIfNilInversesBlocks [
 
 	| translation |
@@ -308,7 +309,7 @@ VMMASTTranslationTest >> testIfNotNilIfNilInversesBlocks [
 		equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMMASTTranslationTest >> testInlineMethodWithLoopDeclaresLoopIndexVariable [
 
 	| translation codeGenerator inlinedMethod |
@@ -323,7 +324,7 @@ VMMASTTranslationTest >> testInlineMethodWithLoopDeclaresLoopIndexVariable [
 	self assert: (translation locals includesAll: inlinedMethod locals)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMMASTTranslationTest >> testInlineSecondLevelMethodWithLoopDeclaresLoopIndexVariable [
 
 	| translation codeGenerator inlinedMethods |
@@ -339,7 +340,7 @@ VMMASTTranslationTest >> testInlineSecondLevelMethodWithLoopDeclaresLoopIndexVar
 	self assert: translation locals asSet size equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMMASTTranslationTest >> testInlineTwiceMethodWithLoopDeclaresTwiceLoopIndexVariable [
 
 	| translation codeGenerator inlinedMethod |
@@ -354,7 +355,7 @@ VMMASTTranslationTest >> testInlineTwiceMethodWithLoopDeclaresTwiceLoopIndexVari
 	self assert: translation locals asSet size equals: 2
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMMASTTranslationTest >> testInlineTwiceSecondLevelMethodWithLoopDeclaresLoopIndexVariable [
 
 	| translation codeGenerator inlinedMethods |
@@ -370,7 +371,7 @@ VMMASTTranslationTest >> testInlineTwiceSecondLevelMethodWithLoopDeclaresLoopInd
 	self assert: translation locals asSet size equals: 2
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMMASTTranslationTest >> testInlinedLocalVariableWithSameNameIsProperlyRenamed [
 
 	|  method codeGenerator  methodTranslation inlinedMethod inlinedMethodTranslation |
@@ -390,7 +391,7 @@ VMMASTTranslationTest >> testInlinedLocalVariableWithSameNameIsProperlyRenamed [
 	self assert: (methodTranslation declarations at: #cond2) equals: 'pthread_cond_t cond2'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMMASTTranslationTest >> testKeywordMethodHasArgument [
 
 	| translation method |
@@ -400,7 +401,7 @@ VMMASTTranslationTest >> testKeywordMethodHasArgument [
 	self assert: (translation args includes: method methodNode arguments first name)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMMASTTranslationTest >> testMethodWithConditionInLoopLimitHasLimitVariable [
 
 	| translation method loop |
@@ -411,7 +412,7 @@ VMMASTTranslationTest >> testMethodWithConditionInLoopLimitHasLimitVariable [
 	self assert: loop arguments size equals: 4
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMMASTTranslationTest >> testMethodWithConstantConditionInLoopHasNoLimitVariable [
 
 	| translation method loop |
@@ -422,7 +423,7 @@ VMMASTTranslationTest >> testMethodWithConstantConditionInLoopHasNoLimitVariable
 	self assert: loop arguments size equals: 6
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMMASTTranslationTest >> testMethodWithLoopDeclaresLoopIndexVariable [
 
 	| translation method block |
@@ -433,7 +434,7 @@ VMMASTTranslationTest >> testMethodWithLoopDeclaresLoopIndexVariable [
 	self deny: (translation locals includes: block arguments first)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMMASTTranslationTest >> testMethodWithoutExplicitReturnInOtherMethodReturnsVoid [
 
 	| translation codeGenerator |
@@ -450,7 +451,7 @@ VMMASTTranslationTest >> testMethodWithoutExplicitReturnInOtherMethodReturnsVoid
 	self assert: translation returnType equals: #void
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMMASTTranslationTest >> testMethodWithoutExplicitReturnReturnsVoid [
 
 	| translation codeGenerator |
@@ -467,7 +468,7 @@ VMMASTTranslationTest >> testMethodWithoutExplicitReturnReturnsVoid [
 	self assert: translation returnType equals: #void
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMMASTTranslationTest >> testTranslateBinaryMethodHasSameName [
 
 	| translation |
@@ -476,7 +477,7 @@ VMMASTTranslationTest >> testTranslateBinaryMethodHasSameName [
 	self assert: translation selector equals: #+.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMMASTTranslationTest >> testTranslateKeywordMethodHasSameName [
 
 	| translation method |
@@ -486,7 +487,7 @@ VMMASTTranslationTest >> testTranslateKeywordMethodHasSameName [
 	self assert: translation selector equals: method selector.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMMASTTranslationTest >> testTranslateUnaryMethodHasSameName [
 
 	| translation method |

--- a/smalltalksrc/VMMakerTests/VMMachineCodeFrameBuilderForTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMMachineCodeFrameBuilderForTest.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #VMMachineCodeFrameBuilderForTest,
-	#superclass : #Object,
+	#name : 'VMMachineCodeFrameBuilderForTest',
+	#superclass : 'Object',
 	#instVars : [
 		'test',
 		'returnAddress',
@@ -10,20 +10,21 @@ Class {
 		'spouseContext',
 		'method'
 	],
-	#category : #VMMakerTests
+	#category : 'VMMakerTests',
+	#package : 'VMMakerTests'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeFrameBuilderForTest >> arguments [
 	^ arguments
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeFrameBuilderForTest >> arguments: anObject [
 	arguments := anObject
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 VMMachineCodeFrameBuilderForTest >> buildFrame [
 
 	| methodAddress |
@@ -54,13 +55,13 @@ VMMachineCodeFrameBuilderForTest >> buildFrame [
 	test cogit needsFrame: true.
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 VMMachineCodeFrameBuilderForTest >> hasSpouseContext [
 
 	^ spouseContext notNil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeFrameBuilderForTest >> initializeWithTest: aTest [
 	
 	self test: aTest.
@@ -70,63 +71,63 @@ VMMachineCodeFrameBuilderForTest >> initializeWithTest: aTest [
 	temporaries := #().
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeFrameBuilderForTest >> method [
 	^ method
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeFrameBuilderForTest >> method: anObject [
 	method := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeFrameBuilderForTest >> receiver [
 	^ receiver
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeFrameBuilderForTest >> receiver: anObject [
 	receiver := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeFrameBuilderForTest >> returnAddress [
 	^ returnAddress
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeFrameBuilderForTest >> returnAddress: anObject [
 	returnAddress := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeFrameBuilderForTest >> spouseContext [
 	^ spouseContext
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeFrameBuilderForTest >> spouseContext: aContextOop [
 	
 	spouseContext := aContextOop
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeFrameBuilderForTest >> temporaries [
 	^ temporaries
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeFrameBuilderForTest >> temporaries: anObject [
 	temporaries := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeFrameBuilderForTest >> test [
 	^ test
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeFrameBuilderForTest >> test: anObject [
 	test := anObject
 ]

--- a/smalltalksrc/VMMakerTests/VMMachineCodeMethod.class.st
+++ b/smalltalksrc/VMMakerTests/VMMachineCodeMethod.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #VMMachineCodeMethod,
-	#superclass : #Object,
+	#name : 'VMMachineCodeMethod',
+	#superclass : 'Object',
 	#instVars : [
 		'virtualMachine',
 		'cogMethodSurrogate'
@@ -8,10 +8,12 @@ Class {
 	#pools : [
 		'VMStackFrameOffsets'
 	],
-	#category : #'VMMakerTests-Visualisation'
+	#category : 'VMMakerTests-Visualisation',
+	#package : 'VMMakerTests',
+	#tag : 'Visualisation'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 VMMachineCodeMethod class >> newOnInterpreter: aVirtualMachine cogMethodSurrogate: aCogMethodSurrogate [
 	
 	^ self new
@@ -20,17 +22,17 @@ VMMachineCodeMethod class >> newOnInterpreter: aVirtualMachine cogMethodSurrogat
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeMethod >> cogMethodSurrogate [
 	^ cogMethodSurrogate
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeMethod >> cogMethodSurrogate: anObject [
 	cogMethodSurrogate := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeMethod >> disassemble [
 	| methodEntry instructions |
 	methodEntry := cogMethodSurrogate asInteger + virtualMachine cogit entryOffset.
@@ -42,12 +44,12 @@ VMMachineCodeMethod >> disassemble [
 ' join: (instructions collect: [:i | i assemblyCodeString])
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeMethod >> virtualMachine [
 	^ virtualMachine
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeMethod >> virtualMachine: anObject [
 	virtualMachine := anObject
 ]

--- a/smalltalksrc/VMMakerTests/VMMachineSimulatorTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMMachineSimulatorTest.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #VMMachineSimulatorTest,
-	#superclass : #VMSimpleStackBasedCogitAbstractTest,
+	#name : 'VMMachineSimulatorTest',
+	#superclass : 'VMSimpleStackBasedCogitAbstractTest',
 	#pools : [
 		'CogAbstractRegisters'
 	],
-	#category : #'VMMakerTests-JitTests'
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #'tests - instruction exception' }
+{ #category : 'tests - instruction exception' }
 VMMachineSimulatorTest >> testInstructionExceptionHasCorrectInstructionAddress [
 
 	| label lastInstruction subInstruction breakInstruction |
@@ -36,7 +38,7 @@ VMMachineSimulatorTest >> testInstructionExceptionHasCorrectInstructionAddress [
 
 ]
 
-{ #category : #'tests - instruction exception' }
+{ #category : 'tests - instruction exception' }
 VMMachineSimulatorTest >> testInstructionExceptionIsRaisedAsUnicornError [
 
 	| label lastInstruction subInstruction breakInstruction |
@@ -65,7 +67,7 @@ VMMachineSimulatorTest >> testInstructionExceptionIsRaisedAsUnicornError [
 
 ]
 
-{ #category : #'tests - memory access exception' }
+{ #category : 'tests - memory access exception' }
 VMMachineSimulatorTest >> testMemoryAccessExceptionComesWithCorrectAddress [
 
 	| lastInstruction invalidAccessInstruction invalidAddressHandled |
@@ -93,7 +95,7 @@ VMMachineSimulatorTest >> testMemoryAccessExceptionComesWithCorrectAddress [
 	self assert: invalidAddressHandled
 ]
 
-{ #category : #'tests - memory access exception' }
+{ #category : 'tests - memory access exception' }
 VMMachineSimulatorTest >> testMemoryAccessExceptionHandledCountIsRespected [
 
 	| label lastInstruction invalidAddressHandled addInstruction jumpInstruction expectedAddress |
@@ -137,7 +139,7 @@ VMMachineSimulatorTest >> testMemoryAccessExceptionHandledCountIsRespected [
 		equals: expectedAddress
 ]
 
-{ #category : #'tests - memory access exception' }
+{ #category : 'tests - memory access exception' }
 VMMachineSimulatorTest >> testMemoryAccessExceptionHandledTimeoutIsRespected [
 
 	| label lastInstruction invalidAddressHandled |
@@ -181,7 +183,7 @@ VMMachineSimulatorTest >> testMemoryAccessExceptionHandledTimeoutIsRespected [
 			^ self ]
 ]
 
-{ #category : #'tests - memory access exception' }
+{ #category : 'tests - memory access exception' }
 VMMachineSimulatorTest >> testMemoryAccessExceptionHandledUntilAddressIsRespected [
 
 	| label invalidAddressHandled addInstruction jumpInstruction |
@@ -217,7 +219,7 @@ VMMachineSimulatorTest >> testMemoryAccessExceptionHandledUntilAddressIsRespecte
 	self assert: self temporaryRegisterValue equals: 1
 ]
 
-{ #category : #'tests - memory access exception' }
+{ #category : 'tests - memory access exception' }
 VMMachineSimulatorTest >> testMemoryAccessExceptionHandledUntilAddressIsRespectedCorrectInstructionPointer [
 
 	| label invalidAddressHandled addInstruction jumpInstruction |
@@ -253,7 +255,7 @@ VMMachineSimulatorTest >> testMemoryAccessExceptionHandledUntilAddressIsRespecte
 	self assert: self machineSimulator instructionPointerRegisterValue equals: jumpInstruction address
 ]
 
-{ #category : #'tests - memory access exception' }
+{ #category : 'tests - memory access exception' }
 VMMachineSimulatorTest >> testMemoryAccessExceptionInCallContinuesToCorrectPC [
 
 	| lastInstruction invalidAddressHandled returningPoint |
@@ -280,7 +282,7 @@ VMMachineSimulatorTest >> testMemoryAccessExceptionInCallContinuesToCorrectPC [
 	self assert: invalidAddressHandled
 ]
 
-{ #category : #'tests - memory access exception' }
+{ #category : 'tests - memory access exception' }
 VMMachineSimulatorTest >> testMemoryAccessExceptionInCallHasUpdatedPC [
 
 	| lastInstruction invalidAddressHandled |
@@ -306,7 +308,7 @@ VMMachineSimulatorTest >> testMemoryAccessExceptionInCallHasUpdatedPC [
 	self assert: invalidAddressHandled
 ]
 
-{ #category : #'tests - memory access exception' }
+{ #category : 'tests - memory access exception' }
 VMMachineSimulatorTest >> testMemoryAccessExceptionInJumpContinuesToCorrectPC [
 
 	| lastInstruction invalidAddressHandled returningPoint |
@@ -333,7 +335,7 @@ VMMachineSimulatorTest >> testMemoryAccessExceptionInJumpContinuesToCorrectPC [
 	self assert: invalidAddressHandled
 ]
 
-{ #category : #'tests - memory access exception' }
+{ #category : 'tests - memory access exception' }
 VMMachineSimulatorTest >> testMemoryAccessExceptionInJumpHasUpdatedPC [
 
 	| lastInstruction invalidAddressHandled |
@@ -359,7 +361,7 @@ VMMachineSimulatorTest >> testMemoryAccessExceptionInJumpHasUpdatedPC [
 	self assert: invalidAddressHandled
 ]
 
-{ #category : #'tests - memory access exception' }
+{ #category : 'tests - memory access exception' }
 VMMachineSimulatorTest >> testMemoryAccessExceptionInstructionPointerInCorrectAddress [
 
 	| lastInstruction invalidAccessInstruction invalidAddressHandled exptectedAddress |
@@ -395,7 +397,7 @@ VMMachineSimulatorTest >> testMemoryAccessExceptionInstructionPointerInCorrectAd
 	self assert: invalidAddressHandled
 ]
 
-{ #category : #'tests - normal execution' }
+{ #category : 'tests - normal execution' }
 VMMachineSimulatorTest >> testNormalExecutionCountIsRespected [
 
 	| label lastInstruction subInstruction |
@@ -421,7 +423,7 @@ VMMachineSimulatorTest >> testNormalExecutionCountIsRespected [
 
 ]
 
-{ #category : #'tests - normal execution' }
+{ #category : 'tests - normal execution' }
 VMMachineSimulatorTest >> testNormalExecutionCountIsRespectedAndHasCorrectInstructionPointer [
 
 	| label lastInstruction subInstruction jumpInstruction |
@@ -446,7 +448,7 @@ VMMachineSimulatorTest >> testNormalExecutionCountIsRespectedAndHasCorrectInstru
 
 ]
 
-{ #category : #'tests - normal execution' }
+{ #category : 'tests - normal execution' }
 VMMachineSimulatorTest >> testNormalExecutionRespectTimeout [
 
 	| label lastInstruction |
@@ -468,7 +470,7 @@ VMMachineSimulatorTest >> testNormalExecutionRespectTimeout [
 	self fail.
 ]
 
-{ #category : #'tests - normal execution' }
+{ #category : 'tests - normal execution' }
 VMMachineSimulatorTest >> testNormalExecutionRespectTimeoutUpdatesInstructionPointer [
 
 	| label lastInstruction |
@@ -492,7 +494,7 @@ VMMachineSimulatorTest >> testNormalExecutionRespectTimeoutUpdatesInstructionPoi
 	self fail.
 ]
 
-{ #category : #'tests - normal execution' }
+{ #category : 'tests - normal execution' }
 VMMachineSimulatorTest >> testNormalExecutionUntilAddressIsRespected [
 
 	| label lastInstruction |

--- a/smalltalksrc/VMMakerTests/VMMockCodeGenerator.class.st
+++ b/smalltalksrc/VMMakerTests/VMMockCodeGenerator.class.st
@@ -1,14 +1,16 @@
 Class {
-	#name : #VMMockCodeGenerator,
-	#superclass : #Object,
+	#name : 'VMMockCodeGenerator',
+	#superclass : 'Object',
 	#instVars : [
 		'interpreter',
 		'addedPrimitives'
 	],
-	#category : #'VMMakerTests-JitTests'
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMMockCodeGenerator class >> for: aCogVMSimulatorLSB [ 
 
 	^ self new
@@ -16,13 +18,13 @@ VMMockCodeGenerator class >> for: aCogVMSimulatorLSB [
 		yourself
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMMockCodeGenerator >> accessorDepthCalculator [
 
 	^ self 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMMockCodeGenerator >> accessorDepthForSelector: aString [ 
 	
 	^ addedPrimitives at: aString 
@@ -30,31 +32,31 @@ VMMockCodeGenerator >> accessorDepthForSelector: aString [
 	
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMMockCodeGenerator >> addPrimitive: aSelector [ 
 	
 	self addPrimitive: aSelector accessorDepth: -1
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMMockCodeGenerator >> addPrimitive: aSelector accessorDepth: aDepth [
 	
 	addedPrimitives at: aSelector put: aDepth
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMMockCodeGenerator >> exportedPrimitiveNames [
 
 	^ (addedPrimitives keys collect: [ :e | e -> e ]) asDictionary
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 VMMockCodeGenerator >> initialize [ 
 
 	addedPrimitives := Dictionary new
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMMockCodeGenerator >> initializeWithPrimitiveTable [
 
 	interpreter primitiveTable
@@ -62,7 +64,7 @@ VMMockCodeGenerator >> initializeWithPrimitiveTable [
 		thenDo: [ :aSelector | self addPrimitive: aSelector ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMMockCodeGenerator >> interpreter: aCogVMSimulatorLSB [ 
 
 	interpreter := aCogVMSimulatorLSB.

--- a/smalltalksrc/VMMakerTests/VMObjectAccessorIdentificationTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMObjectAccessorIdentificationTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #VMObjectAccessorIdentificationTest,
-	#superclass : #TestCase,
-	#category : #'VMMakerTests-Simulation'
+	#name : 'VMObjectAccessorIdentificationTest',
+	#superclass : 'TestCase',
+	#category : 'VMMakerTests-Simulation',
+	#package : 'VMMakerTests',
+	#tag : 'Simulation'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectAccessorIdentificationTest >> testObjectAccessorMessagesAreCorrectlyDetected [
 
 	| knownSelectors nonAccessorSelectors |

--- a/smalltalksrc/VMMakerTests/VMObjectLayoutTests.class.st
+++ b/smalltalksrc/VMMakerTests/VMObjectLayoutTests.class.st
@@ -1,17 +1,19 @@
 Class {
-	#name : #VMObjectLayoutTests,
-	#superclass : #VMInterpreterTests,
-	#category : #'VMMakerTests-ObjectLayoutTests'
+	#name : 'VMObjectLayoutTests',
+	#superclass : 'VMInterpreterTests',
+	#category : 'VMMakerTests-ObjectLayoutTests',
+	#package : 'VMMakerTests',
+	#tag : 'ObjectLayoutTests'
 }
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMObjectLayoutTests >> formatFromInstSpec: instSpecInt instSize: instSizeInt [ 		
 	"A class format is composed by"
 	"<5 bits inst spec><16 bits inst size>"
 	^ instSpecInt << 16 + instSizeInt
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMObjectLayoutTests >> installClassIntoClassTableWithInstSpec: aFormatInt instSize: aSizeInt [ 
 	| class |
 	class := self
@@ -21,7 +23,7 @@ VMObjectLayoutTests >> installClassIntoClassTableWithInstSpec: aFormatInt instSi
 	^class	
 ]
 
-{ #category : #helper }
+{ #category : 'helper' }
 VMObjectLayoutTests >> objSizeWithNumberOfSlots: numberOfSlots [ 
 	| objSize |
 	"always have at least one slot for forwarders"
@@ -37,7 +39,7 @@ VMObjectLayoutTests >> objSizeWithNumberOfSlots: numberOfSlots [
 	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectLayoutTests >> testCharacterIsImmediate [
 	| char |
 	char := memory characterObjectOf: $a asInteger.
@@ -45,7 +47,7 @@ VMObjectLayoutTests >> testCharacterIsImmediate [
 	self assert: (memory fetchClassTagOf: char) equals: 2
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectLayoutTests >> testHeaderOfObjectEncodesTheCorrectAmountOfSlots [
 	| class objOop |
 	0 to: 254 do: [ :slots | 
@@ -61,19 +63,19 @@ VMObjectLayoutTests >> testHeaderOfObjectEncodesTheCorrectAmountOfSlots [
 			equals: objSize ]
 ]
 
-{ #category : #'tests - integerValues' }
+{ #category : 'tests - integerValues' }
 VMObjectLayoutTests >> testNegativeIntegerValuesInRange [
 
 	self assert: (memory isIntegerValue: memory minSmallInteger)
 ]
 
-{ #category : #'tests - integerValues' }
+{ #category : 'tests - integerValues' }
 VMObjectLayoutTests >> testNegativeIntegerValuesNotInRange [
 	"An integer smaller than the smallest integer is not in a valid range"
 	self deny: (memory isIntegerValue: memory minSmallInteger - 1)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectLayoutTests >> testObjectAlignment [
 	| class objOop1 objOop2 instSpec |
 	instSpec := 0.
@@ -84,7 +86,7 @@ VMObjectLayoutTests >> testObjectAlignment [
 	self assert: objOop2 \\ 8 equals: 0
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectLayoutTests >> testObjectHeaderEncodesAmountOfSlots [
 	| class objOop header |
 	0 to: 254 do: [ :slots |
@@ -95,7 +97,7 @@ VMObjectLayoutTests >> testObjectHeaderEncodesAmountOfSlots [
 	]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectLayoutTests >> testObjectHeaderEncodesClassIndex [
 	| class objOop header classIndex |
 	0 to: 10 do: [ :slots |
@@ -108,7 +110,7 @@ VMObjectLayoutTests >> testObjectHeaderEncodesClassIndex [
 	]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectLayoutTests >> testObjectHeaderEncodesObjecFormatForFixedLayout [
 	| class objOop header classInstSpec |
 	 "instSpec: 
@@ -123,7 +125,7 @@ VMObjectLayoutTests >> testObjectHeaderEncodesObjecFormatForFixedLayout [
 	]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectLayoutTests >> testObjectHeaderEncodesObjecFormatForIndexableOpaqueLayout16Bit [
 	| class objOop header classInstSpec instSpec bits maxSize |
 	 "instSpec: 	12-15	= 16-bit indexable
@@ -145,7 +147,7 @@ VMObjectLayoutTests >> testObjectHeaderEncodesObjecFormatForIndexableOpaqueLayou
 		] 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectLayoutTests >> testObjectHeaderEncodesObjecFormatForIndexableOpaqueLayout32Bit [
 	| class objOop header classInstSpec instSpec bits maxSize |
 	 "instSpec: 	10-11	= 32-bit indexable
@@ -165,7 +167,7 @@ VMObjectLayoutTests >> testObjectHeaderEncodesObjecFormatForIndexableOpaqueLayou
 		] 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectLayoutTests >> testObjectHeaderEncodesObjecFormatForIndexableOpaqueLayout8Bit [
 	| class objOop header classInstSpec instSpec bits maxSize |
 	 "instSpec: 	16-23	= 8-bit indexable
@@ -192,7 +194,7 @@ VMObjectLayoutTests >> testObjectHeaderEncodesObjecFormatForIndexableOpaqueLayou
 	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectLayoutTests >> testObjectHeaderEncodesObjecFormatForIndexablePointerLayout [
 	| class objOop header classInstSpec instSpec |
 	instSpec := 2. "instSpec for indexable objects with no inst vars (Array et al)"	
@@ -206,7 +208,7 @@ VMObjectLayoutTests >> testObjectHeaderEncodesObjecFormatForIndexablePointerLayo
 	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectLayoutTests >> testObjectMinimumSize [
 	| class objOop1 objOop2 instSpec |
 	instSpec := 0.
@@ -216,7 +218,7 @@ VMObjectLayoutTests >> testObjectMinimumSize [
 	self assert: objOop2 - objOop1 equals: 16
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectLayoutTests >> testObjectWith0SlotsIsAreAlwaysAligned [
 	| class slots obj1oop obj2oop |
 	"objects always are allocated with at least one slots for forwarding"
@@ -227,7 +229,7 @@ VMObjectLayoutTests >> testObjectWith0SlotsIsAreAlwaysAligned [
 	self assert: obj2oop - obj1oop equals: self objectHeaderSize + memory allocationUnit
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectLayoutTests >> testObjectWith0SlotsIsAreAlwaysWithAtLeastOneSlotsForForwarding [
 	| class slots  oop |
 	slots := 0.
@@ -236,7 +238,7 @@ VMObjectLayoutTests >> testObjectWith0SlotsIsAreAlwaysWithAtLeastOneSlotsForForw
 	self assert: (memory bytesInObject: oop) equals: self objectHeaderSize + memory allocationUnit.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectLayoutTests >> testObjectWithMoreThan254SlotsHasTheCorrectSize [
 	| class objOop slots |
 	slots := 255.
@@ -251,7 +253,7 @@ VMObjectLayoutTests >> testObjectWithMoreThan254SlotsHasTheCorrectSize [
 	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectLayoutTests >> testObjectWithMoreThan254SlotsHasTwoHeaders [
 	| class objOop bigOopHeader mask numSlots |
 	mask := 16rFFFFFFFFFFFFFF.
@@ -265,7 +267,7 @@ VMObjectLayoutTests >> testObjectWithMoreThan254SlotsHasTwoHeaders [
 		self assert: numSlots equals: slots ]
 ]
 
-{ #category : #'tests - integerValues' }
+{ #category : 'tests - integerValues' }
 VMObjectLayoutTests >> testPositiveIntegerBorderCase1 [
 	"Test of the border case when int = 2r000111111... . The highest possible value using usqInt encoding is (2**61) -1 since (2**61) can be confused with a pointer (on a 64 bits machine)
 	Regarding the cCode implementation, the sign bit can be lost if this test fails. The maxCInteger and numSmallIntegerTagBits guarantees the portability 
@@ -274,25 +276,25 @@ VMObjectLayoutTests >> testPositiveIntegerBorderCase1 [
 	self deny: (memory isIntegerValue: memory maxCInteger >> memory numSmallIntegerTagBits)
 ]
 
-{ #category : #'tests - integerValues' }
+{ #category : 'tests - integerValues' }
 VMObjectLayoutTests >> testPositiveIntegerBorderCase2 [
 "Test of the border case when int = 2r111000000 ... . Regarding the cCode implementation, the sign bit can be lost if this test fails. The maxCInteger and numSmallIntegerTagBits guaranties the portability of the test on 32 and 64 bit computer. "
 	self deny: (memory isIntegerValue: (memory maxCInteger >> memory numSmallIntegerTagBits) bitInvert) "<=> isIntegerValue: (0001111) bitInvert" 
 ]
 
-{ #category : #'tests - integerValues' }
+{ #category : 'tests - integerValues' }
 VMObjectLayoutTests >> testPositiveIntegerValuesInRange [
 
 	self assert: (memory isIntegerValue: memory maxSmallInteger)
 ]
 
-{ #category : #'tests - integerValues' }
+{ #category : 'tests - integerValues' }
 VMObjectLayoutTests >> testPositiveIntegerValuesNotInRange [
 
 	self deny: (memory isIntegerValue: memory maxSmallInteger + 1)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectLayoutTests >> testSmallIntegerIsImmediate [
 	| int |
 	int := memory integerObjectOf: 42.
@@ -300,7 +302,7 @@ VMObjectLayoutTests >> testSmallIntegerIsImmediate [
 	self assert: (memory fetchClassTagOf: int) equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectLayoutTests >> testVariableObjectWithInstVarsHasTheRightSize [
 	| class objOop fixedFieldsSize indexableSize |
 	indexableSize := 12.

--- a/smalltalksrc/VMMakerTests/VMObjectStackTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMObjectStackTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #VMObjectStackTest,
-	#superclass : #VMSpurInitializedOldSpaceTest,
-	#category : #'VMMakerTests-MemoryTests'
+	#name : 'VMObjectStackTest',
+	#superclass : 'VMSpurInitializedOldSpaceTest',
+	#category : 'VMMakerTests-MemoryTests',
+	#package : 'VMMakerTests',
+	#tag : 'MemoryTests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectStackTest >> testGrowingMournQueueUpdatesVMGlobalVariable [
 
 	
@@ -12,7 +14,7 @@ VMObjectStackTest >> testGrowingMournQueueUpdatesVMGlobalVariable [
 	self assert: memory mournQueue equals: (memory objStackAt: 4098"MournQueueRootIndex")
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectStackTest >> testNewMournQueueIsEmpty [
 
 	| objStack |
@@ -22,7 +24,7 @@ VMObjectStackTest >> testNewMournQueueIsEmpty [
 	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectStackTest >> testNewObjectStackIsEmpty [
 
 	"Create an object stack at the position of the mark stack in the class table (4096)"
@@ -33,7 +35,7 @@ VMObjectStackTest >> testNewObjectStackIsEmpty [
 	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectStackTest >> testObjectsInMournQueueArePoppedInOrder [
 
 	| objStack |
@@ -46,7 +48,7 @@ VMObjectStackTest >> testObjectsInMournQueueArePoppedInOrder [
 	].
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectStackTest >> testObjectsInObjectStackArePoppedInOrder [
 
 	"Create an object stack at the position of the mark stack in the class table (4096)"
@@ -60,7 +62,7 @@ VMObjectStackTest >> testObjectsInObjectStackArePoppedInOrder [
 	].
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectStackTest >> testPopMournQueueReducesSize [
 
 	| objStack |
@@ -70,7 +72,7 @@ VMObjectStackTest >> testPopMournQueueReducesSize [
 	self assert: (memory isEmptyObjStack: objStack)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectStackTest >> testPopObjectInMournQueueReturnsInitiallyPushedObject [
 
 	| objStack |
@@ -79,7 +81,7 @@ VMObjectStackTest >> testPopObjectInMournQueueReturnsInitiallyPushedObject [
 	self assert: (memory popObjStack: objStack) equals: memory trueObject
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectStackTest >> testPopObjectInStackReturnsInitiallyPushedObject [
 
 	"Create an object stack at the position of the mark stack in the class table (4096)"
@@ -89,7 +91,7 @@ VMObjectStackTest >> testPopObjectInStackReturnsInitiallyPushedObject [
 	self assert: (memory popObjStack: objStack) equals: memory trueObject
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectStackTest >> testPopObjectStackReducesSize [
 
 	"Create an object stack at the position of the mark stack in the class table (4096)"
@@ -100,14 +102,14 @@ VMObjectStackTest >> testPopObjectStackReducesSize [
 	self assert: (memory isEmptyObjStack: objStack)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectStackTest >> testPushObjects: n [
 
 	"Create an object stack at the position of the mark stack in the class table (4096)"
 	self testPushObjects: n inStackAtIndex: 4096
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectStackTest >> testPushObjects: n inStackAtIndex: objectStackIndex [
 
 	memory ensureRoomOnObjStackAt: objectStackIndex.
@@ -119,19 +121,19 @@ VMObjectStackTest >> testPushObjects: n inStackAtIndex: objectStackIndex [
 	self assert: (memory sizeOfObjStack: (memory objStackAt: objectStackIndex)) equals: n
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectStackTest >> testPushObjectsAboveObjectStackLimit [
 
 	self testPushObjects: memory objectStackPageLimit + 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectStackTest >> testPushObjectsToObjectStackLimit [
 
 	self testPushObjects: memory objectStackPageLimit
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectStackTest >> testPushToMournQueueIncreasesSize [
 
 	| objStack |
@@ -140,7 +142,7 @@ VMObjectStackTest >> testPushToMournQueueIncreasesSize [
 	self assert: (memory sizeOfObjStack: objStack) equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMObjectStackTest >> testPushToObjectStackIncreasesSize [
 
 	"Create an object stack at the position of the mark stack in the class table (4096)"

--- a/smalltalksrc/VMMakerTests/VMPermanentSpaceImageReadingTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPermanentSpaceImageReadingTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #VMPermanentSpaceImageReadingTest,
-	#superclass : #VMAbstractImageFormatTest,
-	#category : #'VMMakerTests-PermSpace'
+	#name : 'VMPermanentSpaceImageReadingTest',
+	#superclass : 'VMAbstractImageFormatTest',
+	#category : 'VMMakerTests-PermSpace',
+	#package : 'VMMakerTests',
+	#tag : 'PermSpace'
 }
 
-{ #category : #utilities }
+{ #category : 'utilities' }
 VMPermanentSpaceImageReadingTest >> loadImage [
 
 	| memoryClass isa |
@@ -38,7 +40,7 @@ VMPermanentSpaceImageReadingTest >> loadImage [
 
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 VMPermanentSpaceImageReadingTest >> setUp [
 
 	super setUp.
@@ -50,7 +52,7 @@ VMPermanentSpaceImageReadingTest >> setUp [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMPermanentSpaceImageReadingTest >> testLoadingImageHasEmptyPermSpaceWhenImageDoesNotHave [
 
 	self saveImage.	

--- a/smalltalksrc/VMMakerTests/VMPermanentSpaceMemoryTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPermanentSpaceMemoryTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #VMPermanentSpaceMemoryTest,
-	#superclass : #VMSpurInitializedOldSpaceTest,
-	#category : #'VMMakerTests-PermSpace'
+	#name : 'VMPermanentSpaceMemoryTest',
+	#superclass : 'VMSpurInitializedOldSpaceTest',
+	#category : 'VMMakerTests-PermSpace',
+	#package : 'VMMakerTests',
+	#tag : 'PermSpace'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 VMPermanentSpaceMemoryTest >> setUp [
 
 	super setUp.
@@ -12,7 +14,7 @@ VMPermanentSpaceMemoryTest >> setUp [
 	self createWeakArrayClass
 ]
 
-{ #category : #'tests - allocation' }
+{ #category : 'tests - allocation' }
 VMPermanentSpaceMemoryTest >> testAllInstancesReturnsObjectsInPermSpace [
 
 	| permanentObject allInstances |
@@ -25,7 +27,7 @@ VMPermanentSpaceMemoryTest >> testAllInstancesReturnsObjectsInPermSpace [
 	self assert: (memory fetchPointer: 0 ofObject: allInstances) equals: permanentObject.
 ]
 
-{ #category : #'tests - allocation' }
+{ #category : 'tests - allocation' }
 VMPermanentSpaceMemoryTest >> testBecomingOfPermanentObjectFails [
 
 	| permanentObject oldObject youngReplacement arrFrom arrTo ec |
@@ -52,7 +54,7 @@ VMPermanentSpaceMemoryTest >> testBecomingOfPermanentObjectFails [
 	self deny: ec equals: PrimNoErr
 ]
 
-{ #category : #'test - moving' }
+{ #category : 'test - moving' }
 VMPermanentSpaceMemoryTest >> testCompiledMethodWithMachineCodeIsNotRememberedWhenModified [
 
 	| oldObject1 permanentObject1 |
@@ -73,7 +75,7 @@ VMPermanentSpaceMemoryTest >> testCompiledMethodWithMachineCodeIsNotRememberedWh
 			 permanentObject1)
 ]
 
-{ #category : #'test - moving' }
+{ #category : 'test - moving' }
 VMPermanentSpaceMemoryTest >> testCompiledMethodWithMachineCodeIsNotRememberedWhenMoving [
 
 	| oldObject1 permanentObject1 |
@@ -94,7 +96,7 @@ VMPermanentSpaceMemoryTest >> testCompiledMethodWithMachineCodeIsNotRememberedWh
 			 permanentObject1)
 ]
 
-{ #category : #'tests - allocation' }
+{ #category : 'tests - allocation' }
 VMPermanentSpaceMemoryTest >> testMarkingNewSpaceDoesNotMarkPermSpace [
 
 	| permanentObject newObject |
@@ -112,7 +114,7 @@ VMPermanentSpaceMemoryTest >> testMarkingNewSpaceDoesNotMarkPermSpace [
 	self deny: (memory isMarked: permanentObject)
 ]
 
-{ #category : #'tests - allocation' }
+{ #category : 'tests - allocation' }
 VMPermanentSpaceMemoryTest >> testMarkingOldSpaceDoesNotMarkPermSpace [
 
 	| permanentObject oldObject |
@@ -130,7 +132,7 @@ VMPermanentSpaceMemoryTest >> testMarkingOldSpaceDoesNotMarkPermSpace [
 	self deny: (memory isMarked: permanentObject)
 ]
 
-{ #category : #'test - moving' }
+{ #category : 'test - moving' }
 VMPermanentSpaceMemoryTest >> testMoveOldObjectInRememberedSetIsMovedFromSet [
 
 	| oldObject youngObject permanentObject |
@@ -159,7 +161,7 @@ VMPermanentSpaceMemoryTest >> testMoveOldObjectInRememberedSetIsMovedFromSet [
 
 ]
 
-{ #category : #'test - moving' }
+{ #category : 'test - moving' }
 VMPermanentSpaceMemoryTest >> testMovingAnObjectReferencingAYoungOnePutsInRememberedSet [
 
 	| permanentObject youngObject rootObject|
@@ -175,7 +177,7 @@ VMPermanentSpaceMemoryTest >> testMovingAnObjectReferencingAYoungOnePutsInRememb
 	self assert: (memory getFromPermToNewSpaceRememberedSet isInRememberedSet: permanentObject).
 ]
 
-{ #category : #'test - moving' }
+{ #category : 'test - moving' }
 VMPermanentSpaceMemoryTest >> testMovingAnObjectReferencingAnOldOnePutsInRememberedSet [
 
 	| permanentObject oldObject rootObject|
@@ -192,7 +194,7 @@ VMPermanentSpaceMemoryTest >> testMovingAnObjectReferencingAnOldOnePutsInRemembe
 	self assert: (memory getFromPermToOldSpaceRememberedSet isInRememberedSet: permanentObject).
 ]
 
-{ #category : #'test - moving' }
+{ #category : 'test - moving' }
 VMPermanentSpaceMemoryTest >> testMovingOldObjectToPermSpaceIsCorrectlyForwarded [
 
 	| permanentObject oldObject rootObject|
@@ -215,7 +217,7 @@ VMPermanentSpaceMemoryTest >> testMovingOldObjectToPermSpaceIsCorrectlyForwarded
 
 ]
 
-{ #category : #'test - moving' }
+{ #category : 'test - moving' }
 VMPermanentSpaceMemoryTest >> testMovingOldObjectToPermSpaceLeavesForwarder [
 
 	| permanentObject oldObject |
@@ -230,7 +232,7 @@ VMPermanentSpaceMemoryTest >> testMovingOldObjectToPermSpaceLeavesForwarder [
 
 ]
 
-{ #category : #'test - moving' }
+{ #category : 'test - moving' }
 VMPermanentSpaceMemoryTest >> testMovingTwoObjectsPutBothInPermSpaceAndUpdatesArray [
 
 	| permanentObject youngObject rootObject anArray|
@@ -254,7 +256,7 @@ VMPermanentSpaceMemoryTest >> testMovingTwoObjectsPutBothInPermSpaceAndUpdatesAr
 	self assert: (memory getMemoryMap isPermanentObject: youngObject).	
 ]
 
-{ #category : #'tests - allocation' }
+{ #category : 'tests - allocation' }
 VMPermanentSpaceMemoryTest >> testNewPermanentByteArrayIsCorrectlyAllocated [
 
 	| permanentObject |
@@ -264,7 +266,7 @@ VMPermanentSpaceMemoryTest >> testNewPermanentByteArrayIsCorrectlyAllocated [
 	self assert: permanentObject equals: memory getMemoryMap permSpaceStart + 16 "There is a zero-slot objects always in the perm space"
 ]
 
-{ #category : #'tests - allocation' }
+{ #category : 'tests - allocation' }
 VMPermanentSpaceMemoryTest >> testNewPermanentByteArrayIsNonYoungObject [
 
 	| permanentObject |
@@ -274,7 +276,7 @@ VMPermanentSpaceMemoryTest >> testNewPermanentByteArrayIsNonYoungObject [
 	self deny: (memory getMemoryMap isYoungObject: permanentObject)
 ]
 
-{ #category : #'tests - allocation' }
+{ #category : 'tests - allocation' }
 VMPermanentSpaceMemoryTest >> testNewPermanentByteArrayIsNotAnOldObject [
 
 	| permanentObject |
@@ -284,7 +286,7 @@ VMPermanentSpaceMemoryTest >> testNewPermanentByteArrayIsNotAnOldObject [
 	self deny: (memory getMemoryMap isOldObject: permanentObject)
 ]
 
-{ #category : #'tests - allocation' }
+{ #category : 'tests - allocation' }
 VMPermanentSpaceMemoryTest >> testNewPermanentByteArrayIsPermanentObject [
 
 	| permanentObject |
@@ -294,7 +296,7 @@ VMPermanentSpaceMemoryTest >> testNewPermanentByteArrayIsPermanentObject [
 	self assert: (memory getMemoryMap isPermanentObject: permanentObject)
 ]
 
-{ #category : #'tests - allocation' }
+{ #category : 'tests - allocation' }
 VMPermanentSpaceMemoryTest >> testNextObjectIsReturningAGoodValue [
 
 	| permanentObject nextObject |
@@ -306,7 +308,7 @@ VMPermanentSpaceMemoryTest >> testNextObjectIsReturningAGoodValue [
 	
 ]
 
-{ #category : #'test - moving' }
+{ #category : 'test - moving' }
 VMPermanentSpaceMemoryTest >> testObjectInBothRememberedSetIsCorrectlyUpdated [
 
 	| oldObject1 permanentObject1 oldObject2 youngObject |
@@ -343,7 +345,7 @@ VMPermanentSpaceMemoryTest >> testObjectInBothRememberedSetIsCorrectlyUpdated [
 	
 ]
 
-{ #category : #'tests - allocation' }
+{ #category : 'tests - allocation' }
 VMPermanentSpaceMemoryTest >> testObjectReferencingOldIsAddedToCorrectRememberedSetAndThenRemoved [
 
 	| oldObject1 oldObject2 permObject2 |
@@ -367,7 +369,7 @@ VMPermanentSpaceMemoryTest >> testObjectReferencingOldIsAddedToCorrectRemembered
 	self assert: memory getFromPermToNewSpaceRememberedSet rememberedSetSize equals: 0.
 ]
 
-{ #category : #'test - moving' }
+{ #category : 'test - moving' }
 VMPermanentSpaceMemoryTest >> testObjectWithForwarderIsCorrectlyResolved [
 
 	
@@ -385,7 +387,7 @@ VMPermanentSpaceMemoryTest >> testObjectWithForwarderIsCorrectlyResolved [
 
 ]
 
-{ #category : #'test - moving' }
+{ #category : 'test - moving' }
 VMPermanentSpaceMemoryTest >> testPassingObjectInBulkToPermSpaceKeepsFirstInRememberedSet [
 
 	| oldObject1 permanentObject1 oldObject2 array |
@@ -406,7 +408,7 @@ VMPermanentSpaceMemoryTest >> testPassingObjectInBulkToPermSpaceKeepsFirstInReme
 
 ]
 
-{ #category : #'test - moving' }
+{ #category : 'test - moving' }
 VMPermanentSpaceMemoryTest >> testPassingObjectsInBulkPreservesObjectAlreadyInTheRememberedSet [
 
 	| oldObject1 permanentObject1 oldObject2 permanentObject2 array youngObject |
@@ -438,7 +440,7 @@ VMPermanentSpaceMemoryTest >> testPassingObjectsInBulkPreservesObjectAlreadyInTh
 
 ]
 
-{ #category : #'test - moving' }
+{ #category : 'test - moving' }
 VMPermanentSpaceMemoryTest >> testPassingTwoObjectsInBulkToPermSpaceIsRemovedFromRememberedSet [
 
 	| oldObject1 permanentObject1 oldObject2 permanentObject2 array |
@@ -461,7 +463,7 @@ VMPermanentSpaceMemoryTest >> testPassingTwoObjectsInBulkToPermSpaceIsRemovedFro
 	self deny: (memory getFromPermToOldSpaceRememberedSet isInRememberedSet: permanentObject1).		
 ]
 
-{ #category : #'test - moving' }
+{ #category : 'test - moving' }
 VMPermanentSpaceMemoryTest >> testPassingTwoObjectsToPermSpaceIsRemovedFromRememberedSet [
 
 	| oldObject1 permanentObject1 oldObject2 permanentObject2 |
@@ -481,7 +483,7 @@ VMPermanentSpaceMemoryTest >> testPassingTwoObjectsToPermSpaceIsRemovedFromRemem
 	self deny: (memory getFromPermToOldSpaceRememberedSet isInRememberedSet: permanentObject1).		
 ]
 
-{ #category : #'test - moving' }
+{ #category : 'test - moving' }
 VMPermanentSpaceMemoryTest >> testPassingTwoObjectsToPermSpaceKeepsFirstInRememberedSet [
 
 	| oldObject1 permanentObject1 oldObject2 permanentObject2 |
@@ -499,7 +501,7 @@ VMPermanentSpaceMemoryTest >> testPassingTwoObjectsToPermSpaceKeepsFirstInRememb
 
 ]
 
-{ #category : #'test - moving' }
+{ #category : 'test - moving' }
 VMPermanentSpaceMemoryTest >> testPassingTwoObjectsToPermSpaceKeepsPointerToForwarderInOldSpace [
 
 	| oldObject1 permanentObject1 oldObject2 permanentObject2 |
@@ -514,7 +516,7 @@ VMPermanentSpaceMemoryTest >> testPassingTwoObjectsToPermSpaceKeepsPointerToForw
 	self assert: (memory fetchPointer: 0 ofObject: permanentObject1) equals: oldObject2
 ]
 
-{ #category : #'test - moving' }
+{ #category : 'test - moving' }
 VMPermanentSpaceMemoryTest >> testPassingTwoObjectsToPermSpaceNotUpdatesForwarderInScanvenge [
 
 	| oldObject1 permanentObject1 oldObject2 permanentObject2 |
@@ -531,7 +533,7 @@ VMPermanentSpaceMemoryTest >> testPassingTwoObjectsToPermSpaceNotUpdatesForwarde
 	self deny: (memory fetchPointer: 0 ofObject: permanentObject1) equals: permanentObject2
 ]
 
-{ #category : #'test - moving' }
+{ #category : 'test - moving' }
 VMPermanentSpaceMemoryTest >> testPassingTwoObjectsToPermSpaceUpdatesForwarderInGC [
 
 	| oldObject1 permanentObject1 oldObject2 permanentObject2 |
@@ -548,7 +550,7 @@ VMPermanentSpaceMemoryTest >> testPassingTwoObjectsToPermSpaceUpdatesForwarderIn
 	self assert: (memory fetchPointer: 0 ofObject: permanentObject1) equals: permanentObject2
 ]
 
-{ #category : #'test - moving' }
+{ #category : 'test - moving' }
 VMPermanentSpaceMemoryTest >> testPermObjectPointingToOldSpaceIsUpdatedWhenCompactingForSaving [
 
 	| oldObject1 permanentObject1 oldObject2 oldObject2Hash |
@@ -572,7 +574,7 @@ VMPermanentSpaceMemoryTest >> testPermObjectPointingToOldSpaceIsUpdatedWhenCompa
 	self assert: (memory hashBitsOf: (memory fetchPointer: 0 ofObject: permanentObject1)) equals: oldObject2Hash 
 ]
 
-{ #category : #'test - moving' }
+{ #category : 'test - moving' }
 VMPermanentSpaceMemoryTest >> testPermanentObjectMarksItsOldClass [
 
 	| permanentObject oldObject oldClass oldClassHash found |
@@ -598,7 +600,7 @@ VMPermanentSpaceMemoryTest >> testPermanentObjectMarksItsOldClass [
 	self assert: found
 ]
 
-{ #category : #'test - moving' }
+{ #category : 'test - moving' }
 VMPermanentSpaceMemoryTest >> testPermanentObjectPointingToFalseIsNotRemembered [
 
 	
@@ -611,7 +613,7 @@ VMPermanentSpaceMemoryTest >> testPermanentObjectPointingToFalseIsNotRemembered 
 	self deny: (memory getFromPermToOldSpaceRememberedSet isInRememberedSet: permanentObject ).	
 ]
 
-{ #category : #'test - moving' }
+{ #category : 'test - moving' }
 VMPermanentSpaceMemoryTest >> testPermanentObjectPointingToMachineCodeIsNotRemembered [
 
 	
@@ -624,7 +626,7 @@ VMPermanentSpaceMemoryTest >> testPermanentObjectPointingToMachineCodeIsNotRemem
 	self deny: (memory getFromPermToOldSpaceRememberedSet isInRememberedSet: permanentObject ).	
 ]
 
-{ #category : #'test - moving' }
+{ #category : 'test - moving' }
 VMPermanentSpaceMemoryTest >> testPermanentObjectPointingToNilIsNotRemembered [
 
 	
@@ -636,7 +638,7 @@ VMPermanentSpaceMemoryTest >> testPermanentObjectPointingToNilIsNotRemembered [
 	self deny: (memory getFromPermToOldSpaceRememberedSet isInRememberedSet: permanentObject ).	
 ]
 
-{ #category : #'test - moving' }
+{ #category : 'test - moving' }
 VMPermanentSpaceMemoryTest >> testPermanentObjectPointingToTrueIsNotRemembered [
 
 	
@@ -649,7 +651,7 @@ VMPermanentSpaceMemoryTest >> testPermanentObjectPointingToTrueIsNotRemembered [
 	self deny: (memory getFromPermToOldSpaceRememberedSet isInRememberedSet: permanentObject ).	
 ]
 
-{ #category : #'test - moving' }
+{ #category : 'test - moving' }
 VMPermanentSpaceMemoryTest >> testPermanentObjectPointingToYoungObjectIsRemovedWhenPointingToMachineCodeMethod [
 
 	
@@ -671,7 +673,7 @@ VMPermanentSpaceMemoryTest >> testPermanentObjectPointingToYoungObjectIsRemovedW
 
 ]
 
-{ #category : #'test - moving' }
+{ #category : 'test - moving' }
 VMPermanentSpaceMemoryTest >> testPermanentObjectUpdatedToTrueIsRemovedFromRememberedSet [
 
 	
@@ -693,7 +695,7 @@ VMPermanentSpaceMemoryTest >> testPermanentObjectUpdatedToTrueIsRemovedFromRemem
 
 ]
 
-{ #category : #'test - moving' }
+{ #category : 'test - moving' }
 VMPermanentSpaceMemoryTest >> testReferencingAnObjectFromOldEphemeronIsNotFired [
 
 	| permanentObject oldObject ephemeronObject |
@@ -719,7 +721,7 @@ VMPermanentSpaceMemoryTest >> testReferencingAnObjectFromOldEphemeronIsNotFired 
 
 ]
 
-{ #category : #'test - moving' }
+{ #category : 'test - moving' }
 VMPermanentSpaceMemoryTest >> testReferencingAnObjectFromOldWeakObjectIsNotNilled [
 
 	| permanentObject oldObject weakObject |
@@ -748,7 +750,7 @@ VMPermanentSpaceMemoryTest >> testReferencingAnObjectFromOldWeakObjectIsNotNille
 
 ]
 
-{ #category : #'test - moving' }
+{ #category : 'test - moving' }
 VMPermanentSpaceMemoryTest >> testReferencingAnObjectFromYoungEphemeronIsNotFired [
 
 	| permanentObject oldObject ephemeronObject |
@@ -771,7 +773,7 @@ VMPermanentSpaceMemoryTest >> testReferencingAnObjectFromYoungEphemeronIsNotFire
 
 ]
 
-{ #category : #'test - moving' }
+{ #category : 'test - moving' }
 VMPermanentSpaceMemoryTest >> testReferencingAnObjectFromYoungWeakObjectIsNotNilled [
 
 	| permanentObject oldObject weakObject |

--- a/smalltalksrc/VMMakerTests/VMPermanentSpacePrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPermanentSpacePrimitiveTest.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #VMPermanentSpacePrimitiveTest,
-	#superclass : #VMAbstractPrimitiveTest,
+	#name : 'VMPermanentSpacePrimitiveTest',
+	#superclass : 'VMAbstractPrimitiveTest',
 	#pools : [
 		'VMBasicConstants',
 		'VMBytecodeConstants',
 		'VMObjectIndices'
 	],
-	#category : #'VMMakerTests-PermSpace'
+	#category : 'VMMakerTests-PermSpace',
+	#package : 'VMMakerTests',
+	#tag : 'PermSpace'
 }
 
-{ #category : #configuring }
+{ #category : 'configuring' }
 VMPermanentSpacePrimitiveTest >> configureEnvironmentBuilder [ 
 
 	super configureEnvironmentBuilder.
@@ -17,7 +19,7 @@ VMPermanentSpacePrimitiveTest >> configureEnvironmentBuilder [
 	environmentBuilder permSpaceSize: 10*1024*1024.
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 VMPermanentSpacePrimitiveTest >> setUp [ 
 	
 	super setUp.
@@ -25,7 +27,7 @@ VMPermanentSpacePrimitiveTest >> setUp [
 	self createWeakArrayClass.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMPermanentSpacePrimitiveTest >> testIsInmmediateInPermSpace [
 
 	interpreter push: (memory integerObjectOf: 42).
@@ -35,7 +37,7 @@ VMPermanentSpacePrimitiveTest >> testIsInmmediateInPermSpace [
 	self assert: interpreter stackTop equals: memory falseObject
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMPermanentSpacePrimitiveTest >> testIsNewObjectInPermSpace [
 
 	interpreter push: (self newZeroSizedObject).
@@ -45,7 +47,7 @@ VMPermanentSpacePrimitiveTest >> testIsNewObjectInPermSpace [
 	self assert: interpreter stackTop equals: memory falseObject
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMPermanentSpacePrimitiveTest >> testIsOldObjectInPermSpace [
 
 	interpreter push: (self newOldSpaceObjectWithSlots: 0).
@@ -55,7 +57,7 @@ VMPermanentSpacePrimitiveTest >> testIsOldObjectInPermSpace [
 	self assert: interpreter stackTop equals: memory falseObject
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMPermanentSpacePrimitiveTest >> testIsPermObjectInPermSpace [
 
 	| oldObj permObject |
@@ -69,7 +71,7 @@ VMPermanentSpacePrimitiveTest >> testIsPermObjectInPermSpace [
 	self assert: interpreter stackTop equals: memory trueObject
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMPermanentSpacePrimitiveTest >> testMoveToPermSpaceFailsOnEphemeron [
 
 	| oldObject |
@@ -84,7 +86,7 @@ VMPermanentSpacePrimitiveTest >> testMoveToPermSpaceFailsOnEphemeron [
 	self assert: interpreter primFailCode equals: PrimErrBadReceiver
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMPermanentSpacePrimitiveTest >> testMoveToPermSpaceFailsOnWeakObject [
 
 	| oldObject |
@@ -99,7 +101,7 @@ VMPermanentSpacePrimitiveTest >> testMoveToPermSpaceFailsOnWeakObject [
 	self assert: interpreter primFailCode equals: PrimErrBadReceiver
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMPermanentSpacePrimitiveTest >> testMoveToPermSpaceWorksOnNewPointerObject [
 
 	| newObject |
@@ -114,7 +116,7 @@ VMPermanentSpacePrimitiveTest >> testMoveToPermSpaceWorksOnNewPointerObject [
 	self assert: interpreter primFailCode equals: 0
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMPermanentSpacePrimitiveTest >> testMoveToPermSpaceWorksOnOldPointerObject [
 
 	| oldObject |
@@ -129,7 +131,7 @@ VMPermanentSpacePrimitiveTest >> testMoveToPermSpaceWorksOnOldPointerObject [
 	self assert: interpreter primFailCode equals: 0
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMPermanentSpacePrimitiveTest >> testMoveToPermSpaceWorksWithByteArray [
 
 	| oldObject |

--- a/smalltalksrc/VMMakerTests/VMPinnedObjectTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPinnedObjectTest.class.st
@@ -1,20 +1,22 @@
 Class {
-	#name : #VMPinnedObjectTest,
-	#superclass : #VMSpurInitializedOldSpaceTest,
-	#category : #'VMMakerTests-MemoryTests'
+	#name : 'VMPinnedObjectTest',
+	#superclass : 'VMSpurInitializedOldSpaceTest',
+	#category : 'VMMakerTests-MemoryTests',
+	#package : 'VMMakerTests',
+	#tag : 'MemoryTests'
 }
 
-{ #category : #helper }
+{ #category : 'helper' }
 VMPinnedObjectTest >> lastAliveObject [
 	^ self keptObjectInVMVariable2
 ]
 
-{ #category : #helper }
+{ #category : 'helper' }
 VMPinnedObjectTest >> lastPinnedObject [
 	^ self keptObjectInVMVariable1
 ]
 
-{ #category : #helper }
+{ #category : 'helper' }
 VMPinnedObjectTest >> newAliveObject [
 	| newAliveObject |
 	newAliveObject := self newOldSpaceObjectWithSlots: 1.
@@ -23,12 +25,12 @@ VMPinnedObjectTest >> newAliveObject [
 	^ newAliveObject
 ]
 
-{ #category : #helper }
+{ #category : 'helper' }
 VMPinnedObjectTest >> newDeadObject [
 	^ self newOldSpaceObjectWithSlots: 1
 ]
 
-{ #category : #helper }
+{ #category : 'helper' }
 VMPinnedObjectTest >> newKeptPinnedObject [
 	| newPinned |
 	newPinned := self newOldSpaceObjectWithSlots: 1.
@@ -38,7 +40,7 @@ VMPinnedObjectTest >> newKeptPinnedObject [
 	^ newPinned
 ]
 
-{ #category : #testCompactor }
+{ #category : 'testCompactor' }
 VMPinnedObjectTest >> testAllocatingObjectAfterAPinObjectShouldSlideAtStartOfOldSpace [
 	| aliveObject destination shouldBeFreed aliveHash |
 	"D = Dead
@@ -68,7 +70,7 @@ VMPinnedObjectTest >> testAllocatingObjectAfterAPinObjectShouldSlideAtStartOfOld
 	self assert: (memory isFreeObject: shouldBeFreed)
 ]
 
-{ #category : #testCompactor }
+{ #category : 'testCompactor' }
 VMPinnedObjectTest >> testAllocatingObjectAfterAPinObjectShouldSlideBeforeLastPinnedObject [
 	| aliveObject destination |
 	"D = Dead
@@ -96,7 +98,7 @@ VMPinnedObjectTest >> testAllocatingObjectAfterAPinObjectShouldSlideBeforeLastPi
 	self assert: self lastAliveObject equals: destination.
 ]
 
-{ #category : #testCompactor }
+{ #category : 'testCompactor' }
 VMPinnedObjectTest >> testAllocatingObjectAfterManyPinnedObjectShouldSlideAtStartOfOldSpace [
 	| aliveObject destination shouldBeFreed |
 	"D = Dead
@@ -126,7 +128,7 @@ VMPinnedObjectTest >> testAllocatingObjectAfterManyPinnedObjectShouldSlideAtStar
 	self assert: (memory isFreeObject: shouldBeFreed)
 ]
 
-{ #category : #testCompactor }
+{ #category : 'testCompactor' }
 VMPinnedObjectTest >> testAllocatingObjectAfterManyPinnedObjectShouldSlideBeforeFirstPinned [
 	| aliveObject destination |
 	"D = Dead
@@ -154,7 +156,7 @@ VMPinnedObjectTest >> testAllocatingObjectAfterManyPinnedObjectShouldSlideBefore
 	self assert: self lastAliveObject equals: destination.
 ]
 
-{ #category : #testCompactor }
+{ #category : 'testCompactor' }
 VMPinnedObjectTest >> testAllocatingObjectAfterTwoPinObjectShouldSlideAtStartOfOldSpace [
 	| aliveObject destination shouldBeFreed |
 	"D = Dead
@@ -184,7 +186,7 @@ VMPinnedObjectTest >> testAllocatingObjectAfterTwoPinObjectShouldSlideAtStartOfO
 	self assert: (memory isFreeObject: shouldBeFreed)
 ]
 
-{ #category : #testCompactor }
+{ #category : 'testCompactor' }
 VMPinnedObjectTest >> testAllocatingObjectRightAfterPinnedShouldMoveItOnFirstDead [
 	| destination aliveObject aliveObjectHash |
 	"D = Dead
@@ -210,7 +212,7 @@ VMPinnedObjectTest >> testAllocatingObjectRightAfterPinnedShouldMoveItOnFirstDea
 	self assert: (memory isFreeObject: (memory objectAfter: self lastPinnedObject)).
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMPinnedObjectTest >> testPinANewObjectShouldMoveItToTheOldSpace [
 	"if we follow the forwarder, the object is in the old space"
 	| obj |
@@ -221,7 +223,7 @@ VMPinnedObjectTest >> testPinANewObjectShouldMoveItToTheOldSpace [
 	self assert: (memory isInOldSpace: (memory followForwarded: obj))
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMPinnedObjectTest >> testPinANewObjectShouldMoveItToTheOldSpaceAndLeaveAForwarderBehind [
 	| obj |
 	obj := self newObjectWithSlots: 0.
@@ -231,7 +233,7 @@ VMPinnedObjectTest >> testPinANewObjectShouldMoveItToTheOldSpaceAndLeaveAForward
 	self assert: (memory isForwarded: obj)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMPinnedObjectTest >> testPinnedObjectShouldNotBeMovedByGC [
 	| pinned |
 	self newOldSpaceObjectWithSlots: 0. "deadObject, that differenciate the start of the old space to the pin"	

--- a/smalltalksrc/VMMakerTests/VMPrimitiveCallAbstractTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveCallAbstractTest.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #VMPrimitiveCallAbstractTest,
-	#superclass : #VMSimpleStackBasedCogitAbstractTest,
+	#name : 'VMPrimitiveCallAbstractTest',
+	#superclass : 'VMSimpleStackBasedCogitAbstractTest',
 	#instVars : [
 		'baseMethodIP',
 		'baseFrame',
 		'baseMethod'
 	],
-	#category : #'VMMakerTests-JitTests'
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMPrimitiveCallAbstractTest >> callCogMethod: callingMethod receiver: receiver arguments: arguments returnAddress: returnAddress [
 
 	machineSimulator receiverRegisterValue: receiver.
@@ -32,19 +34,19 @@ VMPrimitiveCallAbstractTest >> callCogMethod: callingMethod receiver: receiver a
 
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMPrimitiveCallAbstractTest >> findMethod: aSelector [
 
 	^ self class lookupSelector: aSelector
 ]
 
-{ #category : #'methods under test' }
+{ #category : 'methods under test' }
 VMPrimitiveCallAbstractTest >> jitCompilerClass [
 
 	^ StackToRegisterMappingCogit 
 ]
 
-{ #category : #'methods under test' }
+{ #category : 'methods under test' }
 VMPrimitiveCallAbstractTest >> jitOptions [
 
 	^ super jitOptions
@@ -52,13 +54,13 @@ VMPrimitiveCallAbstractTest >> jitOptions [
 		  yourself
 ]
 
-{ #category : #'methods under test' }
+{ #category : 'methods under test' }
 VMPrimitiveCallAbstractTest >> methodReturningNil [
 
 	^ nil
 ]
 
-{ #category : #'methods under test' }
+{ #category : 'methods under test' }
 VMPrimitiveCallAbstractTest >> methodSendingCharacterArgument [
 
 	"This method is used to test sends.
@@ -66,7 +68,7 @@ VMPrimitiveCallAbstractTest >> methodSendingCharacterArgument [
 	^ self methodWithSend: $7
 ]
 
-{ #category : #'methods under test' }
+{ #category : 'methods under test' }
 VMPrimitiveCallAbstractTest >> methodSendingLiteralVariableArgument [
 
 	"This method is used to test sends.
@@ -74,7 +76,7 @@ VMPrimitiveCallAbstractTest >> methodSendingLiteralVariableArgument [
 	^ self methodWithSend: Object
 ]
 
-{ #category : #'methods under test' }
+{ #category : 'methods under test' }
 VMPrimitiveCallAbstractTest >> methodSendingNilArgument [
 
 	"This method is used to test sends.
@@ -82,7 +84,7 @@ VMPrimitiveCallAbstractTest >> methodSendingNilArgument [
 	^ self methodWithSend: nil
 ]
 
-{ #category : #'methods under test' }
+{ #category : 'methods under test' }
 VMPrimitiveCallAbstractTest >> methodThatCallNamedPrimitive: anArg [
 
 	"This method is used to test the invocation of a primitive.
@@ -92,7 +94,7 @@ VMPrimitiveCallAbstractTest >> methodThatCallNamedPrimitive: anArg [
 	^ 84
 ]
 
-{ #category : #'methods under test' }
+{ #category : 'methods under test' }
 VMPrimitiveCallAbstractTest >> methodThatCallNamedPrimitiveCounting: anArg [
 
 	"This method is used to test the invocation of a primitive.
@@ -102,7 +104,7 @@ VMPrimitiveCallAbstractTest >> methodThatCallNamedPrimitiveCounting: anArg [
 	^ 84
 ]
 
-{ #category : #'methods under test' }
+{ #category : 'methods under test' }
 VMPrimitiveCallAbstractTest >> methodThatCallPrimitive159 [
 
 	<primitive: 159>
@@ -110,7 +112,7 @@ VMPrimitiveCallAbstractTest >> methodThatCallPrimitive159 [
 	^ 42 
 ]
 
-{ #category : #'methods under test' }
+{ #category : 'methods under test' }
 VMPrimitiveCallAbstractTest >> methodThatCallPrimitive173: anArg [
 
 	"This method is used to test the invocation of a primitive.
@@ -120,7 +122,7 @@ VMPrimitiveCallAbstractTest >> methodThatCallPrimitive173: anArg [
 	^ 42
 ]
 
-{ #category : #'methods under test' }
+{ #category : 'methods under test' }
 VMPrimitiveCallAbstractTest >> methodThatCallPrimitive1: anArg [
 
 	"This method is used to test the invocation of a primitive.
@@ -130,13 +132,13 @@ VMPrimitiveCallAbstractTest >> methodThatCallPrimitive1: anArg [
 	^ 42
 ]
 
-{ #category : #'methods under test' }
+{ #category : 'methods under test' }
 VMPrimitiveCallAbstractTest >> methodToCompile1 [
 
 	^ 42
 ]
 
-{ #category : #'methods under test' }
+{ #category : 'methods under test' }
 VMPrimitiveCallAbstractTest >> methodWithSend [
 
 	"This method is used to test sends.
@@ -144,7 +146,7 @@ VMPrimitiveCallAbstractTest >> methodWithSend [
 	^ self send
 ]
 
-{ #category : #'methods under test' }
+{ #category : 'methods under test' }
 VMPrimitiveCallAbstractTest >> methodWithSend: arg [
 
 	"This method is used to test sends.
@@ -152,7 +154,7 @@ VMPrimitiveCallAbstractTest >> methodWithSend: arg [
 	^ arg send
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMPrimitiveCallAbstractTest >> setUp [
 
 	| primitiveAccessorDepthTable |
@@ -177,7 +179,7 @@ VMPrimitiveCallAbstractTest >> setUp [
 
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMPrimitiveCallAbstractTest >> setUpTrampolines [
 
 	super setUpTrampolines.

--- a/smalltalksrc/VMMakerTests/VMPrimitiveCallingTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveCallingTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #VMPrimitiveCallingTest,
-	#superclass : #VMInterpreterTests,
-	#category : #'VMMakerTests-InterpreterTests'
+	#name : 'VMPrimitiveCallingTest',
+	#superclass : 'VMInterpreterTests',
+	#category : 'VMMakerTests-InterpreterTests',
+	#package : 'VMMakerTests',
+	#tag : 'InterpreterTests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMPrimitiveCallingTest >> testPrimitiveFailingDoesNotSetErrorCodeInOtherTemp [
 
 	"The method has two temporaries. The first one is the error code, the second one is a user defined temp."
@@ -26,7 +28,7 @@ VMPrimitiveCallingTest >> testPrimitiveFailingDoesNotSetErrorCodeInOtherTemp [
 	self assert: (interpreter temporary: 1 in: interpreter framePointer) equals: memory nilObject
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMPrimitiveCallingTest >> testPrimitiveFailingDoesNotSkipSecondBytecodeIfNotLongStore [
 
 	"The method has two temporaries. The first one is the error code, the second one is a user defined temp."
@@ -48,7 +50,7 @@ VMPrimitiveCallingTest >> testPrimitiveFailingDoesNotSkipSecondBytecodeIfNotLong
 	self assert: interpreter fetchByte equals: 16rF4
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMPrimitiveCallingTest >> testPrimitiveFailingSetsErrorCodeInCorrectTemp [
 
 	"The method has two temporaries. The first one is the error code, the second one is a user defined temp."
@@ -70,7 +72,7 @@ VMPrimitiveCallingTest >> testPrimitiveFailingSetsErrorCodeInCorrectTemp [
 	self assert: (interpreter temporary: 0 in: interpreter framePointer) equals: (memory integerObjectOf: -1)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMPrimitiveCallingTest >> testPrimitiveFailingSetsErrorCodeInCorrectTempWithInternalActivation [
 
 	"The method has two temporaries. The first one is the error code, the second one is a user defined temp."

--- a/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #VMPrimitiveTest,
-	#superclass : #VMInterpreterTests,
+	#name : 'VMPrimitiveTest',
+	#superclass : 'VMInterpreterTests',
 	#instVars : [
 		'imageName'
 	],
@@ -9,10 +9,12 @@ Class {
 		'VMBytecodeConstants',
 		'VMObjectIndices'
 	],
-	#category : #'VMMakerTests-InterpreterTests'
+	#category : 'VMMakerTests-InterpreterTests',
+	#package : 'VMMakerTests',
+	#tag : 'InterpreterTests'
 }
 
-{ #category : #asserting }
+{ #category : 'asserting' }
 VMPrimitiveTest >> assert: anOop contentEquals: oopToCompare [ 
 
 	| numSlotOop numSlotOopToCompare |
@@ -26,7 +28,7 @@ VMPrimitiveTest >> assert: anOop contentEquals: oopToCompare [
 	
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMPrimitiveTest >> fillNewSpace [
 
 	"Allocate enough space to generate a full new space"
@@ -38,7 +40,7 @@ VMPrimitiveTest >> fillNewSpace [
 			 classIndex: memory arrayClassIndexPun) isNotNil
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 VMPrimitiveTest >> newArrayWith: aCollection [ 
 	| array |
 	array := self newObjectWithSlots: aCollection size format: memory arrayFormat classIndex: memory arrayClassIndexPun.
@@ -49,7 +51,7 @@ VMPrimitiveTest >> newArrayWith: aCollection [
 	
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMPrimitiveTest >> setUp [
 
 	"taken from VMSimpleStackBasedCogitBytecodeTest >> #setup"
@@ -76,16 +78,16 @@ VMPrimitiveTest >> setUp [
 	imageName := VMPrimitiveTest name
 ]
 
-{ #category : #'tests - primitiveIdentical' }
+{ #category : 'tests - primitiveIdentical' }
 VMPrimitiveTest >> setUpForwardedObjects [
 	| class1 class2 object1 object2 array1 array2 |
-	
+
 	class1 := self newClassInOldSpaceWithSlots: 1 instSpec: memory nonIndexablePointerFormat.
 	class2 := self newClassInOldSpaceWithSlots: 2 instSpec: memory nonIndexablePointerFormat.
 	
 	object1 := memory instantiateClass: class1.
 	object2 := memory instantiateClass: class2.
-	
+
 	array1 := self newArrayWith: { object1 }.
 	array2 := self newArrayWith: { object2 }.
 	
@@ -100,14 +102,14 @@ VMPrimitiveTest >> setUpForwardedObjects [
 	^ object1. 
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMPrimitiveTest >> tearDown [
 
 	imageName ifNotNil: [ imageName asFileReference ensureDeleteAll ].
 	super tearDown
 ]
 
-{ #category : #'tests - primitiveAdd' }
+{ #category : 'tests - primitiveAdd' }
 VMPrimitiveTest >> testPrimitiveAddFailsWithTypeErrorOnFirstOperand [
 
 	interpreter push: memory trueObject.
@@ -120,7 +122,7 @@ VMPrimitiveTest >> testPrimitiveAddFailsWithTypeErrorOnFirstOperand [
 	
 ]
 
-{ #category : #'tests - primitiveAdd' }
+{ #category : 'tests - primitiveAdd' }
 VMPrimitiveTest >> testPrimitiveAddFailsWithTypeErrorOnSecondOperand [
 
 	interpreter push: (memory integerObjectOf: 2).
@@ -133,7 +135,7 @@ VMPrimitiveTest >> testPrimitiveAddFailsWithTypeErrorOnSecondOperand [
 	
 ]
 
-{ #category : #'tests - primitiveAdd' }
+{ #category : 'tests - primitiveAdd' }
 VMPrimitiveTest >> testPrimitiveAddFailsWithTypeErrorPreservesStack [
 	| string |
 	
@@ -149,7 +151,7 @@ VMPrimitiveTest >> testPrimitiveAddFailsWithTypeErrorPreservesStack [
 	
 ]
 
-{ #category : #'tests - primitiveAdd' }
+{ #category : 'tests - primitiveAdd' }
 VMPrimitiveTest >> testPrimitiveAddWithNoOverflow [
 
 	interpreter push: (memory integerObjectOf: 1).
@@ -164,7 +166,7 @@ VMPrimitiveTest >> testPrimitiveAddWithNoOverflow [
 	
 ]
 
-{ #category : #'tests - primitiveAdd' }
+{ #category : 'tests - primitiveAdd' }
 VMPrimitiveTest >> testPrimitiveAddWithNoOverflowPopsOperands [
 
 	interpreter push: (memory integerObjectOf: 42). "Marker"
@@ -181,7 +183,7 @@ VMPrimitiveTest >> testPrimitiveAddWithNoOverflowPopsOperands [
 	
 ]
 
-{ #category : #'tests - primitiveAdd' }
+{ #category : 'tests - primitiveAdd' }
 VMPrimitiveTest >> testPrimitiveAddWithOverflow [
 
 	interpreter push: (memory integerObjectOf: memory maxSmallInteger).
@@ -194,7 +196,7 @@ VMPrimitiveTest >> testPrimitiveAddWithOverflow [
 	
 ]
 
-{ #category : #'tests - primitiveAdd' }
+{ #category : 'tests - primitiveAdd' }
 VMPrimitiveTest >> testPrimitiveAddWithOverflowPreservesStack [
 	
 	| maxSmallInt |
@@ -212,7 +214,7 @@ VMPrimitiveTest >> testPrimitiveAddWithOverflowPreservesStack [
 	
 ]
 
-{ #category : #'tests - become' }
+{ #category : 'tests - become' }
 VMPrimitiveTest >> testPrimitiveArrayBecomeCreatesForwardersForObjectsOfDifferentSize [
 	| class1 class2 object1 object2 array1 array2 |
 	class1 := self newClassInOldSpaceWithSlots: 1 instSpec: memory nonIndexablePointerFormat.
@@ -233,7 +235,7 @@ VMPrimitiveTest >> testPrimitiveArrayBecomeCreatesForwardersForObjectsOfDifferen
 	self assert: (memory isForwarded: object2) equals: true
 ]
 
-{ #category : #'tests - become' }
+{ #category : 'tests - become' }
 VMPrimitiveTest >> testPrimitiveArrayBecomeExchangesClass [
 	| class1 class2 object1 object2 array1 array2 |
 	class1 := self newClassInOldSpaceWithSlots: 1 instSpec: memory nonIndexablePointerFormat.
@@ -254,7 +256,7 @@ VMPrimitiveTest >> testPrimitiveArrayBecomeExchangesClass [
 	self assert: (memory fetchClassOf: object2) equals: class1
 ]
 
-{ #category : #'tests - become' }
+{ #category : 'tests - become' }
 VMPrimitiveTest >> testPrimitiveArrayBecomeExchangesClassForObjectsOfDifferentSize [
 	| class1 class2 object1 object2 array1 array2 |
 	class1 := self newClassInOldSpaceWithSlots: 1 instSpec: memory nonIndexablePointerFormat.
@@ -275,7 +277,7 @@ VMPrimitiveTest >> testPrimitiveArrayBecomeExchangesClassForObjectsOfDifferentSi
 	self assert: (memory fetchClassOf: (memory followForwarded: object2)) equals: class1
 ]
 
-{ #category : #'tests - become' }
+{ #category : 'tests - become' }
 VMPrimitiveTest >> testPrimitiveArrayBecomeExchangesContents [
 	| class object1 object2 array1 array2 |
 	class := self newClassInOldSpaceWithSlots: 1 instSpec: memory nonIndexablePointerFormat.
@@ -297,7 +299,7 @@ VMPrimitiveTest >> testPrimitiveArrayBecomeExchangesContents [
 	self assert: (memory fetchInteger: 0 ofObject: object2) equals: 42.
 ]
 
-{ #category : #'tests - become' }
+{ #category : 'tests - become' }
 VMPrimitiveTest >> testPrimitiveArrayBecomeExchangesContentsForObjectsOfDifferentSize [
 	| class1 class2 object1 object2 array1 array2 |
 	class1 := self newClassInOldSpaceWithSlots: 1 instSpec: memory nonIndexablePointerFormat.
@@ -323,7 +325,7 @@ VMPrimitiveTest >> testPrimitiveArrayBecomeExchangesContentsForObjectsOfDifferen
 	self assert: (memory fetchInteger: 0 ofObject: (memory followForwarded: object2)) equals: 42
 ]
 
-{ #category : #'tests - become' }
+{ #category : 'tests - become' }
 VMPrimitiveTest >> testPrimitiveArrayBecomeExchangesIdentityHash [
 	| class object1 object2 hash1 hash2 array1 array2 |
 	class := self newClassInOldSpaceWithSlots: 1 instSpec: memory nonIndexablePointerFormat.
@@ -346,7 +348,7 @@ VMPrimitiveTest >> testPrimitiveArrayBecomeExchangesIdentityHash [
 	self assert: (memory rawHashBitsOf: object2) equals: hash1
 ]
 
-{ #category : #'tests - become' }
+{ #category : 'tests - become' }
 VMPrimitiveTest >> testPrimitiveArrayBecomeExchangesIdentityHashForObjectsOfDifferentSize [
 	| class1 class2 object1 object2 hash1 hash2 array1 array2 |
 	class1 := self newClassInOldSpaceWithSlots: 1 instSpec: memory nonIndexablePointerFormat.
@@ -370,7 +372,7 @@ VMPrimitiveTest >> testPrimitiveArrayBecomeExchangesIdentityHashForObjectsOfDiff
 	self assert: (memory rawHashBitsOf: (memory followForwarded: object2)) equals: hash1
 ]
 
-{ #category : #'tests - become' }
+{ #category : 'tests - become' }
 VMPrimitiveTest >> testPrimitiveArrayBecomeFailsForImmediates [
 	| class immediate array1 array2 |
 	class := self newClassInOldSpaceWithSlots: 1 instSpec: memory nonIndexablePointerFormat.
@@ -389,7 +391,7 @@ VMPrimitiveTest >> testPrimitiveArrayBecomeFailsForImmediates [
 	
 ]
 
-{ #category : #'tests - become' }
+{ #category : 'tests - become' }
 VMPrimitiveTest >> testPrimitiveArrayBecomeFailsForImmutableObject [
 	| class object1 object2 array1 array2 |
 	class := self newClassInOldSpaceWithSlots: 1 instSpec: memory nonIndexablePointerFormat.
@@ -410,7 +412,7 @@ VMPrimitiveTest >> testPrimitiveArrayBecomeFailsForImmutableObject [
 	self assert: interpreter primFailCode equals: PrimErrNoModification
 ]
 
-{ #category : #'tests - become' }
+{ #category : 'tests - become' }
 VMPrimitiveTest >> testPrimitiveArrayBecomeFailsForPinnedObject [
 	| class object1 object2 array1 array2 |
 	class := self newClassInOldSpaceWithSlots: 1 instSpec: memory nonIndexablePointerFormat.
@@ -430,7 +432,7 @@ VMPrimitiveTest >> testPrimitiveArrayBecomeFailsForPinnedObject [
 	self assert: interpreter primFailCode equals: PrimErrObjectIsPinned
 ]
 
-{ #category : #'tests - become' }
+{ #category : 'tests - become' }
 VMPrimitiveTest >> testPrimitiveArrayBecomeOneWayCopyHashIfCopyHasIsFalseDoesNotCopyHash [
 	| class object1 object2 hash2BeforeBecome array1 array2 object2FromForwarder |
 	class := self
@@ -453,7 +455,7 @@ VMPrimitiveTest >> testPrimitiveArrayBecomeOneWayCopyHashIfCopyHasIsFalseDoesNot
 	self assert: (memory hashBitsOf: object2) equals: hash2BeforeBecome
 ]
 
-{ #category : #'tests - become' }
+{ #category : 'tests - become' }
 VMPrimitiveTest >> testPrimitiveArrayBecomeOneWayCopyHashIfCopyHasIsTrueCopiesHash [
 	| class object1 object2 hash1 hash2 array1 array2 |
 	class := self newClassInOldSpaceWithSlots: 1 instSpec: memory nonIndexablePointerFormat.
@@ -476,7 +478,7 @@ VMPrimitiveTest >> testPrimitiveArrayBecomeOneWayCopyHashIfCopyHasIsTrueCopiesHa
 	self deny: (memory hashBitsOf: object2) equals: hash2
 ]
 
-{ #category : #'tests - become' }
+{ #category : 'tests - become' }
 VMPrimitiveTest >> testPrimitiveArrayBecomeOneWayCreatesForwardThatPointsToOriginalObject [
 	| class object1 object2 array1 array2 |
 	class := self newClassInOldSpaceWithSlots: 1 instSpec: memory nonIndexablePointerFormat.
@@ -496,7 +498,7 @@ VMPrimitiveTest >> testPrimitiveArrayBecomeOneWayCreatesForwardThatPointsToOrigi
 	self assert: (memory followForwarded: object1)  equals: object2
 ]
 
-{ #category : #'tests - primitiveAsCharacter' }
+{ #category : 'tests - primitiveAsCharacter' }
 VMPrimitiveTest >> testPrimitiveAsCharacter [
 	interpreter push: (memory integerObjectOf: 65).
 	
@@ -506,7 +508,7 @@ VMPrimitiveTest >> testPrimitiveAsCharacter [
 	self assert: interpreter stackTop equals: (memory characterObjectOf: 65). 
 ]
 
-{ #category : #'tests - primitiveAsCharacter' }
+{ #category : 'tests - primitiveAsCharacter' }
 VMPrimitiveTest >> testPrimitiveAsCharacterFailsForOutOfRangeArg [
 
 	| invalidNumber |
@@ -525,7 +527,7 @@ VMPrimitiveTest >> testPrimitiveAsCharacterFailsForOutOfRangeArg [
 	self assert: interpreter primFailCode equals: PrimErrBadReceiver.
 ]
 
-{ #category : #'tests - primitiveAsCharacter' }
+{ #category : 'tests - primitiveAsCharacter' }
 VMPrimitiveTest >> testPrimitiveAsCharacterFailsWithNonIntObject [
 	
 	interpreter push: memory trueObject. 
@@ -536,7 +538,7 @@ VMPrimitiveTest >> testPrimitiveAsCharacterFailsWithNonIntObject [
 	self assert: interpreter primFailCode equals: PrimErrBadReceiver. 
 ]
 
-{ #category : #'tests - primitiveAt' }
+{ #category : 'tests - primitiveAt' }
 VMPrimitiveTest >> testPrimitiveAtDoesntFailsIfObjectIsImmutable [
 
 	| class object slotIndex objectToPutInSlot |
@@ -560,7 +562,7 @@ VMPrimitiveTest >> testPrimitiveAtDoesntFailsIfObjectIsImmutable [
 self assert: (memory fetchPointer: 0 ofObject: object) equals: interpreter stackTop. 
 ]
 
-{ #category : #'tests - primitiveAt' }
+{ #category : 'tests - primitiveAt' }
 VMPrimitiveTest >> testPrimitiveAtFailsForImmediate [
 
 	interpreter push: (memory integerObjectOf: 32).
@@ -571,7 +573,7 @@ VMPrimitiveTest >> testPrimitiveAtFailsForImmediate [
 	self assert: interpreter primFailCode equals: PrimErrInappropriate. 
 ]
 
-{ #category : #'tests - primitiveAt' }
+{ #category : 'tests - primitiveAt' }
 VMPrimitiveTest >> testPrimitiveAtFailsForNonIndexableObject [
 	| class object |
 	class := self newClassInOldSpaceWithSlots: 0 instSpec: memory nonIndexablePointerFormat.
@@ -586,7 +588,7 @@ VMPrimitiveTest >> testPrimitiveAtFailsForNonIndexableObject [
 	self assert: interpreter primFailCode equals: PrimErrBadReceiver. 
 ]
 
-{ #category : #'tests - primitiveAt' }
+{ #category : 'tests - primitiveAt' }
 VMPrimitiveTest >> testPrimitiveAtFailsForNonIntegerArgument [
 	| class objectInstance |
 	class := self newClassInOldSpaceWithSlots: 0 instSpec: memory nonIndexablePointerFormat.
@@ -600,7 +602,7 @@ VMPrimitiveTest >> testPrimitiveAtFailsForNonIntegerArgument [
 	self assert: interpreter primFailCode equals: PrimErrBadArgument. 
 ]
 
-{ #category : #'tests - primitiveAtPut' }
+{ #category : 'tests - primitiveAtPut' }
 VMPrimitiveTest >> testPrimitiveAtPutFailsForForwardedReceiver [
 	| class objectInstance biggerClass objectForwarded array1 array2 |
 	"Forwarding an object happens when becoming it with a bigger object"
@@ -630,7 +632,7 @@ VMPrimitiveTest >> testPrimitiveAtPutFailsForForwardedReceiver [
 	self assert: interpreter primFailCode equals: PrimErrBadArgument. 
 ]
 
-{ #category : #'tests - primitiveAtPut' }
+{ #category : 'tests - primitiveAtPut' }
 VMPrimitiveTest >> testPrimitiveAtPutFailsForImmediate [
 
 	interpreter push: (memory integerObjectOf: 32).
@@ -642,7 +644,7 @@ VMPrimitiveTest >> testPrimitiveAtPutFailsForImmediate [
 	self assert: interpreter primFailCode equals: PrimErrInappropriate. 
 ]
 
-{ #category : #'tests - primitiveAtPut' }
+{ #category : 'tests - primitiveAtPut' }
 VMPrimitiveTest >> testPrimitiveAtPutFailsForMoreThanTwoArguments [
 	| class objectInstance |
 	"I don't know how to force a bad argument count."
@@ -665,7 +667,7 @@ VMPrimitiveTest >> testPrimitiveAtPutFailsForMoreThanTwoArguments [
 	self assert: interpreter primFailCode equals: PrimErrInappropriate. 
 ]
 
-{ #category : #'tests - primitiveAtPut' }
+{ #category : 'tests - primitiveAtPut' }
 VMPrimitiveTest >> testPrimitiveAtPutFailsForNonIndexableObject [
 	| class object |
 	class := self newClassInOldSpaceWithSlots: 0 instSpec: memory nonIndexablePointerFormat.
@@ -681,7 +683,7 @@ VMPrimitiveTest >> testPrimitiveAtPutFailsForNonIndexableObject [
 	self assert: interpreter primFailCode equals: PrimErrBadReceiver. 
 ]
 
-{ #category : #'tests - primitiveAtPut' }
+{ #category : 'tests - primitiveAtPut' }
 VMPrimitiveTest >> testPrimitiveAtPutFailsForNonIntegerArgument [
 	| class objectInstance |
 	class := self newClassInOldSpaceWithSlots: 0 instSpec: memory nonIndexablePointerFormat.
@@ -696,7 +698,7 @@ VMPrimitiveTest >> testPrimitiveAtPutFailsForNonIntegerArgument [
 	self assert: interpreter primFailCode equals: PrimErrBadArgument. 
 ]
 
-{ #category : #'tests - primitiveImmutability' }
+{ #category : 'tests - primitiveImmutability' }
 VMPrimitiveTest >> testPrimitiveAtPutFailsIfObjectIsContext [
 
 	| class object slotIndex objectToPutInSlot |
@@ -719,7 +721,7 @@ VMPrimitiveTest >> testPrimitiveAtPutFailsIfObjectIsContext [
 	self assert: interpreter primFailCode equals: 2. 
 ]
 
-{ #category : #'tests - primitiveAtPut' }
+{ #category : 'tests - primitiveAtPut' }
 VMPrimitiveTest >> testPrimitiveAtPutFailsIfObjectIsImmutable [
 
 	| class object slotIndex objectToPutInSlot |
@@ -743,7 +745,7 @@ VMPrimitiveTest >> testPrimitiveAtPutFailsIfObjectIsImmutable [
 	self assert: interpreter primFailCode equals: PrimErrNoModification. 
 ]
 
-{ #category : #'tests - primitiveAtPut' }
+{ #category : 'tests - primitiveAtPut' }
 VMPrimitiveTest >> testPrimitiveAtPutPutsTheValueForAnIndexableObject [
 	| class object |
 	class := self newClassInOldSpaceWithSlots: 0 instSpec: memory arrayFormat.
@@ -759,7 +761,7 @@ VMPrimitiveTest >> testPrimitiveAtPutPutsTheValueForAnIndexableObject [
 	self assert: (memory fetchPointer: 0 ofObject: object) equals: memory falseObject.
 ]
 
-{ #category : #'tests - primitiveAt' }
+{ #category : 'tests - primitiveAt' }
 VMPrimitiveTest >> testPrimitiveAtReturnsTheValueForAnIndexableObject [
 	| class object |
 	class := self newClassInOldSpaceWithSlots: 0 instSpec: memory arrayFormat.
@@ -782,7 +784,7 @@ VMPrimitiveTest >> testPrimitiveAtReturnsTheValueForAnIndexableObject [
 	self assert: interpreter stackTop equals: memory falseObject. 
 ]
 
-{ #category : #'tests - primitiveBitShift' }
+{ #category : 'tests - primitiveBitShift' }
 VMPrimitiveTest >> testPrimitiveBifShitBorderCase [
 
 	interpreter push: (memory integerObjectOf: (memory maxSmallInteger >> memory numSmallIntegerTagBits)).
@@ -793,7 +795,7 @@ VMPrimitiveTest >> testPrimitiveBifShitBorderCase [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 0).
 ]
 
-{ #category : #'tests - primitiveBitAnd' }
+{ #category : 'tests - primitiveBitAnd' }
 VMPrimitiveTest >> testPrimitiveBitAnd1 [
 
 	interpreter push: (memory integerObjectOf: 16r1).
@@ -804,7 +806,7 @@ VMPrimitiveTest >> testPrimitiveBitAnd1 [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 1). 
 ]
 
-{ #category : #'tests - primitiveBitAnd' }
+{ #category : 'tests - primitiveBitAnd' }
 VMPrimitiveTest >> testPrimitiveBitAnd2 [
 
 	interpreter push: (memory integerObjectOf: 16r1).
@@ -815,7 +817,7 @@ VMPrimitiveTest >> testPrimitiveBitAnd2 [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 0). 
 ]
 
-{ #category : #'tests - primitiveBitAnd' }
+{ #category : 'tests - primitiveBitAnd' }
 VMPrimitiveTest >> testPrimitiveBitAndFailsPreservesStack [
 	
 	| string |
@@ -832,7 +834,7 @@ VMPrimitiveTest >> testPrimitiveBitAndFailsPreservesStack [
 	self assert: (interpreter stackValue: 1) equals: string. 
 ]
 
-{ #category : #'tests - primitiveBitAnd' }
+{ #category : 'tests - primitiveBitAnd' }
 VMPrimitiveTest >> testPrimitiveBitAndFailsWithTypeErrorOnFirstOperand [
 	
 	| string |
@@ -846,7 +848,7 @@ VMPrimitiveTest >> testPrimitiveBitAndFailsWithTypeErrorOnFirstOperand [
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveBitAnd' }
+{ #category : 'tests - primitiveBitAnd' }
 VMPrimitiveTest >> testPrimitiveBitAndFailsWithTypeErrorOnSecondOperand [
 	
 	interpreter push: (memory integerObjectOf: 2).
@@ -857,7 +859,7 @@ VMPrimitiveTest >> testPrimitiveBitAndFailsWithTypeErrorOnSecondOperand [
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveBitAnd' }
+{ #category : 'tests - primitiveBitAnd' }
 VMPrimitiveTest >> testPrimitiveBitAndWithMaxBitIntWithNoDataLoss [
 	"This insures the fact that no data is lost during the processing of usqInt by the primitive"
 
@@ -873,7 +875,7 @@ VMPrimitiveTest >> testPrimitiveBitAndWithMaxBitIntWithNoDataLoss [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: (num - 1)).
 ]
 
-{ #category : #'tests - primitiveBitAnd' }
+{ #category : 'tests - primitiveBitAnd' }
 VMPrimitiveTest >> testPrimitiveBitAndWithNegativNumbers [
 "111... 010110 -> -42
  000... 010110 ->  21"""
@@ -886,7 +888,7 @@ VMPrimitiveTest >> testPrimitiveBitAndWithNegativNumbers [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 21). 
 ]
 
-{ #category : #'tests - primitiveBitOr' }
+{ #category : 'tests - primitiveBitOr' }
 VMPrimitiveTest >> testPrimitiveBitOr1 [ 
 
 	interpreter push: (memory integerObjectOf: 16r1).
@@ -897,7 +899,7 @@ VMPrimitiveTest >> testPrimitiveBitOr1 [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 1). 
 ]
 
-{ #category : #'tests - primitiveBitOr' }
+{ #category : 'tests - primitiveBitOr' }
 VMPrimitiveTest >> testPrimitiveBitOr2 [
 
 	interpreter push: (memory integerObjectOf: 16r1).
@@ -912,7 +914,7 @@ VMPrimitiveTest >> testPrimitiveBitOr2 [
 	
 ]
 
-{ #category : #'tests - primitiveBitOr' }
+{ #category : 'tests - primitiveBitOr' }
 VMPrimitiveTest >> testPrimitiveBitOr3 [
 
 	interpreter push: (memory integerObjectOf: 16r0).
@@ -927,7 +929,7 @@ VMPrimitiveTest >> testPrimitiveBitOr3 [
 	
 ]
 
-{ #category : #'tests - primitiveBitOr' }
+{ #category : 'tests - primitiveBitOr' }
 VMPrimitiveTest >> testPrimitiveBitOr4 [
 
 	"This is to insure that primitiveBitOr executes a logical Or and not an XOr"
@@ -943,7 +945,7 @@ VMPrimitiveTest >> testPrimitiveBitOr4 [
 	
 ]
 
-{ #category : #'tests - primitiveBitOr' }
+{ #category : 'tests - primitiveBitOr' }
 VMPrimitiveTest >> testPrimitiveBitOrFailsPreservesStack [
 	
 	interpreter push: memory trueObject.
@@ -957,7 +959,7 @@ VMPrimitiveTest >> testPrimitiveBitOrFailsPreservesStack [
 	self assert: (interpreter stackValue: 1) equals: memory trueObject.
 ]
 
-{ #category : #'tests - primitiveBitOr' }
+{ #category : 'tests - primitiveBitOr' }
 VMPrimitiveTest >> testPrimitiveBitOrFailsWithTypeErrorOnFirstOperand [
 	
 	interpreter push: memory trueObject.
@@ -968,7 +970,7 @@ VMPrimitiveTest >> testPrimitiveBitOrFailsWithTypeErrorOnFirstOperand [
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveBitOr' }
+{ #category : 'tests - primitiveBitOr' }
 VMPrimitiveTest >> testPrimitiveBitOrFailsWithTypeErrorOnSecondOperand [
 	
 	interpreter push: (memory integerObjectOf: 2).
@@ -979,7 +981,7 @@ VMPrimitiveTest >> testPrimitiveBitOrFailsWithTypeErrorOnSecondOperand [
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveBitOr' }
+{ #category : 'tests - primitiveBitOr' }
 VMPrimitiveTest >> testPrimitiveBitOrWithMaxBitIntWithNoDataLoss [
 	"This insure the fact that no data is lost during the processing of usqInt by the primitive"
 
@@ -995,7 +997,7 @@ VMPrimitiveTest >> testPrimitiveBitOrWithMaxBitIntWithNoDataLoss [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: (num - 1)).
 ]
 
-{ #category : #'tests - primitiveBitOr' }
+{ #category : 'tests - primitiveBitOr' }
 VMPrimitiveTest >> testPrimitiveBitOrWithNegativNumbers [
 
 	interpreter push: (memory integerObjectOf: -73).
@@ -1006,7 +1008,7 @@ VMPrimitiveTest >> testPrimitiveBitOrWithNegativNumbers [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: ((memory maxCInteger >> memory numSmallIntegerTagBits) - 1)).
 ]
 
-{ #category : #'tests - primitiveBitShift' }
+{ #category : 'tests - primitiveBitShift' }
 VMPrimitiveTest >> testPrimitiveBitShift1 [
 
 	interpreter push: (memory integerObjectOf: 2).
@@ -1017,7 +1019,7 @@ VMPrimitiveTest >> testPrimitiveBitShift1 [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 0). 
 ]
 
-{ #category : #'tests - primitiveBitShift' }
+{ #category : 'tests - primitiveBitShift' }
 VMPrimitiveTest >> testPrimitiveBitShiftFailsWithTypeErrorOnFirstOperand [
 
 	interpreter push: memory trueObject. 
@@ -1030,7 +1032,7 @@ VMPrimitiveTest >> testPrimitiveBitShiftFailsWithTypeErrorOnFirstOperand [
 		
 ]
 
-{ #category : #'tests - primitiveBitShift' }
+{ #category : 'tests - primitiveBitShift' }
 VMPrimitiveTest >> testPrimitiveBitShiftFailsWithTypeErrorOnSecondOperand [
 	
 	interpreter push: (memory integerObjectOf: (memory maxSmallInteger)).
@@ -1043,7 +1045,7 @@ VMPrimitiveTest >> testPrimitiveBitShiftFailsWithTypeErrorOnSecondOperand [
 		
 ]
 
-{ #category : #'tests - primitiveBitShift' }
+{ #category : 'tests - primitiveBitShift' }
 VMPrimitiveTest >> testPrimitiveBitShiftFailsWithTypeErrorPreservesStack [
 
 	interpreter push: memory trueObject. 
@@ -1056,7 +1058,7 @@ VMPrimitiveTest >> testPrimitiveBitShiftFailsWithTypeErrorPreservesStack [
 		
 ]
 
-{ #category : #'tests - primitiveBitShift' }
+{ #category : 'tests - primitiveBitShift' }
 VMPrimitiveTest >> testPrimitiveBitShiftLeft [
 
 	interpreter push: (memory integerObjectOf: 16). 
@@ -1067,7 +1069,7 @@ VMPrimitiveTest >> testPrimitiveBitShiftLeft [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 32). 
 ]
 
-{ #category : #'tests - primitiveBitShift' }
+{ #category : 'tests - primitiveBitShift' }
 VMPrimitiveTest >> testPrimitiveBitShiftRight [
 
 	interpreter push: (memory integerObjectOf: 16). 
@@ -1078,7 +1080,7 @@ VMPrimitiveTest >> testPrimitiveBitShiftRight [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 8). 
 ]
 
-{ #category : #'tests - primitiveBitShift' }
+{ #category : 'tests - primitiveBitShift' }
 VMPrimitiveTest >> testPrimitiveBitShiftWithNegativNumbers [
 
 	memory wordSize = 8 ifFalse: [ ^ self ]. "The 32 bits version of the primitive doesn't handle the negativ number case"
@@ -1090,7 +1092,7 @@ VMPrimitiveTest >> testPrimitiveBitShiftWithNegativNumbers [
 		equals: (memory integerObjectOf: 16r1C00000000000000)
 ]
 
-{ #category : #'tests - primitiveBitShift' }
+{ #category : 'tests - primitiveBitShift' }
 VMPrimitiveTest >> testPrimitiveBitShiftWithOverflow [
 "Insures no data is lost when bitshift overflows the integer type."
 
@@ -1102,7 +1104,7 @@ VMPrimitiveTest >> testPrimitiveBitShiftWithOverflow [
 	self assert: (interpreter stackTop) > (memory maxSmallInteger).
 ]
 
-{ #category : #'tests - primitiveBitXor' }
+{ #category : 'tests - primitiveBitXor' }
 VMPrimitiveTest >> testPrimitiveBitXor1 [
 
 	interpreter push: (memory integerObjectOf: 16r1).
@@ -1113,7 +1115,7 @@ VMPrimitiveTest >> testPrimitiveBitXor1 [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 0). 
 ]
 
-{ #category : #'tests - primitiveBitXor' }
+{ #category : 'tests - primitiveBitXor' }
 VMPrimitiveTest >> testPrimitiveBitXor2 [
 
 	interpreter push: (memory integerObjectOf: 16r0).
@@ -1124,7 +1126,7 @@ VMPrimitiveTest >> testPrimitiveBitXor2 [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 1). 
 ]
 
-{ #category : #'tests - primitiveBitXor' }
+{ #category : 'tests - primitiveBitXor' }
 VMPrimitiveTest >> testPrimitiveBitXor3 [
 
 	interpreter push: (memory integerObjectOf: 16r1).
@@ -1135,7 +1137,7 @@ VMPrimitiveTest >> testPrimitiveBitXor3 [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 1). 
 ]
 
-{ #category : #'tests - primitiveBitXor' }
+{ #category : 'tests - primitiveBitXor' }
 VMPrimitiveTest >> testPrimitiveBitXor4 [
 
 	interpreter push: (memory integerObjectOf: 16r0).
@@ -1146,7 +1148,7 @@ VMPrimitiveTest >> testPrimitiveBitXor4 [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 0). 
 ]
 
-{ #category : #'tests - primitiveBitXor' }
+{ #category : 'tests - primitiveBitXor' }
 VMPrimitiveTest >> testPrimitiveBitXorFailsPreservesStack [
 	
 	interpreter push: memory trueObject.
@@ -1160,7 +1162,7 @@ VMPrimitiveTest >> testPrimitiveBitXorFailsPreservesStack [
 	self assert: (interpreter stackValue: 1) equals: memory trueObject.
 ]
 
-{ #category : #'tests - primitiveBitXor' }
+{ #category : 'tests - primitiveBitXor' }
 VMPrimitiveTest >> testPrimitiveBitXorFailsWithTypeErrorOnFirstOperand [
 	
 	interpreter push: memory trueObject.
@@ -1171,7 +1173,7 @@ VMPrimitiveTest >> testPrimitiveBitXorFailsWithTypeErrorOnFirstOperand [
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveBitXor' }
+{ #category : 'tests - primitiveBitXor' }
 VMPrimitiveTest >> testPrimitiveBitXorFailsWithTypeErrorOnSecondOperand [
 	
 	interpreter push: (memory integerObjectOf: 2).
@@ -1182,7 +1184,7 @@ VMPrimitiveTest >> testPrimitiveBitXorFailsWithTypeErrorOnSecondOperand [
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveBitXor' }
+{ #category : 'tests - primitiveBitXor' }
 VMPrimitiveTest >> testPrimitiveBitXorWithMaxBitIntWithNoDataLoss [
 	"This guarantees the fact that no data is lost during the processing of usqInt by the primitive"
 	"111... 111
@@ -1202,7 +1204,7 @@ VMPrimitiveTest >> testPrimitiveBitXorWithMaxBitIntWithNoDataLoss [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: ((memory maxCInteger >> (memory numSmallIntegerTagBits + 1)))).
 ]
 
-{ #category : #'tests - primitiveBitXor' }
+{ #category : 'tests - primitiveBitXor' }
 VMPrimitiveTest >> testPrimitiveBitXorWithNegativNumbers [
 
 	interpreter push: (memory integerObjectOf: -42).
@@ -1213,7 +1215,7 @@ VMPrimitiveTest >> testPrimitiveBitXorWithNegativNumbers [
 	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 40).
 ]
 
-{ #category : #'tests - primitiveClass' }
+{ #category : 'tests - primitiveClass' }
 VMPrimitiveTest >> testPrimitiveClassDoesntFailsForForwardedObjectAndArgCountEqualsZero [
 	
 	interpreter push: self setUpForwardedObjects. 
@@ -1227,7 +1229,7 @@ VMPrimitiveTest >> testPrimitiveClassDoesntFailsForForwardedObjectAndArgCountEqu
 	
 ]
 
-{ #category : #'tests - primitiveClass' }
+{ #category : 'tests - primitiveClass' }
 VMPrimitiveTest >> testPrimitiveClassFailsForForwardedObjectAndArgCountMoreThanZero [
 	
 	interpreter push: self setUpForwardedObjects. 
@@ -1242,7 +1244,7 @@ VMPrimitiveTest >> testPrimitiveClassFailsForForwardedObjectAndArgCountMoreThanZ
 	
 ]
 
-{ #category : #'tests - primitiveClass' }
+{ #category : 'tests - primitiveClass' }
 VMPrimitiveTest >> testPrimitiveClassReturnsAClass [
 
 	interpreter push: memory trueObject.
@@ -1254,7 +1256,7 @@ VMPrimitiveTest >> testPrimitiveClassReturnsAClass [
 	
 ]
 
-{ #category : #'tests - primitiveDiv' }
+{ #category : 'tests - primitiveDiv' }
 VMPrimitiveTest >> testPrimitiveDiv [
 
 	interpreter push: (memory integerObjectOf: 15).
@@ -1267,7 +1269,7 @@ VMPrimitiveTest >> testPrimitiveDiv [
 	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 7). 
 ]
 
-{ #category : #'tests - primitiveDiv' }
+{ #category : 'tests - primitiveDiv' }
 VMPrimitiveTest >> testPrimitiveDivFailPreservesStack [
 	
 	interpreter push: (memory trueObject).
@@ -1280,7 +1282,7 @@ VMPrimitiveTest >> testPrimitiveDivFailPreservesStack [
 	self assert: (interpreter stackValue: 1) equals: (memory trueObject).
 ]
 
-{ #category : #'tests - primitiveDiv' }
+{ #category : 'tests - primitiveDiv' }
 VMPrimitiveTest >> testPrimitiveDivFailsWithTypeErrorOnFirstOperand [
 	
 	interpreter push: memory trueObject.
@@ -1291,7 +1293,7 @@ VMPrimitiveTest >> testPrimitiveDivFailsWithTypeErrorOnFirstOperand [
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveDiv' }
+{ #category : 'tests - primitiveDiv' }
 VMPrimitiveTest >> testPrimitiveDivFailsWithTypeErrorOnSecondOperand [
 	
 	interpreter push: (memory integerObjectOf: 2).
@@ -1302,7 +1304,7 @@ VMPrimitiveTest >> testPrimitiveDivFailsWithTypeErrorOnSecondOperand [
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveDiv' }
+{ #category : 'tests - primitiveDiv' }
 VMPrimitiveTest >> testPrimitiveDivOnNonIntegerResultRoundsAndDoesntFail [
 "In the primitive implementation of quo, it doesnt push the rest of the operation on the stack"
 
@@ -1314,7 +1316,7 @@ VMPrimitiveTest >> testPrimitiveDivOnNonIntegerResultRoundsAndDoesntFail [
 	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 10). 
 ]
 
-{ #category : #'tests - primitiveDiv' }
+{ #category : 'tests - primitiveDiv' }
 VMPrimitiveTest >> testPrimitiveDivWith0DivisionOnFirstOperand [
 
 	interpreter push: (memory integerObjectOf: 0).
@@ -1325,7 +1327,7 @@ VMPrimitiveTest >> testPrimitiveDivWith0DivisionOnFirstOperand [
 	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 0). 
 ]
 
-{ #category : #'tests - primitiveDiv' }
+{ #category : 'tests - primitiveDiv' }
 VMPrimitiveTest >> testPrimitiveDivWith0DivisionOnSecondOperand [
 
 	interpreter push: (memory integerObjectOf: 4).
@@ -1336,7 +1338,7 @@ VMPrimitiveTest >> testPrimitiveDivWith0DivisionOnSecondOperand [
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveDiv' }
+{ #category : 'tests - primitiveDiv' }
 VMPrimitiveTest >> testPrimitiveDivWithNegativeNumbers [
 	
 	interpreter push: (memory integerObjectOf: 4).
@@ -1347,7 +1349,7 @@ VMPrimitiveTest >> testPrimitiveDivWithNegativeNumbers [
 	self assert: (interpreter stackTop) equals: (memory integerObjectOf: -2). 
 ]
 
-{ #category : #'tests - primitiveDiv' }
+{ #category : 'tests - primitiveDiv' }
 VMPrimitiveTest >> testPrimitiveDivWithNegativeNumbers2 [
 	
 	interpreter push: (memory integerObjectOf: -9).
@@ -1358,7 +1360,7 @@ VMPrimitiveTest >> testPrimitiveDivWithNegativeNumbers2 [
 	self assert: (interpreter stackTop) equals: (memory integerObjectOf: -3). 
 ]
 
-{ #category : #'tests - primitiveDiv' }
+{ #category : 'tests - primitiveDiv' }
 VMPrimitiveTest >> testPrimitiveDivWithNoErrorPopsOperands [
 	
 	interpreter push: (memory integerObjectOf: 42). "Marker"
@@ -1373,7 +1375,7 @@ VMPrimitiveTest >> testPrimitiveDivWithNoErrorPopsOperands [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 42). 
 ]
 
-{ #category : #'tests - primitiveDivide' }
+{ #category : 'tests - primitiveDivide' }
 VMPrimitiveTest >> testPrimitiveDivide [
 
 	interpreter push: (memory integerObjectOf: 4).
@@ -1384,7 +1386,7 @@ VMPrimitiveTest >> testPrimitiveDivide [
 	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 2). 
 ]
 
-{ #category : #'tests - primitiveDivide' }
+{ #category : 'tests - primitiveDivide' }
 VMPrimitiveTest >> testPrimitiveDivideFailPreservesStack [
 	
 	interpreter push: (memory trueObject).
@@ -1396,7 +1398,7 @@ VMPrimitiveTest >> testPrimitiveDivideFailPreservesStack [
 	self assert: (interpreter stackValue: 1) equals: (memory trueObject).
 ]
 
-{ #category : #'tests - primitiveDivide' }
+{ #category : 'tests - primitiveDivide' }
 VMPrimitiveTest >> testPrimitiveDivideFailsOnFloatResult [
 	"The interpreter fails because 42%4 != 0"
 	
@@ -1410,7 +1412,7 @@ VMPrimitiveTest >> testPrimitiveDivideFailsOnFloatResult [
 
 ]
 
-{ #category : #'tests - primitiveDivide' }
+{ #category : 'tests - primitiveDivide' }
 VMPrimitiveTest >> testPrimitiveDivideFailsWithTypeErrorOnFirstOperand [
 	
 	interpreter push: memory trueObject.
@@ -1421,7 +1423,7 @@ VMPrimitiveTest >> testPrimitiveDivideFailsWithTypeErrorOnFirstOperand [
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveDivide' }
+{ #category : 'tests - primitiveDivide' }
 VMPrimitiveTest >> testPrimitiveDivideFailsWithTypeErrorOnSecondOperand [
 	
 	interpreter push: (memory integerObjectOf: 2).
@@ -1432,7 +1434,7 @@ VMPrimitiveTest >> testPrimitiveDivideFailsWithTypeErrorOnSecondOperand [
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveDivide' }
+{ #category : 'tests - primitiveDivide' }
 VMPrimitiveTest >> testPrimitiveDivideWith0DivisionOnFirstOperand [
 
 	interpreter push: (memory integerObjectOf: 0).
@@ -1443,7 +1445,7 @@ VMPrimitiveTest >> testPrimitiveDivideWith0DivisionOnFirstOperand [
 	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 0). 
 ]
 
-{ #category : #'tests - primitiveDivide' }
+{ #category : 'tests - primitiveDivide' }
 VMPrimitiveTest >> testPrimitiveDivideWith0DivisionOnSecondOperand [
 
 	interpreter push: (memory integerObjectOf: 4).
@@ -1454,7 +1456,7 @@ VMPrimitiveTest >> testPrimitiveDivideWith0DivisionOnSecondOperand [
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveDivide' }
+{ #category : 'tests - primitiveDivide' }
 VMPrimitiveTest >> testPrimitiveDivideWithNegativeNumbers [
 	
 	interpreter push: (memory integerObjectOf: 6).
@@ -1465,7 +1467,7 @@ VMPrimitiveTest >> testPrimitiveDivideWithNegativeNumbers [
 	self assert: (interpreter stackTop) equals: (memory integerObjectOf: -3). 
 ]
 
-{ #category : #'tests - primitiveDivide' }
+{ #category : 'tests - primitiveDivide' }
 VMPrimitiveTest >> testPrimitiveDivideWithNegativeNumbers2 [
 	
 	interpreter push: (memory integerObjectOf: -42).
@@ -1476,7 +1478,7 @@ VMPrimitiveTest >> testPrimitiveDivideWithNegativeNumbers2 [
 	self assert: (interpreter stackTop) equals: (memory integerObjectOf: -21). 
 ]
 
-{ #category : #'tests - primitiveEqual' }
+{ #category : 'tests - primitiveEqual' }
 VMPrimitiveTest >> testPrimitiveEqualFailsWithFloat [
 
 	self installFloatClass.
@@ -1489,7 +1491,7 @@ VMPrimitiveTest >> testPrimitiveEqualFailsWithFloat [
 	self assert: interpreter failed
 ]
 
-{ #category : #'tests - primitiveEqual' }
+{ #category : 'tests - primitiveEqual' }
 VMPrimitiveTest >> testPrimitiveEqualWithNegativeNumbers [
 
 	interpreter push: (memory integerObjectOf: -13).
@@ -1500,7 +1502,7 @@ VMPrimitiveTest >> testPrimitiveEqualWithNegativeNumbers [
 	self deny: interpreter failed. 
 ]
 
-{ #category : #'tests - primitiveEqual' }
+{ #category : 'tests - primitiveEqual' }
 VMPrimitiveTest >> testPrimitiveEqualWithNoError1 [
 
 	interpreter push: (memory integerObjectOf: 15).
@@ -1511,7 +1513,7 @@ VMPrimitiveTest >> testPrimitiveEqualWithNoError1 [
 	self assert: interpreter stackTop equals: (memory trueObject). 
 ]
 
-{ #category : #'tests - primitiveEqual' }
+{ #category : 'tests - primitiveEqual' }
 VMPrimitiveTest >> testPrimitiveEqualWithNoError2 [
 
 	interpreter push: (memory integerObjectOf: 15).
@@ -1522,7 +1524,7 @@ VMPrimitiveTest >> testPrimitiveEqualWithNoError2 [
 	self assert: interpreter stackTop equals: (memory falseObject). 
 ]
 
-{ #category : #'tests - primitiveEqual' }
+{ #category : 'tests - primitiveEqual' }
 VMPrimitiveTest >> testPrimitiveEqualWithNoErrorPopsOperands [
 
 	interpreter push: (memory integerObjectOf: 42). "Marker"
@@ -1537,7 +1539,7 @@ VMPrimitiveTest >> testPrimitiveEqualWithNoErrorPopsOperands [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 42). 
 ]
 
-{ #category : #'tests - primitiveEqual' }
+{ #category : 'tests - primitiveEqual' }
 VMPrimitiveTest >> testPrimitiveEqualWithTypeErrorOnFirstOperand [
 
 	interpreter push: (memory falseObject).
@@ -1548,7 +1550,7 @@ VMPrimitiveTest >> testPrimitiveEqualWithTypeErrorOnFirstOperand [
 	self assert: interpreter failed. 
 ]
 
-{ #category : #'tests - primitiveEqual' }
+{ #category : 'tests - primitiveEqual' }
 VMPrimitiveTest >> testPrimitiveEqualWithTypeErrorOnSecondOperand [
 
 	interpreter push: (memory integerObjectOf: 16).
@@ -1559,7 +1561,7 @@ VMPrimitiveTest >> testPrimitiveEqualWithTypeErrorOnSecondOperand [
 	self assert: interpreter failed. 
 ]
 
-{ #category : #'tests - primitiveAdd - Float64Array' }
+{ #category : 'tests - primitiveAdd - Float64Array' }
 VMPrimitiveTest >> testPrimitiveFloat64ArrayAdd [
 
 	| x y z result firstTerm size |
@@ -1583,7 +1585,7 @@ VMPrimitiveTest >> testPrimitiveFloat64ArrayAdd [
 	self assert: (memory fetchFloat64: 1 ofObject: result) equals: 22.0.
 ]
 
-{ #category : #'tests - primitiveImmutability' }
+{ #category : 'tests - primitiveImmutability' }
 VMPrimitiveTest >> testPrimitiveGetImmutabilityOfImmediateReturnsTrue [
 
 	interpreter push: (memory integerObjectOf: 1).
@@ -1592,7 +1594,7 @@ VMPrimitiveTest >> testPrimitiveGetImmutabilityOfImmediateReturnsTrue [
 	self assert: interpreter stackTop equals: memory trueObject
 ]
 
-{ #category : #'tests - primitiveImmutability' }
+{ #category : 'tests - primitiveImmutability' }
 VMPrimitiveTest >> testPrimitiveGetImmutabilityOnANewObjectIsFalse [
 	| class object |
 	class := self newClassInOldSpaceWithSlots: 0 instSpec: memory nonIndexablePointerFormat.
@@ -1605,7 +1607,7 @@ VMPrimitiveTest >> testPrimitiveGetImmutabilityOnANewObjectIsFalse [
 	self assert: interpreter stackTop equals: memory falseObject
 ]
 
-{ #category : #'tests - primitiveImmutability' }
+{ #category : 'tests - primitiveImmutability' }
 VMPrimitiveTest >> testPrimitiveGetImmutabilityReturnsTrueIfObjectIsImmutable [
 	| class object |
 	class := self newClassInOldSpaceWithSlots: 0 instSpec: memory nonIndexablePointerFormat.
@@ -1619,7 +1621,7 @@ VMPrimitiveTest >> testPrimitiveGetImmutabilityReturnsTrueIfObjectIsImmutable [
 	self assert: interpreter stackTop equals: memory trueObject
 ]
 
-{ #category : #'tests - primitiveGreaterOrEqual' }
+{ #category : 'tests - primitiveGreaterOrEqual' }
 VMPrimitiveTest >> testPrimitiveGreaterOrEqualFailsWithFloat [
 
 	"This simulated classFloat class is necessary because the 32bits VM cannot instanciate boxed floats by itself"
@@ -1633,7 +1635,7 @@ VMPrimitiveTest >> testPrimitiveGreaterOrEqualFailsWithFloat [
 	self assert: interpreter failed
 ]
 
-{ #category : #'tests - primitiveGreaterOrEqual' }
+{ #category : 'tests - primitiveGreaterOrEqual' }
 VMPrimitiveTest >> testPrimitiveGreaterOrEqualFailsWithTypeErrorOnFirstOperand [
 	
 	interpreter push: (memory trueObject).
@@ -1644,7 +1646,7 @@ VMPrimitiveTest >> testPrimitiveGreaterOrEqualFailsWithTypeErrorOnFirstOperand [
 	self assert: interpreter failed. 
 ]
 
-{ #category : #'tests - primitiveGreaterOrEqual' }
+{ #category : 'tests - primitiveGreaterOrEqual' }
 VMPrimitiveTest >> testPrimitiveGreaterOrEqualFailsWithTypeErrorOnSecondOperand [
 	
 	interpreter push: (memory integerObjectOf: 2).
@@ -1655,7 +1657,7 @@ VMPrimitiveTest >> testPrimitiveGreaterOrEqualFailsWithTypeErrorOnSecondOperand 
 	self assert: interpreter failed. 
 ]
 
-{ #category : #'tests - primitiveGreaterOrEqual' }
+{ #category : 'tests - primitiveGreaterOrEqual' }
 VMPrimitiveTest >> testPrimitiveGreaterOrEqualWithNegativeNumbers [
 
 	interpreter push: (memory integerObjectOf: -13).
@@ -1666,7 +1668,7 @@ VMPrimitiveTest >> testPrimitiveGreaterOrEqualWithNegativeNumbers [
 	self deny: interpreter failed. 
 ]
 
-{ #category : #'tests - primitiveGreaterOrEqual' }
+{ #category : 'tests - primitiveGreaterOrEqual' }
 VMPrimitiveTest >> testPrimitiveGreaterOrEqualWithNoError1 [
 
 	interpreter push: (memory integerObjectOf: 42).
@@ -1677,7 +1679,7 @@ VMPrimitiveTest >> testPrimitiveGreaterOrEqualWithNoError1 [
 	self assert: interpreter stackTop equals: (memory trueObject). 
 ]
 
-{ #category : #'tests - primitiveGreaterOrEqual' }
+{ #category : 'tests - primitiveGreaterOrEqual' }
 VMPrimitiveTest >> testPrimitiveGreaterOrEqualWithNoError2 [
 	
 	interpreter push: (memory integerObjectOf: 16).
@@ -1688,7 +1690,7 @@ VMPrimitiveTest >> testPrimitiveGreaterOrEqualWithNoError2 [
 	self assert: interpreter stackTop equals: (memory falseObject). 
 ]
 
-{ #category : #'tests - primitiveGreaterOrEqual' }
+{ #category : 'tests - primitiveGreaterOrEqual' }
 VMPrimitiveTest >> testPrimitiveGreaterOrEqualWithNoErrorEquals [
 	
 	interpreter push: (memory integerObjectOf: 0).
@@ -1699,7 +1701,7 @@ VMPrimitiveTest >> testPrimitiveGreaterOrEqualWithNoErrorEquals [
 	self assert: interpreter stackTop equals: (memory trueObject). 
 ]
 
-{ #category : #'tests - primitiveGreaterOrEqual' }
+{ #category : 'tests - primitiveGreaterOrEqual' }
 VMPrimitiveTest >> testPrimitiveGreaterOrEqualWithNoErrorPopsOperands [
 	
 	interpreter push: (memory integerObjectOf: 42). "Marker"
@@ -1714,7 +1716,7 @@ VMPrimitiveTest >> testPrimitiveGreaterOrEqualWithNoErrorPopsOperands [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 42). 
 ]
 
-{ #category : #'tests - primitiveGreaterThan' }
+{ #category : 'tests - primitiveGreaterThan' }
 VMPrimitiveTest >> testPrimitiveGreaterThanFailsWithFloat [
 
 	"This simulated classFloat class is necessary because the 32bits VM cannot instanciate boxed floats by itself"
@@ -1725,7 +1727,7 @@ VMPrimitiveTest >> testPrimitiveGreaterThanFailsWithFloat [
 	self assert: interpreter failed
 ]
 
-{ #category : #'tests - primitiveGreaterThan' }
+{ #category : 'tests - primitiveGreaterThan' }
 VMPrimitiveTest >> testPrimitiveGreaterThanFailsWithTypeErrorOnFirstOperand [
 	
 	interpreter push: (memory trueObject).
@@ -1736,7 +1738,7 @@ VMPrimitiveTest >> testPrimitiveGreaterThanFailsWithTypeErrorOnFirstOperand [
 	self assert: interpreter failed. 
 ]
 
-{ #category : #'tests - primitiveGreaterThan' }
+{ #category : 'tests - primitiveGreaterThan' }
 VMPrimitiveTest >> testPrimitiveGreaterThanFailsWithTypeErrorOnSecondOperand [
 	
 	interpreter push: (memory integerObjectOf: 2).
@@ -1747,7 +1749,7 @@ VMPrimitiveTest >> testPrimitiveGreaterThanFailsWithTypeErrorOnSecondOperand [
 	self assert: interpreter failed. 
 ]
 
-{ #category : #'tests - primitiveGreaterThan' }
+{ #category : 'tests - primitiveGreaterThan' }
 VMPrimitiveTest >> testPrimitiveGreaterThanWithNegativeNumbers [
 
 	interpreter push: (memory integerObjectOf: -13).
@@ -1758,7 +1760,7 @@ VMPrimitiveTest >> testPrimitiveGreaterThanWithNegativeNumbers [
 	self deny: interpreter failed. 
 ]
 
-{ #category : #'tests - primitiveGreaterThan' }
+{ #category : 'tests - primitiveGreaterThan' }
 VMPrimitiveTest >> testPrimitiveGreaterThanWithNoError1 [
 	
 	interpreter push: (memory integerObjectOf: 42).
@@ -1769,7 +1771,7 @@ VMPrimitiveTest >> testPrimitiveGreaterThanWithNoError1 [
 	self assert: interpreter stackTop equals: (memory trueObject). 
 ]
 
-{ #category : #'tests - primitiveGreaterThan' }
+{ #category : 'tests - primitiveGreaterThan' }
 VMPrimitiveTest >> testPrimitiveGreaterThanWithNoError2 [
 	
 	interpreter push: (memory integerObjectOf: -1000).
@@ -1780,7 +1782,7 @@ VMPrimitiveTest >> testPrimitiveGreaterThanWithNoError2 [
 	self assert: interpreter stackTop equals: (memory falseObject). 
 ]
 
-{ #category : #'tests - primitiveGreaterThan' }
+{ #category : 'tests - primitiveGreaterThan' }
 VMPrimitiveTest >> testPrimitiveGreaterThanWithNoErrorEquals [
 	
 	interpreter push: (memory integerObjectOf: 0).
@@ -1791,7 +1793,7 @@ VMPrimitiveTest >> testPrimitiveGreaterThanWithNoErrorEquals [
 	self assert: interpreter stackTop equals: (memory falseObject). 
 ]
 
-{ #category : #'tests - primitiveGreaterThan' }
+{ #category : 'tests - primitiveGreaterThan' }
 VMPrimitiveTest >> testPrimitiveGreaterThanWithNoErrorPopsOperands [
 	
 	interpreter push: (memory integerObjectOf: 42). "Marker"
@@ -1806,7 +1808,7 @@ VMPrimitiveTest >> testPrimitiveGreaterThanWithNoErrorPopsOperands [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 42).
 ]
 
-{ #category : #'tests - primitiveIdentical' }
+{ #category : 'tests - primitiveIdentical' }
 VMPrimitiveTest >> testPrimitiveIdenticalDoesntFailForForwardedOopOnOtherObjectWithArgCountLessThanOne [
 	|object1|
 	"Tests the case where objectArg = 1 and: isOopFowarded: stackTop"
@@ -1823,7 +1825,7 @@ VMPrimitiveTest >> testPrimitiveIdenticalDoesntFailForForwardedOopOnOtherObjectW
 	self deny: interpreter failed. 
 ]
 
-{ #category : #'tests - primitiveIdentical' }
+{ #category : 'tests - primitiveIdentical' }
 VMPrimitiveTest >> testPrimitiveIdenticalFailsForForwardedOopOnOtherObject [
 	|object1|
 	"Tests the case where objectArg > 1 and: isOopFowarded: stackTop"
@@ -1842,7 +1844,7 @@ VMPrimitiveTest >> testPrimitiveIdenticalFailsForForwardedOopOnOtherObject [
 	
 ]
 
-{ #category : #'tests - primitiveIdentical' }
+{ #category : 'tests - primitiveIdentical' }
 VMPrimitiveTest >> testPrimitiveIdenticalFailsForForwardedOopOnReceiver [
 	|object1|
 	
@@ -1858,7 +1860,7 @@ VMPrimitiveTest >> testPrimitiveIdenticalFailsForForwardedOopOnReceiver [
 	
 ]
 
-{ #category : #'tests - primitiveIdentical' }
+{ #category : 'tests - primitiveIdentical' }
 VMPrimitiveTest >> testPrimitiveIdenticalReturnsBool [
 
 	interpreter push: memory trueObject.
@@ -1870,7 +1872,7 @@ VMPrimitiveTest >> testPrimitiveIdenticalReturnsBool [
 	
 ]
 
-{ #category : #'tests - primitiveIdentical' }
+{ #category : 'tests - primitiveIdentical' }
 VMPrimitiveTest >> testPrimitiveIdenticalReturnsFalseForObjectsWithSameValueButDifferentType [
 	| object1 object2 |
 	
@@ -1889,7 +1891,7 @@ VMPrimitiveTest >> testPrimitiveIdenticalReturnsFalseForObjectsWithSameValueButD
 	
 ]
 
-{ #category : #'tests - primitiveIdentical' }
+{ #category : 'tests - primitiveIdentical' }
 VMPrimitiveTest >> testPrimitiveIdenticalReturnsFalseWithWrongArgCount [
 	| object |
 	
@@ -1905,7 +1907,7 @@ VMPrimitiveTest >> testPrimitiveIdenticalReturnsFalseWithWrongArgCount [
 	
 ]
 
-{ #category : #'tests - primitiveIdentical' }
+{ #category : 'tests - primitiveIdentical' }
 VMPrimitiveTest >> testPrimitiveIdenticalReturnsTrueForIdenticalObject [
 	| object |
 	
@@ -1919,7 +1921,7 @@ VMPrimitiveTest >> testPrimitiveIdenticalReturnsTrueForIdenticalObject [
 	
 ]
 
-{ #category : #'tests - primitiveIdentical' }
+{ #category : 'tests - primitiveIdentical' }
 VMPrimitiveTest >> testPrimitiveIdenticalReturnsTrueForImmediateObjectsWithSameValue [
 	| object1 object2 |
 	
@@ -1935,7 +1937,7 @@ VMPrimitiveTest >> testPrimitiveIdenticalReturnsTrueForImmediateObjectsWithSameV
 	
 ]
 
-{ #category : #'tests - primitiveImmediateAsInteger' }
+{ #category : 'tests - primitiveImmediateAsInteger' }
 VMPrimitiveTest >> testPrimitiveImmediateAsIntegerFailsWithTypeError [
 
 	interpreter push: (memory trueObject).
@@ -1948,7 +1950,7 @@ VMPrimitiveTest >> testPrimitiveImmediateAsIntegerFailsWithTypeError [
 	
 ]
 
-{ #category : #'tests - primitiveImmediateAsInteger' }
+{ #category : 'tests - primitiveImmediateAsInteger' }
 VMPrimitiveTest >> testPrimitiveImmediateAsIntegerWithChar [
 
 	interpreter push: (memory characterObjectOf: 66).
@@ -1961,7 +1963,7 @@ VMPrimitiveTest >> testPrimitiveImmediateAsIntegerWithChar [
 	
 ]
 
-{ #category : #'tests - primitiveImmediateAsInteger' }
+{ #category : 'tests - primitiveImmediateAsInteger' }
 VMPrimitiveTest >> testPrimitiveImmediateAsIntegerWithFloat [
 
 	interpreter push: (memory integerObjectOf: 0). 
@@ -1974,7 +1976,7 @@ VMPrimitiveTest >> testPrimitiveImmediateAsIntegerWithFloat [
 	
 ]
 
-{ #category : #'tests - primitiveImmediateAsInteger' }
+{ #category : 'tests - primitiveImmediateAsInteger' }
 VMPrimitiveTest >> testPrimitiveImmediateAsIntegerWithInt [
 
 	interpreter push: (memory integerObjectOf: memory maxSmallInteger).
@@ -1987,7 +1989,7 @@ VMPrimitiveTest >> testPrimitiveImmediateAsIntegerWithInt [
 	
 ]
 
-{ #category : #'tests - primitiveAt' }
+{ #category : 'tests - primitiveAt' }
 VMPrimitiveTest >> testPrimitiveInstVarAtOverBoundShouldFailForIndexable [
 	| class object |
 	class := self newClassInOldSpaceWithSlots: 1 instSpec: memory arrayFormat.
@@ -2002,7 +2004,7 @@ VMPrimitiveTest >> testPrimitiveInstVarAtOverBoundShouldFailForIndexable [
 	self assert: interpreter primFailCode equals: PrimErrBadIndex. 
 ]
 
-{ #category : #'tests - primitiveAt' }
+{ #category : 'tests - primitiveAt' }
 VMPrimitiveTest >> testPrimitiveInstVarAtOverBoundShouldFailForNonIndexable [
 	| class object |
 	class := self newClassInOldSpaceWithSlots: 1 instSpec: memory nonIndexablePointerFormat.
@@ -2017,7 +2019,7 @@ VMPrimitiveTest >> testPrimitiveInstVarAtOverBoundShouldFailForNonIndexable [
 	self assert: interpreter primFailCode equals: PrimErrBadIndex.
 ]
 
-{ #category : #'tests - primitiveAtPut' }
+{ #category : 'tests - primitiveAtPut' }
 VMPrimitiveTest >> testPrimitiveInstVarAtPutOverBoundShouldFailForIndexable [
 	| class object |
 	class := self newClassInOldSpaceWithSlots: 1 instSpec: memory arrayFormat .
@@ -2033,7 +2035,7 @@ VMPrimitiveTest >> testPrimitiveInstVarAtPutOverBoundShouldFailForIndexable [
 	self assert: interpreter primFailCode equals: PrimErrBadIndex. 
 ]
 
-{ #category : #'tests - primitiveAtPut' }
+{ #category : 'tests - primitiveAtPut' }
 VMPrimitiveTest >> testPrimitiveInstVarAtPutOverBoundShouldFailNonIndexable [
 	| class object |
 	class := self newClassInOldSpaceWithSlots: 1 instSpec: memory nonIndexablePointerFormat.
@@ -2049,7 +2051,7 @@ VMPrimitiveTest >> testPrimitiveInstVarAtPutOverBoundShouldFailNonIndexable [
 	self assert: interpreter primFailCode equals: PrimErrBadIndex.
 ]
 
-{ #category : #'tests - primitiveAtPut' }
+{ #category : 'tests - primitiveAtPut' }
 VMPrimitiveTest >> testPrimitiveInstVarAtPutPutsTheValueForNonIndexable [
 	| class object |
 	class := self newClassInOldSpaceWithSlots: 1 instSpec: memory nonIndexablePointerFormat.
@@ -2065,7 +2067,7 @@ VMPrimitiveTest >> testPrimitiveInstVarAtPutPutsTheValueForNonIndexable [
 	self assert: (memory fetchPointer: 0 ofObject: object) equals: memory falseObject.
 ]
 
-{ #category : #'tests - primitiveAt' }
+{ #category : 'tests - primitiveAt' }
 VMPrimitiveTest >> testPrimitiveInstVarAtReturnsTheValueForNonIndexable [
 	| class object |
 	class := self newClassInOldSpaceWithSlots: 1 instSpec: memory nonIndexablePointerFormat.
@@ -2090,7 +2092,7 @@ VMPrimitiveTest >> testPrimitiveInstVarAtReturnsTheValueForNonIndexable [
 	self assert: interpreter stackTop equals: memory falseObject.
 ]
 
-{ #category : #'tests - primitiveIsPinned' }
+{ #category : 'tests - primitiveIsPinned' }
 VMPrimitiveTest >> testPrimitiveIsPinnedBool [
 
 	interpreter push: (memory trueObject). 
@@ -2101,7 +2103,7 @@ VMPrimitiveTest >> testPrimitiveIsPinnedBool [
 	self assert: interpreter stackTop equals: memory falseObject. 
 ]
 
-{ #category : #'tests - primitiveIsPinned' }
+{ #category : 'tests - primitiveIsPinned' }
 VMPrimitiveTest >> testPrimitiveIsPinnedFailsForForwardedObjects [
 
 	interpreter push: self setUpForwardedObjects. 
@@ -2112,7 +2114,7 @@ VMPrimitiveTest >> testPrimitiveIsPinnedFailsForForwardedObjects [
 	self assert: interpreter primFailCode equals: PrimErrBadReceiver. 
 ]
 
-{ #category : #'tests - primitiveIsPinned' }
+{ #category : 'tests - primitiveIsPinned' }
 VMPrimitiveTest >> testPrimitiveIsPinnedFailsForImmediateObjects [
 
 	interpreter push: (memory integerObjectOf: 16). 
@@ -2123,7 +2125,7 @@ VMPrimitiveTest >> testPrimitiveIsPinnedFailsForImmediateObjects [
 	self assert: interpreter primFailCode equals: PrimErrBadReceiver. 
 ]
 
-{ #category : #'tests - primitiveLessOrEqual' }
+{ #category : 'tests - primitiveLessOrEqual' }
 VMPrimitiveTest >> testPrimitiveLessOrEqualFailsWithFloat [
 
 	"This simulated classFloat class is necessary because the 32bits VM cannot instanciate boxed floats by itself"
@@ -2134,7 +2136,7 @@ VMPrimitiveTest >> testPrimitiveLessOrEqualFailsWithFloat [
 	self assert: interpreter failed
 ]
 
-{ #category : #'tests - primitiveLessOrEqual' }
+{ #category : 'tests - primitiveLessOrEqual' }
 VMPrimitiveTest >> testPrimitiveLessOrEqualWithNegativeNumbers [
 
 	interpreter push: (memory integerObjectOf: -13).
@@ -2145,7 +2147,7 @@ VMPrimitiveTest >> testPrimitiveLessOrEqualWithNegativeNumbers [
 	self deny: interpreter failed. 
 ]
 
-{ #category : #'tests - primitiveLessOrEqual' }
+{ #category : 'tests - primitiveLessOrEqual' }
 VMPrimitiveTest >> testPrimitiveLessOrEqualWithNoError1 [
 	
 	interpreter push: (memory integerObjectOf: 42).
@@ -2156,7 +2158,7 @@ VMPrimitiveTest >> testPrimitiveLessOrEqualWithNoError1 [
 	self assert: interpreter stackTop equals: (memory falseObject). 
 ]
 
-{ #category : #'tests - primitiveLessOrEqual' }
+{ #category : 'tests - primitiveLessOrEqual' }
 VMPrimitiveTest >> testPrimitiveLessOrEqualWithNoError2 [
 	
 	interpreter push: (memory integerObjectOf: 16).
@@ -2167,7 +2169,7 @@ VMPrimitiveTest >> testPrimitiveLessOrEqualWithNoError2 [
 	self assert: interpreter stackTop equals: (memory trueObject). 
 ]
 
-{ #category : #'tests - primitiveLessOrEqual' }
+{ #category : 'tests - primitiveLessOrEqual' }
 VMPrimitiveTest >> testPrimitiveLessOrEqualWithNoErrorEquals [
 	
 	interpreter push: (memory integerObjectOf: 0).
@@ -2178,7 +2180,7 @@ VMPrimitiveTest >> testPrimitiveLessOrEqualWithNoErrorEquals [
 	self assert: interpreter stackTop equals: (memory trueObject). 
 ]
 
-{ #category : #'tests - primitiveLessOrEqual' }
+{ #category : 'tests - primitiveLessOrEqual' }
 VMPrimitiveTest >> testPrimitiveLessOrEqualWithNoErrorPopsOperands [
 	
 	interpreter push: (memory integerObjectOf: 42). "Marker"
@@ -2193,7 +2195,7 @@ VMPrimitiveTest >> testPrimitiveLessOrEqualWithNoErrorPopsOperands [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 42).
 ]
 
-{ #category : #'tests - primitiveLessOrEqual' }
+{ #category : 'tests - primitiveLessOrEqual' }
 VMPrimitiveTest >> testPrimitiveLessOrEqualsFailsWithTypeErrorOnFirstOperand [
 	
 	interpreter push: (memory trueObject).
@@ -2204,7 +2206,7 @@ VMPrimitiveTest >> testPrimitiveLessOrEqualsFailsWithTypeErrorOnFirstOperand [
 	self assert: interpreter failed. 
 ]
 
-{ #category : #'tests - primitiveLessOrEqual' }
+{ #category : 'tests - primitiveLessOrEqual' }
 VMPrimitiveTest >> testPrimitiveLessOrEqualsFailsWithTypeErrorOnSecondOperand [
 	
 	interpreter push: (memory trueObject).
@@ -2215,7 +2217,7 @@ VMPrimitiveTest >> testPrimitiveLessOrEqualsFailsWithTypeErrorOnSecondOperand [
 	self assert: interpreter failed. 
 ]
 
-{ #category : #'tests - primitiveLessThan' }
+{ #category : 'tests - primitiveLessThan' }
 VMPrimitiveTest >> testPrimitiveLessThanFailsWithFloat [
 
 	"This simulated classFloat class is necessary because the 32bits VM cannot instanciate boxed floats by itself"
@@ -2226,7 +2228,7 @@ VMPrimitiveTest >> testPrimitiveLessThanFailsWithFloat [
 	self assert: interpreter failed
 ]
 
-{ #category : #'tests - primitiveLessThan' }
+{ #category : 'tests - primitiveLessThan' }
 VMPrimitiveTest >> testPrimitiveLessThanFailsWithTypeErrorOnFirstOperand [
 	
 	interpreter push: (memory trueObject).
@@ -2237,7 +2239,7 @@ VMPrimitiveTest >> testPrimitiveLessThanFailsWithTypeErrorOnFirstOperand [
 	self assert: interpreter failed. 
 ]
 
-{ #category : #'tests - primitiveLessThan' }
+{ #category : 'tests - primitiveLessThan' }
 VMPrimitiveTest >> testPrimitiveLessThanFailsWithTypeErrorOnSecondOperand [
 	
 	interpreter push: (memory integerObjectOf: 2).
@@ -2248,7 +2250,7 @@ VMPrimitiveTest >> testPrimitiveLessThanFailsWithTypeErrorOnSecondOperand [
 	self assert: interpreter failed. 
 ]
 
-{ #category : #'tests - primitiveLessThan' }
+{ #category : 'tests - primitiveLessThan' }
 VMPrimitiveTest >> testPrimitiveLessThanWithNegativeNumbers [
 
 	interpreter push: (memory integerObjectOf: -13).
@@ -2259,7 +2261,7 @@ VMPrimitiveTest >> testPrimitiveLessThanWithNegativeNumbers [
 	self deny: interpreter failed. 
 ]
 
-{ #category : #'tests - primitiveLessThan' }
+{ #category : 'tests - primitiveLessThan' }
 VMPrimitiveTest >> testPrimitiveLessThanWithNoError1 [
 	
 	interpreter push: (memory integerObjectOf: 42).
@@ -2270,7 +2272,7 @@ VMPrimitiveTest >> testPrimitiveLessThanWithNoError1 [
 	self assert: interpreter stackTop equals: (memory falseObject). 
 ]
 
-{ #category : #'tests - primitiveLessThan' }
+{ #category : 'tests - primitiveLessThan' }
 VMPrimitiveTest >> testPrimitiveLessThanWithNoError2 [
 	
 	interpreter push: (memory integerObjectOf: 16).
@@ -2281,7 +2283,7 @@ VMPrimitiveTest >> testPrimitiveLessThanWithNoError2 [
 	self assert: interpreter stackTop equals: (memory trueObject). 
 ]
 
-{ #category : #'tests - primitiveLessThan' }
+{ #category : 'tests - primitiveLessThan' }
 VMPrimitiveTest >> testPrimitiveLessThanWithNoErrorEquals [
 	
 	interpreter push: (memory integerObjectOf: 0).
@@ -2292,7 +2294,7 @@ VMPrimitiveTest >> testPrimitiveLessThanWithNoErrorEquals [
 	self assert: interpreter stackTop equals: (memory falseObject). 
 ]
 
-{ #category : #'tests - primitiveLessThan' }
+{ #category : 'tests - primitiveLessThan' }
 VMPrimitiveTest >> testPrimitiveLessThanWithNoErrorPopsOperands [
 	
 	interpreter push: (memory integerObjectOf: 42). "Marker"
@@ -2307,7 +2309,7 @@ VMPrimitiveTest >> testPrimitiveLessThanWithNoErrorPopsOperands [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 42). 
 ]
 
-{ #category : #'tests - primitiveFloat64' }
+{ #category : 'tests - primitiveFloat64' }
 VMPrimitiveTest >> testPrimitiveLoadFloat64FromBytesFrom64BitArrays [
 
 	| class array |
@@ -2327,7 +2329,7 @@ VMPrimitiveTest >> testPrimitiveLoadFloat64FromBytesFrom64BitArrays [
 	self assert: (memory floatValueOf: interpreter stackTop) equals: 42.0. 
 ]
 
-{ #category : #'tests - primitiveFloat64' }
+{ #category : 'tests - primitiveFloat64' }
 VMPrimitiveTest >> testPrimitiveLoadFloat64FromBytesFrom64BitEmptyArrays [
 
 	| class array |
@@ -2345,7 +2347,7 @@ VMPrimitiveTest >> testPrimitiveLoadFloat64FromBytesFrom64BitEmptyArrays [
 	self assert: (memory floatValueOf: interpreter stackTop) equals: 0.0. 
 ]
 
-{ #category : #'tests - primitiveFloat64' }
+{ #category : 'tests - primitiveFloat64' }
 VMPrimitiveTest >> testPrimitiveLoadFloat64FromBytesFromByteArrays [
 
 	| class array |
@@ -2365,7 +2367,7 @@ VMPrimitiveTest >> testPrimitiveLoadFloat64FromBytesFromByteArrays [
 	self assert: (memory floatValueOf: interpreter stackTop) equals: 42.0. 
 ]
 
-{ #category : #'tests - primitiveFloat64' }
+{ #category : 'tests - primitiveFloat64' }
 VMPrimitiveTest >> testPrimitiveLoadFloat64FromBytesFromInteger16Arrays [
 
 	| class array |
@@ -2385,7 +2387,7 @@ VMPrimitiveTest >> testPrimitiveLoadFloat64FromBytesFromInteger16Arrays [
 	self assert: (memory floatValueOf: interpreter stackTop) equals: 42.0. 
 ]
 
-{ #category : #'tests - primitiveFloat64' }
+{ #category : 'tests - primitiveFloat64' }
 VMPrimitiveTest >> testPrimitiveLoadFloat64FromBytesFromInteger32Arrays [
 
 	| class array |
@@ -2405,7 +2407,7 @@ VMPrimitiveTest >> testPrimitiveLoadFloat64FromBytesFromInteger32Arrays [
 	self assert: (memory floatValueOf: interpreter stackTop) equals: 42.0. 
 ]
 
-{ #category : #'tests - primitiveFloat64' }
+{ #category : 'tests - primitiveFloat64' }
 VMPrimitiveTest >> testPrimitiveLoadFloat64FromBytesNegativeIndex [
 
 	| class array |
@@ -2425,7 +2427,7 @@ VMPrimitiveTest >> testPrimitiveLoadFloat64FromBytesNegativeIndex [
 	self assert: interpreter stackTop equals: 42
 ]
 
-{ #category : #'tests - primitiveFloat64' }
+{ #category : 'tests - primitiveFloat64' }
 VMPrimitiveTest >> testPrimitiveLoadFloat64FromBytesOverflowIndex [
 
 	| class array |
@@ -2445,7 +2447,7 @@ VMPrimitiveTest >> testPrimitiveLoadFloat64FromBytesOverflowIndex [
 	self assert: interpreter stackTop equals: 42
 ]
 
-{ #category : #'tests - primitiveFloat64' }
+{ #category : 'tests - primitiveFloat64' }
 VMPrimitiveTest >> testPrimitiveLoadFloat64FromBytesSecondBytes [
 
 	| class array |
@@ -2467,7 +2469,7 @@ VMPrimitiveTest >> testPrimitiveLoadFloat64FromBytesSecondBytes [
 	self assert: (memory floatValueOf: interpreter stackTop) equals: 42.0. 
 ]
 
-{ #category : #'tests - primitiveMod' }
+{ #category : 'tests - primitiveMod' }
 VMPrimitiveTest >> testPrimitiveMod [
 
 	interpreter push: (memory integerObjectOf: 16).
@@ -2480,7 +2482,7 @@ VMPrimitiveTest >> testPrimitiveMod [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 0). 
 ]
 
-{ #category : #'tests - primitiveMod' }
+{ #category : 'tests - primitiveMod' }
 VMPrimitiveTest >> testPrimitiveModFailPreservesStack [
 
 	interpreter push: (memory trueObject).
@@ -2495,7 +2497,7 @@ VMPrimitiveTest >> testPrimitiveModFailPreservesStack [
 	self assert: (interpreter stackValue: 1) equals: (memory trueObject).
 ]
 
-{ #category : #'tests - primitiveMod' }
+{ #category : 'tests - primitiveMod' }
 VMPrimitiveTest >> testPrimitiveModFailsWithTypeErrorOnFirstOperand [
 
 	interpreter push: (memory trueObject).
@@ -2506,7 +2508,7 @@ VMPrimitiveTest >> testPrimitiveModFailsWithTypeErrorOnFirstOperand [
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveMod' }
+{ #category : 'tests - primitiveMod' }
 VMPrimitiveTest >> testPrimitiveModFailsWithTypeErrorOnSecondOperand [
 
 	interpreter push: (memory integerObjectOf: 42).
@@ -2518,7 +2520,7 @@ VMPrimitiveTest >> testPrimitiveModFailsWithTypeErrorOnSecondOperand [
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveMod' }
+{ #category : 'tests - primitiveMod' }
 VMPrimitiveTest >> testPrimitiveModNegativeValue [
 
 	interpreter push: (memory integerObjectOf: 16).
@@ -2531,7 +2533,7 @@ VMPrimitiveTest >> testPrimitiveModNegativeValue [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 0). 
 ]
 
-{ #category : #'tests - primitiveMultiply' }
+{ #category : 'tests - primitiveMultiply' }
 VMPrimitiveTest >> testPrimitiveMultiplyBy0 [
 
 	interpreter push: (memory integerObjectOf: memory maxCInteger >> memory numSmallIntegerTagBits).
@@ -2544,7 +2546,7 @@ VMPrimitiveTest >> testPrimitiveMultiplyBy0 [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 0). 
 ]
 
-{ #category : #'tests - primitiveMultiply' }
+{ #category : 'tests - primitiveMultiply' }
 VMPrimitiveTest >> testPrimitiveMultiplyFailsWithTypeErrorOnFirstOperand [
 
 	interpreter push: memory trueObject.
@@ -2555,7 +2557,7 @@ VMPrimitiveTest >> testPrimitiveMultiplyFailsWithTypeErrorOnFirstOperand [
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveMultiply' }
+{ #category : 'tests - primitiveMultiply' }
 VMPrimitiveTest >> testPrimitiveMultiplyFailsWithTypeErrorOnSecondOperand [
 	
 	interpreter push: (memory integerObjectOf: 2).
@@ -2566,7 +2568,7 @@ VMPrimitiveTest >> testPrimitiveMultiplyFailsWithTypeErrorOnSecondOperand [
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveMultiply' }
+{ #category : 'tests - primitiveMultiply' }
 VMPrimitiveTest >> testPrimitiveMultiplyFailsWithTypeErrorPreservesStack [
 
 	interpreter push: (memory trueObject).
@@ -2579,7 +2581,7 @@ VMPrimitiveTest >> testPrimitiveMultiplyFailsWithTypeErrorPreservesStack [
 	self assert: (interpreter stackValue: 1) equals: (memory trueObject).
 ]
 
-{ #category : #'tests - primitiveMultiply' }
+{ #category : 'tests - primitiveMultiply' }
 VMPrimitiveTest >> testPrimitiveMultiplyWithNoOverflow [
 
 	interpreter push: (memory integerObjectOf: 16).
@@ -2592,7 +2594,7 @@ VMPrimitiveTest >> testPrimitiveMultiplyWithNoOverflow [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 32). 
 ]
 
-{ #category : #'tests - primitiveMultiply' }
+{ #category : 'tests - primitiveMultiply' }
 VMPrimitiveTest >> testPrimitiveMultiplyWithNoOverflowPopsOperands [
 
 	interpreter push: (memory integerObjectOf: 42). "Marker"
@@ -2607,7 +2609,7 @@ VMPrimitiveTest >> testPrimitiveMultiplyWithNoOverflowPopsOperands [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 42). 
 ]
 
-{ #category : #'tests - primitiveMultiply' }
+{ #category : 'tests - primitiveMultiply' }
 VMPrimitiveTest >> testPrimitiveMultiplyWithOverflow [
 
 	interpreter push: (memory integerObjectOf: (memory maxSmallInteger)).
@@ -2618,7 +2620,7 @@ VMPrimitiveTest >> testPrimitiveMultiplyWithOverflow [
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveMultiply' }
+{ #category : 'tests - primitiveMultiply' }
 VMPrimitiveTest >> testPrimitiveMultiplyWithOverflowPreservesStack [
 
 	interpreter push: (memory integerObjectOf: 16).
@@ -2630,7 +2632,7 @@ VMPrimitiveTest >> testPrimitiveMultiplyWithOverflowPreservesStack [
 	self assert: (interpreter stackValue: 2) equals: (memory integerObjectOf: 16). 
 ]
 
-{ #category : #'tests - primitiveNew' }
+{ #category : 'tests - primitiveNew' }
 VMPrimitiveTest >> testPrimitiveNewCreatesTheObjectInYoungSpace [
 	| class |
 	class := self newClassInOldSpaceWithSlots: 0 instSpec: memory nonIndexablePointerFormat.
@@ -2642,7 +2644,7 @@ VMPrimitiveTest >> testPrimitiveNewCreatesTheObjectInYoungSpace [
 	self assert: (memory isYoung: interpreter stackTop)
 ]
 
-{ #category : #'tests - primitiveNew' }
+{ #category : 'tests - primitiveNew' }
 VMPrimitiveTest >> testPrimitiveNewCreatesTheObjectWithCorrectSize [
 	| class |
 	class := self newClassInOldSpaceWithSlots: 4 instSpec: memory nonIndexablePointerFormat.
@@ -2653,7 +2655,7 @@ VMPrimitiveTest >> testPrimitiveNewCreatesTheObjectWithCorrectSize [
 	self assert: (memory numSlotsOf: interpreter stackTop) equals: 4
 ]
 
-{ #category : #'tests - primitiveNew' }
+{ #category : 'tests - primitiveNew' }
 VMPrimitiveTest >> testPrimitiveNewInFullNewSpaceAllocatesInOldSpace [
 	| class |
 
@@ -2667,7 +2669,7 @@ VMPrimitiveTest >> testPrimitiveNewInFullNewSpaceAllocatesInOldSpace [
 	self deny: (memory isYoung: interpreter stackTop)
 ]
 
-{ #category : #'tests - primitiveNew' }
+{ #category : 'tests - primitiveNew' }
 VMPrimitiveTest >> testPrimitiveNewInFullNewSpaceScheduleGC [
 	| class |
 
@@ -2681,7 +2683,7 @@ VMPrimitiveTest >> testPrimitiveNewInFullNewSpaceScheduleGC [
 	self assert: memory needGCFlag
 ]
 
-{ #category : #'tests - primitiveNewWithArgs' }
+{ #category : 'tests - primitiveNewWithArgs' }
 VMPrimitiveTest >> testPrimitiveNewIsNotPinned [
 	| class |
 	class := self newClassInOldSpaceWithSlots: 0 instSpec: memory nonIndexablePointerFormat.
@@ -2692,7 +2694,7 @@ VMPrimitiveTest >> testPrimitiveNewIsNotPinned [
 	self deny: (memory isPinned: interpreter stackTop)
 ]
 
-{ #category : #'tests - primitiveNewPinned' }
+{ #category : 'tests - primitiveNewPinned' }
 VMPrimitiveTest >> testPrimitiveNewPinnedCreatesTheObjectInOldSpace [
 	| class |
 	class := self newClassInOldSpaceWithSlots: 0 instSpec: memory nonIndexablePointerFormat.
@@ -2704,7 +2706,7 @@ VMPrimitiveTest >> testPrimitiveNewPinnedCreatesTheObjectInOldSpace [
 	self deny: (memory isYoung: interpreter stackTop)
 ]
 
-{ #category : #'tests - primitiveNewPinned' }
+{ #category : 'tests - primitiveNewPinned' }
 VMPrimitiveTest >> testPrimitiveNewPinnedObjectInFullNewSpaceIsSchedulingGC [
 	| class |
 	class := self newClassInOldSpaceWithSlots: 3 instSpec: memory nonIndexablePointerFormat.
@@ -2720,7 +2722,7 @@ VMPrimitiveTest >> testPrimitiveNewPinnedObjectInFullNewSpaceIsSchedulingGC [
 	self assert: memory needGCFlag 
 ]
 
-{ #category : #'tests - primitiveNewPinned' }
+{ #category : 'tests - primitiveNewPinned' }
 VMPrimitiveTest >> testPrimitiveNewPinnedObjectIsNotSchedulingGC [
 	| class |
 	class := self newClassInOldSpaceWithSlots: 0 instSpec: memory nonIndexablePointerFormat.
@@ -2732,7 +2734,7 @@ VMPrimitiveTest >> testPrimitiveNewPinnedObjectIsNotSchedulingGC [
 	self deny: memory needGCFlag 
 ]
 
-{ #category : #'tests - primitiveNewPinned' }
+{ #category : 'tests - primitiveNewPinned' }
 VMPrimitiveTest >> testPrimitiveNewPinnedObjectIsPinned [
 	| class |
 	class := self newClassInOldSpaceWithSlots: 0 instSpec: memory nonIndexablePointerFormat.
@@ -2744,7 +2746,7 @@ VMPrimitiveTest >> testPrimitiveNewPinnedObjectIsPinned [
 	self assert: (memory isPinned: interpreter stackTop)
 ]
 
-{ #category : #'tests - primitiveNewPinned' }
+{ #category : 'tests - primitiveNewPinned' }
 VMPrimitiveTest >> testPrimitiveNewPinnedWithArgsCreatesTheObjectInOldSpace [
 	| class |
 	class := self newClassInOldSpaceWithSlots: 0 instSpec: memory arrayFormat.
@@ -2757,7 +2759,7 @@ VMPrimitiveTest >> testPrimitiveNewPinnedWithArgsCreatesTheObjectInOldSpace [
 	self deny: (memory isYoung: interpreter stackTop)
 ]
 
-{ #category : #'tests - primitiveNewPinned' }
+{ #category : 'tests - primitiveNewPinned' }
 VMPrimitiveTest >> testPrimitiveNewPinnedWithArgsObjectIsNotSchedulingGC [
 	| class |
 	class := self newClassInOldSpaceWithSlots: 0 instSpec: memory arrayFormat.
@@ -2770,7 +2772,7 @@ VMPrimitiveTest >> testPrimitiveNewPinnedWithArgsObjectIsNotSchedulingGC [
 	self deny: memory needGCFlag 
 ]
 
-{ #category : #'tests - primitiveNewPinned' }
+{ #category : 'tests - primitiveNewPinned' }
 VMPrimitiveTest >> testPrimitiveNewPinnedWithArgsObjectIsPinned [
 	| class |
 	class := self newClassInOldSpaceWithSlots: 0 instSpec: memory arrayFormat.
@@ -2783,7 +2785,7 @@ VMPrimitiveTest >> testPrimitiveNewPinnedWithArgsObjectIsPinned [
 	self assert: (memory isPinned: interpreter stackTop)
 ]
 
-{ #category : #'tests - primitiveNewWithArgs' }
+{ #category : 'tests - primitiveNewWithArgs' }
 VMPrimitiveTest >> testPrimitiveNewWithArgCreatesTheObjectInYoungSpace [
 	| newObj class |
 
@@ -2800,7 +2802,7 @@ VMPrimitiveTest >> testPrimitiveNewWithArgCreatesTheObjectInYoungSpace [
 	self assert: (memory isYoung: newObj)
 ]
 
-{ #category : #'tests - primitiveNewWithArgs' }
+{ #category : 'tests - primitiveNewWithArgs' }
 VMPrimitiveTest >> testPrimitiveNewWithArgCreatesTheObjectWithCorrectSize [
 	| newObj class |
 
@@ -2816,7 +2818,7 @@ VMPrimitiveTest >> testPrimitiveNewWithArgCreatesTheObjectWithCorrectSize [
 	self assert: (memory numSlotsOf: newObj) equals: 7
 ]
 
-{ #category : #'tests - primitiveNewWithArgs' }
+{ #category : 'tests - primitiveNewWithArgs' }
 VMPrimitiveTest >> testPrimitiveNewWithArgInFullNewSpaceAllocatesInOldSpace [
 	| newObj class |
 
@@ -2834,7 +2836,7 @@ VMPrimitiveTest >> testPrimitiveNewWithArgInFullNewSpaceAllocatesInOldSpace [
 	self assert: (memory getMemoryMap isOldObject: newObj)
 ]
 
-{ #category : #'tests - primitiveNewWithArgs' }
+{ #category : 'tests - primitiveNewWithArgs' }
 VMPrimitiveTest >> testPrimitiveNewWithArgInFullNewSpaceScheduleGC [
 	| class |
 
@@ -2850,7 +2852,7 @@ VMPrimitiveTest >> testPrimitiveNewWithArgInFullNewSpaceScheduleGC [
 	self assert: memory needGCFlag
 ]
 
-{ #category : #'tests - primitiveNewWithArgs' }
+{ #category : 'tests - primitiveNewWithArgs' }
 VMPrimitiveTest >> testPrimitiveNewWithArgWithInvalidClassFails [
 	| class |
 
@@ -2864,7 +2866,7 @@ VMPrimitiveTest >> testPrimitiveNewWithArgWithInvalidClassFails [
 	self assert: interpreter primFailCode equals: PrimErrBadReceiver
 ]
 
-{ #category : #'tests - primitiveNewWithArgs' }
+{ #category : 'tests - primitiveNewWithArgs' }
 VMPrimitiveTest >> testPrimitiveNewWithArgWithInvalidClassFails2 [
 	| class |
 
@@ -2879,7 +2881,7 @@ VMPrimitiveTest >> testPrimitiveNewWithArgWithInvalidClassFails2 [
 	self assert: interpreter primFailCode equals: PrimErrBadReceiver
 ]
 
-{ #category : #'tests - primitiveNewWithArgs' }
+{ #category : 'tests - primitiveNewWithArgs' }
 VMPrimitiveTest >> testPrimitiveNewWithArgWithInvalidClassFails3 [
 	| class |
 
@@ -2895,7 +2897,7 @@ VMPrimitiveTest >> testPrimitiveNewWithArgWithInvalidClassFails3 [
 	self assert: interpreter primFailCode equals: PrimErrBadReceiver
 ]
 
-{ #category : #'tests - primitiveNewWithArgs' }
+{ #category : 'tests - primitiveNewWithArgs' }
 VMPrimitiveTest >> testPrimitiveNewWithArgWithNegativeArgumentFails [
 	| class |
 
@@ -2909,7 +2911,7 @@ VMPrimitiveTest >> testPrimitiveNewWithArgWithNegativeArgumentFails [
 	self assert: interpreter primFailCode equals: PrimErrBadArgument
 ]
 
-{ #category : #'tests - primitiveNew' }
+{ #category : 'tests - primitiveNew' }
 VMPrimitiveTest >> testPrimitiveNewWithInvalidClassFails [
 	| class |
 	class := self newClassInOldSpaceWithSlots: 0 instSpec: memory arrayFormat.
@@ -2920,7 +2922,7 @@ VMPrimitiveTest >> testPrimitiveNewWithInvalidClassFails [
 	self assert: interpreter primFailCode equals: PrimErrBadReceiver
 ]
 
-{ #category : #'tests - primitiveNew' }
+{ #category : 'tests - primitiveNew' }
 VMPrimitiveTest >> testPrimitiveNewWithInvalidClassFails2 [
 	| class |
 	"class object with no slots, so no format"
@@ -2932,7 +2934,7 @@ VMPrimitiveTest >> testPrimitiveNewWithInvalidClassFails2 [
 	self assert: interpreter primFailCode equals: PrimErrBadReceiver
 ]
 
-{ #category : #'tests - primitiveNew' }
+{ #category : 'tests - primitiveNew' }
 VMPrimitiveTest >> testPrimitiveNewWithInvalidClassFails3 [
 	| class |
 	"class with nil used as format"
@@ -2945,7 +2947,7 @@ VMPrimitiveTest >> testPrimitiveNewWithInvalidClassFails3 [
 	self assert: interpreter primFailCode equals: PrimErrBadReceiver
 ]
 
-{ #category : #'tests - primitiveNotEqual' }
+{ #category : 'tests - primitiveNotEqual' }
 VMPrimitiveTest >> testPrimitiveNotEqualFailsWithFloat [
 
 	"This simulated classFloat class is necessary because the 32bits VM cannot instanciate boxed floats by itself"
@@ -2956,7 +2958,7 @@ VMPrimitiveTest >> testPrimitiveNotEqualFailsWithFloat [
 	self assert: interpreter failed
 ]
 
-{ #category : #'tests - primitiveNotEqual' }
+{ #category : 'tests - primitiveNotEqual' }
 VMPrimitiveTest >> testPrimitiveNotEqualWithNegativeNumbers [
 
 	interpreter push: (memory integerObjectOf: -13).
@@ -2967,7 +2969,7 @@ VMPrimitiveTest >> testPrimitiveNotEqualWithNegativeNumbers [
 	self deny: interpreter failed. 
 ]
 
-{ #category : #'tests - primitiveNotEqual' }
+{ #category : 'tests - primitiveNotEqual' }
 VMPrimitiveTest >> testPrimitiveNotEqualWithNoError1 [
 
 	interpreter push: (memory integerObjectOf: 16).
@@ -2978,7 +2980,7 @@ VMPrimitiveTest >> testPrimitiveNotEqualWithNoError1 [
 	self assert: interpreter stackTop equals: (memory falseObject). 
 ]
 
-{ #category : #'tests - primitiveNotEqual' }
+{ #category : 'tests - primitiveNotEqual' }
 VMPrimitiveTest >> testPrimitiveNotEqualWithNoError2 [
 
 	interpreter push: (memory integerObjectOf: 16).
@@ -2989,7 +2991,7 @@ VMPrimitiveTest >> testPrimitiveNotEqualWithNoError2 [
 	self assert: interpreter stackTop equals: (memory trueObject). 
 ]
 
-{ #category : #'tests - primitiveNotEqual' }
+{ #category : 'tests - primitiveNotEqual' }
 VMPrimitiveTest >> testPrimitiveNotEqualWithNoErrorPopsOperands [
 
 	interpreter push: (memory integerObjectOf: 42). "Marker"
@@ -3004,7 +3006,7 @@ VMPrimitiveTest >> testPrimitiveNotEqualWithNoErrorPopsOperands [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 42).
 ]
 
-{ #category : #'tests - primitiveNotEqual' }
+{ #category : 'tests - primitiveNotEqual' }
 VMPrimitiveTest >> testPrimitiveNotEqualWithTypeErrorOnFirstOperand [
 
 	interpreter push: (memory trueObject).
@@ -3015,7 +3017,7 @@ VMPrimitiveTest >> testPrimitiveNotEqualWithTypeErrorOnFirstOperand [
 	self assert: interpreter failed. 
 ]
 
-{ #category : #'tests - primitiveNotEqual' }
+{ #category : 'tests - primitiveNotEqual' }
 VMPrimitiveTest >> testPrimitiveNotEqualWithTypeErrorOnSecondOperand [
 
 	interpreter push: (memory integerObjectOf: 16).
@@ -3026,7 +3028,7 @@ VMPrimitiveTest >> testPrimitiveNotEqualWithTypeErrorOnSecondOperand [
 	self assert: interpreter failed. 
 ]
 
-{ #category : #'tests - primitivePin' }
+{ #category : 'tests - primitivePin' }
 VMPrimitiveTest >> testPrimitivePinFailsForForwardedObjects [
 
 	interpreter push: self setUpForwardedObjects. 
@@ -3037,7 +3039,7 @@ VMPrimitiveTest >> testPrimitivePinFailsForForwardedObjects [
 	self assert: interpreter primFailCode equals: PrimErrBadArgument. 
 ]
 
-{ #category : #'tests - primitivePin' }
+{ #category : 'tests - primitivePin' }
 VMPrimitiveTest >> testPrimitivePinFailsForImmediate [
 
 	interpreter push: (memory integerObjectOf: 16).
@@ -3048,7 +3050,7 @@ VMPrimitiveTest >> testPrimitivePinFailsForImmediate [
 	self assert: interpreter primFailCode equals: PrimErrBadReceiver. 
 ]
 
-{ #category : #'tests - primitivePin' }
+{ #category : 'tests - primitivePin' }
 VMPrimitiveTest >> testPrimitivePinFailsForNOnBoolOnSecondArg [
 
 	interpreter push: (memory instantiateClass: (self newClassInOldSpaceWithSlots: 1 instSpec: memory nonIndexablePointerFormat)).
@@ -3060,7 +3062,7 @@ VMPrimitiveTest >> testPrimitivePinFailsForNOnBoolOnSecondArg [
 	self assert: interpreter primFailCode equals: PrimErrBadArgument. 
 ]
 
-{ #category : #'tests - primitivePin' }
+{ #category : 'tests - primitivePin' }
 VMPrimitiveTest >> testPrimitivePinPinsObjectCreatedInNewSpace [
 	|object object2|
 	
@@ -3079,7 +3081,7 @@ VMPrimitiveTest >> testPrimitivePinPinsObjectCreatedInNewSpace [
 	self assert: (memory isPinned: object2). 
 ]
 
-{ #category : #'tests - primitivePin' }
+{ #category : 'tests - primitivePin' }
 VMPrimitiveTest >> testPrimitivePinPinsObjectCreatedInOldSpace [
 	|object|
 	
@@ -3099,7 +3101,7 @@ VMPrimitiveTest >> testPrimitivePinPinsObjectCreatedInOldSpace [
 	
 ]
 
-{ #category : #'tests - primitivePin' }
+{ #category : 'tests - primitivePin' }
 VMPrimitiveTest >> testPrimitivePinReturnsBoolean [
 	|object|
 	
@@ -3119,7 +3121,7 @@ VMPrimitiveTest >> testPrimitivePinReturnsBoolean [
 	
 ]
 
-{ #category : #'tests - primitiveQuo' }
+{ #category : 'tests - primitiveQuo' }
 VMPrimitiveTest >> testPrimitiveQuo [
 
 	interpreter push: (memory integerObjectOf: 15).
@@ -3129,7 +3131,7 @@ VMPrimitiveTest >> testPrimitiveQuo [
 	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 7). 
 ]
 
-{ #category : #'tests - primitiveQuo' }
+{ #category : 'tests - primitiveQuo' }
 VMPrimitiveTest >> testPrimitiveQuoFailPreservesStack [
 	
 	interpreter push: (memory trueObject).
@@ -3142,7 +3144,7 @@ VMPrimitiveTest >> testPrimitiveQuoFailPreservesStack [
 	self assert: (interpreter stackValue: 1) equals: (memory trueObject).
 ]
 
-{ #category : #'tests - primitiveQuo' }
+{ #category : 'tests - primitiveQuo' }
 VMPrimitiveTest >> testPrimitiveQuoFailsWithTypeErrorOnFirstOperand [
 	
 	interpreter push: memory trueObject.
@@ -3153,7 +3155,7 @@ VMPrimitiveTest >> testPrimitiveQuoFailsWithTypeErrorOnFirstOperand [
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveQuo' }
+{ #category : 'tests - primitiveQuo' }
 VMPrimitiveTest >> testPrimitiveQuoFailsWithTypeErrorOnSecondOperand [
 	
 	interpreter push: (memory integerObjectOf: 2).
@@ -3164,7 +3166,7 @@ VMPrimitiveTest >> testPrimitiveQuoFailsWithTypeErrorOnSecondOperand [
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveQuo' }
+{ #category : 'tests - primitiveQuo' }
 VMPrimitiveTest >> testPrimitiveQuoOnFloatResultDoesntReturnRest [
 "Tests that the rest of the integer division is not pushed into the stack, as this is not expected in a primitive behavior"
 	interpreter push: (memory integerObjectOf: 16).
@@ -3176,7 +3178,7 @@ VMPrimitiveTest >> testPrimitiveQuoOnFloatResultDoesntReturnRest [
 	self assert: (interpreter stackValue: 1) equals: (memory integerObjectOf: 16). 
 ]
 
-{ #category : #'tests - primitiveQuo' }
+{ #category : 'tests - primitiveQuo' }
 VMPrimitiveTest >> testPrimitiveQuoOnFloatResultRoundsAndDoesntFail [
 
 	interpreter push: (memory integerObjectOf: 42).
@@ -3187,7 +3189,7 @@ VMPrimitiveTest >> testPrimitiveQuoOnFloatResultRoundsAndDoesntFail [
 	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 10). 
 ]
 
-{ #category : #'tests - primitiveQuo' }
+{ #category : 'tests - primitiveQuo' }
 VMPrimitiveTest >> testPrimitiveQuoWith0DivisionOnFirstOperand [
 
 	interpreter push: (memory integerObjectOf: 0).
@@ -3198,7 +3200,7 @@ VMPrimitiveTest >> testPrimitiveQuoWith0DivisionOnFirstOperand [
 	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 0). 
 ]
 
-{ #category : #'tests - primitiveQuo' }
+{ #category : 'tests - primitiveQuo' }
 VMPrimitiveTest >> testPrimitiveQuoWith0DivisionOnSecondOperand [
 	
 	interpreter push: (memory integerObjectOf: 4).
@@ -3209,7 +3211,7 @@ VMPrimitiveTest >> testPrimitiveQuoWith0DivisionOnSecondOperand [
 	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 0). 
 ]
 
-{ #category : #'tests - primitiveQuo' }
+{ #category : 'tests - primitiveQuo' }
 VMPrimitiveTest >> testPrimitiveQuoWithNegativeNumbers1 [
 
 	interpreter push: (memory integerObjectOf: -13).
@@ -3220,7 +3222,7 @@ VMPrimitiveTest >> testPrimitiveQuoWithNegativeNumbers1 [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 6). 
 ]
 
-{ #category : #'tests - primitiveQuo' }
+{ #category : 'tests - primitiveQuo' }
 VMPrimitiveTest >> testPrimitiveQuoWithNegativeNumbers2 [
 
 	interpreter push: (memory integerObjectOf: -9).
@@ -3231,7 +3233,7 @@ VMPrimitiveTest >> testPrimitiveQuoWithNegativeNumbers2 [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: -2). 
 ]
 
-{ #category : #'tests - primitiveQuo' }
+{ #category : 'tests - primitiveQuo' }
 VMPrimitiveTest >> testPrimitiveQuoWithNoErrorPopsOperands [
 	
 	interpreter push: (memory integerObjectOf: 42). "Marker"
@@ -3246,7 +3248,7 @@ VMPrimitiveTest >> testPrimitiveQuoWithNoErrorPopsOperands [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 42). 
 ]
 
-{ #category : #'tests - primitiveImmutability' }
+{ #category : 'tests - primitiveImmutability' }
 VMPrimitiveTest >> testPrimitiveSetImmutabilityOfImmediateShouldFail [
 
 	interpreter push: (memory integerObjectOf: 1).
@@ -3256,7 +3258,7 @@ VMPrimitiveTest >> testPrimitiveSetImmutabilityOfImmediateShouldFail [
 	self assert: interpreter failed
 ]
 
-{ #category : #'tests - primitiveImmutability' }
+{ #category : 'tests - primitiveImmutability' }
 VMPrimitiveTest >> testPrimitiveSetImmutabilityOfObjectAsTrueSetsImmutability [
 
 	| class object |
@@ -3271,7 +3273,7 @@ VMPrimitiveTest >> testPrimitiveSetImmutabilityOfObjectAsTrueSetsImmutability [
 	self assert: (memory isImmutable: object)
 ]
 
-{ #category : #'tests - primitiveSize' }
+{ #category : 'tests - primitiveSize' }
 VMPrimitiveTest >> testPrimitiveSizeAnswersCorrectSizeForContext [
 
 	| method |
@@ -3286,7 +3288,7 @@ VMPrimitiveTest >> testPrimitiveSizeAnswersCorrectSizeForContext [
 		equals: (memory integerObjectOf: 10 + wordSize)
 ]
 
-{ #category : #'tests - primitiveSize' }
+{ #category : 'tests - primitiveSize' }
 VMPrimitiveTest >> testPrimitiveSizeAnswersCorrectSizeForIndexableObject [
 
 	| array1 |
@@ -3299,7 +3301,7 @@ VMPrimitiveTest >> testPrimitiveSizeAnswersCorrectSizeForIndexableObject [
 
 ]
 
-{ #category : #'tests - primitiveSize' }
+{ #category : 'tests - primitiveSize' }
 VMPrimitiveTest >> testPrimitiveSizeAnswersCorrectSizeForMethod [
 
 	| method |
@@ -3314,7 +3316,7 @@ VMPrimitiveTest >> testPrimitiveSizeAnswersCorrectSizeForMethod [
 		equals: (memory integerObjectOf: 10 + wordSize)
 ]
 
-{ #category : #'tests - primitiveSize' }
+{ #category : 'tests - primitiveSize' }
 VMPrimitiveTest >> testPrimitiveSizeFailsForForwardedObject [
 
 	| array1 array2 arrayForwarder arrayForwardee |
@@ -3339,7 +3341,7 @@ VMPrimitiveTest >> testPrimitiveSizeFailsForForwardedObject [
 
 ]
 
-{ #category : #'tests - primitiveSize' }
+{ #category : 'tests - primitiveSize' }
 VMPrimitiveTest >> testPrimitiveSizeFailsForForwardedObjectThenCallForwarderResolutionAndCallPrimitiveAgain [
 
 	| array1 array2 arrayForwarder arrayForwardee |
@@ -3366,7 +3368,7 @@ VMPrimitiveTest >> testPrimitiveSizeFailsForForwardedObjectThenCallForwarderReso
 
 ]
 
-{ #category : #'tests - primitiveSize' }
+{ #category : 'tests - primitiveSize' }
 VMPrimitiveTest >> testPrimitiveSizeFailsForNonIndexable [
 	| class objectInstance |
 	"Forwarding an object happens when becoming it with a bigger object"
@@ -3382,7 +3384,7 @@ VMPrimitiveTest >> testPrimitiveSizeFailsForNonIndexable [
 	self assert: interpreter primFailCode equals: PrimErrBadReceiver. 
 ]
 
-{ #category : #'tests - primitiveAt' }
+{ #category : 'tests - primitiveAt' }
 VMPrimitiveTest >> testPrimitiveSlotAtOverBoundShouldFailForIndexable [
 	| class object |
 	class := self newClassInOldSpaceWithSlots: 1 instSpec: memory arrayFormat.
@@ -3397,7 +3399,7 @@ VMPrimitiveTest >> testPrimitiveSlotAtOverBoundShouldFailForIndexable [
 	self assert: interpreter primFailCode equals: PrimErrBadIndex. 
 ]
 
-{ #category : #'tests - primitiveAt' }
+{ #category : 'tests - primitiveAt' }
 VMPrimitiveTest >> testPrimitiveSlotAtOverBoundShouldFailNonIndexable [
 	| class object |
 	class := self newClassInOldSpaceWithSlots: 1 instSpec: memory nonIndexablePointerFormat.
@@ -3412,7 +3414,7 @@ VMPrimitiveTest >> testPrimitiveSlotAtOverBoundShouldFailNonIndexable [
 	self assert: interpreter primFailCode equals: PrimErrBadIndex.
 ]
 
-{ #category : #'tests - primitiveAtPut' }
+{ #category : 'tests - primitiveAtPut' }
 VMPrimitiveTest >> testPrimitiveSlotAtPutOverBoundShouldFailForIndexable [
 	| class object |
 	class := self newClassInOldSpaceWithSlots: 1 instSpec: memory arrayFormat.
@@ -3428,7 +3430,7 @@ VMPrimitiveTest >> testPrimitiveSlotAtPutOverBoundShouldFailForIndexable [
 	self assert: interpreter primFailCode equals: PrimErrBadIndex. 
 ]
 
-{ #category : #'tests - primitiveAtPut' }
+{ #category : 'tests - primitiveAtPut' }
 VMPrimitiveTest >> testPrimitiveSlotAtPutOverBoundShouldFailNonIndexable [
 	| class object |
 	class := self newClassInOldSpaceWithSlots: 1 instSpec: memory nonIndexablePointerFormat.
@@ -3444,7 +3446,7 @@ VMPrimitiveTest >> testPrimitiveSlotAtPutOverBoundShouldFailNonIndexable [
 	self assert: interpreter primFailCode equals: PrimErrBadIndex.
 ]
 
-{ #category : #'tests - primitiveAtPut' }
+{ #category : 'tests - primitiveAtPut' }
 VMPrimitiveTest >> testPrimitiveSlotAtPutPutsTheValueForNonIndexable [
 	| class object |
 	class := self newClassInOldSpaceWithSlots: 1 instSpec: memory nonIndexablePointerFormat.
@@ -3460,7 +3462,7 @@ VMPrimitiveTest >> testPrimitiveSlotAtPutPutsTheValueForNonIndexable [
 	self assert: (memory fetchPointer: 0 ofObject: object) equals: memory falseObject.
 ]
 
-{ #category : #'tests - primitiveAt' }
+{ #category : 'tests - primitiveAt' }
 VMPrimitiveTest >> testPrimitiveSlotAtPutsTheValueForNonIndexable [
 	| class object |
 	class := self newClassInOldSpaceWithSlots: 1 instSpec: memory nonIndexablePointerFormat.
@@ -3482,7 +3484,7 @@ VMPrimitiveTest >> testPrimitiveSlotAtPutsTheValueForNonIndexable [
 	self assert: interpreter stackTop equals: memory falseObject.
 ]
 
-{ #category : #'tests - primitiveAdd - SmallFloat' }
+{ #category : 'tests - primitiveAdd - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatAdd [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3499,7 +3501,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatAdd [
 		equals: (memory smallFloatObjectOf: 10.0)
 ]
 
-{ #category : #'tests - primitiveAdd - SmallFloat' }
+{ #category : 'tests - primitiveAdd - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatAddFailsOnFirstOperandWithTypeErrorPreservesStack [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3516,7 +3518,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatAddFailsOnFirstOperandWithTypeErrorPre
 	self assert: (interpreter stackValue: 1) equals: memory trueObject.
 ]
 
-{ #category : #'tests - primitiveAdd - SmallFloat' }
+{ #category : 'tests - primitiveAdd - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatAddFailsOnSecondOperandWithTypeErrorPreservesStack [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3533,7 +3535,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatAddFailsOnSecondOperandWithTypeErrorPr
 	self assert: (interpreter stackValue: 1) equals:  (memory smallFloatObjectOf: 2.0).
 ]
 
-{ #category : #'tests - primitiveAdd - SmallFloat' }
+{ #category : 'tests - primitiveAdd - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatAddFailsWithTypeErrorOnFirstOperand [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3547,7 +3549,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatAddFailsWithTypeErrorOnFirstOperand [
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveAdd - SmallFloat' }
+{ #category : 'tests - primitiveAdd - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatAddFailsWithTypeErrorOnSecondOperand [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3561,7 +3563,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatAddFailsWithTypeErrorOnSecondOperand [
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveAdd - SmallFloat' }
+{ #category : 'tests - primitiveAdd - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatAddPopsOperands [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3579,7 +3581,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatAddPopsOperands [
 	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 42).
 ]
 
-{ #category : #'tests - primitiveDivide - SmallFloat' }
+{ #category : 'tests - primitiveDivide - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatDivide [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3596,7 +3598,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatDivide [
 		equals: (memory smallFloatObjectOf: 1.0)
 ]
 
-{ #category : #'tests - primitiveDivide - SmallFloat' }
+{ #category : 'tests - primitiveDivide - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatDivideFailsOnFirstOperandWithTypeErrorPreservesStack [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3613,7 +3615,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatDivideFailsOnFirstOperandWithTypeError
 	self assert: interpreter stackTop equals: (memory smallFloatObjectOf: 2.0).
 ]
 
-{ #category : #'tests - primitiveDivide - SmallFloat' }
+{ #category : 'tests - primitiveDivide - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatDivideFailsOnSecondOperandWithTypeErrorPreservesStack [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3630,7 +3632,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatDivideFailsOnSecondOperandWithTypeErro
 	self assert: (interpreter stackValue: 1) equals:  (memory smallFloatObjectOf: 2.0).
 ]
 
-{ #category : #'tests - primitiveDivide - SmallFloat' }
+{ #category : 'tests - primitiveDivide - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatDivideFailsOnZeroDivisionPreservesStack [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3648,7 +3650,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatDivideFailsOnZeroDivisionPreservesStac
 	self assert: interpreter stackTop equals: (memory smallFloatObjectOf: 0.0).
 ]
 
-{ #category : #'tests - primitiveDivide - SmallFloat' }
+{ #category : 'tests - primitiveDivide - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatDivideFailsWithTypeErrorOnFirstOperand [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3662,7 +3664,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatDivideFailsWithTypeErrorOnFirstOperand
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveDivide - SmallFloat' }
+{ #category : 'tests - primitiveDivide - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatDivideFailsWithTypeErrorOnSecondOperand [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3676,7 +3678,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatDivideFailsWithTypeErrorOnSecondOperan
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveDivide - SmallFloat' }
+{ #category : 'tests - primitiveDivide - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatDivideFailsWithZeroDivision [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3689,7 +3691,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatDivideFailsWithZeroDivision [
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveDivide - SmallFloat' }
+{ #category : 'tests - primitiveDivide - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatDividePopsOperands [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3707,7 +3709,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatDividePopsOperands [
 	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 42).
 ]
 
-{ #category : #'tests - primitiveEqual - SmallFloat' }
+{ #category : 'tests - primitiveEqual - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatEqual [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3722,7 +3724,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatEqual [
 	self assert: interpreter stackTop equals: memory falseObject.
 ]
 
-{ #category : #'tests - primitiveEqual - SmallFloat' }
+{ #category : 'tests - primitiveEqual - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatEqualEqualEquality [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3737,7 +3739,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatEqualEqualEquality [
 	self assert: interpreter stackTop equals: memory trueObject.
 ]
 
-{ #category : #'tests - primitiveEqual - SmallFloat' }
+{ #category : 'tests - primitiveEqual - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatEqualFailsWithTypeErrorOnFirstOperand [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3751,7 +3753,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatEqualFailsWithTypeErrorOnFirstOperand 
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveEqual - SmallFloat' }
+{ #category : 'tests - primitiveEqual - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatEqualFailsWithTypeErrorOnSecondOperand [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3765,7 +3767,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatEqualFailsWithTypeErrorOnSecondOperand
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveEqual - SmallFloat' }
+{ #category : 'tests - primitiveEqual - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatEqualFailsWithTypeErrorPreservesStack [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3782,7 +3784,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatEqualFailsWithTypeErrorPreservesStack 
 	self assert: (interpreter stackValue: 1) equals:  (memory smallFloatObjectOf: 2.0).
 ]
 
-{ #category : #'tests - primitiveEqual - SmallFloat' }
+{ #category : 'tests - primitiveEqual - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatEqualPopsOperands [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3801,7 +3803,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatEqualPopsOperands [
 	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 42).
 ]
 
-{ #category : #'tests - primitiveEqual - SmallFloat' }
+{ #category : 'tests - primitiveEqual - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatEqualtWithNegativeNumbers [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3816,7 +3818,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatEqualtWithNegativeNumbers [
 	self assert: interpreter stackTop equals: memory falseObject.
 ]
 
-{ #category : #'tests - primitiveGreaterOrEqual - SmallFloat' }
+{ #category : 'tests - primitiveGreaterOrEqual - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatGreaterOrEqual [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3831,7 +3833,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatGreaterOrEqual [
 	self assert: interpreter stackTop equals: memory trueObject.
 ]
 
-{ #category : #'tests - primitiveGreaterOrEqual - SmallFloat' }
+{ #category : 'tests - primitiveGreaterOrEqual - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatGreaterOrEqualEquality [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3848,7 +3850,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatGreaterOrEqualEquality [
 	
 ]
 
-{ #category : #'tests - primitiveGreaterOrEqual - SmallFloat' }
+{ #category : 'tests - primitiveGreaterOrEqual - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatGreaterOrEqualFailsOnFirstOperandWithTypeErrorPreservesStack [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3865,7 +3867,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatGreaterOrEqualFailsOnFirstOperandWithT
 	self assert: (interpreter stackValue: 1) equals:  memory trueObject.
 ]
 
-{ #category : #'tests - primitiveGreaterOrEqual - SmallFloat' }
+{ #category : 'tests - primitiveGreaterOrEqual - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatGreaterOrEqualFailsOnSecondOperandWithTypeErrorPreservesStack [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3882,7 +3884,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatGreaterOrEqualFailsOnSecondOperandWith
 	self assert: (interpreter stackValue: 1) equals:  (memory smallFloatObjectOf: 2.0).
 ]
 
-{ #category : #'tests - primitiveGreaterOrEqual - SmallFloat' }
+{ #category : 'tests - primitiveGreaterOrEqual - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatGreaterOrEqualFailsWithTypeErrorOnFirstOperand [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3896,7 +3898,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatGreaterOrEqualFailsWithTypeErrorOnFirs
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveGreaterOrEqual - SmallFloat' }
+{ #category : 'tests - primitiveGreaterOrEqual - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatGreaterOrEqualFailsWithTypeErrorOnSecondOperand [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3910,7 +3912,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatGreaterOrEqualFailsWithTypeErrorOnSeco
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveGreaterOrEqual - SmallFloat' }
+{ #category : 'tests - primitiveGreaterOrEqual - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatGreaterOrEqualPopsOperands [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3930,7 +3932,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatGreaterOrEqualPopsOperands [
 	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 42).
 ]
 
-{ #category : #'tests - primitiveGreaterOrEqual - SmallFloat' }
+{ #category : 'tests - primitiveGreaterOrEqual - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatGreaterOrEqualtWithNegativeNumbers [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3945,7 +3947,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatGreaterOrEqualtWithNegativeNumbers [
 	self assert: interpreter stackTop equals: memory trueObject.
 ]
 
-{ #category : #'tests - primitiveGreaterThan - SmallFloat' }
+{ #category : 'tests - primitiveGreaterThan - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatGreaterThan [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3960,7 +3962,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatGreaterThan [
 	self assert: interpreter stackTop equals: memory trueObject.
 ]
 
-{ #category : #'tests - primitiveGreaterThan - SmallFloat' }
+{ #category : 'tests - primitiveGreaterThan - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatGreaterThanFailsOnFirstOperandWithTypeErrorPreservesStack [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3977,7 +3979,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatGreaterThanFailsOnFirstOperandWithType
 	self assert: (interpreter stackValue: 1) equals: memory trueObject.
 ]
 
-{ #category : #'tests - primitiveGreaterThan - SmallFloat' }
+{ #category : 'tests - primitiveGreaterThan - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatGreaterThanFailsOnSecondOperandWithTypeErrorPreservesStack [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -3994,7 +3996,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatGreaterThanFailsOnSecondOperandWithTyp
 	self assert: (interpreter stackValue: 1) equals: (memory smallFloatObjectOf: 2.0).
 ]
 
-{ #category : #'tests - primitiveGreaterThan - SmallFloat' }
+{ #category : 'tests - primitiveGreaterThan - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatGreaterThanFailsWithTypeErrorOnFirstOperand [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4008,7 +4010,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatGreaterThanFailsWithTypeErrorOnFirstOp
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveGreaterThan - SmallFloat' }
+{ #category : 'tests - primitiveGreaterThan - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatGreaterThanFailsWithTypeErrorOnSecondOperand [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4022,7 +4024,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatGreaterThanFailsWithTypeErrorOnSecondO
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveGreaterThan - SmallFloat' }
+{ #category : 'tests - primitiveGreaterThan - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatGreaterThanPopsOperands [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4041,7 +4043,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatGreaterThanPopsOperands [
 	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 42).
 ]
 
-{ #category : #'tests - primitiveGreaterThan - SmallFloat' }
+{ #category : 'tests - primitiveGreaterThan - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatGreaterThantWithNegativeNumbers [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4056,7 +4058,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatGreaterThantWithNegativeNumbers [
 	self assert: interpreter stackTop equals: memory trueObject. 
 ]
 
-{ #category : #'tests - primitiveLessOrEqual - SmallFloat' }
+{ #category : 'tests - primitiveLessOrEqual - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatLessOrEqual [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4071,7 +4073,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatLessOrEqual [
 	self assert: interpreter stackTop equals: memory falseObject.
 ]
 
-{ #category : #'tests - primitiveLessOrEqual - SmallFloat' }
+{ #category : 'tests - primitiveLessOrEqual - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatLessOrEqualEquality [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4086,7 +4088,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatLessOrEqualEquality [
 	self assert: interpreter stackTop equals: memory trueObject.
 ]
 
-{ #category : #'tests - primitiveLessOrEqual - SmallFloat' }
+{ #category : 'tests - primitiveLessOrEqual - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatLessOrEqualFailsOnFirstOperandWithTypeErrorPreservesStack [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4103,7 +4105,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatLessOrEqualFailsOnFirstOperandWithType
 	self assert: (interpreter stackValue: 1) equals: memory trueObject.
 ]
 
-{ #category : #'tests - primitiveLessOrEqual - SmallFloat' }
+{ #category : 'tests - primitiveLessOrEqual - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatLessOrEqualFailsOnSecondOperandWithTypeErrorPreservesStack [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4120,7 +4122,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatLessOrEqualFailsOnSecondOperandWithTyp
 	self assert: (interpreter stackValue: 1) equals:  (memory smallFloatObjectOf: 2.0).
 ]
 
-{ #category : #'tests - primitiveLessOrEqual - SmallFloat' }
+{ #category : 'tests - primitiveLessOrEqual - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatLessOrEqualFailsWithTypeErrorOnFirstOperand [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4134,7 +4136,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatLessOrEqualFailsWithTypeErrorOnFirstOp
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveLessOrEqual - SmallFloat' }
+{ #category : 'tests - primitiveLessOrEqual - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatLessOrEqualFailsWithTypeErrorOnSecondOperand [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4148,7 +4150,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatLessOrEqualFailsWithTypeErrorOnSecondO
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveLessOrEqual - SmallFloat' }
+{ #category : 'tests - primitiveLessOrEqual - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatLessOrEqualPopsOperands [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4167,7 +4169,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatLessOrEqualPopsOperands [
 	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 42).
 ]
 
-{ #category : #'tests - primitiveLessOrEqual - SmallFloat' }
+{ #category : 'tests - primitiveLessOrEqual - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatLessOrEqualtWithNegativeNumbers [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4182,7 +4184,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatLessOrEqualtWithNegativeNumbers [
 	self assert: interpreter stackTop equals: memory falseObject.
 ]
 
-{ #category : #'tests - primitiveLessThan - SmallFloat' }
+{ #category : 'tests - primitiveLessThan - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatLessThan [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4199,7 +4201,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatLessThan [
 	
 ]
 
-{ #category : #'tests - primitiveLessThan - SmallFloat' }
+{ #category : 'tests - primitiveLessThan - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatLessThanFailsWithTypeErrorOnFirstOperand [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4215,7 +4217,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatLessThanFailsWithTypeErrorOnFirstOpera
 	
 ]
 
-{ #category : #'tests - primitiveLessThan - SmallFloat' }
+{ #category : 'tests - primitiveLessThan - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatLessThanFailsWithTypeErrorOnSecondOperand [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4231,7 +4233,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatLessThanFailsWithTypeErrorOnSecondOper
 	
 ]
 
-{ #category : #'tests - primitiveLessThan - SmallFloat' }
+{ #category : 'tests - primitiveLessThan - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatLessThanFailsWithTypeErrorPreservesStack [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4250,7 +4252,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatLessThanFailsWithTypeErrorPreservesSta
 	
 ]
 
-{ #category : #'tests - primitiveLessThan - SmallFloat' }
+{ #category : 'tests - primitiveLessThan - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatLessThanPopsOperands [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4272,7 +4274,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatLessThanPopsOperands [
 	
 ]
 
-{ #category : #'tests - primitiveLessThan - SmallFloat' }
+{ #category : 'tests - primitiveLessThan - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatLessThantWithNegativeNumbers [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4288,7 +4290,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatLessThantWithNegativeNumbers [
 	
 ]
 
-{ #category : #'tests - primitiveMultiply - SmallFloat' }
+{ #category : 'tests - primitiveMultiply - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatMultiply [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4305,7 +4307,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatMultiply [
 		equals: (memory smallFloatObjectOf: 100.0)
 ]
 
-{ #category : #'tests - primitiveMultiply - SmallFloat' }
+{ #category : 'tests - primitiveMultiply - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatMultiplyFailsOnFirstOperandWithTypeErrorPreservesStack [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4324,7 +4326,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatMultiplyFailsOnFirstOperandWithTypeErr
 	
 ]
 
-{ #category : #'tests - primitiveMultiply - SmallFloat' }
+{ #category : 'tests - primitiveMultiply - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatMultiplyFailsOnSecondOperandWithTypeErrorPreservesStack [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4343,7 +4345,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatMultiplyFailsOnSecondOperandWithTypeEr
 	
 ]
 
-{ #category : #'tests - primitiveMultiply - SmallFloat' }
+{ #category : 'tests - primitiveMultiply - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatMultiplyFailsWithTypeErrorOnFirstOperand [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4357,7 +4359,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatMultiplyFailsWithTypeErrorOnFirstOpera
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveMultiply - SmallFloat' }
+{ #category : 'tests - primitiveMultiply - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatMultiplyFailsWithTypeErrorOnSecondOperand [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4371,7 +4373,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatMultiplyFailsWithTypeErrorOnSecondOper
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveMultiply - SmallFloat' }
+{ #category : 'tests - primitiveMultiply - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatMultiplyPopsOperands [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4389,7 +4391,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatMultiplyPopsOperands [
 	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 42).
 ]
 
-{ #category : #'tests - primitiveNotEqual - SmallFloat' }
+{ #category : 'tests - primitiveNotEqual - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatNotEqual [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4404,7 +4406,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatNotEqual [
 	self assert: interpreter stackTop equals: memory trueObject.
 ]
 
-{ #category : #'tests - primitiveNotEqual - SmallFloat' }
+{ #category : 'tests - primitiveNotEqual - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatNotEqualEqual [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4419,7 +4421,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatNotEqualEqual [
 	self assert: interpreter stackTop equals: memory falseObject.
 ]
 
-{ #category : #'tests - primitiveNotEqual - SmallFloat' }
+{ #category : 'tests - primitiveNotEqual - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatNotEqualFailsOnFirstOperandWithTypeErrorPreservesStack [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4436,7 +4438,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatNotEqualFailsOnFirstOperandWithTypeErr
 	self assert: (interpreter stackValue: 1) equals: memory trueObject.
 ]
 
-{ #category : #'tests - primitiveNotEqual - SmallFloat' }
+{ #category : 'tests - primitiveNotEqual - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatNotEqualFailsOnSecondOperandWithTypeErrorPreservesStack [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4453,7 +4455,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatNotEqualFailsOnSecondOperandWithTypeEr
 	self assert: (interpreter stackValue: 1) equals:  (memory smallFloatObjectOf: 2.0).
 ]
 
-{ #category : #'tests - primitiveNotEqual - SmallFloat' }
+{ #category : 'tests - primitiveNotEqual - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatNotEqualFailsWithTypeErrorOnFirstOperand [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4467,7 +4469,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatNotEqualFailsWithTypeErrorOnFirstOpera
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveNotEqual - SmallFloat' }
+{ #category : 'tests - primitiveNotEqual - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatNotEqualFailsWithTypeErrorOnSecondOperand [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4481,7 +4483,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatNotEqualFailsWithTypeErrorOnSecondOper
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveNotEqual - SmallFloat' }
+{ #category : 'tests - primitiveNotEqual - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatNotEqualPopsOperands [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4500,7 +4502,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatNotEqualPopsOperands [
 	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 42).
 ]
 
-{ #category : #'tests - primitiveNotEqual - SmallFloat' }
+{ #category : 'tests - primitiveNotEqual - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatNotEqualtWithNegativeNumbers [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4515,7 +4517,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatNotEqualtWithNegativeNumbers [
 	self assert: interpreter stackTop equals: memory trueObject.
 ]
 
-{ #category : #'tests - primitiveSubtract - SmallFloat' }
+{ #category : 'tests - primitiveSubtract - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatSubtract [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4530,7 +4532,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatSubtract [
 	self assert: interpreter stackTop equals: (memory smallFloatObjectOf: 2.0).
 ]
 
-{ #category : #'tests - primitiveSubtract - SmallFloat' }
+{ #category : 'tests - primitiveSubtract - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatSubtractFailsOnSecondOperandWithTypeErrorPreservesStack [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4547,7 +4549,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatSubtractFailsOnSecondOperandWithTypeEr
 	self assert: (interpreter stackValue: 1) equals:  (memory smallFloatObjectOf: 2.0).
 ]
 
-{ #category : #'tests - primitiveSubtract - SmallFloat' }
+{ #category : 'tests - primitiveSubtract - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatSubtractFailsWithTypeErrorOnFirstOperand [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4561,7 +4563,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatSubtractFailsWithTypeErrorOnFirstOpera
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveSubtract - SmallFloat' }
+{ #category : 'tests - primitiveSubtract - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatSubtractFailsWithTypeErrorOnSecondOperand [
 
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4575,7 +4577,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatSubtractFailsWithTypeErrorOnSecondOper
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveSubtract - SmallFloat' }
+{ #category : 'tests - primitiveSubtract - SmallFloat' }
 VMPrimitiveTest >> testPrimitiveSmallFloatSubtractPopsOperands [
 	
 	self wordSize = 8 ifFalse: [ ^ self skip].
@@ -4594,7 +4596,7 @@ VMPrimitiveTest >> testPrimitiveSmallFloatSubtractPopsOperands [
 	self assert: (interpreter stackTop) equals: (memory integerObjectOf: 42).
 ]
 
-{ #category : #'tests - snapshot' }
+{ #category : 'tests - snapshot' }
 VMPrimitiveTest >> testPrimitiveSnapshotContextsShouldBeTenured [
 
 	| method frame contextOop contextIdentityHash suspendedContext |
@@ -4627,7 +4629,7 @@ VMPrimitiveTest >> testPrimitiveSnapshotContextsShouldBeTenured [
 		equals: contextIdentityHash
 ]
 
-{ #category : #'tests - snapshot' }
+{ #category : 'tests - snapshot' }
 VMPrimitiveTest >> testPrimitiveSnapshotCreateImage [
 
 	| method |
@@ -4649,7 +4651,7 @@ VMPrimitiveTest >> testPrimitiveSnapshotCreateImage [
 	interpreter imageReader validateImage: imageName 
 ]
 
-{ #category : #'tests - snapshot' }
+{ #category : 'tests - snapshot' }
 VMPrimitiveTest >> testPrimitiveSnapshotNewKeptObjectShouldBeTenured [
 
 	| method object objectHash |
@@ -4676,7 +4678,7 @@ VMPrimitiveTest >> testPrimitiveSnapshotNewKeptObjectShouldBeTenured [
 		equals: objectHash
 ]
 
-{ #category : #'tests - primitiveFloat64' }
+{ #category : 'tests - primitiveFloat64' }
 VMPrimitiveTest >> testPrimitiveStoreFloat64FromBytesNegativeIndex [
 
 	| class array |
@@ -4697,7 +4699,7 @@ VMPrimitiveTest >> testPrimitiveStoreFloat64FromBytesNegativeIndex [
 	self assert: interpreter stackTop equals: 42
 ]
 
-{ #category : #'tests - primitiveFloat64' }
+{ #category : 'tests - primitiveFloat64' }
 VMPrimitiveTest >> testPrimitiveStoreFloat64FromBytesOverflowIndex [
 
 	| class array |
@@ -4718,7 +4720,7 @@ VMPrimitiveTest >> testPrimitiveStoreFloat64FromBytesOverflowIndex [
 	self assert: interpreter stackTop equals: 42
 ]
 
-{ #category : #'tests - primitiveFloat64' }
+{ #category : 'tests - primitiveFloat64' }
 VMPrimitiveTest >> testPrimitiveStoreFloat64IntoBytesFor64BitArrays [
 
 	| class array |
@@ -4737,7 +4739,7 @@ VMPrimitiveTest >> testPrimitiveStoreFloat64IntoBytesFor64BitArrays [
 
 ]
 
-{ #category : #'tests - primitiveFloat64' }
+{ #category : 'tests - primitiveFloat64' }
 VMPrimitiveTest >> testPrimitiveStoreFloat64IntoBytesForByteArrays [
 
 	| class array |
@@ -4756,7 +4758,7 @@ VMPrimitiveTest >> testPrimitiveStoreFloat64IntoBytesForByteArrays [
 
 ]
 
-{ #category : #'tests - primitiveFloat64' }
+{ #category : 'tests - primitiveFloat64' }
 VMPrimitiveTest >> testPrimitiveStoreFloat64IntoBytesForInteger16Arrays [
 
 	| class array |
@@ -4775,7 +4777,7 @@ VMPrimitiveTest >> testPrimitiveStoreFloat64IntoBytesForInteger16Arrays [
 
 ]
 
-{ #category : #'tests - primitiveFloat64' }
+{ #category : 'tests - primitiveFloat64' }
 VMPrimitiveTest >> testPrimitiveStoreFloat64IntoBytesForInteger32Arrays [
 
 	| class array |
@@ -4794,7 +4796,7 @@ VMPrimitiveTest >> testPrimitiveStoreFloat64IntoBytesForInteger32Arrays [
 
 ]
 
-{ #category : #'tests - primitiveFloat64' }
+{ #category : 'tests - primitiveFloat64' }
 VMPrimitiveTest >> testPrimitiveStoreFloat64IntoBytesForSecondSlotArrays [
 
 	| class array |
@@ -4813,7 +4815,7 @@ VMPrimitiveTest >> testPrimitiveStoreFloat64IntoBytesForSecondSlotArrays [
 
 ]
 
-{ #category : #'tests - primitiveAtPut' }
+{ #category : 'tests - primitiveAtPut' }
 VMPrimitiveTest >> testPrimitiveStringAtPutShouldFailForNonCharacterArgument [
 	"Every other test is common with at:put:"
 	| objectInstance |
@@ -4829,7 +4831,7 @@ VMPrimitiveTest >> testPrimitiveStringAtPutShouldFailForNonCharacterArgument [
 
 ]
 
-{ #category : #'tests - primitiveAtPut' }
+{ #category : 'tests - primitiveAtPut' }
 VMPrimitiveTest >> testPrimitiveStringAtPutShouldNotFailWhenReceiverIsAString [
 	"Every other test is common with at:put:"
 	| string |
@@ -4846,7 +4848,7 @@ VMPrimitiveTest >> testPrimitiveStringAtPutShouldNotFailWhenReceiverIsAString [
 
 ]
 
-{ #category : #'tests - primitiveAtPut' }
+{ #category : 'tests - primitiveAtPut' }
 VMPrimitiveTest >> testPrimitiveStringAtPutShouldNotModifyStringIfFailedWhenNonCharacterArgument [
 	"Every other test is common with at:put:"
 
@@ -4864,7 +4866,7 @@ VMPrimitiveTest >> testPrimitiveStringAtPutShouldNotModifyStringIfFailedWhenNonC
 	self assert: string contentEquals: (self newString: 'po')
 ]
 
-{ #category : #'tests - primitiveAt' }
+{ #category : 'tests - primitiveAt' }
 VMPrimitiveTest >> testPrimitiveStringAtShouldFailForNonCharacterArgument [
 	"Every other test is common with at:put:"
 	| objectInstance |
@@ -4879,7 +4881,7 @@ VMPrimitiveTest >> testPrimitiveStringAtShouldFailForNonCharacterArgument [
 
 ]
 
-{ #category : #'tests - primitiveAt' }
+{ #category : 'tests - primitiveAt' }
 VMPrimitiveTest >> testPrimitiveStringAtShouldNotFailWhenReceiverIsAString [
 	"Every other test is common with at:put:"
 	| string |
@@ -4902,7 +4904,7 @@ VMPrimitiveTest >> testPrimitiveStringAtShouldNotFailWhenReceiverIsAString [
 
 ]
 
-{ #category : #'tests - primitiveAt' }
+{ #category : 'tests - primitiveAt' }
 VMPrimitiveTest >> testPrimitiveStringAtShouldNotModifyStringIfFailedWhenNonCharacterArgument [
 	"Every other test is common with at:put:"
 
@@ -4920,7 +4922,7 @@ VMPrimitiveTest >> testPrimitiveStringAtShouldNotModifyStringIfFailedWhenNonChar
 	self assert: string contentEquals: (self newString: 'po')
 ]
 
-{ #category : #'tests - primitiveStringCompare' }
+{ #category : 'tests - primitiveStringCompare' }
 VMPrimitiveTest >> testPrimitiveStringCompareWithHigherSymbol [
 
 	| asciiOrder aByteSymbol bByteSymbol |
@@ -4940,7 +4942,7 @@ VMPrimitiveTest >> testPrimitiveStringCompareWithHigherSymbol [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 1)
 ]
 
-{ #category : #'tests - primitiveStringCompare' }
+{ #category : 'tests - primitiveStringCompare' }
 VMPrimitiveTest >> testPrimitiveStringCompareWithIsNotCaseSensitive [
 
 	| nonCaseSensitiveOrder lowerByteSymbol upperByteSymbol |
@@ -4960,7 +4962,7 @@ VMPrimitiveTest >> testPrimitiveStringCompareWithIsNotCaseSensitive [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 0)
 ]
 
-{ #category : #'tests - primitiveStringCompare' }
+{ #category : 'tests - primitiveStringCompare' }
 VMPrimitiveTest >> testPrimitiveStringCompareWithLimitCaseRegretion [
 
 	| nonCaseSensitiveOrder lowerByteSymbol upperByteSymbol |
@@ -4980,7 +4982,7 @@ VMPrimitiveTest >> testPrimitiveStringCompareWithLimitCaseRegretion [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 0)
 ]
 
-{ #category : #'tests - primitiveStringCompare' }
+{ #category : 'tests - primitiveStringCompare' }
 VMPrimitiveTest >> testPrimitiveStringCompareWithLowerSymbol [
 
 	| asciiOrder aByteSymbol bByteSymbol |
@@ -5000,7 +5002,7 @@ VMPrimitiveTest >> testPrimitiveStringCompareWithLowerSymbol [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: -1)
 ]
 
-{ #category : #'tests - primitiveStringCompare' }
+{ #category : 'tests - primitiveStringCompare' }
 VMPrimitiveTest >> testPrimitiveStringCompareWithTheSameSymbol [
 
 	| byteSymbol asciiOrder |
@@ -5019,7 +5021,7 @@ VMPrimitiveTest >> testPrimitiveStringCompareWithTheSameSymbol [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 0)
 ]
 
-{ #category : #'tests - primitiveSubtract' }
+{ #category : 'tests - primitiveSubtract' }
 VMPrimitiveTest >> testPrimitiveSubtracFailsWithTypeErrorOnFirstOperand [
 	
 	interpreter push: memory trueObject.
@@ -5032,7 +5034,7 @@ VMPrimitiveTest >> testPrimitiveSubtracFailsWithTypeErrorOnFirstOperand [
 	
 ]
 
-{ #category : #'tests - primitiveSubtract' }
+{ #category : 'tests - primitiveSubtract' }
 VMPrimitiveTest >> testPrimitiveSubtracFailsWithTypeErrorOnSecondOperand [
 	
 	interpreter push: (memory integerObjectOf: 2).
@@ -5045,7 +5047,7 @@ VMPrimitiveTest >> testPrimitiveSubtracFailsWithTypeErrorOnSecondOperand [
 	
 ]
 
-{ #category : #'tests - primitiveSubtract' }
+{ #category : 'tests - primitiveSubtract' }
 VMPrimitiveTest >> testPrimitiveSubtractFailsWithTypeErrorPreservesStack [
 
 	| string |
@@ -5060,7 +5062,7 @@ VMPrimitiveTest >> testPrimitiveSubtractFailsWithTypeErrorPreservesStack [
 	self assert: (interpreter stackValue: 1) equals: string.
 ]
 
-{ #category : #'tests - primitiveSubtract' }
+{ #category : 'tests - primitiveSubtract' }
 VMPrimitiveTest >> testPrimitiveSubtractWithNoOverflow [
 
 	interpreter push: (memory integerObjectOf: 2).
@@ -5075,7 +5077,7 @@ VMPrimitiveTest >> testPrimitiveSubtractWithNoOverflow [
 	
 ]
 
-{ #category : #'tests - primitiveSubtract' }
+{ #category : 'tests - primitiveSubtract' }
 VMPrimitiveTest >> testPrimitiveSubtractWithNoOverflowPopsOperands [
 
 	interpreter push: (memory integerObjectOf: 42). "Marker"
@@ -5092,7 +5094,7 @@ VMPrimitiveTest >> testPrimitiveSubtractWithNoOverflowPopsOperands [
 	
 ]
 
-{ #category : #'tests - primitiveSubtract' }
+{ #category : 'tests - primitiveSubtract' }
 VMPrimitiveTest >> testPrimitiveSubtractWithOverflow [
 
 	interpreter push: (memory integerObjectOf: memory minSmallInteger).
@@ -5103,7 +5105,7 @@ VMPrimitiveTest >> testPrimitiveSubtractWithOverflow [
 	self assert: interpreter failed.
 ]
 
-{ #category : #'tests - primitiveSubtract' }
+{ #category : 'tests - primitiveSubtract' }
 VMPrimitiveTest >> testPrimitiveSubtractWithOverflowPreservesStack [
 
 	| minSmallInt |
@@ -5121,7 +5123,7 @@ VMPrimitiveTest >> testPrimitiveSubtractWithOverflowPreservesStack [
 	
 ]
 
-{ #category : #'tests - primitiveVMParameter' }
+{ #category : 'tests - primitiveVMParameter' }
 VMPrimitiveTest >> testPrimitiveVMParameterGetsImageVersion [
 
 	interpreter setImageVersion: 110.
@@ -5136,7 +5138,7 @@ VMPrimitiveTest >> testPrimitiveVMParameterGetsImageVersion [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 110).
 ]
 
-{ #category : #'tests - primitiveVMParameter' }
+{ #category : 'tests - primitiveVMParameter' }
 VMPrimitiveTest >> testPrimitiveVMParameterReturnsArrayOfOops [
 
 	| slots |
@@ -5162,7 +5164,7 @@ VMPrimitiveTest >> testPrimitiveVMParameterReturnsArrayOfOops [
 		memory okayOop: (memory fetchPointer: i ofObject: interpreter stackTop) ]
 ]
 
-{ #category : #'tests - primitiveVMParameter' }
+{ #category : 'tests - primitiveVMParameter' }
 VMPrimitiveTest >> testPrimitiveVMParameterSetsImageVersion [
 
 	interpreter push: memory nilObject.

--- a/smalltalksrc/VMMakerTests/VMPushThisContextRoutineTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPushThisContextRoutineTest.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #VMPushThisContextRoutineTest,
-	#superclass : #VMSimpleStackBasedCogitAbstractTest,
+	#name : 'VMPushThisContextRoutineTest',
+	#superclass : 'VMSimpleStackBasedCogitAbstractTest',
 	#pools : [
 		'VMClassIndices'
 	],
-	#category : #'VMMakerTests-JitTests'
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMPushThisContextRoutineTest >> setUp [
 
 	| contextClass |
@@ -27,7 +29,7 @@ VMPushThisContextRoutineTest >> setUp [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMPushThisContextRoutineTest >> testMarriedContextReturnsSpouseObject [
 
 	| isLargeContext isInBlock routine numberOfArguments methodObject contextOop |
@@ -72,7 +74,7 @@ VMPushThisContextRoutineTest >> testMarriedContextReturnsSpouseObject [
 		equals: contextOop
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMPushThisContextRoutineTest >> testNewMarriedContextHasLargeSize [
 
 	| isLargeContext isInBlock routine numberOfArguments |
@@ -105,7 +107,7 @@ VMPushThisContextRoutineTest >> testNewMarriedContextHasLargeSize [
 	self assert: (memory numSlotsOf: machineSimulator receiverRegisterValue) equals: LargeContextSlots.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMPushThisContextRoutineTest >> testNewMarriedContextHasSmallSize [
 
 	| isLargeContext isInBlock routine numberOfArguments |
@@ -140,7 +142,7 @@ VMPushThisContextRoutineTest >> testNewMarriedContextHasSmallSize [
 	self assert: (memory numSlotsOf: machineSimulator receiverRegisterValue) equals: SmallContextSlots
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMPushThisContextRoutineTest >> testNewMarriedLargeContextHasCorrectStackPointer [
 
 	| isLargeContext isInBlock routine numberOfArguments expectedStackPointer |
@@ -177,7 +179,7 @@ VMPushThisContextRoutineTest >> testNewMarriedLargeContextHasCorrectStackPointer
 	self assert: (memory fetchPointer: StackPointerIndex ofObject: machineSimulator receiverRegisterValue ) equals: (memory integerObjectOf: expectedStackPointer).
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMPushThisContextRoutineTest >> testNewMarriedSmallContextHasArguments [
 
 	| isLargeContext isInBlock routine numberOfArguments |
@@ -214,7 +216,7 @@ VMPushThisContextRoutineTest >> testNewMarriedSmallContextHasArguments [
 	self assert: (memory fetchPointer: Context allSlots size +2 ofObject: machineSimulator receiverRegisterValue ) equals: (memory integerObjectOf: 3).		
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMPushThisContextRoutineTest >> testNewMarriedSmallContextHasClosureInNil [
 
 	| isLargeContext isInBlock routine numberOfArguments |
@@ -248,7 +250,7 @@ VMPushThisContextRoutineTest >> testNewMarriedSmallContextHasClosureInNil [
 	self assert: (memory fetchPointer: ClosureIndex ofObject: machineSimulator receiverRegisterValue ) equals: (memory nilObject).
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMPushThisContextRoutineTest >> testNewMarriedSmallContextHasClosureInSetOne [
 
 	| isLargeContext isInBlock routine numberOfArguments |
@@ -283,7 +285,7 @@ VMPushThisContextRoutineTest >> testNewMarriedSmallContextHasClosureInSetOne [
 	self assert: (memory fetchPointer: ClosureIndex ofObject: machineSimulator receiverRegisterValue ) equals: (memory trueObject).
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMPushThisContextRoutineTest >> testNewMarriedSmallContextHasCorrectStackPointer [
 
 	| isLargeContext isInBlock routine numberOfArguments methodObject contextOop expectedStackPointer |
@@ -321,7 +323,7 @@ VMPushThisContextRoutineTest >> testNewMarriedSmallContextHasCorrectStackPointer
 	self assert: (memory fetchPointer: StackPointerIndex ofObject: machineSimulator receiverRegisterValue ) equals: (memory integerObjectOf: expectedStackPointer).
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMPushThisContextRoutineTest >> testNewMarriedSmallContextHasReceiver [
 
 	| isLargeContext isInBlock routine numberOfArguments |
@@ -356,7 +358,7 @@ VMPushThisContextRoutineTest >> testNewMarriedSmallContextHasReceiver [
 	self assert: (memory fetchPointer: ReceiverIndex ofObject: machineSimulator receiverRegisterValue ) equals: (memory trueObject).
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMPushThisContextRoutineTest >> testNewMarriedSmallContextHasTemporaries [
 
 	| isLargeContext isInBlock routine numberOfArguments |
@@ -396,7 +398,7 @@ VMPushThisContextRoutineTest >> testNewMarriedSmallContextHasTemporaries [
 	self assert: (memory fetchPointer: Context allSlots size + numberOfArguments + 3 ofObject: machineSimulator receiverRegisterValue ) equals: (memory nilObject).				
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMPushThisContextRoutineTest >> testSingleContextReturnsNewSpouseInNewSpace [
 
 	| isLargeContext isInBlock routine numberOfArguments methodObject contextOop |

--- a/smalltalksrc/VMMakerTests/VMSegmentsImageFormatTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSegmentsImageFormatTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #VMSegmentsImageFormatTest,
-	#superclass : #VMAbstractImageFormatTest,
-	#category : #'VMMakerTests-ImageFormat'
+	#name : 'VMSegmentsImageFormatTest',
+	#superclass : 'VMAbstractImageFormatTest',
+	#category : 'VMMakerTests-ImageFormat',
+	#package : 'VMMakerTests',
+	#tag : 'ImageFormat'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSegmentsImageFormatTest >> testImageWithTwoSegmentsHasCorrectSizeForFirstSegment [
 
 	| header newSegmentSize |
@@ -23,7 +25,7 @@ VMSegmentsImageFormatTest >> testImageWithTwoSegmentsHasCorrectSizeForFirstSegme
 		equals: (memory segmentManager segments at: 0) segSize
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSegmentsImageFormatTest >> testImageWithTwoSegmentsHasCorrectSizeForFullImage [
 
 	| header newSegmentSize |
@@ -46,7 +48,7 @@ VMSegmentsImageFormatTest >> testImageWithTwoSegmentsHasCorrectSizeForFullImage 
 		equals: header firstSegSize + newSegmentSize
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSegmentsImageFormatTest >> testImageWithTwoSegmentsRespectGrowHeadroomWhenIsBigger [
 
 	| newSegmentSize |
@@ -59,7 +61,7 @@ VMSegmentsImageFormatTest >> testImageWithTwoSegmentsRespectGrowHeadroomWhenIsBi
 	self assert: newSegmentSize >= memory growHeadroom
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSegmentsImageFormatTest >> testImageWithTwoSegmentsRespectGrowHeadroomWhenIsSmaller [
 
 	| newSegmentSize |
@@ -74,7 +76,7 @@ VMSegmentsImageFormatTest >> testImageWithTwoSegmentsRespectGrowHeadroomWhenIsSm
 	self assert: newSegmentSize >= memory growHeadroom
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSegmentsImageFormatTest >> testMinimalImageHasASingleSegment [
 
 

--- a/smalltalksrc/VMMakerTests/VMSelectorIndexDereferenceRoutineTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSelectorIndexDereferenceRoutineTest.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #VMSelectorIndexDereferenceRoutineTest,
-	#superclass : #VMSimpleStackBasedCogitAbstractTest,
+	#name : 'VMSelectorIndexDereferenceRoutineTest',
+	#superclass : 'VMSimpleStackBasedCogitAbstractTest',
 	#pools : [
 		'VMClassIndices'
 	],
-	#category : #'VMMakerTests-JitTests'
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSelectorIndexDereferenceRoutineTest >> test32BitsDoesNotGenerateRoutine [
 
 	"32 bit platforms use a direct selector reference and not an index"
@@ -18,7 +20,7 @@ VMSelectorIndexDereferenceRoutineTest >> test32BitsDoesNotGenerateRoutine [
 	self assert: cogit ceDereferenceSelectorIndex isNil
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSelectorIndexDereferenceRoutineTest >> test64BitsGeneratesRoutine [
 
 	"64 bit platforms use a selector index and a routine to map it to the real selector"
@@ -29,7 +31,7 @@ VMSelectorIndexDereferenceRoutineTest >> test64BitsGeneratesRoutine [
 	self assert: cogit ceDereferenceSelectorIndex notNil
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSelectorIndexDereferenceRoutineTest >> testNegativeSelectorIndexIsLookedUpInSpecialSelectorTable [
 
 	"64 bit platforms use a selector index and a routine to map it to the real selector"
@@ -58,7 +60,7 @@ VMSelectorIndexDereferenceRoutineTest >> testNegativeSelectorIndexIsLookedUpInSp
 	self assert: machineSimulator classRegisterValue equals: memory falseObject
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSelectorIndexDereferenceRoutineTest >> testPositiveSelectorIndexIsLookedUpInMethodLiterals [
 
 	"64 bit platforms use a selector index and a routine to map it to the real selector"

--- a/smalltalksrc/VMMakerTests/VMSessionIdTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSessionIdTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #VMSessionIdTest,
-	#superclass : #VMInterpreterTests,
-	#category : #'VMMakerTests-InterpreterTests'
+	#name : 'VMSessionIdTest',
+	#superclass : 'VMInterpreterTests',
+	#category : 'VMMakerTests-InterpreterTests',
+	#package : 'VMMakerTests',
+	#tag : 'InterpreterTests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSessionIdTest >> testGlobalSessionID [
 	"The globalSessionID is stored as a 64 bit number, but for compatibility with older plugins, is restricted to postive signed 32 bit values"
 	| vm predicted diff |

--- a/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitAbstractTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitAbstractTest.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #VMSimpleStackBasedCogitAbstractTest,
-	#superclass : #VMSpurMemoryManagerTest,
+	#name : 'VMSimpleStackBasedCogitAbstractTest',
+	#superclass : 'VMSpurMemoryManagerTest',
 	#instVars : [
 		'cogit',
 		'codeSize',
@@ -31,10 +31,12 @@ Class {
 		'VMBytecodeConstants',
 		'VMClassIndices'
 	],
-	#category : #'VMMakerTests-JitTests'
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #'building suites' }
+{ #category : 'building suites' }
 VMSimpleStackBasedCogitAbstractTest class >> imageFormatParameters [ 
 
 	^ { 
@@ -42,7 +44,7 @@ VMSimpleStackBasedCogitAbstractTest class >> imageFormatParameters [
 	}
 ]
 
-{ #category : #'building suites' }
+{ #category : 'building suites' }
 VMSimpleStackBasedCogitAbstractTest class >> wordSize32Parameters [
 
 	^ ParametrizedTestMatrix new
@@ -51,7 +53,7 @@ VMSimpleStackBasedCogitAbstractTest class >> wordSize32Parameters [
 		yourself
 ]
 
-{ #category : #'building suites' }
+{ #category : 'building suites' }
 VMSimpleStackBasedCogitAbstractTest class >> wordSize64Parameters [
 
 	^ ParametrizedTestMatrix new
@@ -60,26 +62,26 @@ VMSimpleStackBasedCogitAbstractTest class >> wordSize64Parameters [
 		yourself
 ]
 
-{ #category : #'building suites' }
+{ #category : 'building suites' }
 VMSimpleStackBasedCogitAbstractTest class >> wordSizeParameters [
 
 	^ self wordSize64Parameters + self wordSize32Parameters
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMSimpleStackBasedCogitAbstractTest >> ISA: anISA [
 
 	isa := anISA
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSimpleStackBasedCogitAbstractTest >> abstractInstructions [
 
 	^ (0 to: cogit getOpcodeIndex - 1)
 		collect: [ :i | cogit abstractOpcodes at: i ]
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitAbstractTest >> assertPushed: anOop after: aBlockClosure [
 	
 	| before after |
@@ -91,7 +93,7 @@ VMSimpleStackBasedCogitAbstractTest >> assertPushed: anOop after: aBlockClosure 
 	self assert: (self readMemoryAt: after) equals: anOop
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitAbstractTest >> assertStackRemainsUnchangedDuring: aBlockClosure [ 
 	
 	| before |
@@ -103,17 +105,17 @@ VMSimpleStackBasedCogitAbstractTest >> assertStackRemainsUnchangedDuring: aBlock
 		equals: before
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSimpleStackBasedCogitAbstractTest >> callerAddress [
 	^ callerAddress
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSimpleStackBasedCogitAbstractTest >> cogit [
 	^ cogit
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitAbstractTest >> compile: aBlockClosure [ 
 	"Compiles some native code using the code inside the block closure as builder.
 	This version assumes the block has a single 1-bytecode statement 
@@ -122,13 +124,13 @@ VMSimpleStackBasedCogitAbstractTest >> compile: aBlockClosure [
 	^ self compile: aBlockClosure bytecodes: 2
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitAbstractTest >> compile: aBlockClosure bytecodes: bytecodes [
 	
 	^ self compile: aBlockClosure bytecodes: bytecodes headerSize: 0
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitAbstractTest >> compile: aBlockClosure bytecodes: bytecodes headerSize: headerSize [
 	
 	"Compiles some native code using the code inside the block closure as builder.
@@ -153,7 +155,7 @@ VMSimpleStackBasedCogitAbstractTest >> compile: aBlockClosure bytecodes: bytecod
 	^ allocatedAddress
 ]
 
-{ #category : #'tests - special sends' }
+{ #category : 'tests - special sends' }
 VMSimpleStackBasedCogitAbstractTest >> compileSpecialSend [
 	
 	"We will call to this address"
@@ -165,7 +167,7 @@ VMSimpleStackBasedCogitAbstractTest >> compileSpecialSend [
 	sendAddress := self compile: [ cogit genSpecialSelectorSend ].
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitAbstractTest >> compileTrampoline: aBlock named: aTrampolineName [
 
 	| startAddress | 
@@ -185,7 +187,7 @@ VMSimpleStackBasedCogitAbstractTest >> compileTrampoline: aBlock named: aTrampol
 	^ startAddress
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitAbstractTest >> compileWithoutOutput: aBlockClosure bytecodes: bytecodes [
 	
 	"Call a compilation block initializing the compiler before.
@@ -203,7 +205,7 @@ VMSimpleStackBasedCogitAbstractTest >> compileWithoutOutput: aBlockClosure bytec
 	^ aBlockClosure value
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitAbstractTest >> createBaseFrame [
 
 	"Create the root context with a valid method"
@@ -239,7 +241,7 @@ VMSimpleStackBasedCogitAbstractTest >> createBaseFrame [
 	baseFrame := interpreter framePointer
 ]
 
-{ #category : #'helpers - frames' }
+{ #category : 'helpers - frames' }
 VMSimpleStackBasedCogitAbstractTest >> createFramefulCallFrom: anAddress [
 
 	self
@@ -249,13 +251,13 @@ VMSimpleStackBasedCogitAbstractTest >> createFramefulCallFrom: anAddress [
 		temporaries: #()
 ]
 
-{ #category : #'helpers - frames' }
+{ #category : 'helpers - frames' }
 VMSimpleStackBasedCogitAbstractTest >> createFramefulCallFrom: returnAddress receiver: receiver arguments: arguments [
 
 	self createFramefulCallFrom: returnAddress receiver: receiver arguments: arguments temporaries: #()
 ]
 
-{ #category : #'helpers - frames' }
+{ #category : 'helpers - frames' }
 VMSimpleStackBasedCogitAbstractTest >> createFramefulCallFrom: returnAddress receiver: receiver arguments: arguments temporaries: temps [
 
 	"I create a frameful call for machine code. 
@@ -286,7 +288,7 @@ VMSimpleStackBasedCogitAbstractTest >> createFramefulCallFrom: returnAddress rec
 	builder buildFrame
 ]
 
-{ #category : #'helpers - frames' }
+{ #category : 'helpers - frames' }
 VMSimpleStackBasedCogitAbstractTest >> createFramelessCallFrom: anAddress [
 
 	self
@@ -295,7 +297,7 @@ VMSimpleStackBasedCogitAbstractTest >> createFramelessCallFrom: anAddress [
 		arguments: #()
 ]
 
-{ #category : #'helpers - frames' }
+{ #category : 'helpers - frames' }
 VMSimpleStackBasedCogitAbstractTest >> createFramelessCallFrom: returnAddress receiver: receiver arguments: arguments [.
 
 	"I create a frameless call
@@ -322,7 +324,7 @@ VMSimpleStackBasedCogitAbstractTest >> createFramelessCallFrom: returnAddress re
 
 ]
 
-{ #category : #'helpers - frames' }
+{ #category : 'helpers - frames' }
 VMSimpleStackBasedCogitAbstractTest >> createInterpreterFramefulCallFrom: returnAddress receiver: receiver arguments: arguments temporaries: temps [
 
 	"I create a frameful call for interpreter.
@@ -363,7 +365,7 @@ VMSimpleStackBasedCogitAbstractTest >> createInterpreterFramefulCallFrom: return
 	cogit needsFrame: true.
 ]
 
-{ #category : #'tests - special sends' }
+{ #category : 'tests - special sends' }
 VMSimpleStackBasedCogitAbstractTest >> createSpecialSelectorArray [
 
 	| specialObjectsOop  |
@@ -380,19 +382,19 @@ VMSimpleStackBasedCogitAbstractTest >> createSpecialSelectorArray [
 	memory specialObjectsOop: specialObjectsOop.
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitAbstractTest >> disassemble [
 	
 	^ self disassembleFrom: cogInitialAddress
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitAbstractTest >> disassembleFrom: anIndex [
 	
 	^ self disassembleFrom: anIndex opcodes: opcodes
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitAbstractTest >> disassembleFrom: anIndex opcodes: numberOfInstructions [
 	
 	^ machineSimulator disassembler
@@ -405,25 +407,25 @@ VMSimpleStackBasedCogitAbstractTest >> disassembleFrom: anIndex opcodes: numberO
 		pc: 0
 ]
 
-{ #category : #'helpers - registers' }
+{ #category : 'helpers - registers' }
 VMSimpleStackBasedCogitAbstractTest >> framePointerRegisterValue [
 
 	^ machineSimulator framePointerRegisterValue
 ]
 
-{ #category : #'helpers - registers' }
+{ #category : 'helpers - registers' }
 VMSimpleStackBasedCogitAbstractTest >> framePointerRegisterValue: aValue [
 	
 	machineSimulator framePointerRegisterValue: aValue
 ]
 
-{ #category : #configuration }
+{ #category : 'configuration' }
 VMSimpleStackBasedCogitAbstractTest >> generateCaptureCStackPointers [
 	
 	^ true
 ]
 
-{ #category : #'helpers - cog methods' }
+{ #category : 'helpers - cog methods' }
 VMSimpleStackBasedCogitAbstractTest >> generateCogMethod: aBlockClosure selector: anSelectorOop [ 
 
 	| targetCog allocatedAddress |
@@ -442,18 +444,18 @@ VMSimpleStackBasedCogitAbstractTest >> generateCogMethod: aBlockClosure selector
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSimpleStackBasedCogitAbstractTest >> getLastAddress [
 	
 	^ machineSimulator getLastAddress: self abstractInstructions.
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMSimpleStackBasedCogitAbstractTest >> initialCodeSize [
 	^ 4 * 1024
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMSimpleStackBasedCogitAbstractTest >> initializeInitialStackFrame [
 
 	"I will create the initial stack with a well-known caller address so we know if the code comes back
@@ -465,7 +467,7 @@ VMSimpleStackBasedCogitAbstractTest >> initializeInitialStackFrame [
 
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMSimpleStackBasedCogitAbstractTest >> initializeStackMemory [
 	
 	| page |
@@ -478,31 +480,31 @@ VMSimpleStackBasedCogitAbstractTest >> initializeStackMemory [
 	machineSimulator framePointerRegisterValue: page baseAddress.
 ]
 
-{ #category : #'helpers - registers' }
+{ #category : 'helpers - registers' }
 VMSimpleStackBasedCogitAbstractTest >> instructionPointer [
 
 	^ self readRegister: machineSimulator instructionPointerRegister
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitAbstractTest >> interpreterClass [
 
 	^ CogVMSimulatorLSB
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMSimpleStackBasedCogitAbstractTest >> jitCompilerClass [
 
 	^ SimpleStackBasedCogit
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitAbstractTest >> jitMethod: aHostCompiledMethod [ 
 
 	^ self jitMethod: aHostCompiledMethod selector: memory nilObject
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitAbstractTest >> jitMethod: aHostCompiledMethod selector: aSelectorOop [
 
 	| methodOop |
@@ -512,7 +514,7 @@ VMSimpleStackBasedCogitAbstractTest >> jitMethod: aHostCompiledMethod selector: 
 	^ cogit cog: methodOop selector: aSelectorOop
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMSimpleStackBasedCogitAbstractTest >> jitOptions [
 
 	^ Dictionary newFromPairs: { 
@@ -522,7 +524,7 @@ VMSimpleStackBasedCogitAbstractTest >> jitOptions [
 		#ObjectMemory. self memoryClass name }
 ]
 
-{ #category : #'helpers - frames' }
+{ #category : 'helpers - frames' }
 VMSimpleStackBasedCogitAbstractTest >> machineCodeFrameBuilder [
 
 	| builder |
@@ -531,12 +533,12 @@ VMSimpleStackBasedCogitAbstractTest >> machineCodeFrameBuilder [
 	^ builder
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSimpleStackBasedCogitAbstractTest >> machineSimulator [
 	^ machineSimulator
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMSimpleStackBasedCogitAbstractTest >> memoryClass [
 
 	^ self wordSize = 4
@@ -544,7 +546,7 @@ VMSimpleStackBasedCogitAbstractTest >> memoryClass [
 		ifFalse: [ Spur64BitCoMemoryManager ]
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMSimpleStackBasedCogitAbstractTest >> newJitCompiler [
 
 	| compiler |
@@ -559,13 +561,13 @@ VMSimpleStackBasedCogitAbstractTest >> newJitCompiler [
 
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitAbstractTest >> openMachineDebugger [
 	
 	self openMachineDebuggerAt: cogInitialAddress
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitAbstractTest >> openMachineDebuggerAt: anAddress [
 	
 	^ VMMachineCodeDebugger new
@@ -576,7 +578,7 @@ VMSimpleStackBasedCogitAbstractTest >> openMachineDebuggerAt: anAddress [
 		openWithSpec.
 ]
 
-{ #category : #'helpers - stack' }
+{ #category : 'helpers - stack' }
 VMSimpleStackBasedCogitAbstractTest >> pop [
 
 	| stackAddressIntegerValue poppedByteArray |
@@ -593,13 +595,13 @@ VMSimpleStackBasedCogitAbstractTest >> pop [
 	^ poppedByteArray
 ]
 
-{ #category : #'helpers - stack' }
+{ #category : 'helpers - stack' }
 VMSimpleStackBasedCogitAbstractTest >> popAddress [
 	
 	^ self pop integerAt: 1 size: self wordSize signed: false
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitAbstractTest >> prepareCall [
 
 	machineSimulator hasLinkRegister 
@@ -612,13 +614,13 @@ VMSimpleStackBasedCogitAbstractTest >> prepareCall [
 
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitAbstractTest >> prepareStackForSendReceiver: aReceiver [
 
 	self prepareStackForSendReceiver: aReceiver arguments: #()
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitAbstractTest >> prepareStackForSendReceiver: aReceiver arguments: arguments [ 	
 
 	machineSimulator baseRegisterValue: cogit varBaseAddress.
@@ -635,13 +637,13 @@ VMSimpleStackBasedCogitAbstractTest >> prepareStackForSendReceiver: aReceiver ar
 	self prepareCall
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitAbstractTest >> primitiveTraceLogSize [
 	
 	^ 256 * 8 "word size"
 ]
 
-{ #category : #'helpers - stack' }
+{ #category : 'helpers - stack' }
 VMSimpleStackBasedCogitAbstractTest >> push: aByteArray [
 
 	| stackAddressIntegerValue |
@@ -662,7 +664,7 @@ VMSimpleStackBasedCogitAbstractTest >> push: aByteArray [
 
 ]
 
-{ #category : #'helpers - stack' }
+{ #category : 'helpers - stack' }
 VMSimpleStackBasedCogitAbstractTest >> pushAddress: anInteger [
 
 	| aByteArray |
@@ -671,7 +673,7 @@ VMSimpleStackBasedCogitAbstractTest >> pushAddress: anInteger [
 	self push: aByteArray
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitAbstractTest >> readMemoryAt: anAddress [
 
 	| bytes |
@@ -679,7 +681,7 @@ VMSimpleStackBasedCogitAbstractTest >> readMemoryAt: anAddress [
 	^ bytes integerAt: 1 size: self wordSize signed: false
 ]
 
-{ #category : #'helpers - registers' }
+{ #category : 'helpers - registers' }
 VMSimpleStackBasedCogitAbstractTest >> readRegister: aRegisterID [
 
 	registerValue := ByteArray new: self wordSize.
@@ -687,7 +689,7 @@ VMSimpleStackBasedCogitAbstractTest >> readRegister: aRegisterID [
 	^ registerValue integerAt: 1 size: self wordSize signed: false
 ]
 
-{ #category : #'helpers - frames' }
+{ #category : 'helpers - frames' }
 VMSimpleStackBasedCogitAbstractTest >> readTemporaryValueAt: anIndex [
 
 	"
@@ -710,26 +712,26 @@ VMSimpleStackBasedCogitAbstractTest >> readTemporaryValueAt: anIndex [
 	^ self readMemoryAt: machineSimulator framePointerRegisterValue  - ((3 + anIndex) * self wordSize)
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitAbstractTest >> receiverRegister: anInteger [ 
 
 	self writeRegister: UcX86Registers rdx value: anInteger
 ]
 
-{ #category : #'helpers - registers' }
+{ #category : 'helpers - registers' }
 VMSimpleStackBasedCogitAbstractTest >> returnValue [
 
 	^ self readRegister:  machineSimulator receiverRegister
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitAbstractTest >> runFrom: startAddress until: endAddress [
 
 	^ self runFrom: startAddress until: endAddress timeout: 100000. "microseconds"
 
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitAbstractTest >> runFrom: startAddress until: endAddress timeout: microseconds [
 
 	machineSimulator startAt: startAddress
@@ -738,7 +740,7 @@ VMSimpleStackBasedCogitAbstractTest >> runFrom: startAddress until: endAddress t
 		count: 0.
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitAbstractTest >> runGeneratedCode [
 	"The different platforms generates code in a different way, so the number of opcodes can not be valid. Eg: ARM generates more instructions per opcode. It has to calculate the instructions to run differently"
 
@@ -749,7 +751,7 @@ VMSimpleStackBasedCogitAbstractTest >> runGeneratedCode [
 		count: 0
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitAbstractTest >> runUntilReturn [
 
 	machineSimulator startAt: cogInitialAddress
@@ -759,7 +761,7 @@ VMSimpleStackBasedCogitAbstractTest >> runUntilReturn [
 
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitAbstractTest >> runUntilReturnFrom: anAddress [
 
 	machineSimulator startAt: anAddress
@@ -769,17 +771,17 @@ VMSimpleStackBasedCogitAbstractTest >> runUntilReturnFrom: anAddress [
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSimpleStackBasedCogitAbstractTest >> sentSelector [
 	^ sentSelector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSimpleStackBasedCogitAbstractTest >> sentSelector: anObject [
 	sentSelector := anObject
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMSimpleStackBasedCogitAbstractTest >> setUp [
 	super setUp.
 
@@ -822,7 +824,7 @@ VMSimpleStackBasedCogitAbstractTest >> setUp [
 	self initializeInitialStackFrame.	
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMSimpleStackBasedCogitAbstractTest >> setUpCogMethodEntry [
 	
 	cogit allocateOpcodes: 80 bytecodes: 0 ifFail: [ self error: 'Could not allocate opcodes' ].
@@ -839,7 +841,7 @@ VMSimpleStackBasedCogitAbstractTest >> setUpCogMethodEntry [
 	cogit methodZone manageFrom: cogit methodZoneBase to: memory getMemoryMap codeZoneEnd.
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMSimpleStackBasedCogitAbstractTest >> setUpTrampolines [
 
 	"Create a send trampoline so we can stop..."
@@ -866,7 +868,7 @@ VMSimpleStackBasedCogitAbstractTest >> setUpTrampolines [
 
 ]
 
-{ #category : #'helpers - stack' }
+{ #category : 'helpers - stack' }
 VMSimpleStackBasedCogitAbstractTest >> stackAddressAt: index [
 
 	^ (self stackAt: index)
@@ -875,7 +877,7 @@ VMSimpleStackBasedCogitAbstractTest >> stackAddressAt: index [
 		signed: false
 ]
 
-{ #category : #'helpers - stack' }
+{ #category : 'helpers - stack' }
 VMSimpleStackBasedCogitAbstractTest >> stackAt: index [
 
 	| stackAddressIntegerValue |
@@ -885,37 +887,37 @@ VMSimpleStackBasedCogitAbstractTest >> stackAt: index [
 	^ machineSimulator memoryAt: stackAddressIntegerValue readNext: self wordSize.
 ]
 
-{ #category : #'helpers - registers' }
+{ #category : 'helpers - registers' }
 VMSimpleStackBasedCogitAbstractTest >> stackPointerRegisterValue [
 
 	^ machineSimulator stackPointerRegisterValue
 ]
 
-{ #category : #'helpers - registers' }
+{ #category : 'helpers - registers' }
 VMSimpleStackBasedCogitAbstractTest >> stackPointerRegisterValue: aValue [
 
 	machineSimulator stackPointerRegisterValue: aValue
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSimpleStackBasedCogitAbstractTest >> temporaryRegisterValue [
 	
 	^ self machineSimulator temporaryRegisterValue 
 ]
 
-{ #category : #'helpers - stack' }
+{ #category : 'helpers - stack' }
 VMSimpleStackBasedCogitAbstractTest >> top [
 
 	^ self stackAt: 0
 ]
 
-{ #category : #'helpers - stack' }
+{ #category : 'helpers - stack' }
 VMSimpleStackBasedCogitAbstractTest >> topAddress [
 	
 	^ self top integerAt: 1 size: self wordSize signed: false
 ]
 
-{ #category : #'helpers - registers' }
+{ #category : 'helpers - registers' }
 VMSimpleStackBasedCogitAbstractTest >> writeRegister: aRegister value: anInteger [ 
 
 	| value |

--- a/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitBytecodeTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitBytecodeTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #VMSimpleStackBasedCogitBytecodeTest,
-	#superclass : #VMSimpleStackBasedCogitAbstractTest,
-	#category : #'VMMakerTests-JitTests'
+	#name : 'VMSimpleStackBasedCogitBytecodeTest',
+	#superclass : 'VMSimpleStackBasedCogitAbstractTest',
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #'tests - single bytecode - pop into inst var' }
+{ #category : 'tests - single bytecode - pop into inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> doPopIntoReceiverVariableBytecodeStoresVariableAt: instanceVariableToWrite [
 
 	"Create an object with at least `instanceVariableToWrite` instance variables.
@@ -25,7 +27,7 @@ VMSimpleStackBasedCogitBytecodeTest >> doPopIntoReceiverVariableBytecodeStoresVa
 	self runGeneratedCode.
 ]
 
-{ #category : #'tests - single bytecode - return' }
+{ #category : 'tests - single bytecode - return' }
 VMSimpleStackBasedCogitBytecodeTest >> doTestReturnCleansStackWithFrame: isFrameful onBlock: generationBlock [
 
 	| oldFP oldSP |
@@ -45,7 +47,7 @@ VMSimpleStackBasedCogitBytecodeTest >> doTestReturnCleansStackWithFrame: isFrame
 	self assert: oldSP equals: self stackPointerRegisterValue.
 ]
 
-{ #category : #'tests - single bytecode - return' }
+{ #category : 'tests - single bytecode - return' }
 VMSimpleStackBasedCogitBytecodeTest >> doTestReturnReturnsObjectInReturnRegister: anAddress withFrame: isFrameful onBlock: compilationBlock [
 
 	isFrameful 
@@ -58,7 +60,7 @@ VMSimpleStackBasedCogitBytecodeTest >> doTestReturnReturnsObjectInReturnRegister
 	self assert: machineSimulator receiverRegisterValue equals: anAddress
 ]
 
-{ #category : #'tests - single bytecode - return' }
+{ #category : 'tests - single bytecode - return' }
 VMSimpleStackBasedCogitBytecodeTest >> doTestReturnReturnsToCallerWithFrame: isFrameful onBlock: compilationBlock [
 
 	isFrameful 
@@ -69,50 +71,50 @@ VMSimpleStackBasedCogitBytecodeTest >> doTestReturnReturnsToCallerWithFrame: isF
 	self runUntilReturn.
 ]
 
-{ #category : #'tests - extended store bytecode - store inst var' }
+{ #category : 'tests - extended store bytecode - store inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> setUp [
 
 	super setUp.
 	self setUpTrampolines
 ]
 
-{ #category : #'tests - extended push bytecode - push inst var' }
+{ #category : 'tests - extended push bytecode - push inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testExtendedPushPushesInstanceVariable1 [
 
 	self testExtendedPushPushesInstanceVariable: 1
 ]
 
-{ #category : #'tests - extended push bytecode - push inst var' }
+{ #category : 'tests - extended push bytecode - push inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testExtendedPushPushesInstanceVariable2 [
 
 	self testExtendedPushPushesInstanceVariable: 2
 ]
 
-{ #category : #'tests - extended push bytecode - push inst var' }
+{ #category : 'tests - extended push bytecode - push inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testExtendedPushPushesInstanceVariable3 [
 
 	self testExtendedPushPushesInstanceVariable: 3
 ]
 
-{ #category : #'tests - extended push bytecode - push inst var' }
+{ #category : 'tests - extended push bytecode - push inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testExtendedPushPushesInstanceVariable32 [
 
 	self testExtendedPushPushesInstanceVariable: 32
 ]
 
-{ #category : #'tests - extended push bytecode - push inst var' }
+{ #category : 'tests - extended push bytecode - push inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testExtendedPushPushesInstanceVariable64 [
 
 	self testExtendedPushPushesInstanceVariable: 64
 ]
 
-{ #category : #'tests - extended push bytecode - push inst var' }
+{ #category : 'tests - extended push bytecode - push inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testExtendedPushPushesInstanceVariable: instanceVariableToWrite [
 
 	self testExtendedPushPushesVariableType: 0 "Instance variable type" index: instanceVariableToWrite
 ]
 
-{ #category : #'tests - extended push bytecode - push inst var' }
+{ #category : 'tests - extended push bytecode - push inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testExtendedPushPushesVariableType: type index: instanceVariableToWrite [
 
 	"Type = 0 is instance variable"
@@ -136,7 +138,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testExtendedPushPushesVariableType: type 
 	self assert: self popAddress equals: memory falseObject
 ]
 
-{ #category : #'tests - jumps' }
+{ #category : 'tests - jumps' }
 VMSimpleStackBasedCogitBytecodeTest >> testJumpForwardJumpsOverAnInstruction [
 
 	| firstBytecode |
@@ -176,67 +178,67 @@ VMSimpleStackBasedCogitBytecodeTest >> testJumpForwardJumpsOverAnInstruction [
 		equals: memory trueObject
 ]
 
-{ #category : #'tests - single bytecode - pop into temp' }
+{ #category : 'tests - single bytecode - pop into temp' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopInto3rdTempPopsValue [
 
 	self testPopIntoTempPopsValueAt: 3
 ]
 
-{ #category : #'tests - single bytecode - pop into temp' }
+{ #category : 'tests - single bytecode - pop into temp' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopInto3rdTempUpdatesTemporaryWithFalse [
 
 	self testPopIntoTempUpdatesVariableAt: 3
 ]
 
-{ #category : #'tests - single bytecode - pop into temp' }
+{ #category : 'tests - single bytecode - pop into temp' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopInto4thTempPopsValue [
 
 	self testPopIntoTempPopsValueAt: 4
 ]
 
-{ #category : #'tests - single bytecode - pop into temp' }
+{ #category : 'tests - single bytecode - pop into temp' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopInto4thTempUpdatesTemporaryWithFalse [
 
 	self testPopIntoTempUpdatesVariableAt: 4
 ]
 
-{ #category : #'tests - single bytecode - pop into temp' }
+{ #category : 'tests - single bytecode - pop into temp' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopInto5thTempPopsValue [
 
 	self testPopIntoTempPopsValueAt: 5
 ]
 
-{ #category : #'tests - single bytecode - pop into temp' }
+{ #category : 'tests - single bytecode - pop into temp' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopInto5thTempUpdatesTemporaryWithFalse [
 
 	self testPopIntoTempUpdatesVariableAt: 5
 ]
 
-{ #category : #'tests - single bytecode - pop into temp' }
+{ #category : 'tests - single bytecode - pop into temp' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopInto6thTempPopsValue [
 
 	self testPopIntoTempPopsValueAt: 6
 ]
 
-{ #category : #'tests - single bytecode - pop into temp' }
+{ #category : 'tests - single bytecode - pop into temp' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopInto6thTempUpdatesTemporaryWithFalse [
 
 	self testPopIntoTempUpdatesVariableAt: 6
 ]
 
-{ #category : #'tests - single bytecode - pop into temp' }
+{ #category : 'tests - single bytecode - pop into temp' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopInto7thTempPopsValue [
 
 	self testPopIntoTempPopsValueAt: 7
 ]
 
-{ #category : #'tests - single bytecode - pop into temp' }
+{ #category : 'tests - single bytecode - pop into temp' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopInto7thTempUpdatesTemporaryWithFalse [
 
 	self testPopIntoTempUpdatesVariableAt: 7
 ]
 
-{ #category : #'tests - single bytecode - pop into inst var' }
+{ #category : 'tests - single bytecode - pop into inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopIntoEighthReceiverVariableBytecodePopsValue [
 
 	"The block pushed and then pops.
@@ -244,7 +246,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testPopIntoEighthReceiverVariableBytecode
 	self assertStackRemainsUnchangedDuring: [ self doPopIntoReceiverVariableBytecodeStoresVariableAt: 8 ]
 ]
 
-{ #category : #'tests - single bytecode - pop into inst var' }
+{ #category : 'tests - single bytecode - pop into inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopIntoFifthReceiverVariableBytecodePopsValue [
 
 	"The block pushed and then pops.
@@ -252,7 +254,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testPopIntoFifthReceiverVariableBytecodeP
 	self assertStackRemainsUnchangedDuring: [ self doPopIntoReceiverVariableBytecodeStoresVariableAt: 5 ]
 ]
 
-{ #category : #'tests - single bytecode - pop into inst var' }
+{ #category : 'tests - single bytecode - pop into inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopIntoFirstReceiverVariableBytecodePopsValue [
 
 	"The block pushed and then pops.
@@ -260,19 +262,19 @@ VMSimpleStackBasedCogitBytecodeTest >> testPopIntoFirstReceiverVariableBytecodeP
 	self assertStackRemainsUnchangedDuring: [ self doPopIntoReceiverVariableBytecodeStoresVariableAt: 1 ]
 ]
 
-{ #category : #'tests - single bytecode - pop into temp' }
+{ #category : 'tests - single bytecode - pop into temp' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopIntoFirstTempPopsValue [
 
 	self testPopIntoTempPopsValueAt: 1
 ]
 
-{ #category : #'tests - single bytecode - pop into temp' }
+{ #category : 'tests - single bytecode - pop into temp' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopIntoFirstTempUpdatesTemporaryWithFalse [
 
 	self testPopIntoTempUpdatesVariableAt: 1
 ]
 
-{ #category : #'tests - single bytecode - pop into inst var' }
+{ #category : 'tests - single bytecode - pop into inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopIntoFourthReceiverVariableBytecodePopsValue [
 
 	"The block pushed and then pops.
@@ -280,55 +282,55 @@ VMSimpleStackBasedCogitBytecodeTest >> testPopIntoFourthReceiverVariableBytecode
 	self assertStackRemainsUnchangedDuring: [ self doPopIntoReceiverVariableBytecodeStoresVariableAt: 4 ]
 ]
 
-{ #category : #'tests - single bytecode - pop into inst var' }
+{ #category : 'tests - single bytecode - pop into inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopIntoReceiverVariableBytecodeStoresEigthInstanceVariable [
 
 	self testPopIntoReceiverVariableBytecodeStoresVariableAt: 8
 ]
 
-{ #category : #'tests - single bytecode - pop into inst var' }
+{ #category : 'tests - single bytecode - pop into inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopIntoReceiverVariableBytecodeStoresFifthInstanceVariable [
 
 	self testPopIntoReceiverVariableBytecodeStoresVariableAt: 5
 ]
 
-{ #category : #'tests - single bytecode - pop into inst var' }
+{ #category : 'tests - single bytecode - pop into inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopIntoReceiverVariableBytecodeStoresFirstInstanceVariable [
 
 	self testPopIntoReceiverVariableBytecodeStoresVariableAt: 1
 ]
 
-{ #category : #'tests - single bytecode - pop into inst var' }
+{ #category : 'tests - single bytecode - pop into inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopIntoReceiverVariableBytecodeStoresFourthInstanceVariable [
 
 	self testPopIntoReceiverVariableBytecodeStoresVariableAt: 4
 ]
 
-{ #category : #'tests - single bytecode - pop into inst var' }
+{ #category : 'tests - single bytecode - pop into inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopIntoReceiverVariableBytecodeStoresSecondInstanceVariable [
 
 	self testPopIntoReceiverVariableBytecodeStoresVariableAt: 2
 ]
 
-{ #category : #'tests - single bytecode - pop into inst var' }
+{ #category : 'tests - single bytecode - pop into inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopIntoReceiverVariableBytecodeStoresSeventhInstanceVariable [
 
 	self testPopIntoReceiverVariableBytecodeStoresVariableAt: 7
 ]
 
-{ #category : #'tests - single bytecode - pop into inst var' }
+{ #category : 'tests - single bytecode - pop into inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopIntoReceiverVariableBytecodeStoresSixthInstanceVariable [
 
 	self testPopIntoReceiverVariableBytecodeStoresVariableAt: 6
 ]
 
-{ #category : #'tests - single bytecode - pop into inst var' }
+{ #category : 'tests - single bytecode - pop into inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopIntoReceiverVariableBytecodeStoresThirdInstanceVariable [
 
 	self testPopIntoReceiverVariableBytecodeStoresVariableAt: 3
 ]
 
-{ #category : #'tests - single bytecode - pop into inst var' }
+{ #category : 'tests - single bytecode - pop into inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopIntoReceiverVariableBytecodeStoresVariableAt: instanceVariableToWrite [
 
 	self doPopIntoReceiverVariableBytecodeStoresVariableAt: instanceVariableToWrite.
@@ -337,7 +339,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testPopIntoReceiverVariableBytecodeStores
 	self assert: (memory fetchPointer: instanceVariableToWrite - 1 ofObject: obj) equals: memory falseObject
 ]
 
-{ #category : #'tests - single bytecode - pop into inst var' }
+{ #category : 'tests - single bytecode - pop into inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopIntoSecondReceiverVariableBytecodePopsValue [
 
 	"The block pushed and then pops.
@@ -345,19 +347,19 @@ VMSimpleStackBasedCogitBytecodeTest >> testPopIntoSecondReceiverVariableBytecode
 	self assertStackRemainsUnchangedDuring: [ self doPopIntoReceiverVariableBytecodeStoresVariableAt: 2 ]
 ]
 
-{ #category : #'tests - single bytecode - pop into temp' }
+{ #category : 'tests - single bytecode - pop into temp' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopIntoSecondTempPopsValue [
 
 	self testPopIntoTempPopsValueAt: 2
 ]
 
-{ #category : #'tests - single bytecode - pop into temp' }
+{ #category : 'tests - single bytecode - pop into temp' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopIntoSecondTempUpdatesTemporaryWithFalse [
 
 	self testPopIntoTempUpdatesVariableAt: 2
 ]
 
-{ #category : #'tests - single bytecode - pop into inst var' }
+{ #category : 'tests - single bytecode - pop into inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopIntoSeventhReceiverVariableBytecodePopsValue [
 
 	"The block pushed and then pops.
@@ -365,7 +367,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testPopIntoSeventhReceiverVariableBytecod
 	self assertStackRemainsUnchangedDuring: [ self doPopIntoReceiverVariableBytecodeStoresVariableAt: 7 ]
 ]
 
-{ #category : #'tests - single bytecode - pop into inst var' }
+{ #category : 'tests - single bytecode - pop into inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopIntoSixthReceiverVariableBytecodePopsValue [
 
 	"The block pushed and then pops.
@@ -373,7 +375,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testPopIntoSixthReceiverVariableBytecodeP
 	self assertStackRemainsUnchangedDuring: [ self doPopIntoReceiverVariableBytecodeStoresVariableAt: 6 ]
 ]
 
-{ #category : #'tests - single bytecode - pop into temp' }
+{ #category : 'tests - single bytecode - pop into temp' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopIntoTempPopsValueAt: tempVariableUnderTest [
 
 	| temporaries |
@@ -400,7 +402,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testPopIntoTempPopsValueAt: tempVariableU
 	self assert: self popAddress equals: memory trueObject
 ]
 
-{ #category : #'tests - single bytecode - pop into temp' }
+{ #category : 'tests - single bytecode - pop into temp' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopIntoTempUpdatesVariableAt: tempVariableUnderTest [
 
 	| temporaries |
@@ -425,7 +427,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testPopIntoTempUpdatesVariableAt: tempVar
 	self assert: (self readTemporaryValueAt: tempVariableUnderTest) equals: memory falseObject
 ]
 
-{ #category : #'tests - single bytecode - pop into inst var' }
+{ #category : 'tests - single bytecode - pop into inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPopIntoThirdReceiverVariableBytecodePopsValue [
 
 	"The block pushed and then pops.
@@ -433,157 +435,157 @@ VMSimpleStackBasedCogitBytecodeTest >> testPopIntoThirdReceiverVariableBytecodeP
 	self assertStackRemainsUnchangedDuring: [ self doPopIntoReceiverVariableBytecodeStoresVariableAt: 3 ]
 ]
 
-{ #category : #'tests - single bytecode - push temp' }
+{ #category : 'tests - single bytecode - push temp' }
 VMSimpleStackBasedCogitBytecodeTest >> testPush10thTempVariablePushesVariable [
 
 	self testPushTempVariablePushesVariableAt: 10
 ]
 
-{ #category : #'tests - single bytecode - push temp - arg' }
+{ #category : 'tests - single bytecode - push temp - arg' }
 VMSimpleStackBasedCogitBytecodeTest >> testPush10thTempVariableWithArgumentsPushesArgument [
 
 	self testPushTempVariablePushesArgumentAt: 10
 ]
 
-{ #category : #'tests - single bytecode - push temp' }
+{ #category : 'tests - single bytecode - push temp' }
 VMSimpleStackBasedCogitBytecodeTest >> testPush11thTempVariablePushesVariable [
 
 	self testPushTempVariablePushesVariableAt: 11
 ]
 
-{ #category : #'tests - single bytecode - push temp - arg' }
+{ #category : 'tests - single bytecode - push temp - arg' }
 VMSimpleStackBasedCogitBytecodeTest >> testPush11thTempVariableWithArgumentsPushesArgument [
 
 	self testPushTempVariablePushesArgumentAt: 11
 ]
 
-{ #category : #'tests - single bytecode - push temp' }
+{ #category : 'tests - single bytecode - push temp' }
 VMSimpleStackBasedCogitBytecodeTest >> testPush12thTempVariablePushesVariable [
 
 	self testPushTempVariablePushesVariableAt: 12
 ]
 
-{ #category : #'tests - single bytecode - push temp - arg' }
+{ #category : 'tests - single bytecode - push temp - arg' }
 VMSimpleStackBasedCogitBytecodeTest >> testPush12thTempVariableWithArgumentsPushesArgument [
 
 	self testPushTempVariablePushesArgumentAt: 12
 ]
 
-{ #category : #'tests - single bytecode - push temp' }
+{ #category : 'tests - single bytecode - push temp' }
 VMSimpleStackBasedCogitBytecodeTest >> testPush13thTempVariablePushesVariable [
 
 	self testPushTempVariablePushesVariableAt: 13
 ]
 
-{ #category : #'tests - single bytecode - push temp - arg' }
+{ #category : 'tests - single bytecode - push temp - arg' }
 VMSimpleStackBasedCogitBytecodeTest >> testPush13thTempVariableWithArgumentsPushesArgument [
 
 	self testPushTempVariablePushesArgumentAt: 13
 ]
 
-{ #category : #'tests - single bytecode - push temp' }
+{ #category : 'tests - single bytecode - push temp' }
 VMSimpleStackBasedCogitBytecodeTest >> testPush14thTempVariablePushesVariable [
 
 	self testPushTempVariablePushesVariableAt: 14
 ]
 
-{ #category : #'tests - single bytecode - push temp - arg' }
+{ #category : 'tests - single bytecode - push temp - arg' }
 VMSimpleStackBasedCogitBytecodeTest >> testPush14thTempVariableWithArgumentsPushesArgument [
 
 	self testPushTempVariablePushesArgumentAt: 14
 ]
 
-{ #category : #'tests - single bytecode - push temp' }
+{ #category : 'tests - single bytecode - push temp' }
 VMSimpleStackBasedCogitBytecodeTest >> testPush15thTempVariablePushesVariable [
 
 	self testPushTempVariablePushesVariableAt: 15
 ]
 
-{ #category : #'tests - single bytecode - push temp - arg' }
+{ #category : 'tests - single bytecode - push temp - arg' }
 VMSimpleStackBasedCogitBytecodeTest >> testPush15thTempVariableWithArgumentsPushesArgument [
 
 	self testPushTempVariablePushesArgumentAt: 15
 ]
 
-{ #category : #'tests - single bytecode - push temp - arg' }
+{ #category : 'tests - single bytecode - push temp - arg' }
 VMSimpleStackBasedCogitBytecodeTest >> testPush3rdTempVariableWithArgumentsPushesArgument [
 
 	self testPushTempVariablePushesArgumentAt: 3
 ]
 
-{ #category : #'tests - single bytecode - push temp' }
+{ #category : 'tests - single bytecode - push temp' }
 VMSimpleStackBasedCogitBytecodeTest >> testPush4thTempVariablePushesVariable [
 
 	self testPushTempVariablePushesVariableAt: 4
 ]
 
-{ #category : #'tests - single bytecode - push temp - arg' }
+{ #category : 'tests - single bytecode - push temp - arg' }
 VMSimpleStackBasedCogitBytecodeTest >> testPush4thTempVariableWithArgumentsPushesArgument [
 
 	self testPushTempVariablePushesArgumentAt: 4
 ]
 
-{ #category : #'tests - single bytecode - push temp' }
+{ #category : 'tests - single bytecode - push temp' }
 VMSimpleStackBasedCogitBytecodeTest >> testPush5thTempVariablePushesVariable [
 
 	self testPushTempVariablePushesVariableAt: 5
 ]
 
-{ #category : #'tests - single bytecode - push temp - arg' }
+{ #category : 'tests - single bytecode - push temp - arg' }
 VMSimpleStackBasedCogitBytecodeTest >> testPush5thTempVariableWithArgumentsPushesArgument [
 
 	self testPushTempVariablePushesArgumentAt: 5
 ]
 
-{ #category : #'tests - single bytecode - push temp' }
+{ #category : 'tests - single bytecode - push temp' }
 VMSimpleStackBasedCogitBytecodeTest >> testPush6thTempVariablePushesVariable [
 
 	self testPushTempVariablePushesVariableAt: 6
 ]
 
-{ #category : #'tests - single bytecode - push temp - arg' }
+{ #category : 'tests - single bytecode - push temp - arg' }
 VMSimpleStackBasedCogitBytecodeTest >> testPush6thTempVariableWithArgumentsPushesArgument [
 
 	self testPushTempVariablePushesArgumentAt: 6
 ]
 
-{ #category : #'tests - single bytecode - push temp' }
+{ #category : 'tests - single bytecode - push temp' }
 VMSimpleStackBasedCogitBytecodeTest >> testPush7thTempVariablePushesVariable [
 
 	self testPushTempVariablePushesVariableAt: 7
 ]
 
-{ #category : #'tests - single bytecode - push temp - arg' }
+{ #category : 'tests - single bytecode - push temp - arg' }
 VMSimpleStackBasedCogitBytecodeTest >> testPush7thTempVariableWithArgumentsPushesArgument [
 
 	self testPushTempVariablePushesArgumentAt: 7
 ]
 
-{ #category : #'tests - single bytecode - push temp' }
+{ #category : 'tests - single bytecode - push temp' }
 VMSimpleStackBasedCogitBytecodeTest >> testPush8thTempVariablePushesVariable [
 
 	self testPushTempVariablePushesVariableAt: 8
 ]
 
-{ #category : #'tests - single bytecode - push temp - arg' }
+{ #category : 'tests - single bytecode - push temp - arg' }
 VMSimpleStackBasedCogitBytecodeTest >> testPush8thTempVariableWithArgumentsPushesArgument [
 
 	self testPushTempVariablePushesArgumentAt: 8
 ]
 
-{ #category : #'tests - single bytecode - push temp' }
+{ #category : 'tests - single bytecode - push temp' }
 VMSimpleStackBasedCogitBytecodeTest >> testPush9thTempVariablePushesVariable [
 
 	self testPushTempVariablePushesVariableAt: 9
 ]
 
-{ #category : #'tests - single bytecode - push temp - arg' }
+{ #category : 'tests - single bytecode - push temp - arg' }
 VMSimpleStackBasedCogitBytecodeTest >> testPush9thTempVariableWithArgumentsPushesArgument [
 
 	self testPushTempVariablePushesArgumentAt: 9
 ]
 
-{ #category : #'tests - single bytecode' }
+{ #category : 'tests - single bytecode' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushConstantFalseBytecodePushesFalse [
 	
 	self compile: [ cogit genPushConstantFalseBytecode ].	
@@ -592,7 +594,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testPushConstantFalseBytecodePushesFalse 
 	self assert: self popAddress equals: memory falseObject
 ]
 
-{ #category : #'tests - two bytecodes' }
+{ #category : 'tests - two bytecodes' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushConstantNilAndThenReturn [
 	
 	self compile: [ 
@@ -604,7 +606,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testPushConstantNilAndThenReturn [
 	self assert: machineSimulator receiverRegisterValue equals: memory nilObject
 ]
 
-{ #category : #'tests - single bytecode' }
+{ #category : 'tests - single bytecode' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushConstantNilBytecodePushesNil [
 	
 	self compile: [ cogit genPushConstantNilBytecode ].
@@ -613,7 +615,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testPushConstantNilBytecodePushesNil [
 	self assert: self popAddress equals: memory nilObject
 ]
 
-{ #category : #'tests - single bytecode' }
+{ #category : 'tests - single bytecode' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushConstantTrueBytecodePushesTrue [
 
 	self compile: [ cogit genPushConstantTrueBytecode ].
@@ -622,7 +624,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testPushConstantTrueBytecodePushesTrue [
 	self assert: self popAddress equals: memory trueObject
 ]
 
-{ #category : #'tests - single bytecode' }
+{ #category : 'tests - single bytecode' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushConstantZeroBytecodePushesASmallIntegerZero [
 	
 	self compile: [ cogit genPushConstantZeroBytecode ].	
@@ -631,19 +633,19 @@ VMSimpleStackBasedCogitBytecodeTest >> testPushConstantZeroBytecodePushesASmallI
 	self assert: self popAddress equals: (memory integerObjectOf: 0)
 ]
 
-{ #category : #'tests - single bytecode - push temp' }
+{ #category : 'tests - single bytecode - push temp' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushFirstTempVariablePushesVariable [
 
 	self testPushTempVariablePushesVariableAt: 1
 ]
 
-{ #category : #'tests - single bytecode - push temp - arg' }
+{ #category : 'tests - single bytecode - push temp - arg' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushFirstTempVariableWithArgumentsPushesArgument [
 
 	self testPushTempVariablePushesArgumentAt: 1
 ]
 
-{ #category : #'tests - single bytecode' }
+{ #category : 'tests - single bytecode' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushQuickIntegerMinusOnePushesAMinusOne [
 	
 	cogit byte0: 116. 
@@ -654,7 +656,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testPushQuickIntegerMinusOnePushesAMinusO
 	self assert: self popAddress equals: (memory integerObjectOf: -1)
 ]
 
-{ #category : #'tests - single bytecode' }
+{ #category : 'tests - single bytecode' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushQuickIntegerOnePushesOne [
 	
 	cogit byte0: 118. 
@@ -665,7 +667,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testPushQuickIntegerOnePushesOne [
 	self assert: self popAddress equals: (memory integerObjectOf: 1)
 ]
 
-{ #category : #'tests - single bytecode' }
+{ #category : 'tests - single bytecode' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushQuickIntegerTwoPushesTwo [
 	
 	cogit byte0: 119. 
@@ -676,7 +678,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testPushQuickIntegerTwoPushesTwo [
 	self assert: self popAddress equals: (memory integerObjectOf: 2)
 ]
 
-{ #category : #'tests - single bytecode' }
+{ #category : 'tests - single bytecode' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushQuickIntegerZeroPushesAZero [
 	
 	cogit byte0: 117. 
@@ -687,7 +689,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testPushQuickIntegerZeroPushesAZero [
 	self assert: self popAddress equals: (memory integerObjectOf: 0)
 ]
 
-{ #category : #'tests - single bytecode' }
+{ #category : 'tests - single bytecode' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushReceiverBytecodePushesTheReceiver [
 
 	machineSimulator receiverRegisterValue: 75. 
@@ -698,103 +700,103 @@ VMSimpleStackBasedCogitBytecodeTest >> testPushReceiverBytecodePushesTheReceiver
 	self assert: self popAddress equals: 75
 ]
 
-{ #category : #'tests - single bytecode - push inst var' }
+{ #category : 'tests - single bytecode - push inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushReceiverVariableBytecodeZeroPushesEighthVariable [
 
 	self testPushReceiverVariableBytecodeZeroPushesVariableAt: 8
 ]
 
-{ #category : #'tests - single bytecode - push inst var' }
+{ #category : 'tests - single bytecode - push inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushReceiverVariableBytecodeZeroPushesEleventhVariable [
 
 	self testPushReceiverVariableBytecodeZeroPushesVariableAt: 11
 ]
 
-{ #category : #'tests - single bytecode - push inst var' }
+{ #category : 'tests - single bytecode - push inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushReceiverVariableBytecodeZeroPushesFifteenthVariable [
 
 	self testPushReceiverVariableBytecodeZeroPushesVariableAt: 15
 ]
 
-{ #category : #'tests - single bytecode - push inst var' }
+{ #category : 'tests - single bytecode - push inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushReceiverVariableBytecodeZeroPushesFifthVariable [
 
 	self testPushReceiverVariableBytecodeZeroPushesVariableAt: 5
 ]
 
-{ #category : #'tests - single bytecode - push inst var' }
+{ #category : 'tests - single bytecode - push inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushReceiverVariableBytecodeZeroPushesFirstVariable [
 
 	self testPushReceiverVariableBytecodeZeroPushesVariableAt: 1
 ]
 
-{ #category : #'tests - single bytecode - push inst var' }
+{ #category : 'tests - single bytecode - push inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushReceiverVariableBytecodeZeroPushesFourteenthVariable [
 
 	self testPushReceiverVariableBytecodeZeroPushesVariableAt: 14
 ]
 
-{ #category : #'tests - single bytecode - push inst var' }
+{ #category : 'tests - single bytecode - push inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushReceiverVariableBytecodeZeroPushesFourthVariable [
 
 	self testPushReceiverVariableBytecodeZeroPushesVariableAt: 4
 ]
 
-{ #category : #'tests - single bytecode - push inst var' }
+{ #category : 'tests - single bytecode - push inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushReceiverVariableBytecodeZeroPushesNinthVariable [
 
 	self testPushReceiverVariableBytecodeZeroPushesVariableAt: 9
 ]
 
-{ #category : #'tests - single bytecode - push inst var' }
+{ #category : 'tests - single bytecode - push inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushReceiverVariableBytecodeZeroPushesSecondVariable [
 
 	self testPushReceiverVariableBytecodeZeroPushesVariableAt: 2
 ]
 
-{ #category : #'tests - single bytecode - push inst var' }
+{ #category : 'tests - single bytecode - push inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushReceiverVariableBytecodeZeroPushesSeventhVariable [
 
 	self testPushReceiverVariableBytecodeZeroPushesVariableAt: 7
 ]
 
-{ #category : #'tests - single bytecode - push inst var' }
+{ #category : 'tests - single bytecode - push inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushReceiverVariableBytecodeZeroPushesSixteenthVariable [
 
 	self testPushReceiverVariableBytecodeZeroPushesVariableAt: 16
 ]
 
-{ #category : #'tests - single bytecode - push inst var' }
+{ #category : 'tests - single bytecode - push inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushReceiverVariableBytecodeZeroPushesSixthVariable [
 
 	self testPushReceiverVariableBytecodeZeroPushesVariableAt: 6
 ]
 
-{ #category : #'tests - single bytecode - push inst var' }
+{ #category : 'tests - single bytecode - push inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushReceiverVariableBytecodeZeroPushesTenthVariable [
 
 	self testPushReceiverVariableBytecodeZeroPushesVariableAt: 10
 ]
 
-{ #category : #'tests - single bytecode - push inst var' }
+{ #category : 'tests - single bytecode - push inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushReceiverVariableBytecodeZeroPushesThirdVariable [
 
 	self testPushReceiverVariableBytecodeZeroPushesVariableAt: 3
 ]
 
-{ #category : #'tests - single bytecode - push inst var' }
+{ #category : 'tests - single bytecode - push inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushReceiverVariableBytecodeZeroPushesThirteenthVariable [
 
 	self testPushReceiverVariableBytecodeZeroPushesVariableAt: 13
 ]
 
-{ #category : #'tests - single bytecode - push inst var' }
+{ #category : 'tests - single bytecode - push inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushReceiverVariableBytecodeZeroPushesTwelfthVariable [
 
 	self testPushReceiverVariableBytecodeZeroPushesVariableAt: 12
 ]
 
-{ #category : #'tests - single bytecode - push inst var' }
+{ #category : 'tests - single bytecode - push inst var' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushReceiverVariableBytecodeZeroPushesVariableAt: instanceVariableToWrite [
 
 	"Create an object with at least `instanceVariableToWrite` instance variables.
@@ -813,19 +815,19 @@ VMSimpleStackBasedCogitBytecodeTest >> testPushReceiverVariableBytecodeZeroPushe
 	self assert: self popAddress equals: memory falseObject
 ]
 
-{ #category : #'tests - single bytecode - push temp' }
+{ #category : 'tests - single bytecode - push temp' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushSecondTempVariablePushesVariable [
 
 	self testPushTempVariablePushesVariableAt: 2
 ]
 
-{ #category : #'tests - single bytecode - push temp - arg' }
+{ #category : 'tests - single bytecode - push temp - arg' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushSecondTempVariableWithArgumentsPushesArgument [
 
 	self testPushTempVariablePushesArgumentAt: 2
 ]
 
-{ #category : #'tests - single bytecode - push temp - arg' }
+{ #category : 'tests - single bytecode - push temp - arg' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushTempVariablePushesArgumentAt: tempVariableUnderTest [
 
 	| arguments |
@@ -848,7 +850,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testPushTempVariablePushesArgumentAt: tem
 	self assert: self popAddress equals: memory falseObject
 ]
 
-{ #category : #'tests - single bytecode - push temp' }
+{ #category : 'tests - single bytecode - push temp' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushTempVariablePushesVariableAt: tempVariableUnderTest [
 
 	| temporaries |
@@ -873,13 +875,13 @@ VMSimpleStackBasedCogitBytecodeTest >> testPushTempVariablePushesVariableAt: tem
 	self assert: self popAddress equals: memory falseObject
 ]
 
-{ #category : #'tests - single bytecode - push temp' }
+{ #category : 'tests - single bytecode - push temp' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushThirdTempVariablePushesVariable [
 
 	self testPushTempVariablePushesVariableAt: 3
 ]
 
-{ #category : #'tests - thisContext' }
+{ #category : 'tests - thisContext' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushThisContextForFullBlockWithFullFrameCallsLargeFullBlockTrampoline [
 
 	| numberOfArguments methodObject method |
@@ -918,7 +920,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testPushThisContextForFullBlockWithFullFr
 		equals: numberOfArguments
 ]
 
-{ #category : #'tests - thisContext' }
+{ #category : 'tests - thisContext' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushThisContextForFullBlockWithSmallFrameCallsLargeFullBlockTrampoline [
 
 	| numberOfArguments methodObject method |
@@ -956,7 +958,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testPushThisContextForFullBlockWithSmallF
 		equals: numberOfArguments
 ]
 
-{ #category : #'tests - thisContext' }
+{ #category : 'tests - thisContext' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushThisContextForMethodWithLargeFrameCallsLargeMethodTrampoline [
 
 	| numberOfArguments methodObject method |
@@ -993,7 +995,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testPushThisContextForMethodWithLargeFram
 		equals: numberOfArguments
 ]
 
-{ #category : #'tests - thisContext' }
+{ #category : 'tests - thisContext' }
 VMSimpleStackBasedCogitBytecodeTest >> testPushThisContextForMethodWithSmallFrameCallsSmallMethodTrampoline [
 
 	| numberOfArguments methodObject method |
@@ -1030,13 +1032,13 @@ VMSimpleStackBasedCogitBytecodeTest >> testPushThisContextForMethodWithSmallFram
 		equals: numberOfArguments
 ]
 
-{ #category : #'tests - single bytecode - return' }
+{ #category : 'tests - single bytecode - return' }
 VMSimpleStackBasedCogitBytecodeTest >> testReturnNilFramefulCleansStack [
 
 	self doTestReturnCleansStackWithFrame: true onBlock: [ cogit genReturnNil ]
 ]
 
-{ #category : #'tests - single bytecode - return' }
+{ #category : 'tests - single bytecode - return' }
 VMSimpleStackBasedCogitBytecodeTest >> testReturnNilFramefulLeavesNilInReturnRegister [
 
 	self
@@ -1045,19 +1047,19 @@ VMSimpleStackBasedCogitBytecodeTest >> testReturnNilFramefulLeavesNilInReturnReg
 		onBlock: [ cogit genReturnNil ]
 ]
 
-{ #category : #'tests - single bytecode - return' }
+{ #category : 'tests - single bytecode - return' }
 VMSimpleStackBasedCogitBytecodeTest >> testReturnNilFramefulReturnsToCaller [
 
 	self doTestReturnReturnsToCallerWithFrame: true onBlock: [ cogit genReturnNil ]
 ]
 
-{ #category : #'tests - single bytecode - return' }
+{ #category : 'tests - single bytecode - return' }
 VMSimpleStackBasedCogitBytecodeTest >> testReturnNilFramelessCleansStack [
 
 	self doTestReturnCleansStackWithFrame: false onBlock: [ cogit genReturnNil ]
 ]
 
-{ #category : #'tests - single bytecode - return' }
+{ #category : 'tests - single bytecode - return' }
 VMSimpleStackBasedCogitBytecodeTest >> testReturnNilFramelessLeavesNilInReturnRegister [
 
 	self
@@ -1066,13 +1068,13 @@ VMSimpleStackBasedCogitBytecodeTest >> testReturnNilFramelessLeavesNilInReturnRe
 		onBlock: [ cogit genReturnNil ]
 ]
 
-{ #category : #'tests - single bytecode - return' }
+{ #category : 'tests - single bytecode - return' }
 VMSimpleStackBasedCogitBytecodeTest >> testReturnNilFramelessReturnsToCaller [
 
 	self doTestReturnReturnsToCallerWithFrame: false onBlock: [ cogit genReturnNil ]
 ]
 
-{ #category : #'tests - single bytecode - return' }
+{ #category : 'tests - single bytecode - return' }
 VMSimpleStackBasedCogitBytecodeTest >> testReturnTopFramefulLeavesTopObjectInReturnRegister [
 
 	self
@@ -1083,7 +1085,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testReturnTopFramefulLeavesTopObjectInRet
 			cogit genReturnTopFromMethod ]
 ]
 
-{ #category : #'tests - single bytecode - return' }
+{ #category : 'tests - single bytecode - return' }
 VMSimpleStackBasedCogitBytecodeTest >> testReturnTopFramefullCleansStack [
 
 	self doTestReturnCleansStackWithFrame: true onBlock: [ 
@@ -1091,7 +1093,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testReturnTopFramefullCleansStack [
 		cogit genReturnTopFromMethod ]
 ]
 
-{ #category : #'tests - single bytecode - return' }
+{ #category : 'tests - single bytecode - return' }
 VMSimpleStackBasedCogitBytecodeTest >> testReturnTopFramefullReturnsToCaller [
 
 	self doTestReturnReturnsToCallerWithFrame: true onBlock: [ 
@@ -1099,7 +1101,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testReturnTopFramefullReturnsToCaller [
 		cogit genReturnTopFromMethod ]
 ]
 
-{ #category : #'tests - single bytecode - return' }
+{ #category : 'tests - single bytecode - return' }
 VMSimpleStackBasedCogitBytecodeTest >> testReturnTopFramelesCleansStack [
 
 	self doTestReturnCleansStackWithFrame: false onBlock: [ 
@@ -1107,7 +1109,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testReturnTopFramelesCleansStack [
 		cogit genReturnTopFromMethod ]
 ]
 
-{ #category : #'tests - single bytecode - return' }
+{ #category : 'tests - single bytecode - return' }
 VMSimpleStackBasedCogitBytecodeTest >> testReturnTopFramelessLeavesTopObjectInReturnRegister [
 
 	self
@@ -1118,7 +1120,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testReturnTopFramelessLeavesTopObjectInRe
 			cogit genReturnTopFromMethod ]
 ]
 
-{ #category : #'tests - single bytecode - return' }
+{ #category : 'tests - single bytecode - return' }
 VMSimpleStackBasedCogitBytecodeTest >> testReturnTopFramelessReturnsToCaller [
 
 	self doTestReturnReturnsToCallerWithFrame: false onBlock: [ 
@@ -1126,7 +1128,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testReturnTopFramelessReturnsToCaller [
 		cogit genReturnTopFromMethod ]
 ]
 
-{ #category : #'tests - single bytecode - return' }
+{ #category : 'tests - single bytecode - return' }
 VMSimpleStackBasedCogitBytecodeTest >> testReturnTrueFramefulCleansStack [
 
 	self
@@ -1134,7 +1136,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testReturnTrueFramefulCleansStack [
 		onBlock: [ cogit genReturnTrue ]
 ]
 
-{ #category : #'tests - single bytecode - return' }
+{ #category : 'tests - single bytecode - return' }
 VMSimpleStackBasedCogitBytecodeTest >> testReturnTrueFramefulLeavesTrueObjectInReturnRegister [
 
 	self
@@ -1144,7 +1146,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testReturnTrueFramefulLeavesTrueObjectInR
 			cogit genReturnTrue ]
 ]
 
-{ #category : #'tests - single bytecode - return' }
+{ #category : 'tests - single bytecode - return' }
 VMSimpleStackBasedCogitBytecodeTest >> testReturnTrueFramefulReturnsToCaller [
 
 	self
@@ -1152,7 +1154,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testReturnTrueFramefulReturnsToCaller [
 		onBlock: [ cogit genReturnTrue ]
 ]
 
-{ #category : #'tests - single bytecode - return' }
+{ #category : 'tests - single bytecode - return' }
 VMSimpleStackBasedCogitBytecodeTest >> testReturnTrueFramelessCleansStack [
 
 	self
@@ -1160,7 +1162,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testReturnTrueFramelessCleansStack [
 		onBlock: [ cogit genReturnTrue ]
 ]
 
-{ #category : #'tests - single bytecode - return' }
+{ #category : 'tests - single bytecode - return' }
 VMSimpleStackBasedCogitBytecodeTest >> testReturnTrueFramelessLeavesTrueObjectInReturnRegister [
 
 	self
@@ -1170,7 +1172,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testReturnTrueFramelessLeavesTrueObjectIn
 			cogit genReturnTrue ]
 ]
 
-{ #category : #'tests - single bytecode - return' }
+{ #category : 'tests - single bytecode - return' }
 VMSimpleStackBasedCogitBytecodeTest >> testReturnTrueFramelessReturnsToCaller [
 
 	self
@@ -1178,7 +1180,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testReturnTrueFramelessReturnsToCaller [
 		onBlock: [ cogit genReturnTrue ]
 ]
 
-{ #category : #'tests - special sends' }
+{ #category : 'tests - special sends' }
 VMSimpleStackBasedCogitBytecodeTest >> testSendEqualsEqualsWithIdenticalObjectsPushesTrue [
 
 	sendAddress := self compile: [ cogit genSpecialSelectorEqualsEquals ].
@@ -1192,7 +1194,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testSendEqualsEqualsWithIdenticalObjectsP
 		equals: memory trueObject
 ]
 
-{ #category : #'tests - special sends' }
+{ #category : 'tests - special sends' }
 VMSimpleStackBasedCogitBytecodeTest >> testSendEqualsEqualsWithNonIdenticalObjectsPushesFalse [
 
 	sendAddress := self compile: [ cogit genSpecialSelectorEqualsEquals ].
@@ -1207,7 +1209,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testSendEqualsEqualsWithNonIdenticalObjec
 		equals: memory falseObject
 ]
 
-{ #category : #'tests - sends' }
+{ #category : 'tests - sends' }
 VMSimpleStackBasedCogitBytecodeTest >> testSendLiteralOneWithZeroArgsMovesSelectorIndexClassRegisterIn64bits [
 
 	| selector literalIndex |
@@ -1244,7 +1246,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testSendLiteralOneWithZeroArgsMovesSelect
 	self assert: machineSimulator classRegisterValue equals: literalIndex
 ]
 
-{ #category : #'tests - sends' }
+{ #category : 'tests - sends' }
 VMSimpleStackBasedCogitBytecodeTest >> testSendLiteralOneWithZeroArgsMovesSelectorIntoClassRegisterIn32bits [
 
 	| selector literalIndex |
@@ -1272,7 +1274,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testSendLiteralOneWithZeroArgsMovesSelect
 	self assert: machineSimulator classRegisterValue equals: selector
 ]
 
-{ #category : #'tests - sends' }
+{ #category : 'tests - sends' }
 VMSimpleStackBasedCogitBytecodeTest >> testSendLiteralZeroWithZeroArgsMovesReceiverFromStackTopIntoReceiverRegister [
 
 	sendTrampolineAddress := self compile: [ cogit RetN: 0 ].
@@ -1296,7 +1298,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testSendLiteralZeroWithZeroArgsMovesRecei
 		equals: memory falseObject
 ]
 
-{ #category : #'tests - sends' }
+{ #category : 'tests - sends' }
 VMSimpleStackBasedCogitBytecodeTest >> testSendLiteralZeroWithZeroArgsMovesSelectorIndexClassRegisterIn64bits [
 
 	| selector literalIndex |
@@ -1323,7 +1325,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testSendLiteralZeroWithZeroArgsMovesSelec
 	self assert: machineSimulator classRegisterValue equals: literalIndex
 ]
 
-{ #category : #'tests - sends' }
+{ #category : 'tests - sends' }
 VMSimpleStackBasedCogitBytecodeTest >> testSendLiteralZeroWithZeroArgsMovesSelectorIntoClassRegisterIn32bits [
 
 	| selector |
@@ -1350,7 +1352,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testSendLiteralZeroWithZeroArgsMovesSelec
 	self assert: machineSimulator classRegisterValue equals: selector
 ]
 
-{ #category : #'tests - sends' }
+{ #category : 'tests - sends' }
 VMSimpleStackBasedCogitBytecodeTest >> testSendLiteralZeroWithZeroArgsPushesReturnValueFromReceiverRegisterAfterReturn [
 
 	sendTrampolineAddress := self compile: [ cogit RetN: 0 ].
@@ -1379,7 +1381,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testSendLiteralZeroWithZeroArgsPushesRetu
 	self assert: self popAddress equals: (memory integerObjectOf: 42)
 ]
 
-{ #category : #'tests - special sends' }
+{ #category : 'tests - special sends' }
 VMSimpleStackBasedCogitBytecodeTest >> testSendNotEqualsEqualsWithIdenticalObjectsPushesFalse [
 
 	sendAddress := self compile: [ cogit genSpecialSelectorNotEqualsEquals ].
@@ -1394,7 +1396,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testSendNotEqualsEqualsWithIdenticalObjec
 		equals: memory falseObject
 ]
 
-{ #category : #'tests - special sends' }
+{ #category : 'tests - special sends' }
 VMSimpleStackBasedCogitBytecodeTest >> testSendNotEqualsEqualsWithNonIdenticalObjectsPushesTrue [
 
 	sendAddress := self compile: [ cogit genSpecialSelectorNotEqualsEquals ].
@@ -1409,7 +1411,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testSendNotEqualsEqualsWithNonIdenticalOb
 		equals: memory trueObject
 ]
 
-{ #category : #'tests - special sends' }
+{ #category : 'tests - special sends' }
 VMSimpleStackBasedCogitBytecodeTest >> testSendOneArgSpecialMessageDoesNotMovesIntoSendNumArgsRegister [
 	
 	| previousValue |
@@ -1429,7 +1431,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testSendOneArgSpecialMessageDoesNotMovesI
 		equals: previousValue
 ]
 
-{ #category : #'tests - special sends' }
+{ #category : 'tests - special sends' }
 VMSimpleStackBasedCogitBytecodeTest >> testSendOneArgSpecialMessageMovesNegatedSelectorIndexIntoClassRegisterIn64bits [
 	
 	| signed |
@@ -1454,7 +1456,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testSendOneArgSpecialMessageMovesNegatedS
 		equals: (selectorIndex + 1 / 2) negated
 ]
 
-{ #category : #'tests - special sends' }
+{ #category : 'tests - special sends' }
 VMSimpleStackBasedCogitBytecodeTest >> testSendOneArgSpecialMessageMovesReceiverFromStackTopIntoReceiverRegister [
 
 	sentSelector := #+.
@@ -1469,7 +1471,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testSendOneArgSpecialMessageMovesReceiver
 	self assert: machineSimulator receiverRegisterValue equals: memory falseObject
 ]
 
-{ #category : #'tests - special sends' }
+{ #category : 'tests - special sends' }
 VMSimpleStackBasedCogitBytecodeTest >> testSendOneArgSpecialMessageMovesSelectorIntoClassRegisterIn32bits [
 	
 	self wordSize = 8 ifTrue: [ self skip ].
@@ -1488,7 +1490,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testSendOneArgSpecialMessageMovesSelector
 		equals: selectorAtIndex
 ]
 
-{ #category : #'tests - special sends' }
+{ #category : 'tests - special sends' }
 VMSimpleStackBasedCogitBytecodeTest >> testSendOneArgSpecialMessagePushesReturnValueFromReceiverRegisterAfterReturn [
 	
 	sentSelector := #+.
@@ -1507,7 +1509,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testSendOneArgSpecialMessagePushesReturnV
 	self assert: self popAddress equals: (memory integerObjectOf: 42).
 ]
 
-{ #category : #'tests - special sends' }
+{ #category : 'tests - special sends' }
 VMSimpleStackBasedCogitBytecodeTest >> testSendTwoArgSpecialMessageDoesNotMovesIntoSendNumArgsRegister [
 	
 	| previousValue |
@@ -1528,7 +1530,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testSendTwoArgSpecialMessageDoesNotMovesI
 		equals: previousValue
 ]
 
-{ #category : #'tests - special sends' }
+{ #category : 'tests - special sends' }
 VMSimpleStackBasedCogitBytecodeTest >> testSendTwoArgSpecialMessageMovesNegatedSelectorIndexIntoClassRegisterIn64bits [
 	
 	| signed |
@@ -1554,7 +1556,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testSendTwoArgSpecialMessageMovesNegatedS
 		equals: (selectorIndex + 1 / 2) negated
 ]
 
-{ #category : #'tests - special sends' }
+{ #category : 'tests - special sends' }
 VMSimpleStackBasedCogitBytecodeTest >> testSendTwoArgSpecialMessageMovesReceiverFromStackTopIntoReceiverRegister [
 	
 	sentSelector := #at:put:.
@@ -1570,7 +1572,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testSendTwoArgSpecialMessageMovesReceiver
 	self assert: machineSimulator receiverRegisterValue equals: memory falseObject
 ]
 
-{ #category : #'tests - special sends' }
+{ #category : 'tests - special sends' }
 VMSimpleStackBasedCogitBytecodeTest >> testSendTwoArgSpecialMessageMovesSelectorIntoClassRegisterIn32bits [
 	
 	| signed |
@@ -1596,7 +1598,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testSendTwoArgSpecialMessageMovesSelector
 		equals: (selectorIndex + 1 / 2) negated
 ]
 
-{ #category : #'tests - special sends' }
+{ #category : 'tests - special sends' }
 VMSimpleStackBasedCogitBytecodeTest >> testSendTwoArgSpecialMessagePushesReturnValueFromReceiverRegisterAfterReturn [
 	
 	sentSelector := #at:put:.
@@ -1616,7 +1618,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testSendTwoArgSpecialMessagePushesReturnV
 	self assert: self popAddress equals: (memory integerObjectOf: 42).
 ]
 
-{ #category : #'tests - special sends' }
+{ #category : 'tests - special sends' }
 VMSimpleStackBasedCogitBytecodeTest >> testSendZeroArgSpecialMessageDoesNotMovesIntoSendNumArgsRegister [
 	
 	| previousValue |
@@ -1635,7 +1637,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testSendZeroArgSpecialMessageDoesNotMoves
 		equals: previousValue
 ]
 
-{ #category : #'tests - special sends' }
+{ #category : 'tests - special sends' }
 VMSimpleStackBasedCogitBytecodeTest >> testSendZeroArgSpecialMessageMovesNegatedSelectorIndexIntoClassRegisterIn64Bits [
 	
 	| signed |
@@ -1659,7 +1661,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testSendZeroArgSpecialMessageMovesNegated
 		equals: (selectorIndex + 1 / 2) negated
 ]
 
-{ #category : #'tests - special sends' }
+{ #category : 'tests - special sends' }
 VMSimpleStackBasedCogitBytecodeTest >> testSendZeroArgSpecialMessageMovesReceiverFromStackTopIntoReceiverRegister [
 	
 	sentSelector := #atEnd.
@@ -1673,7 +1675,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testSendZeroArgSpecialMessageMovesReceive
 	self assert: machineSimulator receiverRegisterValue equals: memory falseObject
 ]
 
-{ #category : #'tests - special sends' }
+{ #category : 'tests - special sends' }
 VMSimpleStackBasedCogitBytecodeTest >> testSendZeroArgSpecialMessageMovesSelectorIntoClassRegisterIn32Bits [
 	
 	self wordSize = 8 ifTrue: [ self skip ].
@@ -1691,7 +1693,7 @@ VMSimpleStackBasedCogitBytecodeTest >> testSendZeroArgSpecialMessageMovesSelecto
 		equals: selectorAtIndex
 ]
 
-{ #category : #'tests - special sends' }
+{ #category : 'tests - special sends' }
 VMSimpleStackBasedCogitBytecodeTest >> testSendZeroArgSpecialMessagePushesReturnValueFromReceiverRegisterAfterReturn [
 	
 	sentSelector := #atEnd.

--- a/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitCoggedMethods.class.st
+++ b/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitCoggedMethods.class.st
@@ -1,19 +1,21 @@
 Class {
-	#name : #VMSimpleStackBasedCogitCoggedMethods,
-	#superclass : #VMSimpleStackBasedCogitAbstractTest,
+	#name : 'VMSimpleStackBasedCogitCoggedMethods',
+	#superclass : 'VMSimpleStackBasedCogitAbstractTest',
 	#pools : [
 		'CogMethodConstants'
 	],
-	#category : #'VMMakerTests-JitTests'
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 VMSimpleStackBasedCogitCoggedMethods >> setUp [
 	super setUp.
 	self setUpCogMethodEntry.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSimpleStackBasedCogitCoggedMethods >> testUsingEntryOffsetChecksClassRegisterAndContinue [
 
 	| cogMethod otherBlock |
@@ -28,7 +30,7 @@ VMSimpleStackBasedCogitCoggedMethods >> testUsingEntryOffsetChecksClassRegisterA
 	self assert: machineSimulator instructionPointerRegisterValue equals: otherBlock 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSimpleStackBasedCogitCoggedMethods >> testUsingEntryOffsetChecksClassRegisterAndGoesToAbort [
 
 	| cogMethod otherBlock |
@@ -43,7 +45,7 @@ VMSimpleStackBasedCogitCoggedMethods >> testUsingEntryOffsetChecksClassRegisterA
 	self assert: machineSimulator instructionPointerRegisterValue equals: cogit ceMethodAbortTrampoline 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSimpleStackBasedCogitCoggedMethods >> testUsingNoCheckEntryDoesNotCheckClassTag [
 
 	| cogMethod otherBlock |

--- a/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitMegamorphicPICTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitMegamorphicPICTest.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #VMSimpleStackBasedCogitMegamorphicPICTest,
-	#superclass : #VMSimpleStackBasedCogitAbstractTest,
+	#name : 'VMSimpleStackBasedCogitMegamorphicPICTest',
+	#superclass : 'VMSimpleStackBasedCogitAbstractTest',
 	#pools : [
 		'VMMethodCacheConstants'
 	],
-	#category : #'VMMakerTests-JitTests'
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #'tests - PIC' }
+{ #category : 'tests - PIC' }
 VMSimpleStackBasedCogitMegamorphicPICTest >> setUp [
 
 	| specialSelectorsArray |
@@ -25,7 +27,7 @@ VMSimpleStackBasedCogitMegamorphicPICTest >> setUp [
 	cogit generateOpenPICPrototype.
 ]
 
-{ #category : #'tests - PIC' }
+{ #category : 'tests - PIC' }
 VMSimpleStackBasedCogitMegamorphicPICTest >> testLookupExistingMegamorphicPICReturnsPIC [
 
 	| selector createdPic specialObjectsArray |
@@ -36,13 +38,13 @@ VMSimpleStackBasedCogitMegamorphicPICTest >> testLookupExistingMegamorphicPICRet
 	self assert: (cogit methodZone openPICWithSelector: selector) equals: createdPic.
 ]
 
-{ #category : #'tests - PIC' }
+{ #category : 'tests - PIC' }
 VMSimpleStackBasedCogitMegamorphicPICTest >> testLookupNonExistingMegamorphicPICReturnsNil [
 
 	self assert: (cogit methodZone openPICWithSelector: memory trueObject) equals: nil
 ]
 
-{ #category : #'tests - PIC' }
+{ #category : 'tests - PIC' }
 VMSimpleStackBasedCogitMegamorphicPICTest >> testMiss [
 
 	"We have to call the pic and see if it reaches the abort trampoline"
@@ -74,7 +76,7 @@ VMSimpleStackBasedCogitMegamorphicPICTest >> testMiss [
 	self assert: machineSimulator sendNumberOfArgumentsRegisterValue equals: createdPic address
 ]
 
-{ #category : #'tests - metadata' }
+{ #category : 'tests - metadata' }
 VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicPICHasTheCorrectPicAbortTrampoline [
 
 	| createdPic selector |
@@ -87,7 +89,7 @@ VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicPICHasTheCorrectP
 		equals: (cogit picAbortTrampolineFor: 1)
 ]
 
-{ #category : #'tests - metadata' }
+{ #category : 'tests - metadata' }
 VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicPICNumArgs: numArgs [
 
 	| selector createdPic |
@@ -96,43 +98,43 @@ VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicPICNumArgs: numAr
 	self assert: createdPic cmNumArgs equals: numArgs
 ]
 
-{ #category : #'tests - metadata' }
+{ #category : 'tests - metadata' }
 VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicPICNumArgsWith1 [
 
 	self testNewMegamorphicPICNumArgs: 1
 ]
 
-{ #category : #'tests - metadata' }
+{ #category : 'tests - metadata' }
 VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicPICNumArgsWith16 [
 
 	self testNewMegamorphicPICNumArgs: 16
 ]
 
-{ #category : #'tests - metadata' }
+{ #category : 'tests - metadata' }
 VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicPICNumArgsWith2 [
 
 	self testNewMegamorphicPICNumArgs: 2
 ]
 
-{ #category : #'tests - metadata' }
+{ #category : 'tests - metadata' }
 VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicPICNumArgsWith4 [
 
 	self testNewMegamorphicPICNumArgs: 4
 ]
 
-{ #category : #'tests - metadata' }
+{ #category : 'tests - metadata' }
 VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicPICNumArgsWith8 [
 
 	self testNewMegamorphicPICNumArgs: 8
 ]
 
-{ #category : #'tests - metadata' }
+{ #category : 'tests - metadata' }
 VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicPICNumArgsWithoutArgs [
 
 	self testNewMegamorphicPICNumArgs: 0
 ]
 
-{ #category : #'tests - metadata' }
+{ #category : 'tests - metadata' }
 VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicPICSelector [
 	| createdPic selector |
 
@@ -141,7 +143,7 @@ VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicPICSelector [
 	self assert: createdPic selector equals: selector
 ]
 
-{ #category : #'tests - metadata' }
+{ #category : 'tests - metadata' }
 VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicPICSize [
 	| createdPic selector |
 
@@ -150,7 +152,7 @@ VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicPICSize [
 	self assert: createdPic blockSize equals: cogit openPICSize.
 ]
 
-{ #category : #'tests - metadata' }
+{ #category : 'tests - metadata' }
 VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicPICType [
 
 	| selector createdPic |
@@ -160,7 +162,7 @@ VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicPICType [
 
 ]
 
-{ #category : #'tests - PIC' }
+{ #category : 'tests - PIC' }
 VMSimpleStackBasedCogitMegamorphicPICTest >> testRelinkCallSiteToMegamorphicPICCallsNewPIC [
 
 	| selector literalIndex method createdPic returnAfterCallAddress patchedCogMethod startAddress |

--- a/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitMonomorphicPICTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitMonomorphicPICTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #VMSimpleStackBasedCogitMonomorphicPICTest,
-	#superclass : #VMSimpleStackBasedCogitAbstractTest,
-	#category : #'VMMakerTests-JitTests'
+	#name : 'VMSimpleStackBasedCogitMonomorphicPICTest',
+	#superclass : 'VMSimpleStackBasedCogitAbstractTest',
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #'tests - PIC' }
+{ #category : 'tests - PIC' }
 VMSimpleStackBasedCogitMonomorphicPICTest >> testCalculateClosePICSize [
 
 	"Calculate the size of the Closed Pic"
@@ -14,7 +16,7 @@ VMSimpleStackBasedCogitMonomorphicPICTest >> testCalculateClosePICSize [
 	self assert: cogit closedPICSize isNotNil
 ]
 
-{ #category : #'tests - PIC' }
+{ #category : 'tests - PIC' }
 VMSimpleStackBasedCogitMonomorphicPICTest >> testLinkCallDuringSendInTrampolineReplacesTheCallTargetWithTheCogMethodAddress [
 
 	"This is for the monomorphic case"
@@ -64,7 +66,7 @@ VMSimpleStackBasedCogitMonomorphicPICTest >> testLinkCallDuringSendInTrampolineR
 	self deny: executedTheTrampoline
 ]
 
-{ #category : #'tests - PIC' }
+{ #category : 'tests - PIC' }
 VMSimpleStackBasedCogitMonomorphicPICTest >> testObtainInlineCacheFromLinkedCall [
 
 	| sendingMethod targetCog selector executedTheTrampoline |

--- a/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitPolymorphicPICTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitPolymorphicPICTest.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #VMSimpleStackBasedCogitPolymorphicPICTest,
-	#superclass : #VMSimpleStackBasedCogitAbstractTest,
+	#name : 'VMSimpleStackBasedCogitPolymorphicPICTest',
+	#superclass : 'VMSimpleStackBasedCogitAbstractTest',
 	#instVars : [
 		'selector',
 		'numArgs',
@@ -14,10 +14,12 @@ Class {
 	#pools : [
 		'CogMethodConstants'
 	],
-	#category : #'VMMakerTests-JitTests'
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #'building suites' }
+{ #category : 'building suites' }
 VMSimpleStackBasedCogitPolymorphicPICTest class >> testParameters [
 
 	^ super testParameters * 
@@ -26,7 +28,7 @@ VMSimpleStackBasedCogitPolymorphicPICTest class >> testParameters [
 			yourself)
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitPolymorphicPICTest >> assertHitAtCase: aCase [
 	| pic |
 	"Only run this test if the test is configured for so much cases"
@@ -37,7 +39,7 @@ VMSimpleStackBasedCogitPolymorphicPICTest >> assertHitAtCase: aCase [
 	self assertPIC: pic hits: (cogMethods at: aCase)
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitPolymorphicPICTest >> assertPIC: pic hits: hitMethod [
 	"Receiver is nil, class tag of the first entry is the receiver's class tag.
 	 - the receiver matches class tag for case 0
@@ -59,7 +61,7 @@ VMSimpleStackBasedCogitPolymorphicPICTest >> assertPIC: pic hits: hitMethod [
 	self assert: machineSimulator receiverRegisterValue equals: receiver
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitPolymorphicPICTest >> assertPICMiss: pic [
 
 	"Receiver is nil, class tag of the first entry is 1 (a small integer).
@@ -80,19 +82,19 @@ VMSimpleStackBasedCogitPolymorphicPICTest >> assertPICMiss: pic [
 	self assert: machineSimulator receiverRegisterValue equals: receiver
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitPolymorphicPICTest >> configuredPicCases [
 	
 	^ configuredPicCases
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitPolymorphicPICTest >> configuredPicCases: aNumber [
 	
 	configuredPicCases := aNumber
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitPolymorphicPICTest >> extendPIC: aPic [
 
 	cogit
@@ -102,7 +104,7 @@ VMSimpleStackBasedCogitPolymorphicPICTest >> extendPIC: aPic [
 		isMNUCase: false.
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimpleStackBasedCogitPolymorphicPICTest >> makePolymorphicPIC [
 
 	| pic |
@@ -117,7 +119,7 @@ VMSimpleStackBasedCogitPolymorphicPICTest >> makePolymorphicPIC [
 	^ pic
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMSimpleStackBasedCogitPolymorphicPICTest >> setUp [
 
 	super setUp.
@@ -158,7 +160,7 @@ VMSimpleStackBasedCogitPolymorphicPICTest >> setUp [
 		cogMethods at: index - 1 put: cogMethod ] "Maximum polymorphic  cases"
 ]
 
-{ #category : #'tests - metadata' }
+{ #category : 'tests - metadata' }
 VMSimpleStackBasedCogitPolymorphicPICTest >> testHasConfiguredCases [
 	| pic |	
 
@@ -167,7 +169,7 @@ VMSimpleStackBasedCogitPolymorphicPICTest >> testHasConfiguredCases [
 	self assert: pic cPICNumCases equals: self configuredPicCases
 ]
 
-{ #category : #'tests - metadata' }
+{ #category : 'tests - metadata' }
 VMSimpleStackBasedCogitPolymorphicPICTest >> testHasJumpToAbortTrampoline [
 	| pic |	
 	pic := self makePolymorphicPIC.
@@ -175,43 +177,43 @@ VMSimpleStackBasedCogitPolymorphicPICTest >> testHasJumpToAbortTrampoline [
 	self assert: (cogit backend callTargetFromReturnAddress: pic asInteger + cogit missOffset) equals: (cogit picAbortTrampolineFor: numArgs)
 ]
 
-{ #category : #'tests - hit/miss' }
+{ #category : 'tests - hit/miss' }
 VMSimpleStackBasedCogitPolymorphicPICTest >> testHitCase0 [
 
 	self assertHitAtCase: 0
 ]
 
-{ #category : #'tests - hit/miss' }
+{ #category : 'tests - hit/miss' }
 VMSimpleStackBasedCogitPolymorphicPICTest >> testHitCase1 [
 
 	self assertHitAtCase: 1
 ]
 
-{ #category : #'tests - hit/miss' }
+{ #category : 'tests - hit/miss' }
 VMSimpleStackBasedCogitPolymorphicPICTest >> testHitCase2 [
 
 	self assertHitAtCase: 2
 ]
 
-{ #category : #'tests - hit/miss' }
+{ #category : 'tests - hit/miss' }
 VMSimpleStackBasedCogitPolymorphicPICTest >> testHitCase3 [
 
 	self assertHitAtCase: 3
 ]
 
-{ #category : #'tests - hit/miss' }
+{ #category : 'tests - hit/miss' }
 VMSimpleStackBasedCogitPolymorphicPICTest >> testHitCase4 [
 
 	self assertHitAtCase: 4
 ]
 
-{ #category : #'tests - hit/miss' }
+{ #category : 'tests - hit/miss' }
 VMSimpleStackBasedCogitPolymorphicPICTest >> testHitCase5 [
 	"This is the last case. Cog PICs have 6 cases (0-based)"
 	self assertHitAtCase: 5
 ]
 
-{ #category : #'tests - metadata' }
+{ #category : 'tests - metadata' }
 VMSimpleStackBasedCogitPolymorphicPICTest >> testIsClosedPic [
 	| pic |	
 	pic := self makePolymorphicPIC.
@@ -219,7 +221,7 @@ VMSimpleStackBasedCogitPolymorphicPICTest >> testIsClosedPic [
 	self assert: pic cmType equals: CMPolymorphicIC. 
 ]
 
-{ #category : #'tests - hit/miss' }
+{ #category : 'tests - hit/miss' }
 VMSimpleStackBasedCogitPolymorphicPICTest >> testMiss [
 
 	| pic |	
@@ -229,7 +231,7 @@ VMSimpleStackBasedCogitPolymorphicPICTest >> testMiss [
 	self assertPICMiss: pic
 ]
 
-{ #category : #'tests - metadata' }
+{ #category : 'tests - metadata' }
 VMSimpleStackBasedCogitPolymorphicPICTest >> testNumberOfArgumentsInHeader [
 	| pic |
 	
@@ -238,7 +240,7 @@ VMSimpleStackBasedCogitPolymorphicPICTest >> testNumberOfArgumentsInHeader [
 	self assert: pic cmNumArgs equals: numArgs
 ]
 
-{ #category : #'tests - hit/miss' }
+{ #category : 'tests - hit/miss' }
 VMSimpleStackBasedCogitPolymorphicPICTest >> testPolymorphicPICHitDoesNotCallEntryOffset [
 
 	| pic methodCheckEntryPoint methodNoCheckEntryPoint passedByCheckEntryPoint |	
@@ -269,7 +271,7 @@ VMSimpleStackBasedCogitPolymorphicPICTest >> testPolymorphicPICHitDoesNotCallEnt
 	self deny: passedByCheckEntryPoint
 ]
 
-{ #category : #'tests - metadata' }
+{ #category : 'tests - metadata' }
 VMSimpleStackBasedCogitPolymorphicPICTest >> testSelectorInHeader [
 	| pic |	
 

--- a/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitRememberedSetTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitRememberedSetTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #VMSimpleStackBasedCogitRememberedSetTest,
-	#superclass : #VMSimpleStackBasedCogitAbstractTest,
-	#category : #'VMMakerTests-JitTests'
+	#name : 'VMSimpleStackBasedCogitRememberedSetTest',
+	#superclass : 'VMSimpleStackBasedCogitAbstractTest',
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSimpleStackBasedCogitRememberedSetTest >> assertReceiver: receiver value: value shouldCallTrampoline: shouldCallTrampoline [
 
 	| trampoline afterBytecode |
@@ -28,14 +30,14 @@ VMSimpleStackBasedCogitRememberedSetTest >> assertReceiver: receiver value: valu
 	
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 VMSimpleStackBasedCogitRememberedSetTest >> setUp [
 
 	super setUp.
 	self setUpTrampolines
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSimpleStackBasedCogitRememberedSetTest >> testStoringNewObjectInNewObjectDoesNotCallTrampoline [
 
 	| newObject otherNewObject |
@@ -48,7 +50,7 @@ VMSimpleStackBasedCogitRememberedSetTest >> testStoringNewObjectInNewObjectDoesN
 		shouldCallTrampoline: false
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSimpleStackBasedCogitRememberedSetTest >> testStoringNewObjectInOldObjectDoesCallTrampoline [
 
 	| oldObject otherNewObject |
@@ -62,7 +64,7 @@ VMSimpleStackBasedCogitRememberedSetTest >> testStoringNewObjectInOldObjectDoesC
 		shouldCallTrampoline: true
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSimpleStackBasedCogitRememberedSetTest >> testStoringOldObjectInOldObjectDoesNotCallTrampoline [
 
 	| oldObject otherOldObject |
@@ -76,7 +78,7 @@ VMSimpleStackBasedCogitRememberedSetTest >> testStoringOldObjectInOldObjectDoesN
 		shouldCallTrampoline: false
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSimpleStackBasedCogitRememberedSetTest >> testStoringOldObjectInPermObjectDoesCallTrampoline [
 
 	| permObject otherPermObject |

--- a/smalltalksrc/VMMakerTests/VMSimulatedEnvironmentBuilder.class.st
+++ b/smalltalksrc/VMMakerTests/VMSimulatedEnvironmentBuilder.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #VMSimulatedEnvironmentBuilder,
-	#superclass : #Object,
+	#name : 'VMSimulatedEnvironmentBuilder',
+	#superclass : 'Object',
 	#instVars : [
 		'interpreter',
 		'interpreterClass',
@@ -18,17 +18,19 @@ Class {
 		'permSpaceSize',
 		'allocateMemory'
 	],
-	#category : #'VMMakerTests-Builders'
+	#category : 'VMMakerTests-Builders',
+	#package : 'VMMakerTests',
+	#tag : 'Builders'
 }
 
-{ #category : #building }
+{ #category : 'building' }
 VMSimulatedEnvironmentBuilder >> build [
 	
 	self doBuildSimulator.		
 	self doBuild
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 VMSimulatedEnvironmentBuilder >> doBuild [
 
 	"100 k at least to put the class table in the old space.
@@ -85,7 +87,7 @@ VMSimulatedEnvironmentBuilder >> doBuild [
 
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 VMSimulatedEnvironmentBuilder >> doBuildSimulator [
 	
 	objectMemory := objectMemoryClass simulatorClass new.
@@ -100,17 +102,17 @@ VMSimulatedEnvironmentBuilder >> doBuildSimulator [
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSimulatedEnvironmentBuilder >> initialCodeSize: anInteger [ 
 	initialCodeSize := anInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSimulatedEnvironmentBuilder >> initializationOptions: aCollection [ 
 	initializationOptions := aCollection
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 VMSimulatedEnvironmentBuilder >> initialize [
 
 	super initialize.
@@ -118,58 +120,58 @@ VMSimulatedEnvironmentBuilder >> initialize [
 	permSpaceSize := 0.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSimulatedEnvironmentBuilder >> interpreter [
 	^ interpreter
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSimulatedEnvironmentBuilder >> interpreterClass: aClass [ 
 	interpreterClass := aClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSimulatedEnvironmentBuilder >> memoryInitialAddress [
 
 	^ initialAddress 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSimulatedEnvironmentBuilder >> methodCacheSize [
 	^ methodCacheSize
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSimulatedEnvironmentBuilder >> newSpaceSize [
 	^ newSpaceSize
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSimulatedEnvironmentBuilder >> objectMemory [
 	^ objectMemory
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSimulatedEnvironmentBuilder >> objectMemoryClass: aClass [ 
 	objectMemoryClass := aClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSimulatedEnvironmentBuilder >> oldSpaceSize [
 	^ oldSpaceSize
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSimulatedEnvironmentBuilder >> permSpaceSize: anInteger [ 
 	permSpaceSize := anInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSimulatedEnvironmentBuilder >> primitiveTraceLogSize: anInteger [ 
 	primitiveTraceLogSize := anInteger
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSimulatedEnvironmentBuilder >> roundToPageSize: anInteger [ 
 
 	"Unicorn simulator requires mapped memory to be multiple of 4096"
@@ -181,7 +183,7 @@ VMSimulatedEnvironmentBuilder >> roundToPageSize: anInteger [
 	^ anInteger + (pageSize - remainder)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSimulatedEnvironmentBuilder >> rumpCStackSize [
 
 	^ 4096.
@@ -189,12 +191,12 @@ VMSimulatedEnvironmentBuilder >> rumpCStackSize [
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSimulatedEnvironmentBuilder >> stackSpaceSize [
 	^ stackSpaceSize
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSimulatedEnvironmentBuilder >> wordSize: anInteger [ 
 	wordSize := anInteger
 ]

--- a/smalltalksrc/VMMakerTests/VMSimulationTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSimulationTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #VMSimulationTest,
-	#superclass : #TestCase,
-	#category : #'VMMakerTests-Simulation'
+	#name : 'VMSimulationTest',
+	#superclass : 'TestCase',
+	#category : 'VMMakerTests-Simulation',
+	#package : 'VMMakerTests',
+	#tag : 'Simulation'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSimulationTest >> testSetUpJITSimulationReadsImage [
 
 	| options c |
@@ -27,7 +29,7 @@ VMSimulationTest >> testSetUpJITSimulationReadsImage [
 		extraMemory: 100000.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSimulationTest >> testSetUpNonJITSimulationReadsImage [
 
 	| options c |

--- a/smalltalksrc/VMMakerTests/VMSistaSuperSendsTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSistaSuperSendsTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #VMSistaSuperSendsTest,
-	#superclass : #VMStackToRegisterMappingCogitTest,
-	#category : #'VMMakerTests-JitTests'
+	#name : 'VMSistaSuperSendsTest',
+	#superclass : 'VMStackToRegisterMappingCogitTest',
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 VMSistaSuperSendsTest >> jitOptions [
 
 	^ super jitOptions
@@ -12,7 +14,7 @@ VMSistaSuperSendsTest >> jitOptions [
 		  yourself
 ]
 
-{ #category : #'tests - sends/super' }
+{ #category : 'tests - sends/super' }
 VMSistaSuperSendsTest >> testSuperSendLiteralZeroWithZeroArgsMovesSelectorIndexClassRegisterIn64bits [
 
 	| selector binding literalVariableIndex literalSelectorIndex startPC receiver expectedSelector |

--- a/smalltalksrc/VMMakerTests/VMSistaTrampolineTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSistaTrampolineTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #VMSistaTrampolineTest,
-	#superclass : #VMTrampolineTest,
-	#category : #'VMMakerTests-JitTests'
+	#name : 'VMSistaTrampolineTest',
+	#superclass : 'VMTrampolineTest',
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 VMSistaTrampolineTest >> jitOptions [
 
 	^ super jitOptions
@@ -12,7 +14,7 @@ VMSistaTrampolineTest >> jitOptions [
 		  yourself
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSistaTrampolineTest >> testSendTrampolineWithFourArguments [
 	
 	| trampolineStart receiver |

--- a/smalltalksrc/VMMakerTests/VMSpecialSendArithmethicTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpecialSendArithmethicTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #VMSpecialSendArithmethicTest,
-	#superclass : #VMStackToRegisterMappingCogitTest,
-	#category : #'VMMakerTests-JitTests'
+	#name : 'VMSpecialSendArithmethicTest',
+	#superclass : 'VMStackToRegisterMappingCogitTest',
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #'building suites' }
+{ #category : 'building suites' }
 VMSpecialSendArithmethicTest class >> testParameters [ 
 
 	^ super testParameters * { 
@@ -13,7 +15,7 @@ VMSpecialSendArithmethicTest class >> testParameters [
 	 }
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMSpecialSendArithmethicTest >> assertSpecialSendTo: receiverOop withArg: argOop [ 
 
 	self assert: machineSimulator instructionPointerRegisterValue equals: sendTrampolineAddress.
@@ -21,7 +23,7 @@ VMSpecialSendArithmethicTest >> assertSpecialSendTo: receiverOop withArg: argOop
 	self assert: machineSimulator arg0RegisterValue equals: argOop.
 ]
 
-{ #category : #'tests - receiver non integer argument' }
+{ #category : 'tests - receiver non integer argument' }
 VMSpecialSendArithmethicTest >> testNonIntegerArgumentPlusFalseArgumentCallsTrampoline [
 		
 	self
@@ -31,7 +33,7 @@ VMSpecialSendArithmethicTest >> testNonIntegerArgumentPlusFalseArgumentCallsTram
 		shouldCallTrampolineWith: [ memory trueObject ] and: [ memory falseObject ]
 ]
 
-{ #category : #'tests - receiver non integer argument' }
+{ #category : 'tests - receiver non integer argument' }
 VMSpecialSendArithmethicTest >> testNonIntegerArgumentPlusFalseSelfCallsTrampoline [
 		
 	self
@@ -42,7 +44,7 @@ VMSpecialSendArithmethicTest >> testNonIntegerArgumentPlusFalseSelfCallsTrampoli
 		shouldCallTrampolineWith: [ memory trueObject ] and: [ memory falseObject ]
 ]
 
-{ #category : #'tests - receiver non integer argument' }
+{ #category : 'tests - receiver non integer argument' }
 VMSpecialSendArithmethicTest >> testNonIntegerArgumentPlusSmallIntegerArgumentCallsTrampoline [
 		
 	self
@@ -52,7 +54,7 @@ VMSpecialSendArithmethicTest >> testNonIntegerArgumentPlusSmallIntegerArgumentCa
 		shouldCallTrampolineWith: [ memory trueObject ] and: [ memory integerObjectOf: value1 ]
 ]
 
-{ #category : #'tests - receiver non integer argument' }
+{ #category : 'tests - receiver non integer argument' }
 VMSpecialSendArithmethicTest >> testNonIntegerArgumentPlusSmallIntegerConstCallsTrampoline [
 		
 	self
@@ -62,7 +64,7 @@ VMSpecialSendArithmethicTest >> testNonIntegerArgumentPlusSmallIntegerConstCalls
 		shouldCallTrampolineWith: [ memory trueObject ] and: [ memory integerObjectOf: value1 ]
 ]
 
-{ #category : #'tests - receiver non integer argument' }
+{ #category : 'tests - receiver non integer argument' }
 VMSpecialSendArithmethicTest >> testNonIntegerArgumentPlusSmallIntegerSelfCallsTrampoline [
 		
 	self
@@ -73,7 +75,7 @@ VMSpecialSendArithmethicTest >> testNonIntegerArgumentPlusSmallIntegerSelfCallsT
 		shouldCallTrampolineWith: [ memory trueObject ] and: [ (memory integerObjectOf: value1) ]
 ]
 
-{ #category : #'tests - receiver non integer argument' }
+{ #category : 'tests - receiver non integer argument' }
 VMSpecialSendArithmethicTest >> testNonIntegerArgumentPlusTrueConstCallsTrampoline [
 		
 	self
@@ -83,7 +85,7 @@ VMSpecialSendArithmethicTest >> testNonIntegerArgumentPlusTrueConstCallsTrampoli
 		shouldCallTrampolineWith: [ memory trueObject ] and: [ memory falseObject ]
 ]
 
-{ #category : #'tests - receiver integer argument' }
+{ #category : 'tests - receiver integer argument' }
 VMSpecialSendArithmethicTest >> testSmallIntegerArgumentPlusIntegerSelfReturnsSmallInteger [
 	
 	self
@@ -94,7 +96,7 @@ VMSpecialSendArithmethicTest >> testSmallIntegerArgumentPlusIntegerSelfReturnsSm
 		shouldPerformOperationReturning: expectedResult
 ]
 
-{ #category : #'tests - receiver integer argument' }
+{ #category : 'tests - receiver integer argument' }
 VMSpecialSendArithmethicTest >> testSmallIntegerArgumentPlusSmallIntegerArgumentCallsTrampoline [
 	
 	self
@@ -104,7 +106,7 @@ VMSpecialSendArithmethicTest >> testSmallIntegerArgumentPlusSmallIntegerArgument
 		shouldCallTrampolineWith: (memory integerObjectOf: value1) and: (memory integerObjectOf: value2)
 ]
 
-{ #category : #'tests - receiver integer argument' }
+{ #category : 'tests - receiver integer argument' }
 VMSpecialSendArithmethicTest >> testSmallIntegerArgumentPlusSmallIntegerConstReturnsSmallInteger [
 	
 	self
@@ -114,7 +116,7 @@ VMSpecialSendArithmethicTest >> testSmallIntegerArgumentPlusSmallIntegerConstRet
 		shouldPerformOperationReturning: expectedResult.
 ]
 
-{ #category : #'tests - receiver integer argument' }
+{ #category : 'tests - receiver integer argument' }
 VMSpecialSendArithmethicTest >> testSmallIntegerArgumentPlusTrueArgumentCallsTrampoline [
 	
 	self
@@ -124,7 +126,7 @@ VMSpecialSendArithmethicTest >> testSmallIntegerArgumentPlusTrueArgumentCallsTra
 		shouldCallTrampolineWith: (memory integerObjectOf: value2) and: memory trueObject
 ]
 
-{ #category : #'tests - receiver integer argument' }
+{ #category : 'tests - receiver integer argument' }
 VMSpecialSendArithmethicTest >> testSmallIntegerArgumentPlusTrueConstCallsTrampoline [
 	
 	self
@@ -134,7 +136,7 @@ VMSpecialSendArithmethicTest >> testSmallIntegerArgumentPlusTrueConstCallsTrampo
 		shouldCallTrampolineWith: (memory integerObjectOf: value1) and: memory trueObject
 ]
 
-{ #category : #'tests - receiver integer argument' }
+{ #category : 'tests - receiver integer argument' }
 VMSpecialSendArithmethicTest >> testSmallIntegerArgumentPlusTrueSelfCallsTrampoline [
 	
 	self
@@ -145,7 +147,7 @@ VMSpecialSendArithmethicTest >> testSmallIntegerArgumentPlusTrueSelfCallsTrampol
 		shouldCallTrampolineWith: (memory integerObjectOf: value1) and: memory trueObject
 ]
 
-{ #category : #'tests - receiver constant integer' }
+{ #category : 'tests - receiver constant integer' }
 VMSpecialSendArithmethicTest >> testSmallIntegerConstPlusSmallIntegerArgumentReturnsSmallInteger [
 	
 	self
@@ -156,7 +158,7 @@ VMSpecialSendArithmethicTest >> testSmallIntegerConstPlusSmallIntegerArgumentRet
 
 ]
 
-{ #category : #'tests - receiver constant integer' }
+{ #category : 'tests - receiver constant integer' }
 VMSpecialSendArithmethicTest >> testSmallIntegerConstPlusSmallIntegerConstReturnsSmallInteger [
 	
 	self
@@ -166,7 +168,7 @@ VMSpecialSendArithmethicTest >> testSmallIntegerConstPlusSmallIntegerConstReturn
 
 ]
 
-{ #category : #'tests - receiver constant integer' }
+{ #category : 'tests - receiver constant integer' }
 VMSpecialSendArithmethicTest >> testSmallIntegerConstPlusSmallIntegerSelfReturnsSmallInteger [
 	
 	self
@@ -177,7 +179,7 @@ VMSpecialSendArithmethicTest >> testSmallIntegerConstPlusSmallIntegerSelfReturns
 	
 ]
 
-{ #category : #'tests - receiver constant integer' }
+{ #category : 'tests - receiver constant integer' }
 VMSpecialSendArithmethicTest >> testSmallIntegerConstPlusTrueArgumentCallsTrampoline [
 	
 	
@@ -188,7 +190,7 @@ VMSpecialSendArithmethicTest >> testSmallIntegerConstPlusTrueArgumentCallsTrampo
 		shouldCallTrampolineWith: [ memory integerObjectOf: value1 ] and: [ memory trueObject ].	
 ]
 
-{ #category : #'tests - receiver constant integer' }
+{ #category : 'tests - receiver constant integer' }
 VMSpecialSendArithmethicTest >> testSmallIntegerConstPlusTrueConstCallsTrampoline [
 	
 	self
@@ -198,7 +200,7 @@ VMSpecialSendArithmethicTest >> testSmallIntegerConstPlusTrueConstCallsTrampolin
 
 ]
 
-{ #category : #'tests - receiver constant integer' }
+{ #category : 'tests - receiver constant integer' }
 VMSpecialSendArithmethicTest >> testSmallIntegerConstPlusTrueSelfCallsTrampoline [
 
 
@@ -209,7 +211,7 @@ VMSpecialSendArithmethicTest >> testSmallIntegerConstPlusTrueSelfCallsTrampoline
 		shouldCallTrampolineWith: [ memory integerObjectOf: value1 ] and: [ memory trueObject ].	
 ]
 
-{ #category : #'tests - receiver integer self' }
+{ #category : 'tests - receiver integer self' }
 VMSpecialSendArithmethicTest >> testSmallIntegerSelfPlusSmallIntegerArgumentReturnsSmallInteger [
 		
 	self
@@ -220,7 +222,7 @@ VMSpecialSendArithmethicTest >> testSmallIntegerSelfPlusSmallIntegerArgumentRetu
 		shouldPerformOperationReturning: expectedResult
 ]
 
-{ #category : #'tests - receiver integer self' }
+{ #category : 'tests - receiver integer self' }
 VMSpecialSendArithmethicTest >> testSmallIntegerSelfPlusSmallIntegerConstReturnsSmallInteger [
 	
 	self
@@ -231,7 +233,7 @@ VMSpecialSendArithmethicTest >> testSmallIntegerSelfPlusSmallIntegerConstReturns
 
 ]
 
-{ #category : #'tests - receiver integer self' }
+{ #category : 'tests - receiver integer self' }
 VMSpecialSendArithmethicTest >> testSmallIntegerSelfPlusSmallIntegerSelfReturnsSmallInteger [
 		
 	self
@@ -241,7 +243,7 @@ VMSpecialSendArithmethicTest >> testSmallIntegerSelfPlusSmallIntegerSelfReturnsS
 		shouldPerformOperationReturning: expectedReflexiveResult
 ]
 
-{ #category : #'tests - receiver integer self' }
+{ #category : 'tests - receiver integer self' }
 VMSpecialSendArithmethicTest >> testSmallIntegerSelfPlusTrueArgumentCallsTrampoline [
 		
 	self
@@ -252,7 +254,7 @@ VMSpecialSendArithmethicTest >> testSmallIntegerSelfPlusTrueArgumentCallsTrampol
 		shouldCallTrampolineWith: [ memory integerObjectOf: value1 ] and: [ memory trueObject ]
 ]
 
-{ #category : #'tests - receiver integer self' }
+{ #category : 'tests - receiver integer self' }
 VMSpecialSendArithmethicTest >> testSmallIntegerSelfPlusTrueConstCallsTrampoline [
 		
 	self
@@ -262,7 +264,7 @@ VMSpecialSendArithmethicTest >> testSmallIntegerSelfPlusTrueConstCallsTrampoline
 		shouldCallTrampolineWith: [ memory integerObjectOf: value1 ] and: [ memory trueObject ]
 ]
 
-{ #category : #'tests - receiver constant not integer' }
+{ #category : 'tests - receiver constant not integer' }
 VMSpecialSendArithmethicTest >> testTrueConstPlusFalseArgumentCallsTrampoline [
 	
 	self
@@ -272,7 +274,7 @@ VMSpecialSendArithmethicTest >> testTrueConstPlusFalseArgumentCallsTrampoline [
 		shouldCallTrampolineWith: [ memory trueObject ] and: [ memory falseObject ]
 ]
 
-{ #category : #'tests - receiver constant not integer' }
+{ #category : 'tests - receiver constant not integer' }
 VMSpecialSendArithmethicTest >> testTrueConstPlusFalseConstCallsTrampoline [
 	
 	self
@@ -281,7 +283,7 @@ VMSpecialSendArithmethicTest >> testTrueConstPlusFalseConstCallsTrampoline [
 		shouldCallTrampolineWith: [ memory trueObject ] and: [ memory falseObject ]
 ]
 
-{ #category : #'tests - receiver constant not integer' }
+{ #category : 'tests - receiver constant not integer' }
 VMSpecialSendArithmethicTest >> testTrueConstPlusFalseSelfCallsTrampoline [
 	
 	self
@@ -291,7 +293,7 @@ VMSpecialSendArithmethicTest >> testTrueConstPlusFalseSelfCallsTrampoline [
 		shouldCallTrampolineWith: [ memory trueObject ] and: [ memory falseObject ]
 ]
 
-{ #category : #'tests - receiver constant not integer' }
+{ #category : 'tests - receiver constant not integer' }
 VMSpecialSendArithmethicTest >> testTrueConstPlusSmallIntegerArgumentCallsTrampoline [
 	
 	self
@@ -301,7 +303,7 @@ VMSpecialSendArithmethicTest >> testTrueConstPlusSmallIntegerArgumentCallsTrampo
 		shouldCallTrampolineWith: [ memory trueObject ] and: [ memory integerObjectOf: value1 ]
 ]
 
-{ #category : #'tests - receiver constant not integer' }
+{ #category : 'tests - receiver constant not integer' }
 VMSpecialSendArithmethicTest >> testTrueConstPlusSmallIntegerConstCallsTrampoline [
 	
 	self
@@ -310,7 +312,7 @@ VMSpecialSendArithmethicTest >> testTrueConstPlusSmallIntegerConstCallsTrampolin
 		shouldCallTrampolineWith: [ memory trueObject ] and: [ memory integerObjectOf: value1 ].		
 ]
 
-{ #category : #'tests - receiver constant not integer' }
+{ #category : 'tests - receiver constant not integer' }
 VMSpecialSendArithmethicTest >> testTrueConstPlusSmallIntegerSelfCallsTrampoline [
 	
 	self
@@ -320,7 +322,7 @@ VMSpecialSendArithmethicTest >> testTrueConstPlusSmallIntegerSelfCallsTrampoline
 		shouldCallTrampolineWith: [ memory trueObject ] and: [ (memory integerObjectOf: value1) ]
 ]
 
-{ #category : #'tests - receiver non integer self' }
+{ #category : 'tests - receiver non integer self' }
 VMSpecialSendArithmethicTest >> testTrueSelfPlusFalseArgumentCallsTrampoline [
 			
 	self
@@ -331,7 +333,7 @@ VMSpecialSendArithmethicTest >> testTrueSelfPlusFalseArgumentCallsTrampoline [
 		shouldCallTrampolineWith: [ memory trueObject ] and: [ memory falseObject ].		
 ]
 
-{ #category : #'tests - receiver non integer self' }
+{ #category : 'tests - receiver non integer self' }
 VMSpecialSendArithmethicTest >> testTrueSelfPlusFalseConstCallsTrampoline [
 			
 	self
@@ -341,7 +343,7 @@ VMSpecialSendArithmethicTest >> testTrueSelfPlusFalseConstCallsTrampoline [
 		shouldCallTrampolineWith: [ memory trueObject ] and: [ memory falseObject ].		
 ]
 
-{ #category : #'tests - receiver non integer self' }
+{ #category : 'tests - receiver non integer self' }
 VMSpecialSendArithmethicTest >> testTrueSelfPlusSmallIntegerArgumentCallsTrampoline [
 			
 	self
@@ -352,7 +354,7 @@ VMSpecialSendArithmethicTest >> testTrueSelfPlusSmallIntegerArgumentCallsTrampol
 		shouldCallTrampolineWith: [ memory trueObject ] and: [ memory integerObjectOf: value1 ].		
 ]
 
-{ #category : #'tests - receiver non integer self' }
+{ #category : 'tests - receiver non integer self' }
 VMSpecialSendArithmethicTest >> testTrueSelfPlusSmallIntegerConstCallsTrampoline [
 			
 	self
@@ -362,7 +364,7 @@ VMSpecialSendArithmethicTest >> testTrueSelfPlusSmallIntegerConstCallsTrampoline
 		shouldCallTrampolineWith: [ memory trueObject ] and: [ memory integerObjectOf: value1 ].		
 ]
 
-{ #category : #'tests - receiver non integer self' }
+{ #category : 'tests - receiver non integer self' }
 VMSpecialSendArithmethicTest >> testTrueSelfPlusTrueSelfCallsTrampoline [
 			
 	self

--- a/smalltalksrc/VMMakerTests/VMSpurInitializedOldSpaceTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurInitializedOldSpaceTest.class.st
@@ -1,27 +1,29 @@
 Class {
-	#name : #VMSpurInitializedOldSpaceTest,
-	#superclass : #VMSpurMemoryManagerTest,
-	#category : #'VMMakerTests-MemoryTests'
+	#name : 'VMSpurInitializedOldSpaceTest',
+	#superclass : 'VMSpurMemoryManagerTest',
+	#category : 'VMMakerTests-MemoryTests',
+	#package : 'VMMakerTests',
+	#tag : 'MemoryTests'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 VMSpurInitializedOldSpaceTest class >> isAbstract [
 
 	^ self == VMSpurInitializedOldSpaceTest
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurInitializedOldSpaceTest >> assertFreeListEmpty: aFreeListOop [
 
 	self assert: aFreeListOop equals: 0
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurInitializedOldSpaceTest >> createEphemeronClass [
 	ourEphemeronClass := self createEphemeronClassForSlots: 3
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurInitializedOldSpaceTest >> createEphemeronClassForSlots: fixedSlots [
 
 	| theNewClass formatWithSlots hash |
@@ -38,7 +40,7 @@ VMSpurInitializedOldSpaceTest >> createEphemeronClassForSlots: fixedSlots [
 	^ theNewClass
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurInitializedOldSpaceTest >> createFreeChunkOfSize: aSize [
 
 	| address |
@@ -47,24 +49,24 @@ VMSpurInitializedOldSpaceTest >> createFreeChunkOfSize: aSize [
 	^ address
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurInitializedOldSpaceTest >> denyFreeListEmpty: aFreeListOop [
 
 	self deny: aFreeListOop equals: 0
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurInitializedOldSpaceTest >> forgetObject3 [
 	memory coInterpreter profileMethod: memory nilObject
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurInitializedOldSpaceTest >> freeListForSize: allocationSize [
 	
 	^ memory freeLists at: allocationSize / memory allocationUnit
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurInitializedOldSpaceTest >> freeTreeRootOop [
 
 	"Initially the old space has a single big chunk of free memory and no small free chunks.
@@ -77,7 +79,7 @@ VMSpurInitializedOldSpaceTest >> freeTreeRootOop [
 	^ memory freeLists at: 0
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurInitializedOldSpaceTest >> freeTreeRootStartAddress [
 
 	"The free tree lists stores the oop of free tree nodes.
@@ -88,7 +90,7 @@ VMSpurInitializedOldSpaceTest >> freeTreeRootStartAddress [
 	^ memory startOfObject: self freeTreeRootOop
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurInitializedOldSpaceTest >> largerNodeOf: aNode [
 
 	^ memory
@@ -96,7 +98,7 @@ VMSpurInitializedOldSpaceTest >> largerNodeOf: aNode [
 		ofFreeChunk: aNode
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurInitializedOldSpaceTest >> newEphemeronObjectWithSlots: slots [
 
 	| class |
@@ -107,14 +109,14 @@ VMSpurInitializedOldSpaceTest >> newEphemeronObjectWithSlots: slots [
 		classIndex: (memory ensureBehaviorHash: class)
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurInitializedOldSpaceTest >> newOldEphemeronObject [
 
 	"In pharo Ephemerons have 3 slots"
 	^ self newOldEphemeronObjectWithSlots: 3
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurInitializedOldSpaceTest >> newOldEphemeronObjectWithSlots: slots [
 
 	| class |
@@ -125,7 +127,7 @@ VMSpurInitializedOldSpaceTest >> newOldEphemeronObjectWithSlots: slots [
 		classIndex: (memory ensureBehaviorHash: class)
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 VMSpurInitializedOldSpaceTest >> newPermanentByteObjectOfSize: byteSize [
 	
 	| oop numSlots instSpec |
@@ -144,7 +146,7 @@ VMSpurInitializedOldSpaceTest >> newPermanentByteObjectOfSize: byteSize [
 	^ oop
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurInitializedOldSpaceTest >> nextNodeOf: aNode [
 
 	^ memory
@@ -152,7 +154,7 @@ VMSpurInitializedOldSpaceTest >> nextNodeOf: aNode [
 		ofFreeChunk: aNode
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurInitializedOldSpaceTest >> parentNodeOf: aNode [
 
 	^ memory
@@ -160,7 +162,7 @@ VMSpurInitializedOldSpaceTest >> parentNodeOf: aNode [
 		ofFreeChunk: aNode
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurInitializedOldSpaceTest >> previousNodeOf: aNode [
 
 	^ memory
@@ -168,7 +170,7 @@ VMSpurInitializedOldSpaceTest >> previousNodeOf: aNode [
 		ofFreeChunk: aNode
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMSpurInitializedOldSpaceTest >> setUp [
 
 	super setUp.
@@ -178,7 +180,7 @@ VMSpurInitializedOldSpaceTest >> setUp [
 	memory classByteArray: (self newClassInOldSpaceWithSlots: 0 instSpec: (memory byteFormatForNumBytes: 0)).
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurInitializedOldSpaceTest >> smallerNodeOf: aNode [
 
 	^ memory

--- a/smalltalksrc/VMMakerTests/VMSpurMemoryManagerTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurMemoryManagerTest.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #VMSpurMemoryManagerTest,
-	#superclass : #ParametrizedTestCase,
+	#name : 'VMSpurMemoryManagerTest',
+	#superclass : 'ParametrizedTestCase',
 	#instVars : [
 		'memory',
 		'interpreter',
@@ -24,10 +24,12 @@ Class {
 		'VMClassIndices',
 		'VMObjectIndices'
 	],
-	#category : #'VMMakerTests-MemoryTests'
+	#category : 'VMMakerTests-MemoryTests',
+	#package : 'VMMakerTests',
+	#tag : 'MemoryTests'
 }
 
-{ #category : #'building suites' }
+{ #category : 'building suites' }
 VMSpurMemoryManagerTest class >> imageFormatParameters [ 
 
 	^ { 
@@ -36,13 +38,13 @@ VMSpurMemoryManagerTest class >> imageFormatParameters [
 	}
 ]
 
-{ #category : #'building suites' }
+{ #category : 'building suites' }
 VMSpurMemoryManagerTest class >> testParameters [ 
 
 	^ self wordSizeParameters * self imageFormatParameters 
 ]
 
-{ #category : #'building suites' }
+{ #category : 'building suites' }
 VMSpurMemoryManagerTest class >> wordSizeParameters [ 
 
 	^ ParametrizedTestMatrix new
@@ -50,7 +52,7 @@ VMSpurMemoryManagerTest class >> wordSizeParameters [
 			yourself
 ]
 
-{ #category : #configuring }
+{ #category : 'configuring' }
 VMSpurMemoryManagerTest >> configureEnvironmentBuilder [
 
 	environmentBuilder
@@ -62,7 +64,7 @@ VMSpurMemoryManagerTest >> configureEnvironmentBuilder [
 		primitiveTraceLogSize: self primitiveTraceLogSize
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurMemoryManagerTest >> createActiveProcess [
 
 	| processorOopAssociation processorOop processorListsArray priorities |
@@ -84,7 +86,7 @@ VMSpurMemoryManagerTest >> createActiveProcess [
 	memory storePointer: ActiveProcessIndex ofObject: processorOop withValue:  (self newArrayWithSlots: 4).
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 VMSpurMemoryManagerTest >> createArrayClass [
 
 	| ourArrayClass |
@@ -102,7 +104,7 @@ VMSpurMemoryManagerTest >> createArrayClass [
 
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurMemoryManagerTest >> createEphemeronClass [
 	ourEphemeronClass := self newObjectWithSlots: 3.
 	memory 
@@ -112,7 +114,7 @@ VMSpurMemoryManagerTest >> createEphemeronClass [
 	memory ensureBehaviorHash: ourEphemeronClass.
 ]
 
-{ #category : #utils }
+{ #category : 'utils' }
 VMSpurMemoryManagerTest >> createLargeIntegerClasses [
 
 	| classLargeInteger classLargeNegativeInteger |
@@ -133,7 +135,7 @@ VMSpurMemoryManagerTest >> createLargeIntegerClasses [
 		withValue: classLargeNegativeInteger.
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurMemoryManagerTest >> createMethodOopFromHostMethod: aPharoCompiledMethod [
 
 	| methodOop |
@@ -143,7 +145,7 @@ VMSpurMemoryManagerTest >> createMethodOopFromHostMethod: aPharoCompiledMethod [
 	^ methodOop
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurMemoryManagerTest >> createWeakArrayClass [
 	ourWeakClass := self newObjectWithSlots: 3.
 	memory
@@ -154,43 +156,43 @@ VMSpurMemoryManagerTest >> createWeakArrayClass [
 	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSpurMemoryManagerTest >> emptyObjectSize [ 
 
 	"It is the header plus a word, padded to 8 bytes alignment"
 	^ self objectHeaderSize + "memory wordSize" 8
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSpurMemoryManagerTest >> imageReaderClass [
 
 	^ imageReaderClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSpurMemoryManagerTest >> imageReaderClass: anObject [
 
 	imageReaderClass := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSpurMemoryManagerTest >> imageWriterClass [
 
 	^ imageWriterClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSpurMemoryManagerTest >> imageWriterClass: anObject [
 
 	imageWriterClass := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSpurMemoryManagerTest >> initialCodeSize [
 	^ 0
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurMemoryManagerTest >> initializationOptions [
 
 	^ { 
@@ -204,7 +206,7 @@ VMSpurMemoryManagerTest >> initializationOptions [
 		  imageWriterClass name }
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurMemoryManagerTest >> initializeOldSpaceForFullGC [
 
 	| ourArrayClass |
@@ -226,7 +228,7 @@ VMSpurMemoryManagerTest >> initializeOldSpaceForFullGC [
 	memory flushNewSpace.
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurMemoryManagerTest >> initializeOldSpaceForScavenger [
 
 	| freeListOop firstClassTablePage |
@@ -290,7 +292,7 @@ VMSpurMemoryManagerTest >> initializeOldSpaceForScavenger [
 	self deny: memory needGCFlag
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMSpurMemoryManagerTest >> initializeSpecialSelectors [
 
 	| specialSelectorsArrayOop |
@@ -306,7 +308,7 @@ VMSpurMemoryManagerTest >> initializeSpecialSelectors [
 	memory splObj: SpecialSelectors put: specialSelectorsArrayOop
 ]
 
-{ #category : #'tests-simd' }
+{ #category : 'tests-simd' }
 VMSpurMemoryManagerTest >> installFloat64RegisterClass [
 
 	| registerClass |
@@ -325,7 +327,7 @@ VMSpurMemoryManagerTest >> installFloat64RegisterClass [
 
 ]
 
-{ #category : #'tests - primitiveGreaterOrEqual' }
+{ #category : 'tests - primitiveGreaterOrEqual' }
 VMSpurMemoryManagerTest >> installFloatClass [
 
 	| classFloat |
@@ -341,52 +343,52 @@ VMSpurMemoryManagerTest >> installFloatClass [
 	"This simulated classFloat class is necessary because the 32bits VM cannot instanciate boxed floats by itself"
 ]
 
-{ #category : #accessor }
+{ #category : 'accessor' }
 VMSpurMemoryManagerTest >> interpreter [
 	^ interpreter
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurMemoryManagerTest >> interpreterClass [ 
 	^ StackInterpreterSimulatorLSB
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurMemoryManagerTest >> keepObjectInVMVariable1: anOop [
 	interpreter newMethod: anOop
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurMemoryManagerTest >> keepObjectInVMVariable2: anOop [
 	interpreter profileSemaphore: anOop
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurMemoryManagerTest >> keepObjectInVMVariable3: anOop [
 	interpreter profileMethod: anOop
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurMemoryManagerTest >> keptObjectInVMVariable1 [
 	^ interpreter newMethod
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurMemoryManagerTest >> keptObjectInVMVariable2 [
 	^ interpreter profileSemaphore
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurMemoryManagerTest >> keptObjectInVMVariable3 [
 	^ interpreter profileMethod
 ]
 
-{ #category : #accessor }
+{ #category : 'accessor' }
 VMSpurMemoryManagerTest >> memory [
 	^ memory
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMSpurMemoryManagerTest >> memoryClass [
 
 	^ self wordSize = 4
@@ -394,13 +396,13 @@ VMSpurMemoryManagerTest >> memoryClass [
 		ifFalse: [ Spur64BitMemoryManager ]
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurMemoryManagerTest >> new16BitIndexableOfSize: aSize [
 
 	^ self newBitIndexableOfSize: aSize bytesPerSlot: 2 format: memory firstShortFormat
 ]
 
-{ #category : #'helpers - methods' }
+{ #category : 'helpers - methods' }
 VMSpurMemoryManagerTest >> new32BitIndexableFromArray: array [
 
 	| indexable |
@@ -410,13 +412,13 @@ VMSpurMemoryManagerTest >> new32BitIndexableFromArray: array [
 	^ indexable
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurMemoryManagerTest >> new32BitIndexableOfSize: aSize [
 
 	^ self newBitIndexableOfSize: aSize bytesPerSlot: 4 format: memory firstLongFormat
 ]
 
-{ #category : #'helpers - methods' }
+{ #category : 'helpers - methods' }
 VMSpurMemoryManagerTest >> new64BitIndexableFromArray: array [
 
 	| indexable |
@@ -426,31 +428,31 @@ VMSpurMemoryManagerTest >> new64BitIndexableFromArray: array [
 	^ indexable
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurMemoryManagerTest >> new64BitIndexableOfSize: aSize [
 
 	^ self newBitIndexableOfSize: aSize bytesPerSlot: 8 format: memory sixtyFourBitIndexableFormat
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurMemoryManagerTest >> new8BitIndexableOfSize: aSize [
 
 	^ self newBitIndexableOfSize: aSize bytesPerSlot: 1 format: memory firstByteFormat
 ]
 
-{ #category : #'helpers - objects' }
+{ #category : 'helpers - objects' }
 VMSpurMemoryManagerTest >> newArrayWithSlots: slots [
 	
 	^ self newArrayWithSlots: slots classIndex: memory arrayClassIndexPun
 ]
 
-{ #category : #'helpers - objects' }
+{ #category : 'helpers - objects' }
 VMSpurMemoryManagerTest >> newArrayWithSlots: slots classIndex: anIndex [
 	
 	^ self newObjectWithSlots: slots format: memory arrayFormat classIndex: anIndex
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurMemoryManagerTest >> newBitIndexableOfSize: aSize bytesPerSlot: bytesPerSlot format: format [
 
 	| padding numberOfWordSizeSlots desiredByteSize |
@@ -463,7 +465,7 @@ VMSpurMemoryManagerTest >> newBitIndexableOfSize: aSize bytesPerSlot: bytesPerSl
 		  classIndex: self nextOrdinaryClassIndex
 ]
 
-{ #category : #asd }
+{ #category : 'asd' }
 VMSpurMemoryManagerTest >> newByteArrayWithContent: aCollection [
 
 	| oop |
@@ -481,7 +483,7 @@ VMSpurMemoryManagerTest >> newByteArrayWithContent: aCollection [
 	^ oop
 ]
 
-{ #category : #'helpers - classes' }
+{ #category : 'helpers - classes' }
 VMSpurMemoryManagerTest >> newClassInOldSpaceWithSlots: numberOfSlots instSpec: format [
 	| newClass formatWithSlots |
 
@@ -499,7 +501,7 @@ VMSpurMemoryManagerTest >> newClassInOldSpaceWithSlots: numberOfSlots instSpec: 
 	^ newClass	
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurMemoryManagerTest >> newEphemeronObject [
 
 "In pharo Ephemerons have 3 slots"
@@ -510,7 +512,7 @@ VMSpurMemoryManagerTest >> newEphemeronObject [
 		classIndex: (memory ensureBehaviorHash: ourEphemeronClass)
 ]
 
-{ #category : #'helpers - methods' }
+{ #category : 'helpers - methods' }
 VMSpurMemoryManagerTest >> newMethodWithSmallContext: isSmall WithArguments: arguments [
 	
 	| method methodHeader |
@@ -531,13 +533,13 @@ VMSpurMemoryManagerTest >> newMethodWithSmallContext: isSmall WithArguments: arg
 	^ method
 ]
 
-{ #category : #'helpers - objects' }
+{ #category : 'helpers - objects' }
 VMSpurMemoryManagerTest >> newObjectWithSlots: slots [
 	
 	^ self newObjectWithSlots: slots classIndex: memory arrayClassIndexPun
 ]
 
-{ #category : #'helpers - objects' }
+{ #category : 'helpers - objects' }
 VMSpurMemoryManagerTest >> newObjectWithSlots: slots classIndex: anIndex [
 
 	| format |
@@ -548,7 +550,7 @@ VMSpurMemoryManagerTest >> newObjectWithSlots: slots classIndex: anIndex [
 	^ self newObjectWithSlots: slots format: format classIndex: anIndex
 ]
 
-{ #category : #'helpers - objects' }
+{ #category : 'helpers - objects' }
 VMSpurMemoryManagerTest >> newObjectWithSlots: slots format: aFormat classIndex: anIndex [
 	
 	| oop |
@@ -560,7 +562,7 @@ VMSpurMemoryManagerTest >> newObjectWithSlots: slots format: aFormat classIndex:
 	^ oop
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 VMSpurMemoryManagerTest >> newOldByteObjectOfSize: byteSize [
 	
 	| oop numSlots instSpec |
@@ -579,7 +581,7 @@ VMSpurMemoryManagerTest >> newOldByteObjectOfSize: byteSize [
 	^ oop
 ]
 
-{ #category : #'helpers - objects' }
+{ #category : 'helpers - objects' }
 VMSpurMemoryManagerTest >> newOldSpaceArrayWithSlots: slots [
 
 	^ self
@@ -587,13 +589,13 @@ VMSpurMemoryManagerTest >> newOldSpaceArrayWithSlots: slots [
 		  classIndex: memory arrayClassIndexPun
 ]
 
-{ #category : #'helpers - objects' }
+{ #category : 'helpers - objects' }
 VMSpurMemoryManagerTest >> newOldSpaceObjectWithSlots: slots [
 	
 	^ self newOldSpaceObjectWithSlots: slots classIndex: memory arrayClassIndexPun
 ]
 
-{ #category : #'helpers - objects' }
+{ #category : 'helpers - objects' }
 VMSpurMemoryManagerTest >> newOldSpaceObjectWithSlots: slots classIndex: anIndex [
 	
 	| format |
@@ -605,7 +607,7 @@ VMSpurMemoryManagerTest >> newOldSpaceObjectWithSlots: slots classIndex: anIndex
 		classIndex: anIndex
 ]
 
-{ #category : #'helpers - objects' }
+{ #category : 'helpers - objects' }
 VMSpurMemoryManagerTest >> newOldSpaceObjectWithSlots: slots format: aFormat classIndex: anIndex [
 	
 	| oop |
@@ -617,13 +619,13 @@ VMSpurMemoryManagerTest >> newOldSpaceObjectWithSlots: slots format: aFormat cla
 	^ oop
 ]
 
-{ #category : #'helpers - objects' }
+{ #category : 'helpers - objects' }
 VMSpurMemoryManagerTest >> newPermanentObjectWithSlots: slots [ 
 
 	^ self newPermanentSpaceObjectWithSlots: slots classIndex: memory arrayClassIndexPun
 ]
 
-{ #category : #'helpers - objects' }
+{ #category : 'helpers - objects' }
 VMSpurMemoryManagerTest >> newPermanentSpaceObjectWithSlots: slots classIndex: anIndex [
 
 	| format |
@@ -637,7 +639,7 @@ VMSpurMemoryManagerTest >> newPermanentSpaceObjectWithSlots: slots classIndex: a
 		  classIndex: anIndex
 ]
 
-{ #category : #'helpers - objects' }
+{ #category : 'helpers - objects' }
 VMSpurMemoryManagerTest >> newPermanentSpaceObjectWithSlots: slots format: aFormat classIndex: anIndex [
 	
 	| oop |
@@ -649,7 +651,7 @@ VMSpurMemoryManagerTest >> newPermanentSpaceObjectWithSlots: slots format: aForm
 	^ oop
 ]
 
-{ #category : #'helpers - frames' }
+{ #category : 'helpers - frames' }
 VMSpurMemoryManagerTest >> newSmallContextReceiver: anOop method: aMethodOop arguments: aCollectionOfArgumentsOop temporaries: aCollectionOfTemporariesOop ip: anIp [
 
 	| newCtx numArgs numTemps |
@@ -695,7 +697,7 @@ VMSpurMemoryManagerTest >> newSmallContextReceiver: anOop method: aMethodOop arg
 	^ newCtx
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurMemoryManagerTest >> newString: aString [
 	| vmString |
 	
@@ -714,7 +716,7 @@ VMSpurMemoryManagerTest >> newString: aString [
 	^ vmString
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurMemoryManagerTest >> newWeakObjectOfSize: aSize [
 	
 	^ self
@@ -723,7 +725,7 @@ VMSpurMemoryManagerTest >> newWeakObjectOfSize: aSize [
 		classIndex: (memory ensureBehaviorHash: ourWeakClass)
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurMemoryManagerTest >> newZeroSizedObject [
 	
 	^ memory
@@ -732,7 +734,7 @@ VMSpurMemoryManagerTest >> newZeroSizedObject [
 		classIndex: self zeroSizedObjectClassIndex.
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurMemoryManagerTest >> nextOrdinaryClassIndex [
 	
 	^ nextIndex
@@ -740,18 +742,18 @@ VMSpurMemoryManagerTest >> nextOrdinaryClassIndex [
 		ifNotNil: [ nextIndex := nextIndex + 1 ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSpurMemoryManagerTest >> objectHeaderSize [
 
 	^ memory baseHeaderSize 
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurMemoryManagerTest >> primitiveTraceLogSize [
 	^ 0
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMSpurMemoryManagerTest >> setContextClassIntoClassTable [
 	| aClass |
 	aClass := self
@@ -764,7 +766,7 @@ VMSpurMemoryManagerTest >> setContextClassIntoClassTable [
 		withValue: aClass
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMSpurMemoryManagerTest >> setMethodClassIntoClassTable [
 	| aClass |
 	aClass := self
@@ -777,7 +779,7 @@ VMSpurMemoryManagerTest >> setMethodClassIntoClassTable [
 		withValue: aClass
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurMemoryManagerTest >> setSmallIntegerClassIntoClassTable [
 
 	| class |
@@ -801,7 +803,7 @@ VMSpurMemoryManagerTest >> setSmallIntegerClassIntoClassTable [
 	
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMSpurMemoryManagerTest >> setUp [
 	super setUp.
 
@@ -828,7 +830,7 @@ VMSpurMemoryManagerTest >> setUp [
 	memory lastHash: 1.
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMSpurMemoryManagerTest >> setUpScheduler [
 	
 	"The ScheduleAssocation should be initialized to a valid Processor object"
@@ -856,7 +858,7 @@ VMSpurMemoryManagerTest >> setUpScheduler [
 	memory memoryActiveProcess: activeProcessOop.
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMSpurMemoryManagerTest >> setUpUsingImage [
 	"/!\ Only runnable with a wordsize equals to your image's (needs disabling parametizing of wordsize) /!\"
 	
@@ -889,25 +891,25 @@ VMSpurMemoryManagerTest >> setUpUsingImage [
 		
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSpurMemoryManagerTest >> sizeOfObjectWithSlots: slots [
 
 	^ self objectHeaderSize + ((slots min: 1 "at least one for the forwarder pointer") * memory wordSize "bytes")
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSpurMemoryManagerTest >> wordSize [
 	
 	^ wordSize ifNil: [ 8 ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSpurMemoryManagerTest >> wordSize: aWordSize [
 
 	wordSize := aWordSize
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurMemoryManagerTest >> zeroSizedObjectClassIndex [
 
 	^ zeroSizedObjectClassIndex ifNil: [ self nextOrdinaryClassIndex ]

--- a/smalltalksrc/VMMakerTests/VMSpurNewSpaceStructureTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurNewSpaceStructureTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #VMSpurNewSpaceStructureTest,
-	#superclass : #VMSpurMemoryManagerTest,
-	#category : #'VMMakerTests-MemoryTests'
+	#name : 'VMSpurNewSpaceStructureTest',
+	#superclass : 'VMSpurMemoryManagerTest',
+	#category : 'VMMakerTests-MemoryTests',
+	#package : 'VMMakerTests',
+	#tag : 'MemoryTests'
 }
 
-{ #category : #'tests-2-instantiation' }
+{ #category : 'tests-2-instantiation' }
 VMSpurNewSpaceStructureTest >> fillEden [
 
 	"Allocate enough objects to fill the eden."
@@ -13,7 +15,7 @@ VMSpurNewSpaceStructureTest >> fillEden [
 		do: [ :index | self newZeroSizedObject ]
 ]
 
-{ #category : #'tests-2-instantiation' }
+{ #category : 'tests-2-instantiation' }
 VMSpurNewSpaceStructureTest >> testInstantiateNewObjectMovesFreeStartAfterObject [
 	
 	| freeStartBefore |
@@ -24,7 +26,7 @@ VMSpurNewSpaceStructureTest >> testInstantiateNewObjectMovesFreeStartAfterObject
 	self assert: memory freeStart equals: freeStartBefore + self emptyObjectSize
 ]
 
-{ #category : #'tests-2-instantiation' }
+{ #category : 'tests-2-instantiation' }
 VMSpurNewSpaceStructureTest >> testInstantiateNewObjectWithSlotMovesFreeStartAfterObject [
 	
 	| freeStartBefore |
@@ -35,38 +37,38 @@ VMSpurNewSpaceStructureTest >> testInstantiateNewObjectWithSlotMovesFreeStartAft
 	self assert: memory freeStart equals: freeStartBefore + self emptyObjectSize
 ]
 
-{ #category : #'tests-1-memory-initialization' }
+{ #category : 'tests-1-memory-initialization' }
 VMSpurNewSpaceStructureTest >> testNewMemoryEdenEndIsAtTheStartOfOldSpace [
 
 	self assert: memory scavenger eden limit equals: memory getMemoryMap newSpaceEnd 
 ]
 
-{ #category : #'tests-1-memory-initialization' }
+{ #category : 'tests-1-memory-initialization' }
 VMSpurNewSpaceStructureTest >> testNewMemoryEdenIsRestOfNewSpace [
 	
 	self
 		assert: memory scavenger eden size > (environmentBuilder newSpaceSize - memory scavenger pastSpace size - memory scavenger futureSpace size - interpreter interpreterAllocationReserveBytes) 
 ]
 
-{ #category : #'tests-1-memory-initialization' }
+{ #category : 'tests-1-memory-initialization' }
 VMSpurNewSpaceStructureTest >> testNewMemoryFreeStartIsEdenStart [
 	
 	self assert: memory freeStart equals: memory scavenger eden start
 ]
 
-{ #category : #'tests-1-memory-initialization' }
+{ #category : 'tests-1-memory-initialization' }
 VMSpurNewSpaceStructureTest >> testNewMemoryFutureSpaceEndIsAtTheStartOfEden [
 
 	self assert: memory scavenger futureSpace limit equals: memory scavenger eden start
 ]
 
-{ #category : #'tests-1-memory-initialization' }
+{ #category : 'tests-1-memory-initialization' }
 VMSpurNewSpaceStructureTest >> testNewMemoryFutureSpaceIsRoughlyOneSeventhOfNewSpace [
 	
 	self assert: memory scavenger futureSpace size equals: (environmentBuilder newSpaceSize // 7 truncateTo: memory allocationUnit)
 ]
 
-{ #category : #'tests-1-memory-initialization' }
+{ #category : 'tests-1-memory-initialization' }
 VMSpurNewSpaceStructureTest >> testNewMemoryFutureSurvivorSpaceIsAtFutureSpaceStart [
 	
 	"The future survivor start indicates during the execution of the scavenger, where the next free space in future space starts."
@@ -74,13 +76,13 @@ VMSpurNewSpaceStructureTest >> testNewMemoryFutureSurvivorSpaceIsAtFutureSpaceSt
 	self assert: memory scavenger futureSurvivorStart equals: memory scavenger futureSpace start
 ]
 
-{ #category : #'tests-1-memory-initialization' }
+{ #category : 'tests-1-memory-initialization' }
 VMSpurNewSpaceStructureTest >> testNewMemoryPastSpaceEndIsAtTheStartOfFutureSpace [
 
 	self assert: memory scavenger pastSpace limit equals: memory scavenger futureSpace start
 ]
 
-{ #category : #'tests-1-memory-initialization' }
+{ #category : 'tests-1-memory-initialization' }
 VMSpurNewSpaceStructureTest >> testNewMemoryPastSpaceFreeStartIsAtPastSpaceStart [
 	
 	" - pastSpaceStart points to where the free space in the past space starts => it **does** move
@@ -89,19 +91,19 @@ VMSpurNewSpaceStructureTest >> testNewMemoryPastSpaceFreeStartIsAtPastSpaceStart
 	self assert: memory pastSpaceStart equals: memory scavenger pastSpace start
 ]
 
-{ #category : #'tests-1-memory-initialization' }
+{ #category : 'tests-1-memory-initialization' }
 VMSpurNewSpaceStructureTest >> testNewMemoryPastSpaceIsAtTheStartOfNewSpace [
 	
 	self assert: memory scavenger pastSpace start equals: memory getMemoryMap newSpaceStart
 ]
 
-{ #category : #'tests-1-memory-initialization' }
+{ #category : 'tests-1-memory-initialization' }
 VMSpurNewSpaceStructureTest >> testNewMemoryPastSpaceIsRoughlyOneSeventhOfNewSpace [
 	
 	self assert: memory scavenger pastSpaceBytes equals: (environmentBuilder newSpaceSize // 7 truncateTo: memory allocationUnit)
 ]
 
-{ #category : #'tests-2-instantiation' }
+{ #category : 'tests-2-instantiation' }
 VMSpurNewSpaceStructureTest >> testNewObjectAfterEdenLimitThrowsError [
 
 	"Allocate enough objects to fill the eden."
@@ -115,7 +117,7 @@ VMSpurNewSpaceStructureTest >> testNewObjectAfterEdenLimitThrowsError [
 			self assert: error messageText equals: 'no room in eden for allocateNewSpaceSlots:format:classIndex:' ]
 ]
 
-{ #category : #'tests-2-instantiation' }
+{ #category : 'tests-2-instantiation' }
 VMSpurNewSpaceStructureTest >> testNewObjectInEdenDoesNotModifyFutureSpace [
 	
 	| futureSpaceStartBefore |
@@ -125,7 +127,7 @@ VMSpurNewSpaceStructureTest >> testNewObjectInEdenDoesNotModifyFutureSpace [
 	self assert: memory scavenger futureSurvivorStart equals: futureSpaceStartBefore
 ]
 
-{ #category : #'tests-2-instantiation' }
+{ #category : 'tests-2-instantiation' }
 VMSpurNewSpaceStructureTest >> testNewObjectInEdenDoesNotModifyPastSpace [
 	
 	| pastSpaceStartBefore |
@@ -135,7 +137,7 @@ VMSpurNewSpaceStructureTest >> testNewObjectInEdenDoesNotModifyPastSpace [
 	self assert: memory pastSpaceStart equals: pastSpaceStartBefore
 ]
 
-{ #category : #'tests-2-instantiation' }
+{ #category : 'tests-2-instantiation' }
 VMSpurNewSpaceStructureTest >> testNewObjectPositionIsBeforeObjectHeader [
 	
 	| freeStartBefore oop |
@@ -146,7 +148,7 @@ VMSpurNewSpaceStructureTest >> testNewObjectPositionIsBeforeObjectHeader [
 	self assert: oop equals: freeStartBefore
 ]
 
-{ #category : #'tests-2-instantiation' }
+{ #category : 'tests-2-instantiation' }
 VMSpurNewSpaceStructureTest >> testNewObjectWithSlotsPositionIsBeforeObjectHeader [
 	
 	| freeStartBefore oop |
@@ -157,7 +159,7 @@ VMSpurNewSpaceStructureTest >> testNewObjectWithSlotsPositionIsBeforeObjectHeade
 	self assert: oop equals: freeStartBefore
 ]
 
-{ #category : #'tests-2-instantiation' }
+{ #category : 'tests-2-instantiation' }
 VMSpurNewSpaceStructureTest >> testScavengeThresholdIsInsideTheEden [
 
 	self assert:(memory scavengeThreshold

--- a/smalltalksrc/VMMakerTests/VMSpurObjectAllocationTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurObjectAllocationTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #VMSpurObjectAllocationTest,
-	#superclass : #VMSpurInitializedOldSpaceTest,
-	#category : #'VMMakerTests-MemoryTests'
+	#name : 'VMSpurObjectAllocationTest',
+	#superclass : 'VMSpurInitializedOldSpaceTest',
+	#category : 'VMMakerTests-MemoryTests',
+	#package : 'VMMakerTests',
+	#tag : 'MemoryTests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurObjectAllocationTest >> testAllocateObjectInNewSpaceMovesFreeStart [
 
 	| oldFreeStart |
@@ -14,7 +16,7 @@ VMSpurObjectAllocationTest >> testAllocateObjectInNewSpaceMovesFreeStart [
 	self assert: memory freeStart > oldFreeStart
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurObjectAllocationTest >> testAllocateObjectInOldSpaceMovesFreeStart [
 
 	| oldFreeStart |

--- a/smalltalksrc/VMMakerTests/VMSpurOldSpaceBootstrapTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurOldSpaceBootstrapTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #VMSpurOldSpaceBootstrapTest,
-	#superclass : #VMSpurMemoryManagerTest,
-	#category : #'VMMakerTests-MemoryTests'
+	#name : 'VMSpurOldSpaceBootstrapTest',
+	#superclass : 'VMSpurMemoryManagerTest',
+	#category : 'VMMakerTests-MemoryTests',
+	#package : 'VMMakerTests',
+	#tag : 'MemoryTests'
 }
 
-{ #category : #'tests-memory-bootstrap' }
+{ #category : 'tests-memory-bootstrap' }
 VMSpurOldSpaceBootstrapTest >> testClassTableHasTablePagesAndHiddenRoots [
 
 	| tableRoot |
@@ -29,7 +31,7 @@ VMSpurOldSpaceBootstrapTest >> testClassTableHasTablePagesAndHiddenRoots [
 		equals: memory classTableRootSlots + memory hiddenRootSlots
 ]
 
-{ #category : #'tests-memory-bootstrap' }
+{ #category : 'tests-memory-bootstrap' }
 VMSpurOldSpaceBootstrapTest >> testFreeListHasAsManySlotsAsRequiredByTheVM [
 
 	| freeListOop |
@@ -38,7 +40,7 @@ VMSpurOldSpaceBootstrapTest >> testFreeListHasAsManySlotsAsRequiredByTheVM [
 	self assert: (memory numSlotsOf: freeListOop) equals: memory numFreeLists
 ]
 
-{ #category : #'tests-memory-bootstrap' }
+{ #category : 'tests-memory-bootstrap' }
 VMSpurOldSpaceBootstrapTest >> testFreeListIsWordIndexable [
 
 	| freeListOop |
@@ -47,7 +49,7 @@ VMSpurOldSpaceBootstrapTest >> testFreeListIsWordIndexable [
 	self assert: (memory formatOf: freeListOop) equals: memory wordIndexableFormat
 ]
 
-{ #category : #'tests-memory-bootstrap' }
+{ #category : 'tests-memory-bootstrap' }
 VMSpurOldSpaceBootstrapTest >> testNewFreeListHasAllSlotsInitializedInZero [
 
 	| freeListOop |
@@ -57,14 +59,14 @@ VMSpurOldSpaceBootstrapTest >> testNewFreeListHasAllSlotsInitializedInZero [
 		self assert: (memory fetchPointer: i ofObject: freeListOop) equals: 0 ]
 ]
 
-{ #category : #'tests-memory-bootstrap' }
+{ #category : 'tests-memory-bootstrap' }
 VMSpurOldSpaceBootstrapTest >> testNewFreeListIsValid [
 
 	memory initializeFreeList.
 	memory validFreeTree
 ]
 
-{ #category : #'tests-memory-bootstrap' }
+{ #category : 'tests-memory-bootstrap' }
 VMSpurOldSpaceBootstrapTest >> testNewFreeListIsValid2 [
 
 	memory initializeFreeList.

--- a/smalltalksrc/VMMakerTests/VMSpurOldSpaceGarbageCollectorTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurOldSpaceGarbageCollectorTest.class.st
@@ -1,18 +1,20 @@
 Class {
-	#name : #VMSpurOldSpaceGarbageCollectorTest,
-	#superclass : #VMSpurInitializedOldSpaceTest,
+	#name : 'VMSpurOldSpaceGarbageCollectorTest',
+	#superclass : 'VMSpurInitializedOldSpaceTest',
 	#instVars : [
 		'objectStackLimit'
 	],
-	#category : #'VMMakerTests-MemoryTests'
+	#category : 'VMMakerTests-MemoryTests',
+	#package : 'VMMakerTests',
+	#tag : 'MemoryTests'
 }
 
-{ #category : #assertion }
+{ #category : 'assertion' }
 VMSpurOldSpaceGarbageCollectorTest >> assertHashOf: anOop equals: aHash [ 
 	self assert: (memory hashBitsOf: anOop) equals: aHash
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurOldSpaceGarbageCollectorTest >> deltaFreeSpaceAfterGC: aBlock [ 
 	| initialSpace lastObjectToBeRemembered sizeOfLastObject |
 	"The planning compactor frees object by sliding, and therefore does not reclaim memory if there is only dead objects in the oldspace."
@@ -33,34 +35,34 @@ VMSpurOldSpaceGarbageCollectorTest >> deltaFreeSpaceAfterGC: aBlock [
 	^ initialSpace - sizeOfLastObject - memory totalFreeListBytes
 ]
 
-{ #category : #ephemerons }
+{ #category : 'ephemerons' }
 VMSpurOldSpaceGarbageCollectorTest >> initializationOptions [
 
 	^ super initializationOptions , { 
 		#ObjStackPageSlots . objectStackLimit }
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 VMSpurOldSpaceGarbageCollectorTest >> isValidFirstBridge [
 
 	^ memory segmentManager
 		isValidSegmentBridge: (memory segmentManager bridgeAt: 0)
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMSpurOldSpaceGarbageCollectorTest >> runCaseManaged [ 
 
 	^ self runCase
 ]
 
-{ #category : #ephemerons }
+{ #category : 'ephemerons' }
 VMSpurOldSpaceGarbageCollectorTest >> setUp [
 
 	objectStackLimit :=  10.
 	super setUp.
 ]
 
-{ #category : #'tests-OldSpaceSize' }
+{ #category : 'tests-OldSpaceSize' }
 VMSpurOldSpaceGarbageCollectorTest >> testAllocateObjectBiggerThanSizeOfFreeSpace [
 
 	| anObjectOop slotsNumber |
@@ -71,7 +73,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testAllocateObjectBiggerThanSizeOfFreeSpac
 	self assert: anObjectOop isNil
 ]
 
-{ #category : #'tests-OldSpaceSize' }
+{ #category : 'tests-OldSpaceSize' }
 VMSpurOldSpaceGarbageCollectorTest >> testAllocateObjectBiggerThanSizeOfFreeSpaceShouldPlanifyGC [
 
 	| anObjectOop slotsNumber |
@@ -82,7 +84,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testAllocateObjectBiggerThanSizeOfFreeSpac
 	self assert: memory needGCFlag
 ]
 
-{ #category : #testCompactor }
+{ #category : 'testCompactor' }
 VMSpurOldSpaceGarbageCollectorTest >> testAllocateObjectRightBeforeOverflowingFreeChunk [
 	| chuckSize chunk next object free |
 
@@ -117,7 +119,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testAllocateObjectRightBeforeOverflowingFr
 	self assert: (memory isFreeObject: free).
 ]
 
-{ #category : #'tests-OldSpaceSize' }
+{ #category : 'tests-OldSpaceSize' }
 VMSpurOldSpaceGarbageCollectorTest >> testAllocateObjectWithFreeSpaceSize [
 
 	| anObjectOop slotsNumber |
@@ -128,7 +130,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testAllocateObjectWithFreeSpaceSize [
 	self assert: anObjectOop isNotNil
 ]
 
-{ #category : #'tests-OldSpaceSize' }
+{ #category : 'tests-OldSpaceSize' }
 VMSpurOldSpaceGarbageCollectorTest >> testAllocateObjectWithFreeSpaceSizeShouldBeZero [
 
 	| anObjectOop slotsNumber |
@@ -139,7 +141,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testAllocateObjectWithFreeSpaceSizeShouldB
 	self assert: memory totalFreeOldSpace equals: 0
 ]
 
-{ #category : #'tests-OldSpaceSize' }
+{ #category : 'tests-OldSpaceSize' }
 VMSpurOldSpaceGarbageCollectorTest >> testAllocateObjectWithFreeSpaceSizeShouldPlanifyGC [
 
 	| anObjectOop slotsNumber |
@@ -150,7 +152,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testAllocateObjectWithFreeSpaceSizeShouldP
 	self assert: memory needGCFlag
 ]
 
-{ #category : #'tests-OldSpaceSize' }
+{ #category : 'tests-OldSpaceSize' }
 VMSpurOldSpaceGarbageCollectorTest >> testAnOldObjectNotReferencedShouldBeCollected [
 
 	| deltaFreeSpace |
@@ -160,7 +162,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testAnOldObjectNotReferencedShouldBeCollec
 	self assert: deltaFreeSpace equals: 0
 ]
 
-{ #category : #'tests-OldSpaceSize' }
+{ #category : 'tests-OldSpaceSize' }
 VMSpurOldSpaceGarbageCollectorTest >> testAnOldObjectReferencedFromNewObjectShouldBeCollected [
 
 	| deltaFreeSpace |
@@ -173,7 +175,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testAnOldObjectReferencedFromNewObjectShou
 	self assert: deltaFreeSpace equals: 0
 ]
 
-{ #category : #'tests-OldSpaceSize' }
+{ #category : 'tests-OldSpaceSize' }
 VMSpurOldSpaceGarbageCollectorTest >> testAnOldObjectReferencedFromRememberedPermObjectShouldBeKept [
 
 	| oldObjectSize deltaFreeSpace |
@@ -186,7 +188,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testAnOldObjectReferencedFromRememberedPer
 	self assert: deltaFreeSpace equals: oldObjectSize
 ]
 
-{ #category : #'tests-OldSpaceSize' }
+{ #category : 'tests-OldSpaceSize' }
 VMSpurOldSpaceGarbageCollectorTest >> testAnOldObjectReferencedFromUnreferencedCycleObjectShouldBeCollected [
 
 	| deltaFreeSpace |
@@ -200,7 +202,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testAnOldObjectReferencedFromUnreferencedC
 	self assert: deltaFreeSpace equals: 0
 ]
 
-{ #category : #'tests-OldSpaceSize' }
+{ #category : 'tests-OldSpaceSize' }
 VMSpurOldSpaceGarbageCollectorTest >> testAnOldObjectReferencedFromVMVariableShouldBeKept [
 
 	| oldOop objectSize deltaFreeSpace |
@@ -214,7 +216,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testAnOldObjectReferencedFromVMVariableSho
 	self assert: deltaFreeSpace equals: objectSize
 ]
 
-{ #category : #'tests-OldSpaceSize' }
+{ #category : 'tests-OldSpaceSize' }
 VMSpurOldSpaceGarbageCollectorTest >> testAnOldObjectReferencedFromVMVariableShouldBeMoved [
 
 	| anObjectOop hash |
@@ -233,7 +235,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testAnOldObjectReferencedFromVMVariableSho
 	self assertHashOf: self keptObjectInVMVariable1 equals: hash
 ]
 
-{ #category : #'tests-OldSpaceSize' }
+{ #category : 'tests-OldSpaceSize' }
 VMSpurOldSpaceGarbageCollectorTest >> testArrayOfPermanentObjectsPointingToOldObjectsIsCorrectlyMantained [
 
 	| deltaFreeSpace arrayOfPerms objectsSize aPermObject anOldObject originalRememberedSetSize afteRememberedSetSize numberOfObjects originalNewRememberedSetSize afteNewRememberedSetSize |
@@ -260,7 +262,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testArrayOfPermanentObjectsPointingToOldOb
 	self assert: deltaFreeSpace equals: objectsSize + (afteRememberedSetSize - originalRememberedSetSize) + (afteNewRememberedSetSize - originalNewRememberedSetSize)
 ]
 
-{ #category : #'tests-OldSpaceSize' }
+{ #category : 'tests-OldSpaceSize' }
 VMSpurOldSpaceGarbageCollectorTest >> testArrayOfPermanentObjectsPointingToOldObjectsIsCorrectlyMantainedWhenObjectsMoved [
 
 	| numberOfObjects originalHashes permArray anOldObject |
@@ -283,7 +285,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testArrayOfPermanentObjectsPointingToOldOb
 		self assert: (originalHashes at: i) equals: (memory hashBitsOf: (memory fetchPointer: i - 1 ofObject: permArray))]
 ]
 
-{ #category : #ephemerons }
+{ #category : 'ephemerons' }
 VMSpurOldSpaceGarbageCollectorTest >> testCompactEphemeronQueuePass1 [
 
 	| ephemeron |
@@ -305,7 +307,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testCompactEphemeronQueuePass1 [
 	self assert: memory dequeueMourner equals: self keptObjectInVMVariable1.
 ]
 
-{ #category : #ephemerons }
+{ #category : 'ephemerons' }
 VMSpurOldSpaceGarbageCollectorTest >> testCompactEphemeronQueuePass2 [
 
 	| ephemeron |
@@ -335,7 +337,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testCompactEphemeronQueuePass2 [
 	self assert: memory dequeueMourner equals: self keptObjectInVMVariable1.
 ]
 
-{ #category : #'tests-OldSpaceSize' }
+{ #category : 'tests-OldSpaceSize' }
 VMSpurOldSpaceGarbageCollectorTest >> testDoNotCollectRoots [
 
 	memory fullGC.
@@ -346,7 +348,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testDoNotCollectRoots [
 	self deny: (memory isFreeObject: (memory freeListsObj)).
 ]
 
-{ #category : #'tests-OldSpaceSize' }
+{ #category : 'tests-OldSpaceSize' }
 VMSpurOldSpaceGarbageCollectorTest >> testDoubleForwardToYoungs [
 
 		| obj1 obj2 obj3 arrFrom arrTo arrFrom2 arrTo2 |
@@ -378,7 +380,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testDoubleForwardToYoungs [
 		self assert: (memory isRemembered: arrTo2).
 ]
 
-{ #category : #ephemerons }
+{ #category : 'ephemerons' }
 VMSpurOldSpaceGarbageCollectorTest >> testEphemeronDiscoverKey [
 
 	| roots ephemeron1 ephemeron2 ephemeron3 key1 key2 key3 |
@@ -441,7 +443,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testEphemeronDiscoverKey [
 
 ]
 
-{ #category : #ephemerons }
+{ #category : 'ephemerons' }
 VMSpurOldSpaceGarbageCollectorTest >> testEphemeronOverflowUnscannedEphemeronQueue [
 
 	"This test Fires more ephemerons than those that fit in a single page of the mourn queue.
@@ -479,7 +481,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testEphemeronOverflowUnscannedEphemeronQue
 		equals: numberJustOverLimit
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurOldSpaceGarbageCollectorTest >> testEphemeronWithImmediateKeyShouldNotFail [
 
 	| ephemeron1 key |
@@ -497,7 +499,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testEphemeronWithImmediateKeyShouldNotFail
 		equals: 15
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurOldSpaceGarbageCollectorTest >> testGrowOldSpace [
 
 	| freespace freespace2 slotsNumber anObjectOop |
@@ -518,7 +520,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testGrowOldSpace [
 	self assert: freespace equals: memory totalFreeOldSpace.
 ]
 
-{ #category : #ephemerons }
+{ #category : 'ephemerons' }
 VMSpurOldSpaceGarbageCollectorTest >> testMournQueue [
 
 	| roots keyObj ephemeronObj |
@@ -537,7 +539,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testMournQueue [
 	self assert: memory dequeueMourner equals: nil.
 ]
 
-{ #category : #ephemerons }
+{ #category : 'ephemerons' }
 VMSpurOldSpaceGarbageCollectorTest >> testMournQueue2 [
 
 	| roots keyObj ephemeronObj keyObj2 ephemeronObj2 |
@@ -564,7 +566,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testMournQueue2 [
 	self assert: memory dequeueMourner equals: nil.
 ]
 
-{ #category : #ephemerons }
+{ #category : 'ephemerons' }
 VMSpurOldSpaceGarbageCollectorTest >> testMultiPageMournQueue [
 
 	"This test Fires more ephemerons than those that fit in a single page of the mourn queue.
@@ -602,7 +604,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testMultiPageMournQueue [
 		equals: numberJustOverLimit
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurOldSpaceGarbageCollectorTest >> testNewRootEphemeronHoldsAnotherEphemeronAsKeyThenFullGC [
 
 	| ephemeron1 ephemeron2 |
@@ -617,7 +619,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testNewRootEphemeronHoldsAnotherEphemeronA
 	memory fullGC
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurOldSpaceGarbageCollectorTest >> testNewRootEphemeronHoldsOldNonRootEphemeronAsNonKeyThenFullGC [
 
 	| ephemeron1 ephemeron2 |
@@ -631,7 +633,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testNewRootEphemeronHoldsOldNonRootEphemer
 	memory fullGC
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurOldSpaceGarbageCollectorTest >> testNewRootEphemeronIsHeldsByOldNonRootEphemeronAsNonKeyThenFullGC [
 
 	| ephemeron1 ephemeron2 |
@@ -648,7 +650,7 @@ VMSpurOldSpaceGarbageCollectorTest >> testNewRootEphemeronIsHeldsByOldNonRootEph
 	memory fullGC
 ]
 
-{ #category : #ephemerons }
+{ #category : 'ephemerons' }
 VMSpurOldSpaceGarbageCollectorTest >> testPageLimitMournQueue [
 
 	"This test Fires more ephemerons than those that fit in a single page of the mourn queue.

--- a/smalltalksrc/VMMakerTests/VMSpurOldSpaceStructureTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurOldSpaceStructureTest.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #VMSpurOldSpaceStructureTest,
-	#superclass : #VMSpurMemoryManagerTest,
-	#category : #'VMMakerTests-MemoryTests'
+	#name : 'VMSpurOldSpaceStructureTest',
+	#superclass : 'VMSpurMemoryManagerTest',
+	#category : 'VMMakerTests-MemoryTests',
+	#package : 'VMMakerTests',
+	#tag : 'MemoryTests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurOldSpaceStructureTest >> testNewMemoryOldSpaceShouldHaveOneSegment [
 
 	self assert: memory segmentManager numSegments equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurOldSpaceStructureTest >> testNewMemoryOldSpaceSingleSegmentShouldBeHaveSameSizeAsOldSpace [
 
 	self
@@ -18,7 +20,7 @@ VMSpurOldSpaceStructureTest >> testNewMemoryOldSpaceSingleSegmentShouldBeHaveSam
 		equals: memory oldSpaceSize
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurOldSpaceStructureTest >> testNewMemoryOldSpaceSizeShouldBeAskedMemory [
 
 	self assert: memory oldSpaceSize equals: oldSpaceSize

--- a/smalltalksrc/VMMakerTests/VMSpurOldSpaceTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurOldSpaceTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #VMSpurOldSpaceTest,
-	#superclass : #VMSpurInitializedOldSpaceTest,
-	#category : #'VMMakerTests-MemoryTests'
+	#name : 'VMSpurOldSpaceTest',
+	#superclass : 'VMSpurInitializedOldSpaceTest',
+	#category : 'VMMakerTests-MemoryTests',
+	#package : 'VMMakerTests',
+	#tag : 'MemoryTests'
 }
 
-{ #category : #'tests-2-allocation-basic' }
+{ #category : 'tests-2-allocation-basic' }
 VMSpurOldSpaceTest >> testAllocateAllFreeMemoryShouldLeaveNoFreeMemory [
 
 	memory allocateOldSpaceChunkOfBytes: memory totalFreeListBytes.
@@ -12,7 +14,7 @@ VMSpurOldSpaceTest >> testAllocateAllFreeMemoryShouldLeaveNoFreeMemory [
 	self assert: memory totalFreeListBytes equals: 0
 ]
 
-{ #category : #'tests-8-allocation-strategy-list-bestfit' }
+{ #category : 'tests-8-allocation-strategy-list-bestfit' }
 VMSpurOldSpaceTest >> testAllocateBestFitInListShouldAddLeftoverInList [
 
 	self createFreeChunkOfSize: 120.
@@ -24,7 +26,7 @@ VMSpurOldSpaceTest >> testAllocateBestFitInListShouldAddLeftoverInList [
 	self denyFreeListEmpty: (self freeListForSize: 24)
 ]
 
-{ #category : #'tests-8-allocation-strategy-list-bestfit' }
+{ #category : 'tests-8-allocation-strategy-list-bestfit' }
 VMSpurOldSpaceTest >> testAllocateBestFitInListShouldRemoveSmallerNodeFromLists [
 
 	self createFreeChunkOfSize: 120.
@@ -36,7 +38,7 @@ VMSpurOldSpaceTest >> testAllocateBestFitInListShouldRemoveSmallerNodeFromLists 
 	self assertFreeListEmpty: (self freeListForSize: 120)
 ]
 
-{ #category : #'tests-8-allocation-strategy-list-bestfit' }
+{ #category : 'tests-8-allocation-strategy-list-bestfit' }
 VMSpurOldSpaceTest >> testAllocateBestFitInListShouldReuseSmallerAddress [
 
 	| smallerAddress newAddress |
@@ -49,7 +51,7 @@ VMSpurOldSpaceTest >> testAllocateBestFitInListShouldReuseSmallerAddress [
 	self assert: newAddress equals: smallerAddress
 ]
 
-{ #category : #'tests-8-allocation-strategy-list-bestfit' }
+{ #category : 'tests-8-allocation-strategy-list-bestfit' }
 VMSpurOldSpaceTest >> testAllocateBestFitInListShouldUseIgnoreBiggerChunk [
 
 	self createFreeChunkOfSize: 120.
@@ -61,7 +63,7 @@ VMSpurOldSpaceTest >> testAllocateBestFitInListShouldUseIgnoreBiggerChunk [
 	self denyFreeListEmpty: (self freeListForSize: 160)
 ]
 
-{ #category : #'tests-2-allocation-basic' }
+{ #category : 'tests-2-allocation-basic' }
 VMSpurOldSpaceTest >> testAllocateChunkOfMemoryShouldHaveSoMuchMemoryLessAfter [
 
 	| someBytes freeBytesBefore |
@@ -72,7 +74,7 @@ VMSpurOldSpaceTest >> testAllocateChunkOfMemoryShouldHaveSoMuchMemoryLessAfter [
 	self assert: memory totalFreeListBytes equals: freeBytesBefore - someBytes
 ]
 
-{ #category : #'tests-5-allocation-strategy' }
+{ #category : 'tests-5-allocation-strategy' }
 VMSpurOldSpaceTest >> testAllocateExactBiggerChunkShouldNotReuseSmallFreeChunk [
 
 	| secondAddress newAddress |
@@ -83,7 +85,7 @@ VMSpurOldSpaceTest >> testAllocateExactBiggerChunkShouldNotReuseSmallFreeChunk [
 	self deny: newAddress equals: secondAddress
 ]
 
-{ #category : #'tests-6-allocation-strategy-list-exact' }
+{ #category : 'tests-6-allocation-strategy-list-exact' }
 VMSpurOldSpaceTest >> testAllocateExactFitInListShouldIgnoreBiggerChunks [
 
 	self createFreeChunkOfSize: 160.
@@ -95,7 +97,7 @@ VMSpurOldSpaceTest >> testAllocateExactFitInListShouldIgnoreBiggerChunks [
 	self denyFreeListEmpty: (self freeListForSize: 200)
 ]
 
-{ #category : #'tests-6-allocation-strategy-list-exact' }
+{ #category : 'tests-6-allocation-strategy-list-exact' }
 VMSpurOldSpaceTest >> testAllocateExactFitInListShouldRemoveNodeFromList [
 
 	| secondAddress |
@@ -106,7 +108,7 @@ VMSpurOldSpaceTest >> testAllocateExactFitInListShouldRemoveNodeFromList [
 	self assert: (self freeListForSize: 160) equals: 0
 ]
 
-{ #category : #'tests-6-allocation-strategy-list-exact' }
+{ #category : 'tests-6-allocation-strategy-list-exact' }
 VMSpurOldSpaceTest >> testAllocateExactFitInListShouldReuseAddress [
 
 	| secondAddress newAddress |
@@ -116,7 +118,7 @@ VMSpurOldSpaceTest >> testAllocateExactFitInListShouldReuseAddress [
 	self assert: newAddress equals: secondAddress
 ]
 
-{ #category : #'tests-9-allocation-strategy-tree' }
+{ #category : 'tests-9-allocation-strategy-tree' }
 VMSpurOldSpaceTest >> testAllocateExactFitTreeRootShouldRemoveRootFromTree [
 
 	memory allocateOldSpaceChunkOfBytes: (memory bytesInObject: self freeTreeRootOop).
@@ -124,7 +126,7 @@ VMSpurOldSpaceTest >> testAllocateExactFitTreeRootShouldRemoveRootFromTree [
 	self assert: self freeTreeRootOop equals: 0
 ]
 
-{ #category : #'tests-9-allocation-strategy-tree' }
+{ #category : 'tests-9-allocation-strategy-tree' }
 VMSpurOldSpaceTest >> testAllocateExactTreeRootShouldReuseRootAddress [
 
 	| oldRootAddress newAddress |
@@ -135,7 +137,7 @@ VMSpurOldSpaceTest >> testAllocateExactTreeRootShouldReuseRootAddress [
 	self assert: newAddress equals: oldRootAddress
 ]
 
-{ #category : #'tests-4-free-tree' }
+{ #category : 'tests-4-free-tree' }
 VMSpurOldSpaceTest >> testAllocateHalfOfTreeNodeShouldSplitIt [
 	| size childAddress smallerChildOop largerChildOop aBitBiggerThanHalf |
 	
@@ -154,7 +156,7 @@ VMSpurOldSpaceTest >> testAllocateHalfOfTreeNodeShouldSplitIt [
 	self assert: (memory bytesInObject: largerChildOop) equals: aBitBiggerThanHalf
 ]
 
-{ #category : #'tests-4-free-tree' }
+{ #category : 'tests-4-free-tree' }
 VMSpurOldSpaceTest >> testAllocateInFreeTreeShouldChangeRoot [
 
 	| freeRootOopBeforeAllocation |
@@ -165,7 +167,7 @@ VMSpurOldSpaceTest >> testAllocateInFreeTreeShouldChangeRoot [
 	self deny: freeRootOopBeforeAllocation equals: self freeTreeRootOop
 ]
 
-{ #category : #'tests-2-allocation-basic' }
+{ #category : 'tests-2-allocation-basic' }
 VMSpurOldSpaceTest >> testAllocateManyChunksShouldKeepSingleFreeEntry [
 
 	"Allocation should be contiguous because we have a single big chunk of memory to take memory from"
@@ -176,7 +178,7 @@ VMSpurOldSpaceTest >> testAllocateManyChunksShouldKeepSingleFreeEntry [
 	self assert: memory allFreeObjects size equals: 1
 ]
 
-{ #category : #'tests-2-allocation-basic' }
+{ #category : 'tests-2-allocation-basic' }
 VMSpurOldSpaceTest >> testAllocateMoreThanFreeMemoryShouldFailReturningNil [
 	
 	| address |
@@ -185,7 +187,7 @@ VMSpurOldSpaceTest >> testAllocateMoreThanFreeMemoryShouldFailReturningNil [
 	self assert: address isNil
 ]
 
-{ #category : #'tests-9-allocation-strategy-tree' }
+{ #category : 'tests-9-allocation-strategy-tree' }
 VMSpurOldSpaceTest >> testAllocatePartOfTreeRootShouldAddBigLeftOverAsFreeTreeRoot [
 
 	| leftOverSize |
@@ -195,7 +197,7 @@ VMSpurOldSpaceTest >> testAllocatePartOfTreeRootShouldAddBigLeftOverAsFreeTreeRo
 	self assert: (memory bytesInObject: self freeTreeRootOop) equals: leftOverSize
 ]
 
-{ #category : #'tests-9-allocation-strategy-tree' }
+{ #category : 'tests-9-allocation-strategy-tree' }
 VMSpurOldSpaceTest >> testAllocatePartOfTreeRootShouldAddSmallLeftOverInFreeList [
 
 	| leftOverSize |
@@ -205,7 +207,7 @@ VMSpurOldSpaceTest >> testAllocatePartOfTreeRootShouldAddSmallLeftOverInFreeList
 	self denyFreeListEmpty: (self freeListForSize: leftOverSize)
 ]
 
-{ #category : #'tests-9-allocation-strategy-tree' }
+{ #category : 'tests-9-allocation-strategy-tree' }
 VMSpurOldSpaceTest >> testAllocatePartOfTreeRootShouldReuseRootAddress [
 
 	| oldRootAddress newAddress |
@@ -218,7 +220,7 @@ VMSpurOldSpaceTest >> testAllocatePartOfTreeRootShouldReuseRootAddress [
 	self assert: newAddress equals: oldRootAddress
 ]
 
-{ #category : #'tests-7-allocation-strategy-list-power' }
+{ #category : 'tests-7-allocation-strategy-list-power' }
 VMSpurOldSpaceTest >> testAllocatePowerInListShouldAddLeftoverInList [
 
 	| sizeToAllocate powerOfSizeToAllocate leftOverSize |
@@ -231,7 +233,7 @@ VMSpurOldSpaceTest >> testAllocatePowerInListShouldAddLeftoverInList [
 	self denyFreeListEmpty: (self freeListForSize: leftOverSize)
 ]
 
-{ #category : #'tests-7-allocation-strategy-list-power' }
+{ #category : 'tests-7-allocation-strategy-list-power' }
 VMSpurOldSpaceTest >> testAllocatePowerInListShouldIgnoreNonPowers [
 
 	| sizeToAllocate powerOfSizeToAllocate nonMultipleAddress newAddress |
@@ -253,7 +255,7 @@ VMSpurOldSpaceTest >> testAllocatePowerInListShouldIgnoreNonPowers [
 	self deny: newAddress equals: nonMultipleAddress.
 ]
 
-{ #category : #'tests-7-allocation-strategy-list-power' }
+{ #category : 'tests-7-allocation-strategy-list-power' }
 VMSpurOldSpaceTest >> testAllocatePowerInListShouldRemoveNodeFromList [
 
 	| sizeToAllocate powerOfSizeToAllocate |
@@ -265,7 +267,7 @@ VMSpurOldSpaceTest >> testAllocatePowerInListShouldRemoveNodeFromList [
 	self assertFreeListEmpty: (self freeListForSize: powerOfSizeToAllocate)
 ]
 
-{ #category : #'tests-7-allocation-strategy-list-power' }
+{ #category : 'tests-7-allocation-strategy-list-power' }
 VMSpurOldSpaceTest >> testAllocatePowerInListShouldReuseMultipleAddress [
 
 	| sizeToAllocate freeMultipleAddress newAddress powerOfSizeToAllocate |
@@ -277,7 +279,7 @@ VMSpurOldSpaceTest >> testAllocatePowerInListShouldReuseMultipleAddress [
 	self assert: newAddress equals: freeMultipleAddress
 ]
 
-{ #category : #'tests-5-allocation-strategy' }
+{ #category : 'tests-5-allocation-strategy' }
 VMSpurOldSpaceTest >> testAllocateSmallerChunkShouldReusePartiallyFreeChunk [
 
 	| secondAddress newAddress |
@@ -288,7 +290,7 @@ VMSpurOldSpaceTest >> testAllocateSmallerChunkShouldReusePartiallyFreeChunk [
 	self assert: newAddress equals: secondAddress
 ]
 
-{ #category : #'tests-2-allocation-basic' }
+{ #category : 'tests-2-allocation-basic' }
 VMSpurOldSpaceTest >> testAllocatedChunkAddressesShouldBeInAllocationOrder [
 
 	| secondAddress thirdAddress |
@@ -299,7 +301,7 @@ VMSpurOldSpaceTest >> testAllocatedChunkAddressesShouldBeInAllocationOrder [
 	self assert: secondAddress < thirdAddress
 ]
 
-{ #category : #'tests-2-allocation-basic' }
+{ #category : 'tests-2-allocation-basic' }
 VMSpurOldSpaceTest >> testAllocatedChunkOfMemoryShouldRemoveSpaceFromFreeList [
 
 	| freeChunkStartAddress allocatedSize |
@@ -311,7 +313,7 @@ VMSpurOldSpaceTest >> testAllocatedChunkOfMemoryShouldRemoveSpaceFromFreeList [
 		equals: freeChunkStartAddress + allocatedSize
 ]
 
-{ #category : #'tests-2-allocation-basic' }
+{ #category : 'tests-2-allocation-basic' }
 VMSpurOldSpaceTest >> testAllocatedChunkOfMemoryShouldStartWhereFreeChunkStarted [
 
 	| freeChunkStartAddressBeforeAllocation allocatedAddress |
@@ -322,7 +324,7 @@ VMSpurOldSpaceTest >> testAllocatedChunkOfMemoryShouldStartWhereFreeChunkStarted
 		equals: freeChunkStartAddressBeforeAllocation
 ]
 
-{ #category : #'tests-4-free-tree' }
+{ #category : 'tests-4-free-tree' }
 VMSpurOldSpaceTest >> testAllocationLargerThanFreeListLimitShouldUseFreeTree [
 
 	| firstAddress byteSize smallerNodeOop |
@@ -335,7 +337,7 @@ VMSpurOldSpaceTest >> testAllocationLargerThanFreeListLimitShouldUseFreeTree [
 	self assert: smallerNodeOop equals: firstAddress
 ]
 
-{ #category : #'tests-5-allocation-strategy' }
+{ #category : 'tests-5-allocation-strategy' }
 VMSpurOldSpaceTest >> testAllocationShouldNotLeaveFreeChunkSmallerThanLiliputian [
 
 	| newAddress freeLargeSpaceAddressBeforeAllocation freeAddress |
@@ -349,7 +351,7 @@ VMSpurOldSpaceTest >> testAllocationShouldNotLeaveFreeChunkSmallerThanLiliputian
 	self assert: newAddress equals: freeLargeSpaceAddressBeforeAllocation
 ]
 
-{ #category : #'tests-5-allocation-strategy' }
+{ #category : 'tests-5-allocation-strategy' }
 VMSpurOldSpaceTest >> testChildNodeShouldHaveRootAsParent [
 
 	| smallerChild freeTreeRoot parentNode |
@@ -362,7 +364,7 @@ VMSpurOldSpaceTest >> testChildNodeShouldHaveRootAsParent [
 	self assert: parentNode equals: freeTreeRoot
 ]
 
-{ #category : #'tests-5-allocation-strategy' }
+{ #category : 'tests-5-allocation-strategy' }
 VMSpurOldSpaceTest >> testChildSiblingNodesInFreeTreeShouldHavePrevious [
 
 	| freeTreeRoot size child1 child2 nextChildOop child3 siblingOop previousOop |
@@ -389,7 +391,7 @@ VMSpurOldSpaceTest >> testChildSiblingNodesInFreeTreeShouldHavePrevious [
 	self assert: previousOop equals: nextChildOop.
 ]
 
-{ #category : #'tests-5-allocation-strategy' }
+{ #category : 'tests-5-allocation-strategy' }
 VMSpurOldSpaceTest >> testChildSiblingNodesInFreeTreeShouldNotHaveLarger [
 
 	| freeTreeRoot size child1 child2 nextChildOop child3 largerOop largerThanSmaller siblingOop |
@@ -421,7 +423,7 @@ VMSpurOldSpaceTest >> testChildSiblingNodesInFreeTreeShouldNotHaveLarger [
 	self assert: largerOop equals: 0.
 ]
 
-{ #category : #'tests-5-allocation-strategy' }
+{ #category : 'tests-5-allocation-strategy' }
 VMSpurOldSpaceTest >> testChildSiblingNodesInFreeTreeShouldNotHaveParent [
 
 	| freeTreeRoot size child1 child2 nextChild child3 parentOop |
@@ -448,7 +450,7 @@ VMSpurOldSpaceTest >> testChildSiblingNodesInFreeTreeShouldNotHaveParent [
 	self assert: parentOop equals: 0.
 ]
 
-{ #category : #'tests-5-allocation-strategy' }
+{ #category : 'tests-5-allocation-strategy' }
 VMSpurOldSpaceTest >> testChildSiblingNodesInFreeTreeShouldNotHaveSmaller [
 
 	| freeTreeRoot size child1 child2 nextChildOop child3 smallerOop smallerThanSmaller siblingOop |
@@ -480,7 +482,7 @@ VMSpurOldSpaceTest >> testChildSiblingNodesInFreeTreeShouldNotHaveSmaller [
 	self assert: smallerOop equals: 0.
 ]
 
-{ #category : #'tests-5-allocation-strategy' }
+{ #category : 'tests-5-allocation-strategy' }
 VMSpurOldSpaceTest >> testDeallocateShouldNotChangeRoot [
 
 	| freeRoot address |	
@@ -492,7 +494,7 @@ VMSpurOldSpaceTest >> testDeallocateShouldNotChangeRoot [
 	self assert: freeRoot equals: (memory freeLists at: 0)
 ]
 
-{ #category : #'tests-5-allocation-strategy' }
+{ #category : 'tests-5-allocation-strategy' }
 VMSpurOldSpaceTest >> testEqualSizeChildNodeInFreeTreeShouldBeInsertedAfterHead [
 
 	| smallerChild freeTreeRoot size child1 child2 nextChild child3 |
@@ -514,7 +516,7 @@ VMSpurOldSpaceTest >> testEqualSizeChildNodeInFreeTreeShouldBeInsertedAfterHead 
 	self assert: nextChild equals: child2.
 ]
 
-{ #category : #'tests-5-allocation-strategy' }
+{ #category : 'tests-5-allocation-strategy' }
 VMSpurOldSpaceTest >> testEqualSizeChildNodeShouldBeNextNode [
 
 	| smallerChild freeTreeRoot size child1 child2 nextChild |
@@ -532,13 +534,13 @@ VMSpurOldSpaceTest >> testEqualSizeChildNodeShouldBeNextNode [
 	self assert: nextChild equals: child2.
 ]
 
-{ #category : #'tests-5-allocation-strategy' }
+{ #category : 'tests-5-allocation-strategy' }
 VMSpurOldSpaceTest >> testFalseObjectIsNotAnArray [
 
 	self deny: (memory isArray: memory falseObject).
 ]
 
-{ #category : #'tests-3-free-lists' }
+{ #category : 'tests-3-free-lists' }
 VMSpurOldSpaceTest >> testFreeAChunkShouldBePutAsHeadOfFreeList [
 	| firstAddress secondAddress freeListHead chunkSize |
 	chunkSize := 32.
@@ -552,7 +554,7 @@ VMSpurOldSpaceTest >> testFreeAChunkShouldBePutAsHeadOfFreeList [
 	self assert: freeListHead equals: secondAddress
 ]
 
-{ #category : #'tests-2-allocation-basic' }
+{ #category : 'tests-2-allocation-basic' }
 VMSpurOldSpaceTest >> testFreeChunkDoesNotGetMergedWithExistingFreeChunks [
 
 	| secondAddress |
@@ -562,7 +564,7 @@ VMSpurOldSpaceTest >> testFreeChunkDoesNotGetMergedWithExistingFreeChunks [
 	self assert: memory allFreeObjects size equals: 2
 ]
 
-{ #category : #'tests-3-free-lists' }
+{ #category : 'tests-3-free-lists' }
 VMSpurOldSpaceTest >> testFreeChunkShouldKnowNextChunkOfSameSize [
 	| firstAddress secondAddress freeListHead nextFreeChunk allocationSize |
 	allocationSize := 32.
@@ -578,7 +580,7 @@ VMSpurOldSpaceTest >> testFreeChunkShouldKnowNextChunkOfSameSize [
 	self assert: nextFreeChunk equals: firstAddress
 ]
 
-{ #category : #'tests-3-free-lists' }
+{ #category : 'tests-3-free-lists' }
 VMSpurOldSpaceTest >> testFreeChunkShouldKnowPreviousChunkOfSameSize [
 	| firstAddress secondAddress freeListHead nextFreeChunk allocationSize previousFreeChunk |
 	allocationSize := 32.
@@ -595,7 +597,7 @@ VMSpurOldSpaceTest >> testFreeChunkShouldKnowPreviousChunkOfSameSize [
 	self assert: previousFreeChunk equals: freeListHead
 ]
 
-{ #category : #'tests-2-allocation-basic' }
+{ #category : 'tests-2-allocation-basic' }
 VMSpurOldSpaceTest >> testFreeChunksWithSameSizeShouldBeListedAsDifferentFreeChunks [
 
 	| secondAddress newAddress |
@@ -607,7 +609,7 @@ VMSpurOldSpaceTest >> testFreeChunksWithSameSizeShouldBeListedAsDifferentFreeChu
 	self assert: memory allFreeObjects size equals: 3
 ]
 
-{ #category : #'tests-3-free-lists' }
+{ #category : 'tests-3-free-lists' }
 VMSpurOldSpaceTest >> testFreeChunksWithSameSizeShouldShareSingleHead [
 	| secondAddress allocationSize firstAddress |
 	allocationSize := 32.
@@ -620,7 +622,7 @@ VMSpurOldSpaceTest >> testFreeChunksWithSameSizeShouldShareSingleHead [
 	self assert: memory allFreeListHeads size equals: 1
 ]
 
-{ #category : #'tests-3-free-lists' }
+{ #category : 'tests-3-free-lists' }
 VMSpurOldSpaceTest >> testFreeListsShouldBeIndexedBySlotSize [
 
 	| firstAddress freeListHead |
@@ -636,7 +638,7 @@ VMSpurOldSpaceTest >> testFreeListsShouldBeIndexedBySlotSize [
 	]
 ]
 
-{ #category : #'tests-1-startup' }
+{ #category : 'tests-1-startup' }
 VMSpurOldSpaceTest >> testInitialFreeListShouldBeEmpty [
 
 	2 to: memory numFreeLists - 1 do: [ :numberOfSlots |
@@ -646,7 +648,7 @@ VMSpurOldSpaceTest >> testInitialFreeListShouldBeEmpty [
 	]
 ]
 
-{ #category : #'tests-1-startup' }
+{ #category : 'tests-1-startup' }
 VMSpurOldSpaceTest >> testInitialFreeTreeRootHasNoLargerNode [
 
 	| bigChunk nextNode |
@@ -656,7 +658,7 @@ VMSpurOldSpaceTest >> testInitialFreeTreeRootHasNoLargerNode [
 	self assert: nextNode equals: 0.
 ]
 
-{ #category : #'tests-1-startup' }
+{ #category : 'tests-1-startup' }
 VMSpurOldSpaceTest >> testInitialFreeTreeRootHasNoNextNode [
 
 	| bigChunk nextNode |
@@ -666,7 +668,7 @@ VMSpurOldSpaceTest >> testInitialFreeTreeRootHasNoNextNode [
 	self assert: nextNode equals: 0.
 ]
 
-{ #category : #'tests-1-startup' }
+{ #category : 'tests-1-startup' }
 VMSpurOldSpaceTest >> testInitialFreeTreeRootHasNoParentNode [
 
 	| bigChunk nextNode |
@@ -676,7 +678,7 @@ VMSpurOldSpaceTest >> testInitialFreeTreeRootHasNoParentNode [
 	self assert: nextNode equals: 0.
 ]
 
-{ #category : #'tests-1-startup' }
+{ #category : 'tests-1-startup' }
 VMSpurOldSpaceTest >> testInitialFreeTreeRootHasNoPreviousNode [
 
 	| bigChunk nextNode |
@@ -686,7 +688,7 @@ VMSpurOldSpaceTest >> testInitialFreeTreeRootHasNoPreviousNode [
 	self assert: nextNode equals: 0.
 ]
 
-{ #category : #'tests-1-startup' }
+{ #category : 'tests-1-startup' }
 VMSpurOldSpaceTest >> testInitialFreeTreeRootHasNoSmallerNode [
 
 	| bigChunk nextNode |
@@ -696,13 +698,13 @@ VMSpurOldSpaceTest >> testInitialFreeTreeRootHasNoSmallerNode [
 	self assert: nextNode equals: 0.
 ]
 
-{ #category : #'tests-1-startup' }
+{ #category : 'tests-1-startup' }
 VMSpurOldSpaceTest >> testInitialFreeTreeRootIsFreeObject [
 
 	self assert: (memory isFreeObject: self freeTreeRootOop)
 ]
 
-{ #category : #'tests-1-startup' }
+{ #category : 'tests-1-startup' }
 VMSpurOldSpaceTest >> testInitialFreeTreeRootSizeShouldBeTotalFreeSpace [
 
 	self
@@ -710,7 +712,7 @@ VMSpurOldSpaceTest >> testInitialFreeTreeRootSizeShouldBeTotalFreeSpace [
 		equals: memory totalFreeListBytes
 ]
 
-{ #category : #'tests-4-free-tree' }
+{ #category : 'tests-4-free-tree' }
 VMSpurOldSpaceTest >> testLargeFreeChunkInFreeTreeNodeShouldStoreChunkOop [
 
 	| firstAddress byteSize smallerNodeOop |
@@ -723,7 +725,7 @@ VMSpurOldSpaceTest >> testLargeFreeChunkInFreeTreeNodeShouldStoreChunkOop [
 	self assert: (memory startOfObject: smallerNodeOop) equals: firstAddress
 ]
 
-{ #category : #'tests-5-allocation-strategy' }
+{ #category : 'tests-5-allocation-strategy' }
 VMSpurOldSpaceTest >> testNewBigFreeChunkShouldBeFreeTreeChild [
 
 	| firstAddress freeRoot rootSize moreThanHalf newRoot largerChildOop |
@@ -744,7 +746,7 @@ VMSpurOldSpaceTest >> testNewBigFreeChunkShouldBeFreeTreeChild [
 	self assert: (memory startOfObject: largerChildOop) equals: firstAddress
 ]
 
-{ #category : #'tests-5-allocation-strategy' }
+{ #category : 'tests-5-allocation-strategy' }
 VMSpurOldSpaceTest >> testNewBigFreeChunkShouldHaveRootAsParent [
 
 	| firstAddress freeRoot rootSize moreThanHalf newRoot largerChildOop parentNodeOop |
@@ -766,13 +768,13 @@ VMSpurOldSpaceTest >> testNewBigFreeChunkShouldHaveRootAsParent [
 	self assert: parentNodeOop equals: newRoot
 ]
 
-{ #category : #'tests-1-startup' }
+{ #category : 'tests-1-startup' }
 VMSpurOldSpaceTest >> testNewMemoryShouldHaveSingleFreeObject [
 
 	self assert: memory allFreeObjects size equals: 1
 ]
 
-{ #category : #'tests-2-allocation-basic' }
+{ #category : 'tests-2-allocation-basic' }
 VMSpurOldSpaceTest >> testNewObjectShouldBeOld [
 	
 	| oop |
@@ -781,19 +783,19 @@ VMSpurOldSpaceTest >> testNewObjectShouldBeOld [
 	self assert: (memory getMemoryMap isOldObject: oop)
 ]
 
-{ #category : #'tests-5-allocation-strategy' }
+{ #category : 'tests-5-allocation-strategy' }
 VMSpurOldSpaceTest >> testNilObjectIsNotAnArray [
 
 	self deny: (memory isArray: memory nilObject).
 ]
 
-{ #category : #'tests-5-allocation-strategy' }
+{ #category : 'tests-5-allocation-strategy' }
 VMSpurOldSpaceTest >> testNilObjectObjectFormatIsZero [
 
 	self assert: (memory formatOf: memory nilObject) equals: 0.
 ]
 
-{ #category : #'tests-2-allocation-basic' }
+{ #category : 'tests-2-allocation-basic' }
 VMSpurOldSpaceTest >> testPartiallyReusingFreeChunkShouldKeepNumberOfEntriesInFreeList [
 
 	| secondAddress freeChunksBefore |
@@ -806,7 +808,7 @@ VMSpurOldSpaceTest >> testPartiallyReusingFreeChunkShouldKeepNumberOfEntriesInFr
 	self assert: memory allFreeObjects size equals: freeChunksBefore.
 ]
 
-{ #category : #'tests-2-allocation-basic' }
+{ #category : 'tests-2-allocation-basic' }
 VMSpurOldSpaceTest >> testReuseFreeChunkShouldRemoveEntryFromFreeList [
 
 	| secondAddress |
@@ -817,7 +819,7 @@ VMSpurOldSpaceTest >> testReuseFreeChunkShouldRemoveEntryFromFreeList [
 	self assert: memory allFreeObjects size equals: 1
 ]
 
-{ #category : #'tests-3-free-lists' }
+{ #category : 'tests-3-free-lists' }
 VMSpurOldSpaceTest >> testSingleFreeChunkListNextShouldBeZero [
 	| firstAddress freeListHead allocationSize |
 	allocationSize := 32.
@@ -829,7 +831,7 @@ VMSpurOldSpaceTest >> testSingleFreeChunkListNextShouldBeZero [
 	self assert: (self nextNodeOf: freeListHead) equals: 0
 ]
 
-{ #category : #'tests-3-free-lists' }
+{ #category : 'tests-3-free-lists' }
 VMSpurOldSpaceTest >> testSingleFreeChunkListPreviousShouldBeZero [
 	| firstAddress freeListHead allocationSize |
 	allocationSize := 32.
@@ -841,7 +843,7 @@ VMSpurOldSpaceTest >> testSingleFreeChunkListPreviousShouldBeZero [
 	self assert: (self previousNodeOf: freeListHead) equals: 0
 ]
 
-{ #category : #'tests-5-allocation-strategy' }
+{ #category : 'tests-5-allocation-strategy' }
 VMSpurOldSpaceTest >> testSmallerChildNodeShouldBeFreeTreeChild [
 
 	| smallerChild freeTreeRoot parentNode smallerSize rootSize |
@@ -858,7 +860,7 @@ VMSpurOldSpaceTest >> testSmallerChildNodeShouldBeFreeTreeChild [
 	self assert: parentNode equals: freeTreeRoot
 ]
 
-{ #category : #'tests-5-allocation-strategy' }
+{ #category : 'tests-5-allocation-strategy' }
 VMSpurOldSpaceTest >> testTrueObjectIsNotAnArray [
 
 	self deny: (memory isArray: memory trueObject).

--- a/smalltalksrc/VMMakerTests/VMSpurRememberedSetTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurRememberedSetTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #VMSpurRememberedSetTest,
-	#superclass : #VMSpurInitializedOldSpaceTest,
-	#category : #'VMMakerTests-MemoryTests'
+	#name : 'VMSpurRememberedSetTest',
+	#superclass : 'VMSpurInitializedOldSpaceTest',
+	#category : 'VMMakerTests-MemoryTests',
+	#package : 'VMMakerTests',
+	#tag : 'MemoryTests'
 }
 
-{ #category : #'tests - from old to new' }
+{ #category : 'tests - from old to new' }
 VMSpurRememberedSetTest >> testFreeRememberedOldObjectShouldForgetIt [
 
 	| oldObjectAddress rememberedObjectAddress |
@@ -22,7 +24,7 @@ VMSpurRememberedSetTest >> testFreeRememberedOldObjectShouldForgetIt [
 
 ]
 
-{ #category : #'tests - from old to perm' }
+{ #category : 'tests - from old to perm' }
 VMSpurRememberedSetTest >> testMoveToPermSpaceObjectWithOldObjectShouldNotUseNewRememberedSet [
 
 	| oldObjectAddress permObjectAddress referencedOldObjectAddress |
@@ -40,7 +42,7 @@ VMSpurRememberedSetTest >> testMoveToPermSpaceObjectWithOldObjectShouldNotUseNew
 
 ]
 
-{ #category : #'tests - from perm to old' }
+{ #category : 'tests - from perm to old' }
 VMSpurRememberedSetTest >> testMoveToPermSpaceObjectWithOldObjectShouldRememberPermObject [
 
 	| permObjectAddress oldObjectAddress referencedOldObjectAddress |
@@ -63,7 +65,7 @@ VMSpurRememberedSetTest >> testMoveToPermSpaceObjectWithOldObjectShouldRememberP
 
 ]
 
-{ #category : #'tests - from perm to old' }
+{ #category : 'tests - from perm to old' }
 VMSpurRememberedSetTest >> testMoveToPermSpaceObjectWithOldObjectShouldUpdateOldRememberedSet [
 
 	| oldObjectAddress permObjectAddress referencedOldObjectAddress |
@@ -82,7 +84,7 @@ VMSpurRememberedSetTest >> testMoveToPermSpaceObjectWithOldObjectShouldUpdateOld
 
 ]
 
-{ #category : #'tests - from perm to new' }
+{ #category : 'tests - from perm to new' }
 VMSpurRememberedSetTest >> testMoveToPermSpaceRememberedObjectShouldBeRememberedToo [
 
 	| oldObjectAddress rememberedObjectAddress permObjectAddress |
@@ -99,7 +101,7 @@ VMSpurRememberedSetTest >> testMoveToPermSpaceRememberedObjectShouldBeRemembered
 
 ]
 
-{ #category : #'tests - from perm to new' }
+{ #category : 'tests - from perm to new' }
 VMSpurRememberedSetTest >> testMoveToPermSpaceRememberedObjectShouldUpdateNewRememberedSet [
 
 	| oldObjectAddress rememberedObjectAddress permObjectAddress |
@@ -117,7 +119,7 @@ VMSpurRememberedSetTest >> testMoveToPermSpaceRememberedObjectShouldUpdateNewRem
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurRememberedSetTest >> testOldObjectIsNotRemembered [
 
 	| oldObjectAddress |
@@ -126,7 +128,7 @@ VMSpurRememberedSetTest >> testOldObjectIsNotRemembered [
 	self deny: (memory isRemembered: oldObjectAddress).
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurRememberedSetTest >> testOverflowRememberedSetShouldMakeItGrow [
 
 	| oldObjectRootAddress originalLimit youngObjectAddress |
@@ -156,7 +158,7 @@ VMSpurRememberedSetTest >> testOverflowRememberedSetShouldMakeItGrow [
 	self assert: memory getFromOldSpaceRememberedSet rememberedSetLimit equals: originalLimit * 2
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurRememberedSetTest >> testStoreOldObjectInOldObjectShouldNotRememberAnyone [
 
 	| oldObjectAddress storedOldObjectAddress |
@@ -170,7 +172,7 @@ VMSpurRememberedSetTest >> testStoreOldObjectInOldObjectShouldNotRememberAnyone 
 	self deny: (memory isRemembered: storedOldObjectAddress).
 ]
 
-{ #category : #'tests - from perm to old' }
+{ #category : 'tests - from perm to old' }
 VMSpurRememberedSetTest >> testStoreOldObjectInPermObjectShouldRememberPermObject [
 
 	| permObjectAddress oldObjectAddress |
@@ -186,7 +188,7 @@ VMSpurRememberedSetTest >> testStoreOldObjectInPermObjectShouldRememberPermObjec
 	self deny: (memory isRemembered: oldObjectAddress).
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurRememberedSetTest >> testStoreOldObjectInYoungObjectShouldNotRememberAnyone [
 
 	| oldObjectAddress youngObjectAddress |
@@ -200,7 +202,7 @@ VMSpurRememberedSetTest >> testStoreOldObjectInYoungObjectShouldNotRememberAnyon
 	self deny: (memory isRemembered: youngObjectAddress).
 ]
 
-{ #category : #'tests - from old to perm' }
+{ #category : 'tests - from old to perm' }
 VMSpurRememberedSetTest >> testStorePermObjectInOldObjectShouldNotRememberAnyone [
 
 	| permObjectAddress oldObjectAddress |
@@ -214,7 +216,7 @@ VMSpurRememberedSetTest >> testStorePermObjectInOldObjectShouldNotRememberAnyone
 	self deny: (memory isRemembered: oldObjectAddress).
 ]
 
-{ #category : #'tests - from perm to perm' }
+{ #category : 'tests - from perm to perm' }
 VMSpurRememberedSetTest >> testStorePermObjectInPermObjectShouldNotRememberAnyone [
 
 	| permObjectAddress referencedPermObjectAddress |
@@ -228,7 +230,7 @@ VMSpurRememberedSetTest >> testStorePermObjectInPermObjectShouldNotRememberAnyon
 	self deny: (memory isRemembered: referencedPermObjectAddress).
 ]
 
-{ #category : #'tests - from new to perm' }
+{ #category : 'tests - from new to perm' }
 VMSpurRememberedSetTest >> testStorePermObjectInYoungObjectShouldNotRememberAnyone [
 
 	| permObjectAddress youngObjectAddress |
@@ -242,7 +244,7 @@ VMSpurRememberedSetTest >> testStorePermObjectInYoungObjectShouldNotRememberAnyo
 	self deny: (memory isRemembered: youngObjectAddress).
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurRememberedSetTest >> testStoreYoungAndOldObjectInPermObjectShouldRememberPermObject [
 
 	| permObjectAddress oldObjectAddress youngObjectAddress |
@@ -267,7 +269,7 @@ VMSpurRememberedSetTest >> testStoreYoungAndOldObjectInPermObjectShouldRememberP
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurRememberedSetTest >> testStoreYoungObjectInOldObjectShouldRememberOldObject [
 
 	| oldObjectAddress youngObjectAddress |
@@ -281,7 +283,7 @@ VMSpurRememberedSetTest >> testStoreYoungObjectInOldObjectShouldRememberOldObjec
 	self deny: (memory isRemembered: youngObjectAddress).
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurRememberedSetTest >> testStoreYoungObjectInPermObjectShouldRememberPermObject [
 
 	| permObjectAddress youngObjectAddress |
@@ -295,7 +297,7 @@ VMSpurRememberedSetTest >> testStoreYoungObjectInPermObjectShouldRememberPermObj
 	self deny: (memory isRemembered: youngObjectAddress).
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurRememberedSetTest >> testStoreYoungObjectInYoungObjectShouldNotRememberAnyone [
 
 	| youngObjectAddress storedYoungObjectAddress |
@@ -309,7 +311,7 @@ VMSpurRememberedSetTest >> testStoreYoungObjectInYoungObjectShouldNotRememberAny
 	self deny: (memory isRemembered: youngObjectAddress).
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurRememberedSetTest >> testYoungObjectIsNotRemembered [
 
 	| newObjectAddress |

--- a/smalltalksrc/VMMakerTests/VMSpurScavengeEphemeronTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurScavengeEphemeronTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #VMSpurScavengeEphemeronTest,
-	#superclass : #VMSpurInitializedOldSpaceTest,
-	#category : #'VMMakerTests-MemoryTests'
+	#name : 'VMSpurScavengeEphemeronTest',
+	#superclass : 'VMSpurInitializedOldSpaceTest',
+	#category : 'VMMakerTests-MemoryTests',
+	#package : 'VMMakerTests',
+	#tag : 'MemoryTests'
 }
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 VMSpurScavengeEphemeronTest >> setUp [
 
 	super setUp.
@@ -12,7 +14,7 @@ VMSpurScavengeEphemeronTest >> setUp [
 	self createEphemeronClass
 ]
 
-{ #category : #'tests-ephemerons-globals' }
+{ #category : 'tests-ephemerons-globals' }
 VMSpurScavengeEphemeronTest >> testDequeueMournerWithOnlyOneEphemeronShouldEmptyMournQueue [
 
 	| ephemeronObjectOop nonEphemeronObjectOop |
@@ -32,7 +34,7 @@ VMSpurScavengeEphemeronTest >> testDequeueMournerWithOnlyOneEphemeronShouldEmpty
 	self assert: memory dequeueMourner equals: nil
 ]
 
-{ #category : #'tests-ephemerons-globals' }
+{ #category : 'tests-ephemerons-globals' }
 VMSpurScavengeEphemeronTest >> testFireManyEphemeronWithSameKey [
 
 	| numberOfEphemerons ephemeronKey |
@@ -68,7 +70,7 @@ VMSpurScavengeEphemeronTest >> testFireManyEphemeronWithSameKey [
 			withValue: memory nilObject ]
 ]
 
-{ #category : #'tests-ephemerons-globals' }
+{ #category : 'tests-ephemerons-globals' }
 VMSpurScavengeEphemeronTest >> testNewEphemeronObjectShouldBeInstanceOfEphemeronClass [
 
 	| ephemeronObjectOop |
@@ -79,7 +81,7 @@ VMSpurScavengeEphemeronTest >> testNewEphemeronObjectShouldBeInstanceOfEphemeron
 		equals: ourEphemeronClass
 ]
 
-{ #category : #'tests-ephemerons-globals' }
+{ #category : 'tests-ephemerons-globals' }
 VMSpurScavengeEphemeronTest >> testScavengeEphemeronInRememberdSetBecomesNormalObjectAfterFinalizationIsFired [
 
 	| ephemeronObjectOop nonEphemeronObjectOop |
@@ -102,7 +104,7 @@ VMSpurScavengeEphemeronTest >> testScavengeEphemeronInRememberdSetBecomesNormalO
 		equals: memory nonIndexablePointerFormat
 ]
 
-{ #category : #'tests-ephemerons-globals' }
+{ #category : 'tests-ephemerons-globals' }
 VMSpurScavengeEphemeronTest >> testScavengeEphemeronInRememberedSetReferencingDyingObjectShouldBeAddedInTheMournQueue [
 
 	| ephemeronObjectOop nonEphemeronObjectOop |
@@ -123,7 +125,7 @@ VMSpurScavengeEphemeronTest >> testScavengeEphemeronInRememberedSetReferencingDy
 	self assert: memory dequeueMourner equals: ephemeronObjectOop
 ]
 
-{ #category : #'tests-ephemerons-globals' }
+{ #category : 'tests-ephemerons-globals' }
 VMSpurScavengeEphemeronTest >> testScavengeEphemeronInRememberedSetReferencingDyingObjectShouldScavengeEphemeronKey [
 
 	| ephemeronObjectOop nonEphemeronObjectOop nonEphemeronObjectHash |
@@ -150,7 +152,7 @@ VMSpurScavengeEphemeronTest >> testScavengeEphemeronInRememberedSetReferencingDy
 		equals: nonEphemeronObjectHash
 ]
 
-{ #category : #'tests-ephemerons-globals' }
+{ #category : 'tests-ephemerons-globals' }
 VMSpurScavengeEphemeronTest >> testScavengeEphemeronInRememberedSetReferencingSurvivorShouldLeaveEphemeronObjectAsIs [
 
 	| ephemeronObjectOop nonEphemeronObjectOop nonEphemeronObjectHash |
@@ -179,7 +181,7 @@ VMSpurScavengeEphemeronTest >> testScavengeEphemeronInRememberedSetReferencingSu
 		equals: nonEphemeronObjectHash
 ]
 
-{ #category : #'tests-ephemerons-globals' }
+{ #category : 'tests-ephemerons-globals' }
 VMSpurScavengeEphemeronTest >> testScavengeEphemeronObjectBecomesNormalObjectAfterFinalizationIsFired [
 
 	| ephemeronObjectOop nonEphemeronObjectOop |
@@ -200,7 +202,7 @@ VMSpurScavengeEphemeronTest >> testScavengeEphemeronObjectBecomesNormalObjectAft
 		equals: memory nonIndexablePointerFormat
 ]
 
-{ #category : #'tests-ephemerons-globals' }
+{ #category : 'tests-ephemerons-globals' }
 VMSpurScavengeEphemeronTest >> testScavengeEphemeronObjectReferencingDyingObjectShouldBeAddedInTheMournQueue [
 
 	| ephemeronObjectOop nonEphemeronObjectOop |
@@ -219,7 +221,7 @@ VMSpurScavengeEphemeronTest >> testScavengeEphemeronObjectReferencingDyingObject
 	self assert: memory dequeueMourner equals: ephemeronObjectOop
 ]
 
-{ #category : #'tests-ephemerons-globals' }
+{ #category : 'tests-ephemerons-globals' }
 VMSpurScavengeEphemeronTest >> testScavengeEphemeronObjectReferencingDyingObjectShouldScavengeEphemeronKey [
 
 	| ephemeronObjectOop nonEphemeronObjectOop nonEphemeronObjectHash |
@@ -241,7 +243,7 @@ VMSpurScavengeEphemeronTest >> testScavengeEphemeronObjectReferencingDyingObject
 		equals: nonEphemeronObjectHash
 ]
 
-{ #category : #'tests-ephemerons-globals' }
+{ #category : 'tests-ephemerons-globals' }
 VMSpurScavengeEphemeronTest >> testScavengeEphemeronObjectReferencingSurvivorShouldLeaveEphemeronObjectAsIs [
 
 	| ephemeronObjectOop nonEphemeronObjectOop nonEphemeronObjectHash |
@@ -265,7 +267,7 @@ VMSpurScavengeEphemeronTest >> testScavengeEphemeronObjectReferencingSurvivorSho
 		equals: nonEphemeronObjectHash
 ]
 
-{ #category : #'tests-ephemerons-globals' }
+{ #category : 'tests-ephemerons-globals' }
 VMSpurScavengeEphemeronTest >> testScavengeTwoEphemeronObjectsReferencingDifferentDyingObjectsShouldBeAddedInTheMournQueueAfterScavengingInEden [
 
 	| ephemeronObjectOop nonEphemeronObjectOop anotherEphemeronObjectOop anotherNonEphemeronObjectOop |
@@ -296,7 +298,7 @@ VMSpurScavengeEphemeronTest >> testScavengeTwoEphemeronObjectsReferencingDiffere
 	self assert: memory dequeueMourner equals: anotherEphemeronObjectOop
 ]
 
-{ #category : #'tests-ephemerons-globals' }
+{ #category : 'tests-ephemerons-globals' }
 VMSpurScavengeEphemeronTest >> testScavengeTwoEphemeronObjectsReferencingDifferentDyingObjectsShouldBeAddedInTheMournQueueAfterScavengingInPastSpace [
 
 	| ephemeronObjectOop nonEphemeronObjectOop anotherEphemeronObjectOop anotherNonEphemeronObjectOop |
@@ -338,7 +340,7 @@ VMSpurScavengeEphemeronTest >> testScavengeTwoEphemeronObjectsReferencingDiffere
 	self assert: memory dequeueMourner equals: ephemeronObjectOop
 ]
 
-{ #category : #'tests-ephemerons-globals' }
+{ #category : 'tests-ephemerons-globals' }
 VMSpurScavengeEphemeronTest >> testScavengeTwoEphemeronObjectsReferencingSameDyingObjectsShouldAddOnlyOneEphemeron [
 
 	| ephemeronObjectOop nonEphemeronObjectOop anotherEphemeronObjectOop |
@@ -370,7 +372,7 @@ VMSpurScavengeEphemeronTest >> testScavengeTwoEphemeronObjectsReferencingSameDyi
 	self assert: memory dequeueMourner equals: nil
 ]
 
-{ #category : #'tests-ephemerons-globals' }
+{ #category : 'tests-ephemerons-globals' }
 VMSpurScavengeEphemeronTest >> testScavengeTwoEphemeronObjectsReferencingSameDyingObjectsShouldAddOnlySecond [
 
 	| ephemeronObjectOop nonEphemeronObjectOop anotherEphemeronObjectOop |
@@ -400,7 +402,7 @@ VMSpurScavengeEphemeronTest >> testScavengeTwoEphemeronObjectsReferencingSameDyi
 	self assert: memory dequeueMourner equals: anotherEphemeronObjectOop
 ]
 
-{ #category : #'tests-ephemerons-globals' }
+{ #category : 'tests-ephemerons-globals' }
 VMSpurScavengeEphemeronTest >> testScavengeTwoEphemeronObjectsReferencingSameDyingObjectsShouldBeQueuedAfterConsumingMournQueue [
 
 	| ephemeronObjectOop nonEphemeronObjectOop anotherEphemeronObjectOop |
@@ -438,7 +440,7 @@ VMSpurScavengeEphemeronTest >> testScavengeTwoEphemeronObjectsReferencingSameDyi
 	self assert: memory dequeueMourner equals: ephemeronObjectOop
 ]
 
-{ #category : #'tests-ephemerons-globals' }
+{ #category : 'tests-ephemerons-globals' }
 VMSpurScavengeEphemeronTest >> testScavengeTwoEphemeronObjectsReferencingSameDyingObjectsShouldLeaveFirstOneAsEphemeron [
 
 	| ephemeronObjectOop nonEphemeronObjectOop anotherEphemeronObjectOop |
@@ -468,7 +470,7 @@ VMSpurScavengeEphemeronTest >> testScavengeTwoEphemeronObjectsReferencingSameDyi
 	self assert: (memory isEphemeron: ephemeronObjectOop)
 ]
 
-{ #category : #'tests-ephemerons-globals' }
+{ #category : 'tests-ephemerons-globals' }
 VMSpurScavengeEphemeronTest >> testScavengeTwoEphemeronObjectsReferencingSameDyingObjectsShouldScavengeKeyOfSecond [
 
 	| ephemeronObjectOop nonEphemeronObjectOop anotherEphemeronObjectOop |
@@ -500,7 +502,7 @@ VMSpurScavengeEphemeronTest >> testScavengeTwoEphemeronObjectsReferencingSameDyi
 		equals: (memory remapObj: nonEphemeronObjectOop)
 ]
 
-{ #category : #'tests-ephemerons-globals' }
+{ #category : 'tests-ephemerons-globals' }
 VMSpurScavengeEphemeronTest >> testScavengeZeroSizedEphemeronShouldTreatItAsNormalObject [
 	| ephemeronObjectOop zeroSizedEphemeronClass hashBefore addressBefore |
 	

--- a/smalltalksrc/VMMakerTests/VMSpurScavengeWeakTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurScavengeWeakTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #VMSpurScavengeWeakTest,
-	#superclass : #VMSpurInitializedOldSpaceTest,
-	#category : #'VMMakerTests-MemoryTests'
+	#name : 'VMSpurScavengeWeakTest',
+	#superclass : 'VMSpurInitializedOldSpaceTest',
+	#category : 'VMMakerTests-MemoryTests',
+	#package : 'VMMakerTests',
+	#tag : 'MemoryTests'
 }
 
-{ #category : #'test-format' }
+{ #category : 'test-format' }
 VMSpurScavengeWeakTest >> testNewWeakObjectShouldBeInstanceOfWeakClass [
 
 	| weakObjectOop |
@@ -14,7 +16,7 @@ VMSpurScavengeWeakTest >> testNewWeakObjectShouldBeInstanceOfWeakClass [
 	self assert: (memory fetchClassOfNonImm: weakObjectOop) equals: ourWeakClass
 ]
 
-{ #category : #'test-format' }
+{ #category : 'test-format' }
 VMSpurScavengeWeakTest >> testNewWeakObjectShouldHaveClassIndexOfItsClass [
 
 	| weakObjectOop classIndex |
@@ -26,7 +28,7 @@ VMSpurScavengeWeakTest >> testNewWeakObjectShouldHaveClassIndexOfItsClass [
 	self assert: classIndex equals: (memory ensureBehaviorHash: ourWeakClass)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurScavengeWeakTest >> testScavengeOldWeakObjectReferencingNonSurvivorShouldBeNilled [
 
 	| weakObjectOop nonWeakObjectOop nonWeakObjectHash nilHash |
@@ -50,7 +52,7 @@ VMSpurScavengeWeakTest >> testScavengeOldWeakObjectReferencingNonSurvivorShouldB
 		equals: nilHash
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurScavengeWeakTest >> testScavengeWeakObjectReferencingNonSurvivorShouldBeNilled [
 
 	| weakObjectOop nonWeakObjectOop nilHash |
@@ -70,7 +72,7 @@ VMSpurScavengeWeakTest >> testScavengeWeakObjectReferencingNonSurvivorShouldBeNi
 		equals: nilHash
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurScavengeWeakTest >> testScavengeWeakObjectReferencingSurvivorShouldLeaveWeakObjectAsIs [
 
 	| weakObjectOop nonWeakObjectOop nonWeakObjectHash |

--- a/smalltalksrc/VMMakerTests/VMSpurScavengerTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurScavengerTest.class.st
@@ -1,17 +1,19 @@
 Class {
-	#name : #VMSpurScavengerTest,
-	#superclass : #VMSpurInitializedOldSpaceTest,
-	#category : #'VMMakerTests-MemoryTests'
+	#name : 'VMSpurScavengerTest',
+	#superclass : 'VMSpurInitializedOldSpaceTest',
+	#category : 'VMMakerTests-MemoryTests',
+	#package : 'VMMakerTests',
+	#tag : 'MemoryTests'
 }
 
-{ #category : #asserting }
+{ #category : 'asserting' }
 VMSpurScavengerTest >> assertPastSpaceIsEmpty [
 	self
 		assert: memory pastSpaceStart
 		equals: memory scavenger pastSpace start
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurScavengerTest >> fullNewSpace [
 
 	| rootObjectAddress referencedObjectAddress freeStartAtBeginning |
@@ -37,7 +39,7 @@ VMSpurScavengerTest >> fullNewSpace [
 	self error: 'New space is not full!'
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMSpurScavengerTest >> makeBaseFrameWithMethod: aMethodOop context: aContextOop receiver: aReceiverOop args: argsOops andStack: stackOops [
 	
 	| page pointer |
@@ -85,7 +87,7 @@ VMSpurScavengerTest >> makeBaseFrameWithMethod: aMethodOop context: aContextOop 
 			withValue: (memory coInterpreter withSmallIntegerTags: page baseFP) ]
 ]
 
-{ #category : #'tests-4-scavenge-stack' }
+{ #category : 'tests-4-scavenge-stack' }
 VMSpurScavengerTest >> testAllocatingObjectsBelowThresholdDoesNotScheduleScavenge [
 
 	| times |
@@ -97,7 +99,7 @@ VMSpurScavengerTest >> testAllocatingObjectsBelowThresholdDoesNotScheduleScaveng
 	self deny: memory needGCFlag
 ]
 
-{ #category : #'tests-4-scavenge-stack' }
+{ #category : 'tests-4-scavenge-stack' }
 VMSpurScavengerTest >> testAllocatingObjectsBelowThresholdShouldBeYoung [
 
 	| times anObjectOop |
@@ -108,7 +110,7 @@ VMSpurScavengerTest >> testAllocatingObjectsBelowThresholdShouldBeYoung [
 	self assert: (memory getMemoryMap isYoungObject: anObjectOop)
 ]
 
-{ #category : #'tests-4-scavenge-stack' }
+{ #category : 'tests-4-scavenge-stack' }
 VMSpurScavengerTest >> testAllocatingObjectsOverThresholdShouldBeOld [
 
 	| times anObject |
@@ -126,7 +128,7 @@ VMSpurScavengerTest >> testAllocatingObjectsOverThresholdShouldBeOld [
 	self assert: (memory getMemoryMap isOldObject: anObject)
 ]
 
-{ #category : #'tests-4-scavenge-stack' }
+{ #category : 'tests-4-scavenge-stack' }
 VMSpurScavengerTest >> testAllocatingObjectsOverThresholdShouldScheduleScavenge [
 
 	| times |
@@ -144,7 +146,7 @@ VMSpurScavengerTest >> testAllocatingObjectsOverThresholdShouldScheduleScavenge 
 	self assert: memory needGCFlag
 ]
 
-{ #category : #'tests-4-scavenge-stack' }
+{ #category : 'tests-4-scavenge-stack' }
 VMSpurScavengerTest >> testArgumentInStackShouldSurviveScanvenge [
 
 	| newObjectOop newObjectHash newObjectAddress |	
@@ -165,7 +167,7 @@ VMSpurScavengerTest >> testArgumentInStackShouldSurviveScanvenge [
 	self assert: (memory hashBitsOf: newObjectAddress) equals: newObjectHash
 ]
 
-{ #category : #'tests-8-scavenge-tenuring' }
+{ #category : 'tests-8-scavenge-tenuring' }
 VMSpurScavengerTest >> testComputeTenuringThresholdWithFewSurvivors [
 
 	| rootObjectAddress |
@@ -181,7 +183,7 @@ VMSpurScavengerTest >> testComputeTenuringThresholdWithFewSurvivors [
 	self assert: memory scavenger scavengerTenuringProportion closeTo: 0 "Past space keep not full -> Not tenure next pass"
 ]
 
-{ #category : #'tests-8-scavenge-tenuring' }
+{ #category : 'tests-8-scavenge-tenuring' }
 VMSpurScavengerTest >> testComputeTenuringThresholdWithManySurvivors [
 
 	| rootObjectAddress |
@@ -196,7 +198,7 @@ VMSpurScavengerTest >> testComputeTenuringThresholdWithManySurvivors [
 	self assert: memory scavenger scavengerTenuringProportion closeTo: 0.1 "Past space is full -> Tenure next pass"
 ]
 
-{ #category : #'tests-4-scavenge-stack' }
+{ #category : 'tests-4-scavenge-stack' }
 VMSpurScavengerTest >> testContextInStackShouldSurviveScanvenge [
 
 	| newObjectOop newObjectHash newObjectAddress |
@@ -219,7 +221,7 @@ VMSpurScavengerTest >> testContextInStackShouldSurviveScanvenge [
 		equals: newObjectHash
 ]
 
-{ #category : #'tests-5-scavenge-specialObjects' }
+{ #category : 'tests-5-scavenge-specialObjects' }
 VMSpurScavengerTest >> testInterpreterMethodShouldSurviveScanvenge [
 
 	| newObjectOop newObjectHash newObjectAddress |	
@@ -238,7 +240,7 @@ VMSpurScavengerTest >> testInterpreterMethodShouldSurviveScanvenge [
 	self assert: (memory hashBitsOf: newObjectAddress) equals: newObjectHash
 ]
 
-{ #category : #'tests-5-scavenge-specialObjects' }
+{ #category : 'tests-5-scavenge-specialObjects' }
 VMSpurScavengerTest >> testInterpreterNewMethodShouldSurviveScanvenge [
 
 	| newObjectOop newObjectHash newObjectAddress |	
@@ -257,7 +259,7 @@ VMSpurScavengerTest >> testInterpreterNewMethodShouldSurviveScanvenge [
 	self assert: (memory hashBitsOf: newObjectAddress) equals: newObjectHash
 ]
 
-{ #category : #'tests-5-scavenge-specialObjects' }
+{ #category : 'tests-5-scavenge-specialObjects' }
 VMSpurScavengerTest >> testInterpreterProfileMethodShouldSurviveScanvenge [
 
 	| newObjectOop newObjectHash newObjectAddress |	
@@ -276,7 +278,7 @@ VMSpurScavengerTest >> testInterpreterProfileMethodShouldSurviveScanvenge [
 	self assert: (memory hashBitsOf: newObjectAddress) equals: newObjectHash
 ]
 
-{ #category : #'tests-5-scavenge-specialObjects' }
+{ #category : 'tests-5-scavenge-specialObjects' }
 VMSpurScavengerTest >> testInterpreterProfileProcessShouldSurviveScanvenge [
 
 	| newObjectOop newObjectHash newObjectAddress |	
@@ -295,7 +297,7 @@ VMSpurScavengerTest >> testInterpreterProfileProcessShouldSurviveScanvenge [
 	self assert: (memory hashBitsOf: newObjectAddress) equals: newObjectHash
 ]
 
-{ #category : #'tests-5-scavenge-specialObjects' }
+{ #category : 'tests-5-scavenge-specialObjects' }
 VMSpurScavengerTest >> testInterpreterProfileSemaphoreShouldSurviveScanvenge [
 
 	| newObjectOop newObjectHash newObjectAddress |
@@ -314,7 +316,7 @@ VMSpurScavengerTest >> testInterpreterProfileSemaphoreShouldSurviveScanvenge [
 	self assert: (memory hashBitsOf: newObjectAddress) equals: newObjectHash
 ]
 
-{ #category : #'tests-4-scavenge-stack' }
+{ #category : 'tests-4-scavenge-stack' }
 VMSpurScavengerTest >> testMethodInStackShouldSurviveScanvenge [
 
 	| newObjectOop newObjectHash newObjectAddress |
@@ -336,7 +338,7 @@ VMSpurScavengerTest >> testMethodInStackShouldSurviveScanvenge [
 	self assert: (memory hashBitsOf: newObjectAddress) equals: newObjectHash
 ]
 
-{ #category : #'tests-3-scavenge-basic' }
+{ #category : 'tests-3-scavenge-basic' }
 VMSpurScavengerTest >> testMovingReferencedObjectShouldUpdateReference [
 
 	| rootObjectAddress newRootObjectAddress referencedObjectAddress referencedObjectHash |
@@ -359,7 +361,7 @@ VMSpurScavengerTest >> testMovingReferencedObjectShouldUpdateReference [
 		equals: referencedObjectHash
 ]
 
-{ #category : #'tests-4-scavenge-stack' }
+{ #category : 'tests-4-scavenge-stack' }
 VMSpurScavengerTest >> testObjectInStackShouldSurviveScanvenge [
 
 	| newObjectOop newObjectHash newObjectAddress |
@@ -379,7 +381,7 @@ VMSpurScavengerTest >> testObjectInStackShouldSurviveScanvenge [
 	self assert: (memory hashBitsOf: newObjectAddress) equals: newObjectHash
 ]
 
-{ #category : #'tests-6-scavenge-rememberedset' }
+{ #category : 'tests-6-scavenge-rememberedset' }
 VMSpurScavengerTest >> testOldObjectReferenceToYoungObjectShouldBeRemappedAfterScanvenge [
 
 	| oldObjectAddress rememberedObjectAddress rememberedObjectHash newRememberedObjectAddress maybeMappedReferenceToYoungObject |
@@ -399,7 +401,7 @@ VMSpurScavengerTest >> testOldObjectReferenceToYoungObjectShouldBeRemappedAfterS
 	self assert: maybeMappedReferenceToYoungObject equals: newRememberedObjectAddress
 ]
 
-{ #category : #'tests-6-scavenge-rememberedset' }
+{ #category : 'tests-6-scavenge-rememberedset' }
 VMSpurScavengerTest >> testPermObjectInRemeberedSetShouldBeKeptWhenTheReferencedObjectIsInTheOldSpace [
 
 	| permObjectAddress youngObject otherOldObjectAddress |
@@ -426,7 +428,7 @@ VMSpurScavengerTest >> testPermObjectInRemeberedSetShouldBeKeptWhenTheReferenced
 
 ]
 
-{ #category : #'tests-6-scavenge-rememberedset' }
+{ #category : 'tests-6-scavenge-rememberedset' }
 VMSpurScavengerTest >> testPermObjectInRemeberedSetShouldBeRemovedFromPermSpaceWhenMutatedToPointAPermObject [
 
 	| permObjectAddress youngObject otherPermObjectAddress |
@@ -450,7 +452,7 @@ VMSpurScavengerTest >> testPermObjectInRemeberedSetShouldBeRemovedFromPermSpaceW
 
 ]
 
-{ #category : #'tests-4-scavenge-stack' }
+{ #category : 'tests-4-scavenge-stack' }
 VMSpurScavengerTest >> testReceiverInStackShouldSurviveScanvenge [
 
 	| newObjectOop newObjectHash newObjectAddress |
@@ -470,7 +472,7 @@ VMSpurScavengerTest >> testReceiverInStackShouldSurviveScanvenge [
 	self assert: (memory hashBitsOf: newObjectAddress) equals: newObjectHash
 ]
 
-{ #category : #'tests-3-scavenge-basic' }
+{ #category : 'tests-3-scavenge-basic' }
 VMSpurScavengerTest >> testReferencedObjectShouldSurviveScavenge [
 
 	| rootObjectAddress rootObjectHash newRootObjectAddress referencedObjectAddress referencedObjectHash newReferencedObjectAddress |
@@ -493,7 +495,7 @@ VMSpurScavengerTest >> testReferencedObjectShouldSurviveScavenge [
 	self assert: (memory hashBitsOf: newReferencedObjectAddress) equals: referencedObjectHash
 ]
 
-{ #category : #'tests-6-scavenge-rememberedset' }
+{ #category : 'tests-6-scavenge-rememberedset' }
 VMSpurScavengerTest >> testScanvengeTenureByAgeWithRSInRedZoneShouldShrink [
 
 	| youngObjectAddress oneOldObjectAddress otherOldObjectAddress |
@@ -518,7 +520,7 @@ VMSpurScavengerTest >> testScanvengeTenureByAgeWithRSInRedZoneShouldShrink [
 
 ]
 
-{ #category : #'tests-3-scavenge-basic' }
+{ #category : 'tests-3-scavenge-basic' }
 VMSpurScavengerTest >> testScavengeEmptyMemoryShouldExchangePastAndFutureSpaces [
 
 	| oldPastSpaceStart oldFutureSpaceStart |
@@ -531,7 +533,7 @@ VMSpurScavengerTest >> testScavengeEmptyMemoryShouldExchangePastAndFutureSpaces 
 	self assert: memory scavenger futureSpace start equals: oldPastSpaceStart.
 ]
 
-{ #category : #'tests-3-scavenge-basic' }
+{ #category : 'tests-3-scavenge-basic' }
 VMSpurScavengerTest >> testScavengeNonSurvivorShouldEmptyEden [
 	"Nil should survive."
 	"A new object not referenced should not survive."
@@ -542,7 +544,7 @@ VMSpurScavengerTest >> testScavengeNonSurvivorShouldEmptyEden [
 	self assert: memory freeStart equals: memory scavenger eden start
 ]
 
-{ #category : #'tests-3-scavenge-basic' }
+{ #category : 'tests-3-scavenge-basic' }
 VMSpurScavengerTest >> testScavengeNonSurvivorShouldOnlyCopySurvivorObjectToPastSpace [
 
 	"Only Nil should survive."
@@ -554,7 +556,7 @@ VMSpurScavengerTest >> testScavengeNonSurvivorShouldOnlyCopySurvivorObjectToPast
 	self assertPastSpaceIsEmpty
 ]
 
-{ #category : #'tests-7-scavenge-order' }
+{ #category : 'tests-7-scavenge-order' }
 VMSpurScavengerTest >> testScavengeObjectInRememberedSetShouldBeInvertedToBeBeforeObjectInStack [
 
 	| objectInTheStack oldObjectAddress objectInRememberedSet |
@@ -579,7 +581,7 @@ VMSpurScavengerTest >> testScavengeObjectInRememberedSetShouldBeInvertedToBeBefo
 	self assert: (memory remapObj: objectInRememberedSet) < (memory remapObj: objectInTheStack)
 ]
 
-{ #category : #'tests-7-scavenge-order' }
+{ #category : 'tests-7-scavenge-order' }
 VMSpurScavengerTest >> testScavengeObjectInRemembererdSetShouldBeBeforeObjectInStack [
 
 	| objectInTheStack oldObjectAddress objectInRememberedSet |
@@ -604,7 +606,7 @@ VMSpurScavengerTest >> testScavengeObjectInRemembererdSetShouldBeBeforeObjectInS
 	self assert: (memory remapObj: objectInRememberedSet) < (memory remapObj: objectInTheStack)
 ]
 
-{ #category : #'tests-7-scavenge-order' }
+{ #category : 'tests-7-scavenge-order' }
 VMSpurScavengerTest >> testScavengeObjectInStackShouldBeBeforeObjectInSpecialVariable [
 
 	| objectInTheStack objectInSpecialVariable |
@@ -621,7 +623,7 @@ VMSpurScavengerTest >> testScavengeObjectInStackShouldBeBeforeObjectInSpecialVar
 	self assert: (memory remapObj: objectInTheStack) < (memory remapObj: objectInSpecialVariable)
 ]
 
-{ #category : #'tests-7-scavenge-order' }
+{ #category : 'tests-7-scavenge-order' }
 VMSpurScavengerTest >> testScavengeObjectInStackShouldBeInvertedToBeBeforeObjectInSpecialVariable [
 
 	| objectInTheStack objectInSpecialVariable |
@@ -638,7 +640,7 @@ VMSpurScavengerTest >> testScavengeObjectInStackShouldBeInvertedToBeBeforeObject
 	self assert: (memory remapObj: objectInTheStack) < (memory remapObj: objectInSpecialVariable)
 ]
 
-{ #category : #'tests-3-scavenge-basic' }
+{ #category : 'tests-3-scavenge-basic' }
 VMSpurScavengerTest >> testScavengeShouldCopySurvivorObjectToPastSpace [	
 	"Nil should survive.
 	It is referenced by the roots because many of their slots are nilled."
@@ -647,7 +649,7 @@ VMSpurScavengerTest >> testScavengeShouldCopySurvivorObjectToPastSpace [
 	self assertPastSpaceIsEmpty
 ]
 
-{ #category : #'tests-3-scavenge-basic' }
+{ #category : 'tests-3-scavenge-basic' }
 VMSpurScavengerTest >> testScavengeSurvivorShouldEmptyEden [
 
 	memory doScavenge: 1 "TenureByAge".
@@ -655,7 +657,7 @@ VMSpurScavengerTest >> testScavengeSurvivorShouldEmptyEden [
 	self assert: memory freeStart equals: memory scavenger eden start
 ]
 
-{ #category : #'tests-3-scavenge-basic' }
+{ #category : 'tests-3-scavenge-basic' }
 VMSpurScavengerTest >> testScavengeTwiceShouldExchangePastAndFutureSpacesBackAndForth [
 
 	| oldPastSpaceStart oldFutureSpaceStart |	
@@ -668,7 +670,7 @@ VMSpurScavengerTest >> testScavengeTwiceShouldExchangePastAndFutureSpacesBackAnd
 	self assert: memory scavenger futureSpace start equals: oldFutureSpaceStart.
 ]
 
-{ #category : #'tests-7-scavenge-order' }
+{ #category : 'tests-7-scavenge-order' }
 VMSpurScavengerTest >> testScavengedObjectsShouldBeCopiedInInstanceVariableOrder [
 
 	| rootObjectAddress objectThatShouldGoSecond objectThatShouldGoFirst |
@@ -686,7 +688,7 @@ VMSpurScavengerTest >> testScavengedObjectsShouldBeCopiedInInstanceVariableOrder
 	self assert: (memory remapObj: objectThatShouldGoFirst) < (memory remapObj: objectThatShouldGoSecond)
 ]
 
-{ #category : #'tests-7-scavenge-order' }
+{ #category : 'tests-7-scavenge-order' }
 VMSpurScavengerTest >> testScavengedRootObjectsShouldBeCopiedBeforeOtherObjects [
 
 	| firstRootObjectAddress nonRootObjectAddress secondRootObjectAddress |
@@ -704,7 +706,7 @@ VMSpurScavengerTest >> testScavengedRootObjectsShouldBeCopiedBeforeOtherObjects 
 	self assert: (memory remapObj: secondRootObjectAddress) < (memory remapObj: nonRootObjectAddress)
 ]
 
-{ #category : #'tests-8-scavenge-tenuring' }
+{ #category : 'tests-8-scavenge-tenuring' }
 VMSpurScavengerTest >> testShouldTenureBasedOnTheThreshold [
 
 	| firstObjectAddress secondObjectAddress |
@@ -736,7 +738,7 @@ VMSpurScavengerTest >> testShouldTenureBasedOnTheThreshold [
 
 ]
 
-{ #category : #'tests-8-scavenge-tenuring' }
+{ #category : 'tests-8-scavenge-tenuring' }
 VMSpurScavengerTest >> testShouldTenureObjectsWhenPastSpaceIsFull [
 
 	| rootObjectAddress newRootObjectAddress |
@@ -760,7 +762,7 @@ VMSpurScavengerTest >> testShouldTenureObjectsWhenPastSpaceIsFull [
 	self assert: (memory isInOldSpace: newRootObjectAddress)
 ]
 
-{ #category : #'tests-3-scavenge-basic' }
+{ #category : 'tests-3-scavenge-basic' }
 VMSpurScavengerTest >> testUnreferencedObjectCycleShouldNotSurviveScavenge [
 	| objectA objectB |
 	objectA := self newObjectWithSlots: 1.
@@ -779,7 +781,7 @@ VMSpurScavengerTest >> testUnreferencedObjectCycleShouldNotSurviveScavenge [
 	self assertPastSpaceIsEmpty
 ]
 
-{ #category : #'tests-3-scavenge-basic' }
+{ #category : 'tests-3-scavenge-basic' }
 VMSpurScavengerTest >> testUnreferencedObjectGraphShouldNotSurviveScavenge [
 	| unreferencedRootObjectAddress referencedObjectAddress |
 	unreferencedRootObjectAddress := self newObjectWithSlots: 1.
@@ -794,7 +796,7 @@ VMSpurScavengerTest >> testUnreferencedObjectGraphShouldNotSurviveScavenge [
 	self assertPastSpaceIsEmpty
 ]
 
-{ #category : #'tests-6-scavenge-rememberedset' }
+{ #category : 'tests-6-scavenge-rememberedset' }
 VMSpurScavengerTest >> testYoungObjectRememberedFromOldObjectShouldSurviveScanvenge [
 
 	| oldObjectAddress rememberedObjectAddress rememberedObjectHash newRememberedObjectAddress |
@@ -812,7 +814,7 @@ VMSpurScavengerTest >> testYoungObjectRememberedFromOldObjectShouldSurviveScanve
 	self assert: (memory hashBitsOf: newRememberedObjectAddress) equals: rememberedObjectHash
 ]
 
-{ #category : #'tests-6-scavenge-rememberedset' }
+{ #category : 'tests-6-scavenge-rememberedset' }
 VMSpurScavengerTest >> testYoungObjectRememberedFromPermanentObjectShouldSurviveScanvenge [
 
 	| permObjectAddress rememberedObjectAddress rememberedObjectHash newRememberedObjectAddress |
@@ -830,7 +832,7 @@ VMSpurScavengerTest >> testYoungObjectRememberedFromPermanentObjectShouldSurvive
 	self assert: (memory hashBitsOf: newRememberedObjectAddress) equals: rememberedObjectHash
 ]
 
-{ #category : #'tests-3-scavenge-basic' }
+{ #category : 'tests-3-scavenge-basic' }
 VMSpurScavengerTest >> testYoungObjectsFromPermanentSpaceAreRemapped [
 
 	| newObjectOop newObjectHash permObject newObjectAddress |

--- a/smalltalksrc/VMMakerTests/VMSpurTreeAllocationStrategyForLargeTreeTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurTreeAllocationStrategyForLargeTreeTest.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #VMSpurTreeAllocationStrategyForLargeTreeTest,
-	#superclass : #VMSpurTreeAllocationStrategyForSmallTreeTest,
-	#category : #'VMMakerTests-MemoryTests'
+	#name : 'VMSpurTreeAllocationStrategyForLargeTreeTest',
+	#superclass : 'VMSpurTreeAllocationStrategyForSmallTreeTest',
+	#category : 'VMMakerTests-MemoryTests',
+	#package : 'VMMakerTests',
+	#tag : 'MemoryTests'
 }
 
-{ #category : #'tests-10-bestfit-liliputian-leftovers' }
+{ #category : 'tests-10-bestfit-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForLargeTreeTest class >> shouldInheritSelectors [
 
 	^ true
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMSpurTreeAllocationStrategyForLargeTreeTest >> setUpTree [
 
 	"          1120
@@ -52,7 +54,7 @@ VMSpurTreeAllocationStrategyForLargeTreeTest >> setUpTree [
 	self assert: (memory bytesInObject: (self largerNodeOf: parent)) equals: (sizesInBreadthFirstOrder at: childNumber * 2 + 1).
 ]
 
-{ #category : #'tests-10-bestfit-liliputian-leftovers' }
+{ #category : 'tests-10-bestfit-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForLargeTreeTest >> test01AllocateBestFitTreeRootWithChildrenShouldReplaceNodeWithSmaller [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 1) - 16.
@@ -60,7 +62,7 @@ VMSpurTreeAllocationStrategyForLargeTreeTest >> test01AllocateBestFitTreeRootWit
 	self assert: (memory bytesInObject: self freeTreeRootOop) equals: (self sizeOfChildInBreadthFirstOrder: 2)
 ]
 
-{ #category : #'tests-10-bestfit-liliputian-leftovers' }
+{ #category : 'tests-10-bestfit-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForLargeTreeTest >> test02AllocateBestFitTreeRootWithChildrenShouldReInsertSmallerLargerChildFromRoot [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 1) - 16.
@@ -68,7 +70,7 @@ VMSpurTreeAllocationStrategyForLargeTreeTest >> test02AllocateBestFitTreeRootWit
 	self assert: (memory bytesInObject: (self largerNodeOf: self freeTreeRootOop)) equals: (self sizeOfChildInBreadthFirstOrder: 5)
 ]
 
-{ #category : #'tests-10-bestfit-liliputian-leftovers' }
+{ #category : 'tests-10-bestfit-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForLargeTreeTest >> test03AllocateBestFitTreeRootWithChildrenShouldReplaceSmallerChildWithSmallerSmaller [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 1) - 16.
@@ -76,7 +78,7 @@ VMSpurTreeAllocationStrategyForLargeTreeTest >> test03AllocateBestFitTreeRootWit
 	self assert: (memory bytesInObject: (self smallerNodeOf: self freeTreeRootOop)) equals: (self sizeOfChildInBreadthFirstOrder: 4)
 ]
 
-{ #category : #'tests-10-bestfit-liliputian-leftovers' }
+{ #category : 'tests-10-bestfit-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForLargeTreeTest >> test04AllocateBestFitTreeRootWithChildrenShouldInsertLiliputianInFreeList [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 1) - 16.
@@ -84,7 +86,7 @@ VMSpurTreeAllocationStrategyForLargeTreeTest >> test04AllocateBestFitTreeRootWit
 	self denyFreeListEmpty: (self freeListForSize: 16)
 ]
 
-{ #category : #'tests-10-bestfit-liliputian-leftovers' }
+{ #category : 'tests-10-bestfit-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForLargeTreeTest >> test05AllocateBestFitSmallerTreeNodeShouldReplaceNodeWithSmaller [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 2) - 16.
@@ -92,7 +94,7 @@ VMSpurTreeAllocationStrategyForLargeTreeTest >> test05AllocateBestFitSmallerTree
 	self assert: (memory bytesInObject: (self smallerNodeOf: self freeTreeRootOop)) equals: (self sizeOfChildInBreadthFirstOrder: 4)
 ]
 
-{ #category : #'tests-10-bestfit-liliputian-leftovers' }
+{ #category : 'tests-10-bestfit-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForLargeTreeTest >> test06AllocateBestFitSmallerTreeNodeShouldReuseNodeAddress [
 
 	| desiredAddress allocatedAddress |
@@ -102,7 +104,7 @@ VMSpurTreeAllocationStrategyForLargeTreeTest >> test06AllocateBestFitSmallerTree
 	self assert: allocatedAddress equals: desiredAddress
 ]
 
-{ #category : #'tests-10-bestfit-liliputian-leftovers' }
+{ #category : 'tests-10-bestfit-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForLargeTreeTest >> test07AllocateBestFitSmallerTreeNodeShouldInsertLiliputianInFreeList [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 2) - 16.
@@ -110,7 +112,7 @@ VMSpurTreeAllocationStrategyForLargeTreeTest >> test07AllocateBestFitSmallerTree
 	self denyFreeListEmpty: (self freeListForSize: 16)
 ]
 
-{ #category : #'tests-10-bestfit-liliputian-leftovers' }
+{ #category : 'tests-10-bestfit-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForLargeTreeTest >> test15AllocateBestFitBiggerTreeNodeShouldReplaceNodeWithSmaller [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 3) - 16.
@@ -118,7 +120,7 @@ VMSpurTreeAllocationStrategyForLargeTreeTest >> test15AllocateBestFitBiggerTreeN
 	self assert: (memory bytesInObject: (self largerNodeOf: self freeTreeRootOop)) equals: (self sizeOfChildInBreadthFirstOrder: 6)
 ]
 
-{ #category : #'tests-10-bestfit-liliputian-leftovers' }
+{ #category : 'tests-10-bestfit-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForLargeTreeTest >> test16AllocateBestFitBiggerTreeNodeShouldReuseNodeAddress [
 
 	| desiredAddress allocatedAddress |
@@ -128,7 +130,7 @@ VMSpurTreeAllocationStrategyForLargeTreeTest >> test16AllocateBestFitBiggerTreeN
 	self assert: allocatedAddress equals: desiredAddress
 ]
 
-{ #category : #'tests-10-bestfit-liliputian-leftovers' }
+{ #category : 'tests-10-bestfit-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForLargeTreeTest >> test17AllocateBestFitLargerTreeNodeShouldInsertLiliputianInFreeList [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 3) - 16.
@@ -136,7 +138,7 @@ VMSpurTreeAllocationStrategyForLargeTreeTest >> test17AllocateBestFitLargerTreeN
 	self denyFreeListEmpty: (self freeListForSize: 16)
 ]
 
-{ #category : #'tests-10-bestfit-liliputian-leftovers' }
+{ #category : 'tests-10-bestfit-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForLargeTreeTest >> test20AllocateBestFitSmallerOfSmallerLeafTreeNodeShouldRemoveNode [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 4) - 16.
@@ -144,7 +146,7 @@ VMSpurTreeAllocationStrategyForLargeTreeTest >> test20AllocateBestFitSmallerOfSm
 	self assert: (self smallerNodeOf: (self smallerNodeOf: self freeTreeRootOop)) equals: 0
 ]
 
-{ #category : #'tests-10-bestfit-liliputian-leftovers' }
+{ #category : 'tests-10-bestfit-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForLargeTreeTest >> test21AllocateBestFitSmallerOfSmallerLeafTreeNodeShouldReuseNodeAddress [
 
 	| desiredAddress allocatedAddress |
@@ -154,7 +156,7 @@ VMSpurTreeAllocationStrategyForLargeTreeTest >> test21AllocateBestFitSmallerOfSm
 	self assert: allocatedAddress equals: desiredAddress
 ]
 
-{ #category : #'tests-10-bestfit-liliputian-leftovers' }
+{ #category : 'tests-10-bestfit-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForLargeTreeTest >> test22AllocateBestFitSmallerOfSmallerLeafTreeNodeShouldInsertLiliputianInFreeList [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 4) - 16.
@@ -162,7 +164,7 @@ VMSpurTreeAllocationStrategyForLargeTreeTest >> test22AllocateBestFitSmallerOfSm
 	self denyFreeListEmpty: (self freeListForSize: 16)
 ]
 
-{ #category : #'tests-10-bestfit-liliputian-leftovers' }
+{ #category : 'tests-10-bestfit-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForLargeTreeTest >> test25AllocateBestFitLargerOfSmallerLeafTreeNodeShouldRemoveNode [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 5) - 16.
@@ -170,7 +172,7 @@ VMSpurTreeAllocationStrategyForLargeTreeTest >> test25AllocateBestFitLargerOfSma
 	self assert: (self largerNodeOf: (self smallerNodeOf: self freeTreeRootOop)) equals: 0
 ]
 
-{ #category : #'tests-10-bestfit-liliputian-leftovers' }
+{ #category : 'tests-10-bestfit-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForLargeTreeTest >> test26AllocateBestFitLargerOfSmallerLeafTreeNodeShouldReuseNodeAddress [
 
 	| desiredAddress allocatedAddress |
@@ -179,7 +181,7 @@ VMSpurTreeAllocationStrategyForLargeTreeTest >> test26AllocateBestFitLargerOfSma
 	self assert: allocatedAddress equals: desiredAddress
 ]
 
-{ #category : #'tests-10-bestfit-liliputian-leftovers' }
+{ #category : 'tests-10-bestfit-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForLargeTreeTest >> test27AllocateBestFitLargerOfSmallerLeafTreeNodeShouldShouldInsertLiliputianInFreeList [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 5) - 16.
@@ -187,7 +189,7 @@ VMSpurTreeAllocationStrategyForLargeTreeTest >> test27AllocateBestFitLargerOfSma
 	self denyFreeListEmpty: (self freeListForSize: 16)
 ]
 
-{ #category : #'tests-10-bestfit-liliputian-leftovers' }
+{ #category : 'tests-10-bestfit-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForLargeTreeTest >> test30AllocateBestFitSmallerOfLargerLeafTreeNodeShouldRemoveNode [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 6) - 16.
@@ -195,7 +197,7 @@ VMSpurTreeAllocationStrategyForLargeTreeTest >> test30AllocateBestFitSmallerOfLa
 	self assert: (self smallerNodeOf: (self largerNodeOf: self freeTreeRootOop)) equals: 0
 ]
 
-{ #category : #'tests-10-bestfit-liliputian-leftovers' }
+{ #category : 'tests-10-bestfit-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForLargeTreeTest >> test31AllocateBestFitSmallerOfLargerLeafTreeNodeShouldReuseNodeAddress [
 
 	| desiredAddress allocatedAddress |
@@ -205,7 +207,7 @@ VMSpurTreeAllocationStrategyForLargeTreeTest >> test31AllocateBestFitSmallerOfLa
 	self assert: allocatedAddress equals: desiredAddress
 ]
 
-{ #category : #'tests-10-bestfit-liliputian-leftovers' }
+{ #category : 'tests-10-bestfit-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForLargeTreeTest >> test32AllocateBestFitSmallerOfLargerLeafTreeNodeShouldInsertLiliputianInFreeList [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 6) - 16.
@@ -213,7 +215,7 @@ VMSpurTreeAllocationStrategyForLargeTreeTest >> test32AllocateBestFitSmallerOfLa
 	self denyFreeListEmpty: (self freeListForSize: 16)
 ]
 
-{ #category : #'tests-10-bestfit-liliputian-leftovers' }
+{ #category : 'tests-10-bestfit-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForLargeTreeTest >> test35AllocateBestFitLargerOfLargerLeafTreeNodeShouldRemoveChildNode [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 7) - 16.
@@ -221,7 +223,7 @@ VMSpurTreeAllocationStrategyForLargeTreeTest >> test35AllocateBestFitLargerOfLar
 	self assert: (self largerNodeOf: (self largerNodeOf: self freeTreeRootOop)) equals: 0
 ]
 
-{ #category : #'tests-10-bestfit-liliputian-leftovers' }
+{ #category : 'tests-10-bestfit-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForLargeTreeTest >> test36AllocateBestFitLargerOfLargerLeafTreeNodeShouldReuseNodeAddress [
 
 	| desiredAddress allocatedAddress |
@@ -231,7 +233,7 @@ VMSpurTreeAllocationStrategyForLargeTreeTest >> test36AllocateBestFitLargerOfLar
 	self assert: allocatedAddress equals: desiredAddress
 ]
 
-{ #category : #'tests-10-bestfit-liliputian-leftovers' }
+{ #category : 'tests-10-bestfit-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForLargeTreeTest >> test37AllocateBestFitLargerOfLargerLeafTreeNodeShouldInsertLiliputianInFreeList [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 7) - 16.

--- a/smalltalksrc/VMMakerTests/VMSpurTreeAllocationStrategyForSmallTreeTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurTreeAllocationStrategyForSmallTreeTest.class.st
@@ -1,27 +1,29 @@
 Class {
-	#name : #VMSpurTreeAllocationStrategyForSmallTreeTest,
-	#superclass : #VMSpurInitializedOldSpaceTest,
+	#name : 'VMSpurTreeAllocationStrategyForSmallTreeTest',
+	#superclass : 'VMSpurInitializedOldSpaceTest',
 	#instVars : [
 		'sizesInBreadthFirstOrder',
 		'chunkAddresses'
 	],
-	#category : #'VMMakerTests-MemoryTests'
+	#category : 'VMMakerTests-MemoryTests',
+	#package : 'VMMakerTests',
+	#tag : 'MemoryTests'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> addressOfChunkOf: aSize [
 
 	^ chunkAddresses at: aSize
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> setUp [
 
 	super setUp.
 	self setUpTree.
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> setUpTree [
 
 	"          560
@@ -61,13 +63,13 @@ VMSpurTreeAllocationStrategyForSmallTreeTest >> setUpTree [
 	self assert: (memory bytesInObject: (self largerNodeOf: parent)) equals: (sizesInBreadthFirstOrder at: childNumber * 2 + 1).
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> sizeOfChildInBreadthFirstOrder: anInteger [ 
 
 	^ sizesInBreadthFirstOrder at: anInteger
 ]
 
-{ #category : #'tests-09-exact-fit' }
+{ #category : 'tests-09-exact-fit' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> test01AllocateExactTreeRootWithChildrenShouldReplaceNodeWithSmaller [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 1).
@@ -75,7 +77,7 @@ VMSpurTreeAllocationStrategyForSmallTreeTest >> test01AllocateExactTreeRootWithC
 	self assert: (memory bytesInObject: self freeTreeRootOop) equals: (self sizeOfChildInBreadthFirstOrder: 2)
 ]
 
-{ #category : #'tests-11-bestfit-smaller-than-liliputian-leftovers' }
+{ #category : 'tests-11-bestfit-smaller-than-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> test01AllocateSmallerThanLiliputianDiffFromTreeRootWithChildrenShouldUseLargerThanRoot [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 1) - 8.
@@ -84,7 +86,7 @@ VMSpurTreeAllocationStrategyForSmallTreeTest >> test01AllocateSmallerThanLiliput
 	self assert: (self smallerNodeOf: (self largerNodeOf: self freeTreeRootOop)) equals: 0
 ]
 
-{ #category : #'tests-09-exact-fit' }
+{ #category : 'tests-09-exact-fit' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> test02AllocateExactTreeRootWithChildrenShouldReInsertSmallerLargerChildFromRoot [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 1).
@@ -92,7 +94,7 @@ VMSpurTreeAllocationStrategyForSmallTreeTest >> test02AllocateExactTreeRootWithC
 	self assert: (memory bytesInObject: (self largerNodeOf: self freeTreeRootOop)) equals: (self sizeOfChildInBreadthFirstOrder: 5)
 ]
 
-{ #category : #'tests-11-bestfit-smaller-than-liliputian-leftovers' }
+{ #category : 'tests-11-bestfit-smaller-than-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> test02AllocateSmallerThanLiliputianDiffFromTreeRootWithChildrenShouldInsertLeftOverInFreeList [
 
 	| allocatedSize |
@@ -103,7 +105,7 @@ VMSpurTreeAllocationStrategyForSmallTreeTest >> test02AllocateSmallerThanLiliput
 	self denyFreeListEmpty: (self freeListForSize: 1152 - allocatedSize).
 ]
 
-{ #category : #'tests-09-exact-fit' }
+{ #category : 'tests-09-exact-fit' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> test03AllocateExactTreeRootWithChildrenShouldReplaceSmallerChildWithSmallerSmaller [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 1).
@@ -111,7 +113,7 @@ VMSpurTreeAllocationStrategyForSmallTreeTest >> test03AllocateExactTreeRootWithC
 	self assert: (memory bytesInObject: (self smallerNodeOf: self freeTreeRootOop)) equals: (self sizeOfChildInBreadthFirstOrder: 4)
 ]
 
-{ #category : #'tests-11-bestfit-smaller-than-liliputian-leftovers' }
+{ #category : 'tests-11-bestfit-smaller-than-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> test03AllocateSmallerThanLiliputianDiffFromTreeRootWithChildrenShouldUseLargerThanRootAddress [
 
 	| desiredAddress allocatedAddress |
@@ -121,7 +123,7 @@ VMSpurTreeAllocationStrategyForSmallTreeTest >> test03AllocateSmallerThanLiliput
 	self assert: allocatedAddress equals: desiredAddress
 ]
 
-{ #category : #'tests-09-exact-fit' }
+{ #category : 'tests-09-exact-fit' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> test04AllocateExactSmallerTreeNodeShouldReplaceNodeWithSmaller [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 2).
@@ -129,7 +131,7 @@ VMSpurTreeAllocationStrategyForSmallTreeTest >> test04AllocateExactSmallerTreeNo
 	self assert: (memory bytesInObject: (self smallerNodeOf: self freeTreeRootOop)) equals: (self sizeOfChildInBreadthFirstOrder: 4)
 ]
 
-{ #category : #'tests-11-bestfit-smaller-than-liliputian-leftovers' }
+{ #category : 'tests-11-bestfit-smaller-than-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> test04AllocateSmallerThanLiliputianDiffFromSmallerWithChildrenShouldUseLargestSmallerThanRoot [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 2) - 8.
@@ -138,7 +140,7 @@ VMSpurTreeAllocationStrategyForSmallTreeTest >> test04AllocateSmallerThanLiliput
 	self assert: (self largerNodeOf: (self smallerNodeOf: self freeTreeRootOop)) equals: 0
 ]
 
-{ #category : #'tests-09-exact-fit' }
+{ #category : 'tests-09-exact-fit' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> test05AllocateExactSmallerTreeNodeShouldReuseNodeAddress [
 
 	| desiredAddress allocatedAddress |
@@ -148,7 +150,7 @@ VMSpurTreeAllocationStrategyForSmallTreeTest >> test05AllocateExactSmallerTreeNo
 	self assert: allocatedAddress equals: desiredAddress
 ]
 
-{ #category : #'tests-11-bestfit-smaller-than-liliputian-leftovers' }
+{ #category : 'tests-11-bestfit-smaller-than-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> test05AllocateSmallerThanLiliputianDiffFromSmallerWithChildrenShouldInsertLeftOverInFreeList [
 
 	| allocatedSize |
@@ -159,7 +161,7 @@ VMSpurTreeAllocationStrategyForSmallTreeTest >> test05AllocateSmallerThanLiliput
 	self denyFreeListEmpty: (self freeListForSize: 1088 - allocatedSize)
 ]
 
-{ #category : #'tests-09-exact-fit' }
+{ #category : 'tests-09-exact-fit' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> test06AllocateExactBiggerTreeNodeShouldReplaceNodeWithSmaller [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 3).
@@ -167,7 +169,7 @@ VMSpurTreeAllocationStrategyForSmallTreeTest >> test06AllocateExactBiggerTreeNod
 	self assert: (memory bytesInObject: (self largerNodeOf: self freeTreeRootOop)) equals: (self sizeOfChildInBreadthFirstOrder: 6)
 ]
 
-{ #category : #'tests-11-bestfit-smaller-than-liliputian-leftovers' }
+{ #category : 'tests-11-bestfit-smaller-than-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> test06AllocateSmallerThanLiliputianDiffFromSmallerWithChildrenShouldUseSmallerThanRootAddress [
 
 	| desiredAddress allocatedAddress |
@@ -177,7 +179,7 @@ VMSpurTreeAllocationStrategyForSmallTreeTest >> test06AllocateSmallerThanLiliput
 	self assert: allocatedAddress equals: desiredAddress
 ]
 
-{ #category : #'tests-09-exact-fit' }
+{ #category : 'tests-09-exact-fit' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> test07AllocateExactBiggerTreeNodeShouldReuseNodeAddress [
 
 	| desiredAddress allocatedAddress |
@@ -187,7 +189,7 @@ VMSpurTreeAllocationStrategyForSmallTreeTest >> test07AllocateExactBiggerTreeNod
 	self assert: allocatedAddress equals: desiredAddress
 ]
 
-{ #category : #'tests-11-bestfit-smaller-than-liliputian-leftovers' }
+{ #category : 'tests-11-bestfit-smaller-than-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> test07AllocateSmallerThanLiliputianDiffFromSmallerLeafShouldUseIntermediateNode [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 4) - 8.
@@ -197,7 +199,7 @@ VMSpurTreeAllocationStrategyForSmallTreeTest >> test07AllocateSmallerThanLiliput
 	self assert: (memory bytesInObject: (self largerNodeOf: (self smallerNodeOf: self freeTreeRootOop))) equals: (self sizeOfChildInBreadthFirstOrder: 5)
 ]
 
-{ #category : #'tests-09-exact-fit' }
+{ #category : 'tests-09-exact-fit' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> test08AllocateExactSmallerOfSmallerLeafTreeNodeShouldRemoveNode [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 4).
@@ -205,7 +207,7 @@ VMSpurTreeAllocationStrategyForSmallTreeTest >> test08AllocateExactSmallerOfSmal
 	self assert: (self smallerNodeOf: (self smallerNodeOf: self freeTreeRootOop)) equals: 0
 ]
 
-{ #category : #'tests-11-bestfit-smaller-than-liliputian-leftovers' }
+{ #category : 'tests-11-bestfit-smaller-than-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> test08AllocateSmallerThanLiliputianDiffFromSmallerLeafShouldInsertLeftOverInFreeList [
 	| allocatedSize |
 	allocatedSize :=  (self sizeOfChildInBreadthFirstOrder: 4) - 8.
@@ -215,7 +217,7 @@ VMSpurTreeAllocationStrategyForSmallTreeTest >> test08AllocateSmallerThanLiliput
 	self denyFreeListEmpty: (self freeListForSize: 1056 - allocatedSize).
 ]
 
-{ #category : #'tests-09-exact-fit' }
+{ #category : 'tests-09-exact-fit' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> test09AllocateExactSmallerOfSmallerLeafTreeNodeShouldReuseNodeAddress [
 
 	| desiredAddress allocatedAddress |
@@ -225,7 +227,7 @@ VMSpurTreeAllocationStrategyForSmallTreeTest >> test09AllocateExactSmallerOfSmal
 	self assert: allocatedAddress equals: desiredAddress
 ]
 
-{ #category : #'tests-11-bestfit-smaller-than-liliputian-leftovers' }
+{ #category : 'tests-11-bestfit-smaller-than-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> test09AllocateSecondSmallerThanLiliputianDiffFromSmallerLeafShouldUseRootNode [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 5) - 8.
@@ -235,7 +237,7 @@ VMSpurTreeAllocationStrategyForSmallTreeTest >> test09AllocateSecondSmallerThanL
 	self assert: (memory bytesInObject: (self largerNodeOf: (self largerNodeOf: self freeTreeRootOop))) equals: (self sizeOfChildInBreadthFirstOrder: 3)
 ]
 
-{ #category : #'tests-09-exact-fit' }
+{ #category : 'tests-09-exact-fit' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> test10AllocateExactLargerOfSmallerLeafTreeNodeShouldRemoveNode [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 5).
@@ -243,7 +245,7 @@ VMSpurTreeAllocationStrategyForSmallTreeTest >> test10AllocateExactLargerOfSmall
 	self assert: (self largerNodeOf: (self smallerNodeOf: self freeTreeRootOop)) equals: 0
 ]
 
-{ #category : #'tests-11-bestfit-smaller-than-liliputian-leftovers' }
+{ #category : 'tests-11-bestfit-smaller-than-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> test10AllocateSecondSmallerThanLiliputianDiffFromSmallerLeafShouldInsertLeftOverInFreeList [
 
 	| allocatedSize |
@@ -254,7 +256,7 @@ VMSpurTreeAllocationStrategyForSmallTreeTest >> test10AllocateSecondSmallerThanL
 	self denyFreeListEmpty: (self freeListForSize: 1120 - allocatedSize).
 ]
 
-{ #category : #'tests-09-exact-fit' }
+{ #category : 'tests-09-exact-fit' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> test11AllocateExactLargerOfSmallerLeafTreeNodeShouldReuseNodeAddress [
 
 	| desiredAddress allocatedAddress |
@@ -263,7 +265,7 @@ VMSpurTreeAllocationStrategyForSmallTreeTest >> test11AllocateExactLargerOfSmall
 	self assert: allocatedAddress equals: desiredAddress
 ]
 
-{ #category : #'tests-11-bestfit-smaller-than-liliputian-leftovers' }
+{ #category : 'tests-11-bestfit-smaller-than-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> test11AllocateSmallerThanLiliputianDiffFromLargerWithChildrenShouldUseLargestLeafNode [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 3) - 8.
@@ -272,7 +274,7 @@ VMSpurTreeAllocationStrategyForSmallTreeTest >> test11AllocateSmallerThanLiliput
 	self assert: (self largerNodeOf: (self largerNodeOf: self freeTreeRootOop)) equals: 0
 ]
 
-{ #category : #'tests-09-exact-fit' }
+{ #category : 'tests-09-exact-fit' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> test12AllocateExactSmallerOfLargerLeafTreeNodeShouldRemoveNode [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 6).
@@ -280,7 +282,7 @@ VMSpurTreeAllocationStrategyForSmallTreeTest >> test12AllocateExactSmallerOfLarg
 	self assert: (self smallerNodeOf: (self largerNodeOf: self freeTreeRootOop)) equals: 0
 ]
 
-{ #category : #'tests-11-bestfit-smaller-than-liliputian-leftovers' }
+{ #category : 'tests-11-bestfit-smaller-than-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> test12AllocateSmallerThanLiliputianDiffFromLargerWithChildrenShouldInsertLeftOverInFreeList [
 
 	| allocatedSize |
@@ -292,7 +294,7 @@ VMSpurTreeAllocationStrategyForSmallTreeTest >> test12AllocateSmallerThanLiliput
 	self denyFreeListEmpty: (self freeListForSize: 1216 - allocatedSize).
 ]
 
-{ #category : #'tests-09-exact-fit' }
+{ #category : 'tests-09-exact-fit' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> test13AllocateExactSmallerOfLargerLeafTreeNodeShouldReuseNodeAddress [
 
 	| desiredAddress allocatedAddress |
@@ -302,7 +304,7 @@ VMSpurTreeAllocationStrategyForSmallTreeTest >> test13AllocateExactSmallerOfLarg
 	self assert: allocatedAddress equals: desiredAddress
 ]
 
-{ #category : #'tests-11-bestfit-smaller-than-liliputian-leftovers' }
+{ #category : 'tests-11-bestfit-smaller-than-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> test13AllocateSmallerThanLiliputianDiffFromSmallerLeafInLargerSideShouldUseIntermediateLargerNode [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 6) - 8.
@@ -311,7 +313,7 @@ VMSpurTreeAllocationStrategyForSmallTreeTest >> test13AllocateSmallerThanLiliput
 	self assert: (memory bytesInObject: (self largerNodeOf: self freeTreeRootOop)) equals: (self sizeOfChildInBreadthFirstOrder: 6)
 ]
 
-{ #category : #'tests-09-exact-fit' }
+{ #category : 'tests-09-exact-fit' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> test14AllocateExactLargerOfLargerLeafTreeNodeShouldRemoveChildNode [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 7).
@@ -319,7 +321,7 @@ VMSpurTreeAllocationStrategyForSmallTreeTest >> test14AllocateExactLargerOfLarge
 	self assert: (self largerNodeOf: (self largerNodeOf: self freeTreeRootOop)) equals: 0
 ]
 
-{ #category : #'tests-11-bestfit-smaller-than-liliputian-leftovers' }
+{ #category : 'tests-11-bestfit-smaller-than-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> test14AllocateSmallerThanLiliputianDiffFromSmallerLeafInLargerSideShouldInsertLeftOverInFreeList [
 
 	| allocatedSize |
@@ -331,7 +333,7 @@ VMSpurTreeAllocationStrategyForSmallTreeTest >> test14AllocateSmallerThanLiliput
 	self denyFreeListEmpty: (self freeListForSize: 1184 - allocatedSize).
 ]
 
-{ #category : #'tests-09-exact-fit' }
+{ #category : 'tests-09-exact-fit' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> test15AllocateExactLargerOfLargerLeafTreeNodeShouldReuseNodeAddress [
 
 	| desiredAddress allocatedAddress |
@@ -341,7 +343,7 @@ VMSpurTreeAllocationStrategyForSmallTreeTest >> test15AllocateExactLargerOfLarge
 	self assert: allocatedAddress equals: desiredAddress
 ]
 
-{ #category : #'tests-11-bestfit-smaller-than-liliputian-leftovers' }
+{ #category : 'tests-11-bestfit-smaller-than-liliputian-leftovers' }
 VMSpurTreeAllocationStrategyForSmallTreeTest >> test15AllocateSmallerThanLiliputianDiffFromLargestLeaShouldFindNoMemory [
 
 	self assert: (memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 7) - 8) equals: nil

--- a/smalltalksrc/VMMakerTests/VMSpurTreeAllocationWithBigNodesTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurTreeAllocationWithBigNodesTest.class.st
@@ -1,20 +1,22 @@
 Class {
-	#name : #VMSpurTreeAllocationWithBigNodesTest,
-	#superclass : #VMSpurInitializedOldSpaceTest,
+	#name : 'VMSpurTreeAllocationWithBigNodesTest',
+	#superclass : 'VMSpurInitializedOldSpaceTest',
 	#instVars : [
 		'sizesInBreadthFirstOrder',
 		'chunkAddresses'
 	],
-	#category : #'VMMakerTests-MemoryTests'
+	#category : 'VMMakerTests-MemoryTests',
+	#package : 'VMMakerTests',
+	#tag : 'MemoryTests'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSpurTreeAllocationWithBigNodesTest >> addressOfChunkOf: aSize [
 
 	^ chunkAddresses at: aSize
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMSpurTreeAllocationWithBigNodesTest >> setUp [
 
 	" Allocate a tree that has a large child large enough so a remainder could still be larger than the root
@@ -45,13 +47,13 @@ VMSpurTreeAllocationWithBigNodesTest >> setUp [
 	self assert: (memory bytesInObject: (self largerNodeOf: parent)) equals: (sizesInBreadthFirstOrder at: childNumber * 2 + 1).
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMSpurTreeAllocationWithBigNodesTest >> sizeOfChildInBreadthFirstOrder: anInteger [ 
 
 	^ sizesInBreadthFirstOrder at: anInteger
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurTreeAllocationWithBigNodesTest >> test01LargeLeftoverSmallerThanRootShouldBeInsertedInSmaller [
 
 	memory allocateOldSpaceChunkOfBytes: 16.
@@ -60,7 +62,7 @@ VMSpurTreeAllocationWithBigNodesTest >> test01LargeLeftoverSmallerThanRootShould
 	self assert: (memory bytesInObject: (self smallerNodeOf: self freeTreeRootOop)) equals: 1008
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurTreeAllocationWithBigNodesTest >> test02LargeLeftoverSmallerThanLargerShouldBeInsertedInLarger [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 1) + 16.
@@ -69,7 +71,7 @@ VMSpurTreeAllocationWithBigNodesTest >> test02LargeLeftoverSmallerThanLargerShou
 	self assert: (memory bytesInObject: (self largerNodeOf: self freeTreeRootOop)) equals: 4080
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMSpurTreeAllocationWithBigNodesTest >> test03LargeLeftoverSmallerThanRootShouldBeInsertedInSmaller [
 
 	memory allocateOldSpaceChunkOfBytes: (self sizeOfChildInBreadthFirstOrder: 1) * 2 + 16.

--- a/smalltalksrc/VMMakerTests/VMStackBuilder.class.st
+++ b/smalltalksrc/VMMakerTests/VMStackBuilder.class.st
@@ -27,23 +27,25 @@ Types are not the exact types used.
 
 "
 Class {
-	#name : #VMStackBuilder,
-	#superclass : #VMAbstractBuilder,
+	#name : 'VMStackBuilder',
+	#superclass : 'VMAbstractBuilder',
 	#instVars : [
 		'page',
 		'frames',
 		'args',
 		'methodBuilder'
 	],
-	#category : #'VMMakerTests-Builders'
+	#category : 'VMMakerTests-Builders',
+	#package : 'VMMakerTests',
+	#tag : 'Builders'
 }
 
-{ #category : #frames }
+{ #category : 'frames' }
 VMStackBuilder >> addFrame: aFrame [
 	frames add: aFrame
 ]
 
-{ #category : #frames }
+{ #category : 'frames' }
 VMStackBuilder >> addNewFrame [
 	| frame |
 	"'add' a new frame in the sense of an OrderedCollection, which will be iterated with #do:
@@ -53,17 +55,17 @@ VMStackBuilder >> addNewFrame [
 	^ frame "the frame is then configured by the caller"
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackBuilder >> args [
 	^ args
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackBuilder >> args: anObject [
 	args := anObject
 ]
 
-{ #category : #build }
+{ #category : 'build' }
 VMStackBuilder >> buildStack [
 	self createStackPage.
 	self preparePage.
@@ -72,7 +74,7 @@ VMStackBuilder >> buildStack [
 	^ frames last
 ]
 
-{ #category : #stack }
+{ #category : 'stack' }
 VMStackBuilder >> createStackPage [
 	| sp |
 	frames ifEmpty:[ self error ].
@@ -83,17 +85,17 @@ VMStackBuilder >> createStackPage [
 	interpreter stackPointer: sp.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackBuilder >> frames [
 	^ frames
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackBuilder >> frames: anObject [
 	frames := anObject
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 VMStackBuilder >> initialize [
 	super initialize.
 	frames := OrderedCollection new. "will be treated in reverse"
@@ -103,35 +105,35 @@ VMStackBuilder >> initialize [
 	page := nil.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackBuilder >> lastFrame [
 	
 	^ frames last
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackBuilder >> methodBuilder [
 
 	^ methodBuilder
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackBuilder >> methodBuilder: anObject [
 
 	methodBuilder := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackBuilder >> page [
 	^ page
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackBuilder >> page: anObject [
 	page := anObject
 ]
 
-{ #category : #build }
+{ #category : 'build' }
 VMStackBuilder >> preparePage [
 	"Page setup before the base frame"
 	interpreter push: memory nilObject.	"receiver"
@@ -142,7 +144,7 @@ VMStackBuilder >> preparePage [
 
 ]
 
-{ #category : #build }
+{ #category : 'build' }
 VMStackBuilder >> pushAllButFirstFrames [
 	2 to: frames size do: [ :anIndex | | aFrame |
 			aFrame := frames at: anIndex.
@@ -156,19 +158,19 @@ VMStackBuilder >> pushAllButFirstFrames [
 			]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 VMStackBuilder >> pushArgs [
 	args do: [ :anArg | interpreter push: anArg ]
 ]
 
-{ #category : #build }
+{ #category : 'build' }
 VMStackBuilder >> pushBaseFrame [
 	frames first previousFrameArgsSize: args size.
 	self pushFrame: frames first.
 
 ]
 
-{ #category : #build }
+{ #category : 'build' }
 VMStackBuilder >> pushFrame: aFrame [
 	
 	interpreter framePointer: interpreter stackPointer.
@@ -178,18 +180,18 @@ VMStackBuilder >> pushFrame: aFrame [
 	page headSP: interpreter stackPointer.
 ]
 
-{ #category : #build }
+{ #category : 'build' }
 VMStackBuilder >> pushFrames [
 	self pushBaseFrame.
 	self pushAllButFirstFrames.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMStackBuilder >> reset [
 	self initialize.
 ]
 
-{ #category : #build }
+{ #category : 'build' }
 VMStackBuilder >> setInterpreterVariables [
 	| lastFrame |
 	interpreter setStackPageAndLimit: page.
@@ -204,7 +206,7 @@ VMStackBuilder >> setInterpreterVariables [
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackBuilder >> topFrame [
 	^ frames last
 ]

--- a/smalltalksrc/VMMakerTests/VMStackFrame.class.st
+++ b/smalltalksrc/VMMakerTests/VMStackFrame.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #VMStackFrame,
-	#superclass : #Object,
+	#name : 'VMStackFrame',
+	#superclass : 'Object',
 	#instVars : [
 		'framePointer',
 		'interpreter'
@@ -8,10 +8,12 @@ Class {
 	#pools : [
 		'VMStackFrameOffsets'
 	],
-	#category : #'VMMakerTests-Visualisation'
+	#category : 'VMMakerTests-Visualisation',
+	#package : 'VMMakerTests',
+	#tag : 'Visualisation'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 VMStackFrame class >> newFramePointer: anInteger withInterpreter: aStackInterpreterSimulatorLSB [
 	^self new
 		framePointer: anInteger;
@@ -19,19 +21,19 @@ VMStackFrame class >> newFramePointer: anInteger withInterpreter: aStackInterpre
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 VMStackFrame class >> virtualMachine: aVirtualMachine fp: anInteger [
 	
 	^ self newFramePointer: anInteger withInterpreter: aVirtualMachine
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackFrame >> bytecodeMethod [
 	
 	^ VMBytecodeMethod newOnInterpreter: interpreter methodOop: self method
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackFrame >> caller [
 
 	| callerContext |
@@ -65,41 +67,41 @@ VMStackFrame >> caller [
 	^ VMContext newOnContext: callerContext withInterpreter: interpreter
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackFrame >> callerContext [
 	
 	^ interpreter frameCallerContext: framePointer
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackFrame >> callerFP [
 
 	^ interpreter frameCallerFP: framePointer
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackFrame >> context [
 	^VMContext newOnContext: (interpreter frameContext: framePointer) withInterpreter: interpreter 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackFrame >> description [
 	| selector |
 	selector := interpreter findSelectorOfMethod: self methodOop.
 	^ interpreter stringOf: selector
 ]
 
-{ #category : #accesing }
+{ #category : 'accesing' }
 VMStackFrame >> framePointer: anInteger [ 
 	framePointer := anInteger
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 VMStackFrame >> hasContext [
 	^interpreter frameHasContext: framePointer 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackFrame >> instructionPointer [
 
 	^ interpreter framePointer = framePointer
@@ -107,50 +109,50 @@ VMStackFrame >> instructionPointer [
 		ifFalse: [ interpreter frameCallerSavedIP: ( interpreter findFrameAbove: framePointer inPage: self stackPage) ]
 ]
 
-{ #category : #acccessing }
+{ #category : 'acccessing' }
 VMStackFrame >> interpreter: aStackInterpreterSimulatorLSB [ 
 	interpreter := aStackInterpreterSimulatorLSB
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 VMStackFrame >> isMachineCodeFrame [
 	
 	^ interpreter isMachineCodeFrame: framePointer
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackFrame >> machineCodeMethod [
 	| methodSurrogate |
 	methodSurrogate := interpreter cogMethodZone methodFor: self method.
 	^ VMMachineCodeMethod newOnInterpreter: interpreter cogMethodSurrogate: methodSurrogate
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackFrame >> method [
 
 	^ interpreter iframeMethod: framePointer
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackFrame >> methodOop [
 
 	^ interpreter frameMethodObject: framePointer
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackFrame >> receiver [
 	^ interpreter framePointer = framePointer
 		ifTrue: [ interpreter receiver ]
 		ifFalse: [ self halt. interpreter frameCallerSavedIP: ( interpreter findFrameAbove: framePointer inPage: self stackPage) ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackFrame >> sender [
 	^ VMStackFrame newFramePointer:(interpreter frameCallerFP: framePointer) withInterpreter: interpreter
 	 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackFrame >> sourceCode [
 	
 	^ self isMachineCodeFrame
@@ -158,7 +160,7 @@ VMStackFrame >> sourceCode [
 		ifFalse: [ self bytecodeMethod disassemble ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackFrame >> stack [
 	| stack currentFrame |
 	stack := OrderedCollection new.
@@ -169,7 +171,7 @@ VMStackFrame >> stack [
 	^ stack
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackFrame >> stackPage [
 	^interpreter stackPages stackPageFor: framePointer.
 ]

--- a/smalltalksrc/VMMakerTests/VMStackInterpreterTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMStackInterpreterTest.class.st
@@ -1,32 +1,34 @@
 Class {
-	#name : #VMStackInterpreterTest,
-	#superclass : #TestCase,
+	#name : 'VMStackInterpreterTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'stackInterpreterClass'
 	],
-	#category : #'VMMakerTests-StackInterpreter'
+	#category : 'VMMakerTests-StackInterpreter',
+	#package : 'VMMakerTests',
+	#tag : 'StackInterpreter'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 VMStackInterpreterTest >> setUp [
 
 	super setUp.
 	stackInterpreterClass := StackInterpreter.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackInterpreterTest >> stackInterpreterClass [
 
 	^ stackInterpreterClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackInterpreterTest >> stackInterpreterClass: anObject [
 
 	stackInterpreterClass := anObject
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMStackInterpreterTest >> testIsObjectAccessor [
 
 	self 
@@ -35,7 +37,7 @@ VMStackInterpreterTest >> testIsObjectAccessor [
 		assert: (self stackInterpreterClass isObjectAccessor: #fetchClassOf:)
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMStackInterpreterTest >> testIsStackAccessor [
 
 	self 

--- a/smalltalksrc/VMMakerTests/VMStackMappingTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMStackMappingTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #VMStackMappingTest,
-	#superclass : #VMSpurInitializedOldSpaceTest,
-	#category : #'VMMakerTests-MemoryTests'
+	#name : 'VMStackMappingTest',
+	#superclass : 'VMSpurInitializedOldSpaceTest',
+	#category : 'VMMakerTests-MemoryTests',
+	#package : 'VMMakerTests',
+	#tag : 'MemoryTests'
 }
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMStackMappingTest >> buildStackFromFrames [
 
 	3 timesRepeat: [ 
@@ -17,7 +19,7 @@ VMStackMappingTest >> buildStackFromFrames [
 	stackBuilder buildStack
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 VMStackMappingTest >> newContext [
 
 	| method |
@@ -30,13 +32,13 @@ VMStackMappingTest >> newContext [
 		  ip: 10
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMStackMappingTest >> testCreatingNewContextByHandShouldbeSingle [
 
 	self assert: (interpreter isSingleContext: self newContext)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMStackMappingTest >> testDivorceAMarriedContextShuoldMakeItSingle [
 	| context fp |
 	context := self newContext.
@@ -46,7 +48,7 @@ VMStackMappingTest >> testDivorceAMarriedContextShuoldMakeItSingle [
 	self assert: (interpreter isSingleContext: context)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMStackMappingTest >> testDivorceFramesInPage [
 	| page |
 	self buildStackFromFrames.
@@ -67,7 +69,7 @@ VMStackMappingTest >> testDivorceFramesInPage [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMStackMappingTest >> testMarryNewContextIsMarried [
 	| context |
 	context := self newContext.
@@ -75,7 +77,7 @@ VMStackMappingTest >> testMarryNewContextIsMarried [
 	self assert: (interpreter isStillMarriedContext: context)
 ]
 
-{ #category : #'test-context-tomove' }
+{ #category : 'test-context-tomove' }
 VMStackMappingTest >> testMarryThenDivorceBaseFrameShouldFreeOldPage [
 	| aContext framePointerToMarry stackPointerToMarry oldPage |
 	self buildStackFromFrames.
@@ -89,7 +91,7 @@ VMStackMappingTest >> testMarryThenDivorceBaseFrameShouldFreeOldPage [
 	self assert: oldPage isFree
 ]
 
-{ #category : #'test-context-tomove' }
+{ #category : 'test-context-tomove' }
 VMStackMappingTest >> testMarryThenDivorceBaseFrameShouldSetDivorcedContextAsSenderContextInNewPage [
 	| aContext framePointerToMarry stackPointerToMarry  expectedDivorcedContext |
 	self buildStackFromFrames.
@@ -103,7 +105,7 @@ VMStackMappingTest >> testMarryThenDivorceBaseFrameShouldSetDivorcedContextAsSen
 	self assert: expectedDivorcedContext equals: aContext.
 ]
 
-{ #category : #'test-context-tomove' }
+{ #category : 'test-context-tomove' }
 VMStackMappingTest >> testMarryThenDivorceBaseFrameShouldSplitPage [
 	| aContext framePointerToMarry stackPointerToMarry oldPage newPage |
 	self buildStackFromFrames.
@@ -117,7 +119,7 @@ VMStackMappingTest >> testMarryThenDivorceBaseFrameShouldSplitPage [
 	self deny: oldPage equals: newPage
 ]
 
-{ #category : #'test-context-tomove' }
+{ #category : 'test-context-tomove' }
 VMStackMappingTest >> testMarryThenDivorceMiddleFrame [
 	| aContext framePointerToMarry stackPointerToMarry |
 	self buildStackFromFrames.
@@ -129,7 +131,7 @@ VMStackMappingTest >> testMarryThenDivorceMiddleFrame [
 	self assert: (interpreter isSingleContext: aContext).
 ]
 
-{ #category : #'test-context-tomove' }
+{ #category : 'test-context-tomove' }
 VMStackMappingTest >> testMarryThenDivorceMiddleFrameShouldSetDivorcedContextAsSenderContextInNewPage [
 	| aContext framePointerToMarry stackPointerToMarry  expectedDivorcedContext oldBaseFramePointer callerContext |
 	self buildStackFromFrames.
@@ -149,7 +151,7 @@ VMStackMappingTest >> testMarryThenDivorceMiddleFrameShouldSetDivorcedContextAsS
 	
 ]
 
-{ #category : #'test-context-tomove' }
+{ #category : 'test-context-tomove' }
 VMStackMappingTest >> testMarryThenDivorceMiddleFrameShouldSplitPage [
 	| aContext framePointerToMarry stackPointerToMarry initialiNumberOfusedPages newNumberOfUsedPages |
 	self buildStackFromFrames.
@@ -163,7 +165,7 @@ VMStackMappingTest >> testMarryThenDivorceMiddleFrameShouldSplitPage [
 	self assert: initialiNumberOfusedPages + 1 equals: newNumberOfUsedPages
 ]
 
-{ #category : #'test-context-tomove' }
+{ #category : 'test-context-tomove' }
 VMStackMappingTest >> testMarryThenDivorceTopFrame [
 	| aContext framePointerToMarry stackPointerToMarry |
 	self buildStackFromFrames.
@@ -175,7 +177,7 @@ VMStackMappingTest >> testMarryThenDivorceTopFrame [
 	self assert: (interpreter isSingleContext: aContext).
 ]
 
-{ #category : #'test-context-tomove' }
+{ #category : 'test-context-tomove' }
 VMStackMappingTest >> testMarryThenDivorceTopFrameShouldNotSplitPage [
 	| aContext initialiNumberOfusedPages newNumberOfUsedPages |
 	self buildStackFromFrames.
@@ -187,7 +189,7 @@ VMStackMappingTest >> testMarryThenDivorceTopFrameShouldNotSplitPage [
 	self assert: initialiNumberOfusedPages equals: 	newNumberOfUsedPages
 ]
 
-{ #category : #'test-context-tomove' }
+{ #category : 'test-context-tomove' }
 VMStackMappingTest >> testMarryTopFrame [
 	| aContext |
 	self buildStackFromFrames.

--- a/smalltalksrc/VMMakerTests/VMStackToRegisterMappingCogitTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMStackToRegisterMappingCogitTest.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #VMStackToRegisterMappingCogitTest,
-	#superclass : #VMSimpleStackBasedCogitAbstractTest,
+	#name : 'VMStackToRegisterMappingCogitTest',
+	#superclass : 'VMSimpleStackBasedCogitAbstractTest',
 	#instVars : [
 		'methodReceiver',
 		'receiverOperationBlock',
@@ -15,21 +15,23 @@ Class {
 		'expectedResult',
 		'expectedReflexiveResult'
 	],
-	#category : #'VMMakerTests-JitTests'
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #builder }
+{ #category : 'builder' }
 VMStackToRegisterMappingCogitTest >> argumentOperation: aFullBlockClosure [ 
 	
 	argumentOperation := aFullBlockClosure
 ]
 
-{ #category : #builder }
+{ #category : 'builder' }
 VMStackToRegisterMappingCogitTest >> arguments: aCollection [ 
 	arguments := aCollection
 ]
 
-{ #category : #builder }
+{ #category : 'builder' }
 VMStackToRegisterMappingCogitTest >> buildStackFrame [
 	"Let's prepare the trampoline in case of non-optimized path"
 	self createSpecialSelectorArray.
@@ -49,7 +51,7 @@ VMStackToRegisterMappingCogitTest >> buildStackFrame [
 
 ]
 
-{ #category : #builder }
+{ #category : 'builder' }
 VMStackToRegisterMappingCogitTest >> compileMethod [
 
 	codeAddress := self compile: [ 
@@ -61,54 +63,54 @@ VMStackToRegisterMappingCogitTest >> compileMethod [
 		               cogit genReturnTopFromMethod ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackToRegisterMappingCogitTest >> expectedReflexiveResult [
 	^ expectedReflexiveResult
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackToRegisterMappingCogitTest >> expectedReflexiveResult: anObject [
 	expectedReflexiveResult := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackToRegisterMappingCogitTest >> expectedResult [
 	^ expectedResult
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackToRegisterMappingCogitTest >> expectedResult: anObject [
 	expectedResult := anObject
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMStackToRegisterMappingCogitTest >> jitCompilerClass [
 
 	^ StackToRegisterMappingCogit 
 ]
 
-{ #category : #builder }
+{ #category : 'builder' }
 VMStackToRegisterMappingCogitTest >> methodReceiver: anOop [ 
 	methodReceiver := anOop
 ]
 
-{ #category : #builder }
+{ #category : 'builder' }
 VMStackToRegisterMappingCogitTest >> receiverOperation: aFullBlockClosure [ 
 	
 	receiverOperationBlock := aFullBlockClosure
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackToRegisterMappingCogitTest >> sendBytecode [
 	^ sendBytecode
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackToRegisterMappingCogitTest >> sendBytecode: anObject [
 	sendBytecode := anObject
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 VMStackToRegisterMappingCogitTest >> setUp [
 
 	super setUp.
@@ -116,7 +118,7 @@ VMStackToRegisterMappingCogitTest >> setUp [
 	arguments := #().
 ]
 
-{ #category : #builder }
+{ #category : 'builder' }
 VMStackToRegisterMappingCogitTest >> shouldCallTrampolineWith: receiverOfOperation and: argumentOfOperation [ 
 
 	self buildStackFrame.
@@ -126,7 +128,7 @@ VMStackToRegisterMappingCogitTest >> shouldCallTrampolineWith: receiverOfOperati
 	self assertSpecialSendTo: receiverOfOperation value withArg: argumentOfOperation value
 ]
 
-{ #category : #builder }
+{ #category : 'builder' }
 VMStackToRegisterMappingCogitTest >> shouldPerformOperationReturning: aValue [ 
 
 	self buildStackFrame.
@@ -136,22 +138,22 @@ VMStackToRegisterMappingCogitTest >> shouldPerformOperationReturning: aValue [
 	self assert: machineSimulator receiverRegisterValue equals: (memory integerObjectOf: aValue).
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackToRegisterMappingCogitTest >> value1 [
 	^ value1
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackToRegisterMappingCogitTest >> value1: anObject [
 	value1 := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackToRegisterMappingCogitTest >> value2 [
 	^ value2
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMStackToRegisterMappingCogitTest >> value2: anObject [
 	value2 := anObject
 ]

--- a/smalltalksrc/VMMakerTests/VMStackToRegisterMappingTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMStackToRegisterMappingTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #VMStackToRegisterMappingTest,
-	#superclass : #VMStackToRegisterMappingCogitTest,
-	#category : #'VMMakerTests-JitTests'
+	#name : 'VMStackToRegisterMappingTest',
+	#superclass : 'VMStackToRegisterMappingCogitTest',
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 VMStackToRegisterMappingTest >> setUp [
 
 	super setUp.
@@ -29,7 +31,7 @@ VMStackToRegisterMappingTest >> setUp [
 	cogit needsFrame: true
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMStackToRegisterMappingTest >> testFlushBelowTop [
 
 	| stop stackPointerBefore framePointer |
@@ -57,7 +59,7 @@ VMStackToRegisterMappingTest >> testFlushBelowTop [
 	self assert: self popAddress equals: (memory integerObjectOf: 17)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMStackToRegisterMappingTest >> testPopConstant [
 
 	cogit ssPushConstant: 1.
@@ -67,7 +69,7 @@ VMStackToRegisterMappingTest >> testPopConstant [
 	self assert: cogit ssTop equals: cogit simSelf.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMStackToRegisterMappingTest >> testPopNonSpilledTopToRegister [
 
 	| stop stackPointerBefore framePointer |
@@ -94,7 +96,7 @@ VMStackToRegisterMappingTest >> testPopNonSpilledTopToRegister [
 	self assert: self machineSimulator receiverRegisterValue equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMStackToRegisterMappingTest >> testPopRegister [
 
 	cogit ssPushRegister: TempReg.
@@ -104,7 +106,7 @@ VMStackToRegisterMappingTest >> testPopRegister [
 	self assert: cogit ssTop equals: cogit simSelf
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMStackToRegisterMappingTest >> testPopSpilledConstantShouldPopFromStack [
 
 	| stop stackPointerBefore framePointer |
@@ -130,7 +132,7 @@ VMStackToRegisterMappingTest >> testPopSpilledConstantShouldPopFromStack [
 	self assert: self machineSimulator smalltalkStackPointerRegisterValue equals: stackPointerBefore
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMStackToRegisterMappingTest >> testPopSpilledConstantWithoutPoppingShouldNotPopFromStack [
 
 	| stop stackPointerBefore framePointer |
@@ -157,7 +159,7 @@ VMStackToRegisterMappingTest >> testPopSpilledConstantWithoutPoppingShouldNotPop
 	self assert: self popAddress equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMStackToRegisterMappingTest >> testPopSpilledTopToRegister [
 
 	| stop stackPointerBefore framePointer |
@@ -184,7 +186,7 @@ VMStackToRegisterMappingTest >> testPopSpilledTopToRegister [
 	self assert: self machineSimulator receiverRegisterValue equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMStackToRegisterMappingTest >> testPushConstant [
 
 	cogit ssPushConstant: 1.
@@ -195,7 +197,7 @@ VMStackToRegisterMappingTest >> testPushConstant [
 	self deny: cogit ssTop spilled
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMStackToRegisterMappingTest >> testPushRegister [
 
 	cogit ssPushRegister: TempReg.
@@ -206,7 +208,7 @@ VMStackToRegisterMappingTest >> testPushRegister [
 	self deny: cogit ssTop spilled
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMStackToRegisterMappingTest >> testSpillConstant [
 
 	cogit ssPushConstant: 1.
@@ -223,7 +225,7 @@ VMStackToRegisterMappingTest >> testSpillConstant [
 	self assert: cogit ssTop spilled
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMStackToRegisterMappingTest >> testSpillRegister [
 
 	cogit ssPushRegister: TempReg.
@@ -242,7 +244,7 @@ VMStackToRegisterMappingTest >> testSpillRegister [
 	self assert: cogit ssTop spilled
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMStackToRegisterMappingTest >> testTopOfEmptyIsSimSelf [
 	
 	self assert: cogit ssSize equals: 1.

--- a/smalltalksrc/VMMakerTests/VMTestMockInterpreter.class.st
+++ b/smalltalksrc/VMMakerTests/VMTestMockInterpreter.class.st
@@ -1,14 +1,15 @@
 Class {
-	#name : #VMTestMockInterpreter,
-	#superclass : #StackInterpreterSimulatorLSB,
+	#name : 'VMTestMockInterpreter',
+	#superclass : 'StackInterpreterSimulatorLSB',
 	#instVars : [
 		'interpreteBlock',
 		'allocatedElements'
 	],
-	#category : #VMMakerTests
+	#category : 'VMMakerTests',
+	#package : 'VMMakerTests'
 }
 
-{ #category : #'memory testing' }
+{ #category : 'memory testing' }
 VMTestMockInterpreter >> allocateParameters: anInteger using: allocationBlock [
 	
 	| allocated |
@@ -19,43 +20,43 @@ VMTestMockInterpreter >> allocateParameters: anInteger using: allocationBlock [
 	^ allocated
 ]
 
-{ #category : #'memory testing' }
+{ #category : 'memory testing' }
 VMTestMockInterpreter >> allocatedElements [
 	
 	^ allocatedElements 
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 VMTestMockInterpreter >> basicInitialize [
 
 	super basicInitialize.
 	allocatedElements := Set new
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTestMockInterpreter >> enterSmalltalkExecutiveImplementation [ 
 
 	interpreteBlock value
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 VMTestMockInterpreter >> free: aPointer [
 
 	allocatedElements remove: aPointer.
 	^ super free: aPointer
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTestMockInterpreter >> interpreteBlock [
 	^ interpreteBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTestMockInterpreter >> interpreteBlock: anObject [
 	interpreteBlock := anObject
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 VMTestMockInterpreter >> malloc: aSize [
 
 	^ allocatedElements add: (super malloc: aSize)

--- a/smalltalksrc/VMMakerTests/VMTrampolineTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMTrampolineTest.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #VMTrampolineTest,
-	#superclass : #VMSimpleStackBasedCogitAbstractTest,
+	#name : 'VMTrampolineTest',
+	#superclass : 'VMSimpleStackBasedCogitAbstractTest',
 	#instVars : [
 		'registerMask',
 		'isAligned',
@@ -10,10 +10,12 @@ Class {
 		'CogAbstractRegisters',
 		'VMClassIndices'
 	],
-	#category : #'VMMakerTests-JitTests'
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #'building suites' }
+{ #category : 'building suites' }
 VMTrampolineTest class >> testParameters [ 
 
 	^ super testParameters * { 
@@ -22,25 +24,25 @@ VMTrampolineTest class >> testParameters [
 	}
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMTrampolineTest >> isAligned [
 
 	^ isAligned
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMTrampolineTest >> isAligned: aBoolean [
 
 	isAligned := aBoolean
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMTrampolineTest >> jitCompilerClass [
 
 	^ StackToRegisterMappingCogit
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMTrampolineTest >> setUp [
 
 	super setUp.
@@ -60,7 +62,7 @@ VMTrampolineTest >> setUp [
 	]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMTrampolineTest >> testCallEnilopmartSucceedsExecution [
 
 	| inc baseMethod baseMethodIP ctx page |
@@ -123,7 +125,7 @@ VMTrampolineTest >> testCallEnilopmartSucceedsExecution [
 		equals: (memory integerObjectOf: 3)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMTrampolineTest >> testDetectFrameNotPointerInUse [
 
 	"The code in generateStackPointerCapture detects if the C Frame pointer is in use.
@@ -138,7 +140,7 @@ VMTrampolineTest >> testDetectFrameNotPointerInUse [
 	self deny: cogit isCFramePointerInUse
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMTrampolineTest >> testDetectFramePointerInUse [
 
 	"The code in generateStackPointerCapture detects if the C Frame pointer is in use.
@@ -153,7 +155,7 @@ VMTrampolineTest >> testDetectFramePointerInUse [
 	self assert: cogit isCFramePointerInUse
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMTrampolineTest >> testLoadStackPointersShouldLoadFramePointer [
 	
 	self compile: [ cogit backend genLoadStackPointers ].
@@ -171,7 +173,7 @@ VMTrampolineTest >> testLoadStackPointersShouldLoadFramePointer [
 	self assert: self framePointerRegisterValue equals: 42
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMTrampolineTest >> testLoadStackPointersShouldLoadStackPointer [
 	
 	self compile: [ cogit backend genLoadStackPointers ].
@@ -189,7 +191,7 @@ VMTrampolineTest >> testLoadStackPointersShouldLoadStackPointer [
 	self assert: machineSimulator smalltalkStackPointerRegisterValue equals: 17
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMTrampolineTest >> testRestoreRegistersProducesAlignedStackPointer [
 
 	| initialStackPointer |
@@ -207,7 +209,7 @@ VMTrampolineTest >> testRestoreRegistersProducesAlignedStackPointer [
 	self assert: self stackPointerRegisterValue equals: initialStackPointer
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMTrampolineTest >> testSendTrampolineShouldNotOverrideLinkRegisterWhenCallDereferenceSelectorRoutine [
 	
 	| dereferenceRoutine previousLinkRegister trampoline |
@@ -238,7 +240,7 @@ VMTrampolineTest >> testSendTrampolineShouldNotOverrideLinkRegisterWhenCallDeref
 	self assert: self interpreter stackTop equals: previousLinkRegister
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMTrampolineTest >> testSmalltalkToCStackShouldLoadCFramePointer [
 	
 	self compile: [ cogit genSmalltalkToCStackSwitch: false "do not push link register" ].
@@ -252,7 +254,7 @@ VMTrampolineTest >> testSmalltalkToCStackShouldLoadCFramePointer [
 	self assert: machineSimulator framePointerRegisterValue equals: 888
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMTrampolineTest >> testSmalltalkToCStackShouldLoadCStackPointer [
 	
 	self compile: [ cogit genSmalltalkToCStackSwitch: false "do not push link register" ].
@@ -266,7 +268,7 @@ VMTrampolineTest >> testSmalltalkToCStackShouldLoadCStackPointer [
 	self assert: machineSimulator stackPointerRegisterValue equals: 777
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMTrampolineTest >> testSmalltalkToCStackShouldPushLinkRegister [
 
 	cogit backend hasLinkRegister ifFalse: [ ^ self skip ].
@@ -282,7 +284,7 @@ VMTrampolineTest >> testSmalltalkToCStackShouldPushLinkRegister [
 	self assert: self interpreter stackTop equals: 42
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMTrampolineTest >> testSmalltalkToCStackSwitchShouldUpdateInterpreterFramePointer [
 	
 	self compile: [ cogit genSmalltalkToCStackSwitch: false "do not push link register" ].
@@ -299,7 +301,7 @@ VMTrampolineTest >> testSmalltalkToCStackSwitchShouldUpdateInterpreterFramePoint
 	self assert: self interpreter framePointer equals: 42
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMTrampolineTest >> testSmalltalkToCStackSwitchShouldUpdateInterpreterStackPointer [
 	
 	self compile: [ cogit genSmalltalkToCStackSwitch: false "do not push link register" ].
@@ -316,7 +318,7 @@ VMTrampolineTest >> testSmalltalkToCStackSwitchShouldUpdateInterpreterStackPoint
 	self assert: self interpreter stackPointer equals: 42
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMTrampolineTest >> testStoreRegistersProducesAlignedStackPointer [
 
 	"Some architectures such as ARMv8 require that the SP is always aligned to some value even in between calls.
@@ -329,7 +331,7 @@ VMTrampolineTest >> testStoreRegistersProducesAlignedStackPointer [
 	self assert: self stackPointerRegisterValue \\ cogit stackPointerAlignment equals: 0
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMTrampolineTest >> testStoreRegistersPushesValuesToStack [
 
 	| initialStackPointer actualPushedBytes |

--- a/smalltalksrc/VMMakerTests/VMX64InstructionTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMX64InstructionTest.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #VMX64InstructionTest,
-	#superclass : #VMSimpleStackBasedCogitAbstractTest,
+	#name : 'VMX64InstructionTest',
+	#superclass : 'VMSimpleStackBasedCogitAbstractTest',
 	#pools : [
 		'CogRTLOpcodes'
 	],
-	#category : #'VMMakerTests-JitTests'
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
 }
 
-{ #category : #'building suites' }
+{ #category : 'building suites' }
 VMX64InstructionTest class >> wordSizeParameters [ 
 
 	^ ParametrizedTestMatrix new
@@ -15,13 +17,13 @@ VMX64InstructionTest class >> wordSizeParameters [
 		yourself
 ]
 
-{ #category : #configuration }
+{ #category : 'configuration' }
 VMX64InstructionTest >> generateCaptureCStackPointers [
 	
 	^ false
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMX64InstructionTest >> testDupAndStoreFromVectorRegister [
 
 	| mem |
@@ -45,7 +47,7 @@ VMX64InstructionTest >> testDupAndStoreFromVectorRegister [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMX64InstructionTest >> testDupAndStoreFromVectorRegisterUnAligned [
 
 	| mem |
@@ -70,7 +72,7 @@ VMX64InstructionTest >> testDupAndStoreFromVectorRegisterUnAligned [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMX64InstructionTest >> testDupSRVr [
 
 
@@ -86,7 +88,7 @@ VMX64InstructionTest >> testDupSRVr [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMX64InstructionTest >> testFaddSRvRvRv [
 
 	| result |
@@ -105,7 +107,7 @@ VMX64InstructionTest >> testFaddSRvRvRv [
 	self assert: (result doubleAt: 9) equals: 3.0.	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMX64InstructionTest >> testFaddSRvRvRvWithThreeDifferentRegisters [
 
 	| result |
@@ -124,7 +126,7 @@ VMX64InstructionTest >> testFaddSRvRvRvWithThreeDifferentRegisters [
 	self assert: (result doubleAt: 9) equals: 3.0.	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMX64InstructionTest >> testFsubSRvRvRv [
 
 	| result |
@@ -143,7 +145,7 @@ VMX64InstructionTest >> testFsubSRvRvRv [
 	self assert: (result doubleAt: 9) equals: -1.0.	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 VMX64InstructionTest >> testFsubSRvRvRvWithThreeDifferentRegisters [
 
 	| result |

--- a/smalltalksrc/VMMakerTests/package.st
+++ b/smalltalksrc/VMMakerTests/package.st
@@ -1,1 +1,1 @@
-Package { #name : #VMMakerTests }
+Package { #name : 'VMMakerTests' }


### PR DESCRIPTION
Now we have a new tonel format. It makes really difficult to review PRs because it shows that all the files were changed. This PR only updated the format of the tonel files.

I did it with this script (I took it from Christophe's [PR](https://github.com/pharo-project/pharo/pull/14743)):

```st
self packages do: [ :pkg | 
  IceLibgitTonelWriter forInternalStoreFileOut: pkg latestVersion mcVersion on: self entity  ]
```

Update:

As Pharo 12 is still the developement version, we will wait until it is the stable version to change to the new tonel format.