### PR TITLE
Added new primitive for allocating directly in the old space

### DIFF
--- a/cmake/vmmaker.cmake
+++ b/cmake/vmmaker.cmake
@@ -141,8 +141,8 @@ if(GENERATE_SOURCES)
         ExternalProject_Add(
             vmmaker
 
-            URL https://files.pharo.org/image/110/Pharo11-SNAPSHOT.build.688.sha.cf3d3fd.arch.64bit.zip
-            URL_HASH SHA256=c050ddcedce70ec92c22a3244aa5ebbc655dcaffcb42ac80fbf1f6e795c7010d
+            URL https://files.pharo.org/image/110/Pharo11-SNAPSHOT.build.707.sha.f720787.arch.64bit.zip
+            URL_HASH SHA256=b96a943513c6a79c7319b285e46719fbe74c570ace3fa0c9ead43123c165671a
             BUILD_COMMAND ${VMMAKER_VM} --headless ${VMMAKER_DIR}/image/Pharo11-SNAPSHOT-64bit-cf3d3fd.image --no-default-preferences save VMMaker
 	    COMMAND ${VMMAKER_VM} --headless ${VMMAKER_IMAGE} --no-default-preferences --save --quit "${CMAKE_CURRENT_SOURCE_DIR_TO_OUT}/scripts/installVMMaker.st" "${CMAKE_CURRENT_SOURCE_DIR_TO_OUT}" "${ICEBERG_DEFAULT_REMOTE}"
             UPDATE_COMMAND      ""

--- a/cmake/vmmaker.cmake
+++ b/cmake/vmmaker.cmake
@@ -141,8 +141,8 @@ if(GENERATE_SOURCES)
         ExternalProject_Add(
             vmmaker
 
-            URL https://files.pharo.org/image/110/Pharo11-SNAPSHOT.build.707.sha.f720787.arch.64bit.zip
-            URL_HASH SHA256=b96a943513c6a79c7319b285e46719fbe74c570ace3fa0c9ead43123c165671a
+            URL https://files.pharo.org/image/110/Pharo11-SNAPSHOT.build.688.sha.cf3d3fd.arch.64bit.zip
+            URL_HASH SHA256=c050ddcedce70ec92c22a3244aa5ebbc655dcaffcb42ac80fbf1f6e795c7010d
             BUILD_COMMAND ${VMMAKER_VM} --headless ${VMMAKER_DIR}/image/Pharo11-SNAPSHOT-64bit-cf3d3fd.image --no-default-preferences save VMMaker
 	    COMMAND ${VMMAKER_VM} --headless ${VMMAKER_IMAGE} --no-default-preferences --save --quit "${CMAKE_CURRENT_SOURCE_DIR_TO_OUT}/scripts/installVMMaker.st" "${CMAKE_CURRENT_SOURCE_DIR_TO_OUT}" "${ICEBERG_DEFAULT_REMOTE}"
             UPDATE_COMMAND      ""

--- a/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
@@ -2775,7 +2775,7 @@ InterpreterPrimitives >> primitiveNewOldSpace [
 	"Allocate a new pinned fixed-size instance.  Fail if the allocation would leave
 	less than lowSpaceThreshold bytes free. This *will not* cause a GC :-)"
 
-	(objectMemory instantiateClassInOldSpace: self stackTop)
+	(objectMemory instantiateClass: self stackTop isPinned: false isOldSpace: true)
 		ifNotNil: [ :obj | self pop: argumentCount + 1 thenPush: obj ]
 		ifNil: [
 			self primitiveFailFor:

--- a/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
@@ -2816,15 +2816,21 @@ InterpreterPrimitives >> primitiveNewWithArg [
 InterpreterPrimitives >> primitiveNewWithArgOldSpace [
 
 	| size instSpec |
+	
 	size := self positiveMachineIntegerValueOf: self stackTop.
 
-	(objectMemory instantiateClassInOldSpace: (self stackValue: 1) indexableSize: size)
-		ifNotNil: [ :obj | self pop: argumentCount + 1 thenPush: obj ]
-		ifNil: [
-			instSpec := objectMemory instSpecOfClass: (self stackValue: 1).
-			self primitiveFailFor: (((objectMemory isIndexableFormat: instSpec) and: [
-					  (objectMemory isCompiledMethodFormat: instSpec) not ]) ifTrue: [ PrimErrNoMemory ]
-					 ifFalse: [ PrimErrBadReceiver ]) ]
+	(objectMemory
+		instantiateClass: (self stackValue: 1)
+		indexableSize: size
+		isPinned: false
+		isOldSpace: true)
+			ifNotNil: [ :obj | self pop: argumentCount + 1 thenPush: obj ]
+			ifNil: [ instSpec := objectMemory instSpecOfClass: (self stackValue: 1).
+			self primitiveFailFor:
+					(((objectMemory isIndexableFormat: instSpec)
+						and: [ (objectMemory isCompiledMethodFormat: instSpec) not ])
+						ifTrue: [ PrimErrNoMemory ]
+						ifFalse: [ PrimErrBadReceiver ]) ]
 ]
 
 { #category : #'object access primitives' }

--- a/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
@@ -2771,6 +2771,20 @@ InterpreterPrimitives >> primitiveNewMethod [
 ]
 
 { #category : #'object access primitives' }
+InterpreterPrimitives >> primitiveNewOldSpace [
+	"Allocate a new pinned fixed-size instance.  Fail if the allocation would leave
+	less than lowSpaceThreshold bytes free. This *will not* cause a GC :-)"
+
+	(objectMemory instantiateClassInOldSpace: self stackTop)
+		ifNotNil: [ :obj | self pop: argumentCount + 1 thenPush: obj ]
+		ifNil: [
+			self primitiveFailFor:
+				((objectMemory isFixedSizePointerFormat: (objectMemory instSpecOfClass: self stackTop))
+					 ifTrue: [ PrimErrNoMemory ]
+					 ifFalse: [ PrimErrBadReceiver ]) ]
+]
+
+{ #category : #'object access primitives' }
 InterpreterPrimitives >> primitiveNewPinned [
 	
 	"Allocate a new pinned fixed-size instance.  Fail if the allocation would leave
@@ -2796,6 +2810,21 @@ InterpreterPrimitives >> primitiveNewWithArg [
 		 instantiateClass: (self stackValue: 1)
 		 indexableSize: size)
 		ifNotNil: [ :obj | self pop: argumentCount + 1 thenPush: obj ]
+]
+
+{ #category : #'object access primitives' }
+InterpreterPrimitives >> primitiveNewWithArgOldSpace [
+
+	| size instSpec |
+	size := self positiveMachineIntegerValueOf: self stackTop.
+
+	(objectMemory instantiateClassInOldSpace: (self stackValue: 1) indexableSize: size)
+		ifNotNil: [ :obj | self pop: argumentCount + 1 thenPush: obj ]
+		ifNil: [
+			instSpec := objectMemory instSpecOfClass: (self stackValue: 1).
+			self primitiveFailFor: (((objectMemory isIndexableFormat: instSpec) and: [
+					  (objectMemory isCompiledMethodFormat: instSpec) not ]) ifTrue: [ PrimErrNoMemory ]
+					 ifFalse: [ PrimErrBadReceiver ]) ]
 ]
 
 { #category : #'object access primitives' }

--- a/smalltalksrc/VMMaker/Spur32BitMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/Spur32BitMemoryManager.class.st
@@ -379,7 +379,7 @@ Spur32BitMemoryManager >> initSegmentBridgeWithBytes: numBytes at: address [
 ]
 
 { #category : #instantiation }
-Spur32BitMemoryManager >> instantiateClass: classObj indexableSize: nElements isPinned: isPinned [
+Spur32BitMemoryManager >> instantiateClass: classObj indexableSize: nElements isPinned: isPinned isOldSpace: isOldSpace [
 	<api>
 	<var: #nElements type: #usqInt>
 	"Allocate an instance of a variable class, excepting CompiledMethod."
@@ -433,7 +433,7 @@ Spur32BitMemoryManager >> instantiateClass: classObj indexableSize: nElements is
 		 classIndex < 0 ifTrue:
 			[coInterpreter primitiveFailFor: classIndex negated.
 			 ^nil]].
-	(numSlots > self maxSlotsForNewSpaceAlloc or: [isPinned])
+	(numSlots > self maxSlotsForNewSpaceAlloc or: [isPinned or: [isOldSpace ]])
 		ifTrue:
 			[numSlots > self maxSlotsForAlloc ifTrue:
 				[coInterpreter primitiveFailFor: PrimErrUnsupported.
@@ -445,76 +445,6 @@ Spur32BitMemoryManager >> instantiateClass: classObj indexableSize: nElements is
 				isPinned: isPinned]
 		ifFalse:
 			[newObj := self allocateSlots: numSlots format: instSpec classIndex: classIndex].
-	newObj ifNotNil:
-		[self fillObj: newObj numSlots: numSlots with: fillValue]
-		ifNil: [ self primitiveFailFor: PrimErrNoMemory ].
-	^newObj
-]
-
-{ #category : #instantiation }
-Spur32BitMemoryManager >> instantiateClassInOldSpace: classObj indexableSize: nElements [
-	<api>
-	<var: #nElements type: #usqInt>
-	"Allocate an instance of a variable class, excepting CompiledMethod."
-	| instSpec classFormat numSlots classIndex newObj fillValue |
-	classFormat := self formatOfClassSafe: classObj.
-	classFormat == -1 ifTrue:
-		[self primitiveFailFor: PrimErrBadReceiver. "no format"
-		 ^nil].
-	instSpec := self instSpecOfClassFormat: classFormat.
-	classIndex := self rawHashBitsOf: classObj.
-	fillValue := 0.
-	instSpec caseOf: {
-		[self arrayFormat]	->
-			[numSlots := nElements.
-			 fillValue := nilObj].
-		[self indexablePointersFormat]	->
-			[numSlots := (self fixedFieldsOfClassFormat: classFormat) + nElements.
-			 fillValue := nilObj].
-		[self weakArrayFormat]	->
-			[numSlots := (self fixedFieldsOfClassFormat: classFormat) + nElements.
-			 fillValue := nilObj].
-		[self sixtyFourBitIndexableFormat]	->
-			[nElements > (self maxSlotsForAlloc / 2) ifTrue:
-				[coInterpreter primitiveFailFor: PrimErrUnsupported.
-				 ^nil].
-			 numSlots := nElements * 2].
-		[self firstLongFormat]	->
-			[(classIndex = ClassFloatCompactIndex and: [nElements ~= 2]) ifTrue:
-				[coInterpreter primitiveFailFor: PrimErrBadReceiver.
-				 ^nil].
-			 numSlots := nElements].
-		[self firstShortFormat]	->
-			[numSlots := nElements + 1 // 2.
-			 instSpec := instSpec + (nElements bitAnd: 1)].
-		[self firstByteFormat]	->
-			[numSlots := nElements + 3 // 4.
-			 instSpec := instSpec + (4 - nElements bitAnd: 3)] }
-		otherwise: "non-indexable"
-			["Some Squeak images include funky fixed subclasses of abstract variable
-			  superclasses. e.g. DirectoryEntry as a subclass of ArrayedCollection.
-			  The (Threaded)FFIPlugin expects to be able to instantiate ExternalData via
-			  this method.
-			  Hence allow fixed classes to be instantiated here iff nElements = 0."
-			 (nElements ~= 0 or: [instSpec > self lastPointerFormat]) ifTrue:
-				[coInterpreter primitiveFailFor: PrimErrBadReceiver.
-				 ^nil].
-			 numSlots := self fixedFieldsOfClassFormat: classFormat.
-			 fillValue := nilObj].
-	classIndex = 0 ifTrue:
-		[classIndex := self ensureBehaviorHash: classObj.
-		 classIndex < 0 ifTrue:
-			[coInterpreter primitiveFailFor: classIndex negated.
-			 ^nil]].
-
-	numSlots > self maxSlotsForAlloc ifTrue:
-		[coInterpreter primitiveFailFor: PrimErrUnsupported.
-		^ nil].
-	newObj := self 	
-		allocateSlotsInOldSpace: numSlots 
-		format: instSpec 
-		classIndex: classIndex.
-	
 	newObj ifNotNil:
 		[self fillObj: newObj numSlots: numSlots with: fillValue]
 		ifNil: [ self primitiveFailFor: PrimErrNoMemory ].

--- a/smalltalksrc/VMMaker/Spur32BitMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/Spur32BitMemoryManager.class.st
@@ -452,6 +452,76 @@ Spur32BitMemoryManager >> instantiateClass: classObj indexableSize: nElements is
 ]
 
 { #category : #instantiation }
+Spur32BitMemoryManager >> instantiateClassInOldSpace: classObj indexableSize: nElements [
+	<api>
+	<var: #nElements type: #usqInt>
+	"Allocate an instance of a variable class, excepting CompiledMethod."
+	| instSpec classFormat numSlots classIndex newObj fillValue |
+	classFormat := self formatOfClassSafe: classObj.
+	classFormat == -1 ifTrue:
+		[self primitiveFailFor: PrimErrBadReceiver. "no format"
+		 ^nil].
+	instSpec := self instSpecOfClassFormat: classFormat.
+	classIndex := self rawHashBitsOf: classObj.
+	fillValue := 0.
+	instSpec caseOf: {
+		[self arrayFormat]	->
+			[numSlots := nElements.
+			 fillValue := nilObj].
+		[self indexablePointersFormat]	->
+			[numSlots := (self fixedFieldsOfClassFormat: classFormat) + nElements.
+			 fillValue := nilObj].
+		[self weakArrayFormat]	->
+			[numSlots := (self fixedFieldsOfClassFormat: classFormat) + nElements.
+			 fillValue := nilObj].
+		[self sixtyFourBitIndexableFormat]	->
+			[nElements > (self maxSlotsForAlloc / 2) ifTrue:
+				[coInterpreter primitiveFailFor: PrimErrUnsupported.
+				 ^nil].
+			 numSlots := nElements * 2].
+		[self firstLongFormat]	->
+			[(classIndex = ClassFloatCompactIndex and: [nElements ~= 2]) ifTrue:
+				[coInterpreter primitiveFailFor: PrimErrBadReceiver.
+				 ^nil].
+			 numSlots := nElements].
+		[self firstShortFormat]	->
+			[numSlots := nElements + 1 // 2.
+			 instSpec := instSpec + (nElements bitAnd: 1)].
+		[self firstByteFormat]	->
+			[numSlots := nElements + 3 // 4.
+			 instSpec := instSpec + (4 - nElements bitAnd: 3)] }
+		otherwise: "non-indexable"
+			["Some Squeak images include funky fixed subclasses of abstract variable
+			  superclasses. e.g. DirectoryEntry as a subclass of ArrayedCollection.
+			  The (Threaded)FFIPlugin expects to be able to instantiate ExternalData via
+			  this method.
+			  Hence allow fixed classes to be instantiated here iff nElements = 0."
+			 (nElements ~= 0 or: [instSpec > self lastPointerFormat]) ifTrue:
+				[coInterpreter primitiveFailFor: PrimErrBadReceiver.
+				 ^nil].
+			 numSlots := self fixedFieldsOfClassFormat: classFormat.
+			 fillValue := nilObj].
+	classIndex = 0 ifTrue:
+		[classIndex := self ensureBehaviorHash: classObj.
+		 classIndex < 0 ifTrue:
+			[coInterpreter primitiveFailFor: classIndex negated.
+			 ^nil]].
+
+	numSlots > self maxSlotsForAlloc ifTrue:
+		[coInterpreter primitiveFailFor: PrimErrUnsupported.
+		^ nil].
+	newObj := self 	
+		allocateSlotsInOldSpace: numSlots 
+		format: instSpec 
+		classIndex: classIndex.
+	
+	newObj ifNotNil:
+		[self fillObj: newObj numSlots: numSlots with: fillValue]
+		ifNil: [ self primitiveFailFor: PrimErrNoMemory ].
+	^newObj
+]
+
+{ #category : #instantiation }
 Spur32BitMemoryManager >> instantiateCompiledMethodClass: classObj indexableSize: nElements [
 	<var: #nElements type: #usqInt>
 	"Allocate an instance of a CompiledMethod class."

--- a/smalltalksrc/VMMaker/Spur64BitMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/Spur64BitMemoryManager.class.st
@@ -420,7 +420,7 @@ Spur64BitMemoryManager >> initSegmentBridgeWithBytes: numBytes at: address [
 ]
 
 { #category : #instantiation }
-Spur64BitMemoryManager >> instantiateClass: classObj indexableSize: nElements isPinned: isPinned [
+Spur64BitMemoryManager >> instantiateClass: classObj indexableSize: nElements isPinned: isPinned isOldSpace: isOldSpace [
 	<api>
 	<var: #nElements type: #usqInt>
 	"Allocate an instance of a variable class, excepting CompiledMethod."
@@ -472,7 +472,7 @@ Spur64BitMemoryManager >> instantiateClass: classObj indexableSize: nElements is
 		 classIndex < 0 ifTrue:
 			[coInterpreter primitiveFailFor: classIndex negated.
 			 ^nil]].
-	(numSlots > self maxSlotsForNewSpaceAlloc or: [isPinned])
+	(numSlots > self maxSlotsForNewSpaceAlloc or: [isPinned or: [isOldSpace]])
 		ifTrue:
 			[numSlots > self maxSlotsForAlloc ifTrue:
 				[coInterpreter primitiveFailFor: PrimErrUnsupported.
@@ -484,75 +484,6 @@ Spur64BitMemoryManager >> instantiateClass: classObj indexableSize: nElements is
 				isPinned: isPinned]
 		ifFalse:
 			[newObj := self allocateSlots: numSlots format: instSpec classIndex: classIndex].
-	newObj ifNotNil:
-		[self fillObj: newObj numSlots: numSlots with: fillValue]
-		ifNil: [ self primitiveFailFor: PrimErrNoMemory ].	
-	^newObj
-]
-
-{ #category : #instantiation }
-Spur64BitMemoryManager >> instantiateClassInOldSpace: classObj indexableSize: nElements [
-	<api>
-	<var: #nElements type: #usqInt>
-	"Allocate an instance of a variable class, excepting CompiledMethod."
-	| instSpec classFormat numSlots classIndex newObj fillValue |
-	classFormat := self formatOfClassSafe: classObj.
-	classFormat == -1 ifTrue:
-		[self primitiveFailFor: PrimErrBadReceiver. "no format"
-		 ^nil].
-	instSpec := self instSpecOfClassFormat: classFormat.
-	classIndex := self rawHashBitsOf: classObj.
-	fillValue := 0.
-	instSpec caseOf: {
-		[self arrayFormat]	->
-			[numSlots := nElements.
-			 fillValue := nilObj].
-		[self indexablePointersFormat]	->
-			[numSlots := (self fixedFieldsOfClassFormat: classFormat) + nElements.
-			 fillValue := nilObj].
-		[self weakArrayFormat]	->
-			[numSlots := (self fixedFieldsOfClassFormat: classFormat) + nElements.
-			 fillValue := nilObj].
-		[self sixtyFourBitIndexableFormat]	->
-			[numSlots := nElements].
-		[self firstLongFormat]	->
-			[(classIndex = ClassFloatCompactIndex and: [nElements ~= 2]) ifTrue:
-				[coInterpreter primitiveFailFor: PrimErrBadReceiver.
-				 ^nil].
-			 numSlots := nElements + 1 // 2.
-			 instSpec := instSpec + (nElements bitAnd: 1)].
-		[self firstShortFormat]	->
-			[numSlots := nElements + 3 // 4.
-			 instSpec := instSpec + (4 - nElements bitAnd: 3)].
-		[self firstByteFormat]	->
-			[numSlots := nElements + 7 // 8.
-			 instSpec := instSpec + (8 - nElements bitAnd: 7)] }
-		otherwise: "non-indexable"
-			["Some Squeak images include funky fixed subclasses of abstract variable
-			  superclasses. e.g. DirectoryEntry as a subclass of ArrayedCollection.
-			  The (Threaded)FFIPlugin expects to be able to instantiate ExternalData via
-			  this method.
-			  Hence allow fixed classes to be instantiated here iff nElements = 0."
-			 (nElements ~= 0 or: [instSpec > self lastPointerFormat]) ifTrue:
-				[coInterpreter primitiveFailFor: PrimErrBadReceiver.
-				 ^nil].
-			 numSlots := self fixedFieldsOfClassFormat: classFormat.
-			 fillValue := nilObj].
-
-	classIndex = 0 ifTrue:
-		[classIndex := self ensureBehaviorHash: classObj.
-		 classIndex < 0 ifTrue:
-			[coInterpreter primitiveFailFor: classIndex negated.
-			 ^nil]].
-
-	numSlots > self maxSlotsForAlloc ifTrue:
-		[coInterpreter primitiveFailFor: PrimErrUnsupported.
-		^ nil].
-	newObj := self 
-		allocateSlotsInOldSpace: numSlots 
-		format: instSpec 
-		classIndex: classIndex .
-			
 	newObj ifNotNil:
 		[self fillObj: newObj numSlots: numSlots with: fillValue]
 		ifNil: [ self primitiveFailFor: PrimErrNoMemory ].	

--- a/smalltalksrc/VMMaker/Spur64BitMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/Spur64BitMemoryManager.class.st
@@ -491,6 +491,75 @@ Spur64BitMemoryManager >> instantiateClass: classObj indexableSize: nElements is
 ]
 
 { #category : #instantiation }
+Spur64BitMemoryManager >> instantiateClassInOldSpace: classObj indexableSize: nElements [
+	<api>
+	<var: #nElements type: #usqInt>
+	"Allocate an instance of a variable class, excepting CompiledMethod."
+	| instSpec classFormat numSlots classIndex newObj fillValue |
+	classFormat := self formatOfClassSafe: classObj.
+	classFormat == -1 ifTrue:
+		[self primitiveFailFor: PrimErrBadReceiver. "no format"
+		 ^nil].
+	instSpec := self instSpecOfClassFormat: classFormat.
+	classIndex := self rawHashBitsOf: classObj.
+	fillValue := 0.
+	instSpec caseOf: {
+		[self arrayFormat]	->
+			[numSlots := nElements.
+			 fillValue := nilObj].
+		[self indexablePointersFormat]	->
+			[numSlots := (self fixedFieldsOfClassFormat: classFormat) + nElements.
+			 fillValue := nilObj].
+		[self weakArrayFormat]	->
+			[numSlots := (self fixedFieldsOfClassFormat: classFormat) + nElements.
+			 fillValue := nilObj].
+		[self sixtyFourBitIndexableFormat]	->
+			[numSlots := nElements].
+		[self firstLongFormat]	->
+			[(classIndex = ClassFloatCompactIndex and: [nElements ~= 2]) ifTrue:
+				[coInterpreter primitiveFailFor: PrimErrBadReceiver.
+				 ^nil].
+			 numSlots := nElements + 1 // 2.
+			 instSpec := instSpec + (nElements bitAnd: 1)].
+		[self firstShortFormat]	->
+			[numSlots := nElements + 3 // 4.
+			 instSpec := instSpec + (4 - nElements bitAnd: 3)].
+		[self firstByteFormat]	->
+			[numSlots := nElements + 7 // 8.
+			 instSpec := instSpec + (8 - nElements bitAnd: 7)] }
+		otherwise: "non-indexable"
+			["Some Squeak images include funky fixed subclasses of abstract variable
+			  superclasses. e.g. DirectoryEntry as a subclass of ArrayedCollection.
+			  The (Threaded)FFIPlugin expects to be able to instantiate ExternalData via
+			  this method.
+			  Hence allow fixed classes to be instantiated here iff nElements = 0."
+			 (nElements ~= 0 or: [instSpec > self lastPointerFormat]) ifTrue:
+				[coInterpreter primitiveFailFor: PrimErrBadReceiver.
+				 ^nil].
+			 numSlots := self fixedFieldsOfClassFormat: classFormat.
+			 fillValue := nilObj].
+
+	classIndex = 0 ifTrue:
+		[classIndex := self ensureBehaviorHash: classObj.
+		 classIndex < 0 ifTrue:
+			[coInterpreter primitiveFailFor: classIndex negated.
+			 ^nil]].
+
+	numSlots > self maxSlotsForAlloc ifTrue:
+		[coInterpreter primitiveFailFor: PrimErrUnsupported.
+		^ nil].
+	newObj := self 
+		allocateSlotsInOldSpace: numSlots 
+		format: instSpec 
+		classIndex: classIndex .
+			
+	newObj ifNotNil:
+		[self fillObj: newObj numSlots: numSlots with: fillValue]
+		ifNil: [ self primitiveFailFor: PrimErrNoMemory ].	
+	^newObj
+]
+
+{ #category : #instantiation }
 Spur64BitMemoryManager >> instantiateCompiledMethodClass: classObj indexableSize: nElements [
 	<var: #nElements type: #usqInt>
 	"Allocate an instance of a CompiledMethod class."

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -6982,6 +6982,36 @@ SpurMemoryManager >> instantiateClass: classObj isPinned: isPinned [
 ]
 
 { #category : #instantiation }
+SpurMemoryManager >> instantiateClassInOldSpace: classObj [
+	| instSpec classFormat numSlots classIndex newObj |
+	classFormat := self formatOfClassSafe: classObj.
+	classFormat == -1 ifTrue:
+		[self primitiveFailFor: PrimErrBadReceiver. "no format"
+		 ^nil].
+	instSpec := self instSpecOfClassFormat: classFormat.
+	(self isFixedSizePointerFormat: instSpec) ifFalse:
+		[self primitiveFailFor: PrimErrBadReceiver. "bad format"
+		 ^nil].
+	classIndex := self ensureBehaviorHash: classObj.
+	classIndex < 0 ifTrue:
+		[coInterpreter primitiveFailFor: classIndex negated.
+		 ^nil].
+	numSlots := self fixedFieldsOfClassFormat: classFormat.
+	newObj := self allocateSlotsInOldSpace: numSlots format: instSpec classIndex: classIndex.
+	newObj ifNotNil:
+		[self fillObj: newObj numSlots: numSlots with: nilObj]
+		ifNil: [ self primitiveFailFor: PrimErrNoMemory ].
+	^newObj
+]
+
+{ #category : #instantiation }
+SpurMemoryManager >> instantiateClassInOldSpace: classObj indexableSize: nElements [
+	<api>
+
+	^ self subclassResponsibility
+]
+
+{ #category : #instantiation }
 SpurMemoryManager >> instantiateCompiledMethodClass: classObj indexableSize: nElements [
 	<var: #nElements type: #usqInt>
 	"Allocate an instance of a CompiledMethod class."

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -2332,6 +2332,16 @@ SpurMemoryManager >> allocateSlots: numSlots format: formatField classIndex: cla
 { #category : #allocation }
 SpurMemoryManager >> allocateSlots: numSlots format: formatField classIndex: classIndex isPinned: isPinned [
 
+	^ self allocateSlots: numSlots
+		  format: formatField
+		  classIndex: classIndex
+		  isPinned: isPinned
+		  isOldSpace: false
+]
+
+{ #category : #allocation }
+SpurMemoryManager >> allocateSlots: numSlots format: formatField classIndex: classIndex isPinned: isPinned isOldSpace: isOldSpace [
+
 	"Allocate an object with numSlots space.  If there is room beneath scavengeThreshold
 	 allocate in newSpace, otherwise alocate in oldSpace.  If there is not room in newSpace
 	 and a scavenge is not already scheduled, schedule a scavenge."
@@ -2350,7 +2360,7 @@ SpurMemoryManager >> allocateSlots: numSlots format: formatField classIndex: cla
 
 	hasToScheduleScavenge := freeStart + numBytes > scavengeThreshold.
 
-	(hasToScheduleScavenge or: [ isPinned ]) ifTrue: [ 
+	(hasToScheduleScavenge or: [ isPinned or: [ isOldSpace ] ]) ifTrue: [ 
 		hasToScheduleScavenge ifTrue: [ 
 			needGCFlag ifFalse: [ self scheduleScavenge ] ].
 
@@ -6960,29 +6970,12 @@ SpurMemoryManager >> instantiateClass: classObj indexableSize: nElements isPinne
 
 { #category : #instantiation }
 SpurMemoryManager >> instantiateClass: classObj isPinned: isPinned [
-	| instSpec classFormat numSlots classIndex newObj |
-	classFormat := self formatOfClassSafe: classObj.
-	classFormat == -1 ifTrue:
-		[self primitiveFailFor: PrimErrBadReceiver. "no format"
-		 ^nil].
-	instSpec := self instSpecOfClassFormat: classFormat.
-	(self isFixedSizePointerFormat: instSpec) ifFalse:
-		[self primitiveFailFor: PrimErrBadReceiver. "bad format"
-		 ^nil].
-	classIndex := self ensureBehaviorHash: classObj.
-	classIndex < 0 ifTrue:
-		[coInterpreter primitiveFailFor: classIndex negated.
-		 ^nil].
-	numSlots := self fixedFieldsOfClassFormat: classFormat.
-	newObj := self allocateSlots: numSlots format: instSpec classIndex: classIndex isPinned: isPinned.
-	newObj ifNotNil:
-		[self fillObj: newObj numSlots: numSlots with: nilObj]
-		ifNil: [ self primitiveFailFor: PrimErrNoMemory ].
-	^newObj
+
+	^ self instantiateClass: classObj isPinned: isPinned isOldSpace: false
 ]
 
 { #category : #instantiation }
-SpurMemoryManager >> instantiateClassInOldSpace: classObj [
+SpurMemoryManager >> instantiateClass: classObj isPinned: isPinned isOldSpace: isOldSpace [
 	| instSpec classFormat numSlots classIndex newObj |
 	classFormat := self formatOfClassSafe: classObj.
 	classFormat == -1 ifTrue:
@@ -6997,7 +6990,7 @@ SpurMemoryManager >> instantiateClassInOldSpace: classObj [
 		[coInterpreter primitiveFailFor: classIndex negated.
 		 ^nil].
 	numSlots := self fixedFieldsOfClassFormat: classFormat.
-	newObj := self allocateSlotsInOldSpace: numSlots format: instSpec classIndex: classIndex.
+	newObj := self allocateSlots: numSlots format: instSpec classIndex: classIndex isPinned: isPinned isOldSpace: isOldSpace.
 	newObj ifNotNil:
 		[self fillObj: newObj numSlots: numSlots with: nilObj]
 		ifNil: [ self primitiveFailFor: PrimErrNoMemory ].

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -6965,6 +6965,13 @@ SpurMemoryManager >> instantiateClass: classObj indexableSize: nElements [
 SpurMemoryManager >> instantiateClass: classObj indexableSize: nElements isPinned: isPinned [
 	<api>
 
+	^ self instantiateClass: classObj indexableSize: nElements isPinned: isPinned isOldSpace: false
+]
+
+{ #category : #instantiation }
+SpurMemoryManager >> instantiateClass: classObj indexableSize: nElements isPinned: isPinned isOldSpace: isOldSpace [
+	<api>
+
 	^ self subclassResponsibility
 ]
 
@@ -6995,13 +7002,6 @@ SpurMemoryManager >> instantiateClass: classObj isPinned: isPinned isOldSpace: i
 		[self fillObj: newObj numSlots: numSlots with: nilObj]
 		ifNil: [ self primitiveFailFor: PrimErrNoMemory ].
 	^newObj
-]
-
-{ #category : #instantiation }
-SpurMemoryManager >> instantiateClassInOldSpace: classObj indexableSize: nElements [
-	<api>
-
-	^ self subclassResponsibility
 ]
 
 { #category : #instantiation }

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -1327,7 +1327,7 @@ StackInterpreter class >> initializePrimitiveTable [
 
 		"Unassigned Primitives"
 		(575 595 primitiveFail)
-		
+
 		"Allocate in old space primitive"
 		(596 primitiveNewOldSpace)
 		(597 primitiveNewWithArgOldSpace)

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -1326,7 +1326,11 @@ StackInterpreter class >> initializePrimitiveTable [
 		(574 primitiveFloat64ArrayAdd)
 
 		"Unassigned Primitives"
-		(575 597 primitiveFail)
+		(575 595 primitiveFail)
+		
+		"Allocate in old space primitive"
+		(596 primitiveNewOldSpace)
+		(597 primitiveNewWithArgOldSpace)
 
 		"Pinned object creation primitives"
 		(598 primitiveNewPinned)

--- a/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
@@ -2692,6 +2692,74 @@ VMPrimitiveTest >> testPrimitiveNewIsNotPinned [
 	self deny: (memory isPinned: interpreter stackTop)
 ]
 
+{ #category : #'tests - primitiveNewOldSpace' }
+VMPrimitiveTest >> testPrimitiveNewOldCreatesTheObjectInOldSpace [
+	| class |
+	class := self newClassInOldSpaceWithSlots: 0 instSpec: memory nonIndexablePointerFormat.
+
+	interpreter push: class.
+	interpreter primitiveNewOldSpace.
+
+	self deny: interpreter failed.
+	self deny: (memory isYoung: interpreter stackTop).
+	self assert: (memory isOld: interpreter stackTop)
+]
+
+{ #category : #'tests - primitiveNewOldSpace' }
+VMPrimitiveTest >> testPrimitiveNewOldSpaceObjectInFullNewSpaceIsSchedulingGC [
+	| class |
+	class := self newClassInOldSpaceWithSlots: 3 instSpec: memory nonIndexablePointerFormat.
+
+	self fillNewSpace.
+
+	self deny: memory needGCFlag.
+	
+	interpreter push: class.
+	interpreter primitiveNewOldSpace.
+
+	self deny: interpreter failed.
+	self assert: memory needGCFlag 
+]
+
+{ #category : #'tests - primitiveNewOldSpace' }
+VMPrimitiveTest >> testPrimitiveNewOldSpaceObjectIsNotSchedulingGC [
+	| class |
+	class := self newClassInOldSpaceWithSlots: 0 instSpec: memory nonIndexablePointerFormat.
+
+	interpreter push: class.
+	interpreter primitiveNewOldSpace.
+
+	self deny: interpreter failed.
+	self deny: memory needGCFlag 
+]
+
+{ #category : #'tests - primitiveNewOldSpace' }
+VMPrimitiveTest >> testPrimitiveNewOldSpaceWithArgsCreatesTheObjectInOldSpace [
+	| class |
+	class := self newClassInOldSpaceWithSlots: 0 instSpec: memory arrayFormat.
+
+	interpreter push: class.
+	interpreter push: (memory integerObjectOf: 7).
+	interpreter primitiveNewWithArgOldSpace.
+
+	self deny: interpreter failed.
+	self deny: (memory isYoung: interpreter stackTop).
+	self assert: (memory isOld: interpreter stackTop)
+]
+
+{ #category : #'tests - primitiveNewOldSpace' }
+VMPrimitiveTest >> testPrimitiveNewOldSpaceWithArgsObjectIsNotSchedulingGC [
+	| class |
+	class := self newClassInOldSpaceWithSlots: 0 instSpec: memory arrayFormat.
+
+	interpreter push: class.
+	interpreter push: (memory integerObjectOf: 7).
+	interpreter primitiveNewWithArgOldSpace.
+
+	self deny: interpreter failed.
+	self deny: memory needGCFlag 
+]
+
 { #category : #'tests - primitiveNewPinned' }
 VMPrimitiveTest >> testPrimitiveNewPinnedCreatesTheObjectInOldSpace [
 	| class |


### PR DESCRIPTION
This PR adds a new primitive `primitiveNewOldSpace` and `primitiveNewWithArgOldSpace` to allocate objects directly into the old space