### PR TITLE
Fix ext unconditional jump

### DIFF
--- a/smalltalksrc/VMMaker/CoInterpreter.class.st
+++ b/smalltalksrc/VMMaker/CoInterpreter.class.st
@@ -901,6 +901,8 @@ CoInterpreter >> bytecodePrimAt [
 	"Override to eliminate the atCache, something of little benefit to the JIT."
 
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
+	
 	self normalSendSpecialSelector: 16 argumentCount: 1
 ]
 
@@ -908,6 +910,7 @@ CoInterpreter >> bytecodePrimAt [
 CoInterpreter >> bytecodePrimAtPut [
 	"Override to eliminate the atCache, something of little benefit to the JIT."
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
 
 	self normalSendSpecialSelector: 17 argumentCount: 2
 ]

--- a/smalltalksrc/VMMaker/CogAbstractInstruction.class.st
+++ b/smalltalksrc/VMMaker/CogAbstractInstruction.class.st
@@ -1634,16 +1634,18 @@ CogAbstractInstruction >> relocateMethodReferenceBeforeAddress: pc by: delta [
 
 { #category : #'generate machine code' }
 CogAbstractInstruction >> resolveJumpTarget [
+
 	<var: #fixup type: #'BytecodeFixup *'>
 	| fixup |
 	self assert: self isJump.
 	fixup := cogit cCoerceSimple: (operands at: 0) to: #'BytecodeFixup *'.
-	self cCode: [] inSmalltalk:
-		[(fixup isKindOf: CogBytecodeFixup) ifTrue:
-			[self assert: (self isAFixup: fixup)]].
-	(self isAFixup: fixup) ifTrue:
-		[self assert: (cogit addressIsInInstructions: fixup targetInstruction).
-		 self jmpTarget: fixup targetInstruction]
+	self cCode: [  ] inSmalltalk: [
+		(fixup isKindOf: CogBytecodeFixup) ifTrue: [
+			self assert: (self isAFixup: fixup) ] ].
+	(self isAFixup: fixup) ifTrue: [
+		self assert:
+			(cogit addressIsInInstructions: fixup targetInstruction).
+		self jmpTarget: fixup targetInstruction ]
 ]
 
 { #category : #'calling C function in Smalltalk stack' }

--- a/smalltalksrc/VMMaker/Cogit.class.st
+++ b/smalltalksrc/VMMaker/Cogit.class.st
@@ -8214,6 +8214,13 @@ Cogit >> getCStackPointer [
 ]
 
 { #category : #'method map' }
+Cogit >> getIsBytecodePCReference [
+
+	<cmacro>
+	^ HasBytecodePC
+]
+
+{ #category : #'method map' }
 Cogit >> getIsObjectReference [
 	<cmacro>
 	^IsObjectReference

--- a/smalltalksrc/VMMaker/DruidJIT.class.st
+++ b/smalltalksrc/VMMaker/DruidJIT.class.st
@@ -398,14 +398,30 @@ DruidJIT class >> bytecodeTable [
 		  #branch. #isBranchFalse. #isMapped. #v3:ShortForward:Branch:Distance: }.
 		  { 1. 199. 199. #gen_ShortConditionalJumpFalse7.
 		  #branch. #isBranchFalse. #isMapped. #v3:ShortForward:Branch:Distance: }.
-		  { 1. 200. 200. #unknownBytecode }.
-		  { 1. 201. 201. #unknownBytecode }.
-		  { 1. 202. 202. #unknownBytecode }.
-		  { 1. 203. 203. #unknownBytecode }.
-		  { 1. 204. 204. #unknownBytecode }.
-		  { 1. 205. 205. #unknownBytecode }.
-		  { 1. 206. 206. #unknownBytecode }.
-		  { 1. 207. 207. #unknownBytecode }.
+		  { 1. 200. 200. #gen_StoreAndPopReceiverVariableBytecode0.
+		  #isInstVarRef. #is1ByteInstVarStore. #isMappedIfImmutability.
+		  #needsFrameIfImmutability:.  -1 }.
+		  { 1. 201. 201. #gen_StoreAndPopReceiverVariableBytecode1.
+		  #isInstVarRef. #is1ByteInstVarStore. #isMappedIfImmutability.
+		  #needsFrameIfImmutability:.  -1 }.
+		  { 1. 202. 202. #gen_StoreAndPopReceiverVariableBytecode2.
+		  #isInstVarRef. #is1ByteInstVarStore. #isMappedIfImmutability.
+		  #needsFrameIfImmutability:.  -1 }.
+		  { 1. 203. 203. #gen_StoreAndPopReceiverVariableBytecode3.
+		  #isInstVarRef. #is1ByteInstVarStore. #isMappedIfImmutability.
+		  #needsFrameIfImmutability:.  -1 }.
+		  { 1. 204. 204. #gen_StoreAndPopReceiverVariableBytecode4.
+		  #isInstVarRef. #is1ByteInstVarStore. #isMappedIfImmutability.
+		  #needsFrameIfImmutability:.  -1 }.
+		  { 1. 205. 205. #gen_StoreAndPopReceiverVariableBytecode5.
+		  #isInstVarRef. #is1ByteInstVarStore. #isMappedIfImmutability.
+		  #needsFrameIfImmutability:.  -1 }.
+		  { 1. 206. 206. #gen_StoreAndPopReceiverVariableBytecode6.
+		  #isInstVarRef. #is1ByteInstVarStore. #isMappedIfImmutability.
+		  #needsFrameIfImmutability:.  -1 }.
+		  { 1. 207. 207. #gen_StoreAndPopReceiverVariableBytecode7.
+		  #isInstVarRef. #is1ByteInstVarStore. #isMappedIfImmutability.
+		  #needsFrameIfImmutability:.  -1 }.
 		  { 1. 208. 208. #gen_StoreAndPopTemporaryVariableBytecode0 }.
 		  { 1. 209. 209. #gen_StoreAndPopTemporaryVariableBytecode1 }.
 		  { 1. 210. 210. #gen_StoreAndPopTemporaryVariableBytecode2 }.
@@ -440,7 +456,8 @@ DruidJIT class >> bytecodeTable [
 		  { 2. 234. 234. #gen_ExtSendBytecode. #isMapped }.
 		  { 2. 235. 235. #unknownBytecode }.
 		  { 2. 236. 236. #unknownBytecode }.
-		  { 2. 237. 237. #unknownBytecode }.
+		  { 2. 237. 237. #gen_ExtUnconditionalJump. #branch. #isMapped.
+		  #v4:Long:Branch:Distance: }.
 		  { 2. 238. 238. #gen_ExtJumpIfTrue. #branch. #isBranchTrue.
 		  #isMapped. #v4:Long:Branch:Distance: }.
 		  { 2. 239. 239. #gen_ExtJumpIfFalse. #branch. #isBranchFalse.
@@ -2439,6 +2456,7 @@ DruidJIT >> gen_ExtJumpIfFalse [
 
 	| t0 jump3 jump1 currentBlock r3 live jump2 |
 	live := 0.
+	self annotateBytecode: self Label.
 	r3 := extB.
 	extA := 0.
 	extB := 0.
@@ -2456,7 +2474,6 @@ DruidJIT >> gen_ExtJumpIfFalse [
 	jump2 := self JumpZero: 0.
 	self MoveR: t0 R: TempReg.
 	self CallRT: ceSendMustBeBooleanTrampoline.
-	self annotateBytecode: self Label.
 	jump3 := self Jump: 0.
 	currentBlock := self Label.
 	jump1 jmpTarget: currentBlock.
@@ -2476,6 +2493,7 @@ DruidJIT >> gen_ExtJumpIfTrue [
 
 	| t0 jump3 jump1 currentBlock r3 live jump2 |
 	live := 0.
+	self annotateBytecode: self Label.
 	r3 := extB.
 	extA := 0.
 	extB := 0.
@@ -2493,7 +2511,6 @@ DruidJIT >> gen_ExtJumpIfTrue [
 	jump2 := self JumpZero: 0.
 	self MoveR: t0 R: TempReg.
 	self CallRT: ceSendMustBeBooleanTrampoline.
-	self annotateBytecode: self Label.
 	jump3 := self Jump: 0.
 	currentBlock := self Label.
 	jump1 jmpTarget: currentBlock.
@@ -2697,6 +2714,7 @@ DruidJIT >> gen_ExtUnconditionalJump [
 
 	| t0 jump1 t1 currentBlock r3 live |
 	live := 0.
+	self annotateBytecode: self Label.
 	r3 := extB.
 	self ssFlushStack.
 	(byte1 + (r3 << 8))<0 ifTrue: [
@@ -2722,7 +2740,6 @@ DruidJIT >> gen_ExtUnconditionalJump [
 		self CmpR: t1 R: t0.
 		jump1 := self JumpAboveOrEqual: 0.
 		self CallRT: ceCheckForInterruptTrampoline.
-		self annotateBytecode: self Label.
 		currentBlock := self Label.
 		jump1 jmpTarget: currentBlock.
 		self Jump:
@@ -2749,7 +2766,6 @@ DruidJIT >> gen_ExtUnconditionalJump [
 	self CmpR: t1 R: t0.
 	jump1 := self JumpAboveOrEqual: 0.
 	self CallRT: ceCheckForInterruptTrampoline.
-	self annotateBytecode: self Label.
 	currentBlock := self Label.
 	jump1 jmpTarget: currentBlock.
 	self Jump:
@@ -6760,6 +6776,7 @@ DruidJIT >> gen_ShortConditionalJumpFalse0 [
 
 	| t0 jump3 jump1 currentBlock jump2 live |
 	live := 0.
+	self annotateBytecode: self Label.
 	t0 := self
 		      allocateRegNotConflictingWith: live
 		      ifNone: [ ^ self unknownBytecode ].
@@ -6773,7 +6790,6 @@ DruidJIT >> gen_ShortConditionalJumpFalse0 [
 	jump2 := self JumpZero: 0.
 	self MoveR: t0 R: TempReg.
 	self CallRT: ceSendMustBeBooleanTrampoline.
-	self annotateBytecode: self Label.
 	jump3 := self Jump: 0.
 	currentBlock := self Label.
 	jump1 jmpTarget: currentBlock.
@@ -6792,6 +6808,7 @@ DruidJIT >> gen_ShortConditionalJumpFalse1 [
 
 	| t0 jump3 jump1 currentBlock jump2 live |
 	live := 0.
+	self annotateBytecode: self Label.
 	t0 := self
 		      allocateRegNotConflictingWith: live
 		      ifNone: [ ^ self unknownBytecode ].
@@ -6805,7 +6822,6 @@ DruidJIT >> gen_ShortConditionalJumpFalse1 [
 	jump2 := self JumpZero: 0.
 	self MoveR: t0 R: TempReg.
 	self CallRT: ceSendMustBeBooleanTrampoline.
-	self annotateBytecode: self Label.
 	jump3 := self Jump: 0.
 	currentBlock := self Label.
 	jump1 jmpTarget: currentBlock.
@@ -6824,6 +6840,7 @@ DruidJIT >> gen_ShortConditionalJumpFalse2 [
 
 	| t0 jump3 jump1 currentBlock jump2 live |
 	live := 0.
+	self annotateBytecode: self Label.
 	t0 := self
 		      allocateRegNotConflictingWith: live
 		      ifNone: [ ^ self unknownBytecode ].
@@ -6837,7 +6854,6 @@ DruidJIT >> gen_ShortConditionalJumpFalse2 [
 	jump2 := self JumpZero: 0.
 	self MoveR: t0 R: TempReg.
 	self CallRT: ceSendMustBeBooleanTrampoline.
-	self annotateBytecode: self Label.
 	jump3 := self Jump: 0.
 	currentBlock := self Label.
 	jump1 jmpTarget: currentBlock.
@@ -6856,6 +6872,7 @@ DruidJIT >> gen_ShortConditionalJumpFalse3 [
 
 	| t0 jump3 jump1 currentBlock jump2 live |
 	live := 0.
+	self annotateBytecode: self Label.
 	t0 := self
 		      allocateRegNotConflictingWith: live
 		      ifNone: [ ^ self unknownBytecode ].
@@ -6869,7 +6886,6 @@ DruidJIT >> gen_ShortConditionalJumpFalse3 [
 	jump2 := self JumpZero: 0.
 	self MoveR: t0 R: TempReg.
 	self CallRT: ceSendMustBeBooleanTrampoline.
-	self annotateBytecode: self Label.
 	jump3 := self Jump: 0.
 	currentBlock := self Label.
 	jump1 jmpTarget: currentBlock.
@@ -6888,6 +6904,7 @@ DruidJIT >> gen_ShortConditionalJumpFalse4 [
 
 	| t0 jump3 jump1 currentBlock jump2 live |
 	live := 0.
+	self annotateBytecode: self Label.
 	t0 := self
 		      allocateRegNotConflictingWith: live
 		      ifNone: [ ^ self unknownBytecode ].
@@ -6901,7 +6918,6 @@ DruidJIT >> gen_ShortConditionalJumpFalse4 [
 	jump2 := self JumpZero: 0.
 	self MoveR: t0 R: TempReg.
 	self CallRT: ceSendMustBeBooleanTrampoline.
-	self annotateBytecode: self Label.
 	jump3 := self Jump: 0.
 	currentBlock := self Label.
 	jump1 jmpTarget: currentBlock.
@@ -6920,6 +6936,7 @@ DruidJIT >> gen_ShortConditionalJumpFalse5 [
 
 	| t0 jump3 jump1 currentBlock jump2 live |
 	live := 0.
+	self annotateBytecode: self Label.
 	t0 := self
 		      allocateRegNotConflictingWith: live
 		      ifNone: [ ^ self unknownBytecode ].
@@ -6933,7 +6950,6 @@ DruidJIT >> gen_ShortConditionalJumpFalse5 [
 	jump2 := self JumpZero: 0.
 	self MoveR: t0 R: TempReg.
 	self CallRT: ceSendMustBeBooleanTrampoline.
-	self annotateBytecode: self Label.
 	jump3 := self Jump: 0.
 	currentBlock := self Label.
 	jump1 jmpTarget: currentBlock.
@@ -6952,6 +6968,7 @@ DruidJIT >> gen_ShortConditionalJumpFalse6 [
 
 	| t0 jump3 jump1 currentBlock jump2 live |
 	live := 0.
+	self annotateBytecode: self Label.
 	t0 := self
 		      allocateRegNotConflictingWith: live
 		      ifNone: [ ^ self unknownBytecode ].
@@ -6965,7 +6982,6 @@ DruidJIT >> gen_ShortConditionalJumpFalse6 [
 	jump2 := self JumpZero: 0.
 	self MoveR: t0 R: TempReg.
 	self CallRT: ceSendMustBeBooleanTrampoline.
-	self annotateBytecode: self Label.
 	jump3 := self Jump: 0.
 	currentBlock := self Label.
 	jump1 jmpTarget: currentBlock.
@@ -6984,6 +7000,7 @@ DruidJIT >> gen_ShortConditionalJumpFalse7 [
 
 	| t0 jump3 jump1 currentBlock jump2 live |
 	live := 0.
+	self annotateBytecode: self Label.
 	t0 := self
 		      allocateRegNotConflictingWith: live
 		      ifNone: [ ^ self unknownBytecode ].
@@ -6997,7 +7014,6 @@ DruidJIT >> gen_ShortConditionalJumpFalse7 [
 	jump2 := self JumpZero: 0.
 	self MoveR: t0 R: TempReg.
 	self CallRT: ceSendMustBeBooleanTrampoline.
-	self annotateBytecode: self Label.
 	jump3 := self Jump: 0.
 	currentBlock := self Label.
 	jump1 jmpTarget: currentBlock.
@@ -7016,6 +7032,7 @@ DruidJIT >> gen_ShortConditionalJumpTrue0 [
 
 	| t0 jump3 jump1 currentBlock jump2 live |
 	live := 0.
+	self annotateBytecode: self Label.
 	t0 := self
 		      allocateRegNotConflictingWith: live
 		      ifNone: [ ^ self unknownBytecode ].
@@ -7029,7 +7046,6 @@ DruidJIT >> gen_ShortConditionalJumpTrue0 [
 	jump2 := self JumpZero: 0.
 	self MoveR: t0 R: TempReg.
 	self CallRT: ceSendMustBeBooleanTrampoline.
-	self annotateBytecode: self Label.
 	jump3 := self Jump: 0.
 	currentBlock := self Label.
 	jump1 jmpTarget: currentBlock.
@@ -7048,6 +7064,7 @@ DruidJIT >> gen_ShortConditionalJumpTrue1 [
 
 	| t0 jump3 jump1 currentBlock jump2 live |
 	live := 0.
+	self annotateBytecode: self Label.
 	t0 := self
 		      allocateRegNotConflictingWith: live
 		      ifNone: [ ^ self unknownBytecode ].
@@ -7061,7 +7078,6 @@ DruidJIT >> gen_ShortConditionalJumpTrue1 [
 	jump2 := self JumpZero: 0.
 	self MoveR: t0 R: TempReg.
 	self CallRT: ceSendMustBeBooleanTrampoline.
-	self annotateBytecode: self Label.
 	jump3 := self Jump: 0.
 	currentBlock := self Label.
 	jump1 jmpTarget: currentBlock.
@@ -7080,6 +7096,7 @@ DruidJIT >> gen_ShortConditionalJumpTrue2 [
 
 	| t0 jump3 jump1 currentBlock jump2 live |
 	live := 0.
+	self annotateBytecode: self Label.
 	t0 := self
 		      allocateRegNotConflictingWith: live
 		      ifNone: [ ^ self unknownBytecode ].
@@ -7093,7 +7110,6 @@ DruidJIT >> gen_ShortConditionalJumpTrue2 [
 	jump2 := self JumpZero: 0.
 	self MoveR: t0 R: TempReg.
 	self CallRT: ceSendMustBeBooleanTrampoline.
-	self annotateBytecode: self Label.
 	jump3 := self Jump: 0.
 	currentBlock := self Label.
 	jump1 jmpTarget: currentBlock.
@@ -7112,6 +7128,7 @@ DruidJIT >> gen_ShortConditionalJumpTrue3 [
 
 	| t0 jump3 jump1 currentBlock jump2 live |
 	live := 0.
+	self annotateBytecode: self Label.
 	t0 := self
 		      allocateRegNotConflictingWith: live
 		      ifNone: [ ^ self unknownBytecode ].
@@ -7125,7 +7142,6 @@ DruidJIT >> gen_ShortConditionalJumpTrue3 [
 	jump2 := self JumpZero: 0.
 	self MoveR: t0 R: TempReg.
 	self CallRT: ceSendMustBeBooleanTrampoline.
-	self annotateBytecode: self Label.
 	jump3 := self Jump: 0.
 	currentBlock := self Label.
 	jump1 jmpTarget: currentBlock.
@@ -7144,6 +7160,7 @@ DruidJIT >> gen_ShortConditionalJumpTrue4 [
 
 	| t0 jump3 jump1 currentBlock jump2 live |
 	live := 0.
+	self annotateBytecode: self Label.
 	t0 := self
 		      allocateRegNotConflictingWith: live
 		      ifNone: [ ^ self unknownBytecode ].
@@ -7157,7 +7174,6 @@ DruidJIT >> gen_ShortConditionalJumpTrue4 [
 	jump2 := self JumpZero: 0.
 	self MoveR: t0 R: TempReg.
 	self CallRT: ceSendMustBeBooleanTrampoline.
-	self annotateBytecode: self Label.
 	jump3 := self Jump: 0.
 	currentBlock := self Label.
 	jump1 jmpTarget: currentBlock.
@@ -7176,6 +7192,7 @@ DruidJIT >> gen_ShortConditionalJumpTrue5 [
 
 	| t0 jump3 jump1 currentBlock jump2 live |
 	live := 0.
+	self annotateBytecode: self Label.
 	t0 := self
 		      allocateRegNotConflictingWith: live
 		      ifNone: [ ^ self unknownBytecode ].
@@ -7189,7 +7206,6 @@ DruidJIT >> gen_ShortConditionalJumpTrue5 [
 	jump2 := self JumpZero: 0.
 	self MoveR: t0 R: TempReg.
 	self CallRT: ceSendMustBeBooleanTrampoline.
-	self annotateBytecode: self Label.
 	jump3 := self Jump: 0.
 	currentBlock := self Label.
 	jump1 jmpTarget: currentBlock.
@@ -7208,6 +7224,7 @@ DruidJIT >> gen_ShortConditionalJumpTrue6 [
 
 	| t0 jump3 jump1 currentBlock jump2 live |
 	live := 0.
+	self annotateBytecode: self Label.
 	t0 := self
 		      allocateRegNotConflictingWith: live
 		      ifNone: [ ^ self unknownBytecode ].
@@ -7221,7 +7238,6 @@ DruidJIT >> gen_ShortConditionalJumpTrue6 [
 	jump2 := self JumpZero: 0.
 	self MoveR: t0 R: TempReg.
 	self CallRT: ceSendMustBeBooleanTrampoline.
-	self annotateBytecode: self Label.
 	jump3 := self Jump: 0.
 	currentBlock := self Label.
 	jump1 jmpTarget: currentBlock.
@@ -7240,6 +7256,7 @@ DruidJIT >> gen_ShortConditionalJumpTrue7 [
 
 	| t0 jump3 jump1 currentBlock jump2 live |
 	live := 0.
+	self annotateBytecode: self Label.
 	t0 := self
 		      allocateRegNotConflictingWith: live
 		      ifNone: [ ^ self unknownBytecode ].
@@ -7253,7 +7270,6 @@ DruidJIT >> gen_ShortConditionalJumpTrue7 [
 	jump2 := self JumpZero: 0.
 	self MoveR: t0 R: TempReg.
 	self CallRT: ceSendMustBeBooleanTrampoline.
-	self annotateBytecode: self Label.
 	jump3 := self Jump: 0.
 	currentBlock := self Label.
 	jump1 jmpTarget: currentBlock.
@@ -7368,6 +7384,7 @@ DruidJIT >> gen_StoreAndPopReceiverVariableBytecode0 [
 
 	| jump1 jump7 jumpNext t1 jump6 jump3 currentBlock t0 jump5 jump2 jumpTrue live t2 jump4 |
 	live := 0.
+	self annotateBytecode: self Label.
 	self ensureReceiverResultRegContainsSelf.
 	t0 := self
 		      allocateRegNotConflictingWith: live
@@ -7428,7 +7445,6 @@ DruidJIT >> gen_StoreAndPopReceiverVariableBytecode0 [
 	self MoveR: t0 R: TempReg.
 	backEnd saveAndRestoreLinkRegAround: [
 		self CallRT: ceStoreCheckTrampoline ].
-	self annotateBytecode: self Label.
 	self TstCq: 7 R: t1.
 	jump6 := self JumpNonZero: 0.
 	jump7 := self JumpZero: 0.
@@ -7495,7 +7511,6 @@ DruidJIT >> gen_StoreAndPopReceiverVariableBytecode0 [
 	self MoveR: t0 R: TempReg.
 	backEnd saveAndRestoreLinkRegAround: [
 		self CallRT: ceStoreCheckTrampoline ].
-	self annotateBytecode: self Label.
 	currentBlock := self Label.
 	jump6 jmpTarget: currentBlock.
 	jump4 jmpTarget: currentBlock.
@@ -7514,6 +7529,7 @@ DruidJIT >> gen_StoreAndPopReceiverVariableBytecode1 [
 
 	| jump1 jump7 jumpNext t1 jump6 jump3 currentBlock t0 jump5 jump2 jumpTrue live t2 jump4 |
 	live := 0.
+	self annotateBytecode: self Label.
 	self ensureReceiverResultRegContainsSelf.
 	t0 := self
 		      allocateRegNotConflictingWith: live
@@ -7574,7 +7590,6 @@ DruidJIT >> gen_StoreAndPopReceiverVariableBytecode1 [
 	self MoveR: t0 R: TempReg.
 	backEnd saveAndRestoreLinkRegAround: [
 		self CallRT: ceStoreCheckTrampoline ].
-	self annotateBytecode: self Label.
 	self TstCq: 7 R: t1.
 	jump6 := self JumpNonZero: 0.
 	jump7 := self JumpZero: 0.
@@ -7641,7 +7656,6 @@ DruidJIT >> gen_StoreAndPopReceiverVariableBytecode1 [
 	self MoveR: t0 R: TempReg.
 	backEnd saveAndRestoreLinkRegAround: [
 		self CallRT: ceStoreCheckTrampoline ].
-	self annotateBytecode: self Label.
 	currentBlock := self Label.
 	jump6 jmpTarget: currentBlock.
 	jump4 jmpTarget: currentBlock.
@@ -7660,6 +7674,7 @@ DruidJIT >> gen_StoreAndPopReceiverVariableBytecode2 [
 
 	| jump1 jump7 jumpNext t1 jump6 jump3 currentBlock t0 jump5 jump2 jumpTrue live t2 jump4 |
 	live := 0.
+	self annotateBytecode: self Label.
 	self ensureReceiverResultRegContainsSelf.
 	t0 := self
 		      allocateRegNotConflictingWith: live
@@ -7720,7 +7735,6 @@ DruidJIT >> gen_StoreAndPopReceiverVariableBytecode2 [
 	self MoveR: t0 R: TempReg.
 	backEnd saveAndRestoreLinkRegAround: [
 		self CallRT: ceStoreCheckTrampoline ].
-	self annotateBytecode: self Label.
 	self TstCq: 7 R: t1.
 	jump6 := self JumpNonZero: 0.
 	jump7 := self JumpZero: 0.
@@ -7787,7 +7801,6 @@ DruidJIT >> gen_StoreAndPopReceiverVariableBytecode2 [
 	self MoveR: t0 R: TempReg.
 	backEnd saveAndRestoreLinkRegAround: [
 		self CallRT: ceStoreCheckTrampoline ].
-	self annotateBytecode: self Label.
 	currentBlock := self Label.
 	jump6 jmpTarget: currentBlock.
 	jump4 jmpTarget: currentBlock.
@@ -7806,6 +7819,7 @@ DruidJIT >> gen_StoreAndPopReceiverVariableBytecode3 [
 
 	| jump1 jump7 jumpNext t1 jump6 jump3 currentBlock t0 jump5 jump2 jumpTrue live t2 jump4 |
 	live := 0.
+	self annotateBytecode: self Label.
 	self ensureReceiverResultRegContainsSelf.
 	t0 := self
 		      allocateRegNotConflictingWith: live
@@ -7866,7 +7880,6 @@ DruidJIT >> gen_StoreAndPopReceiverVariableBytecode3 [
 	self MoveR: t0 R: TempReg.
 	backEnd saveAndRestoreLinkRegAround: [
 		self CallRT: ceStoreCheckTrampoline ].
-	self annotateBytecode: self Label.
 	self TstCq: 7 R: t1.
 	jump6 := self JumpNonZero: 0.
 	jump7 := self JumpZero: 0.
@@ -7933,7 +7946,6 @@ DruidJIT >> gen_StoreAndPopReceiverVariableBytecode3 [
 	self MoveR: t0 R: TempReg.
 	backEnd saveAndRestoreLinkRegAround: [
 		self CallRT: ceStoreCheckTrampoline ].
-	self annotateBytecode: self Label.
 	currentBlock := self Label.
 	jump6 jmpTarget: currentBlock.
 	jump4 jmpTarget: currentBlock.
@@ -7952,6 +7964,7 @@ DruidJIT >> gen_StoreAndPopReceiverVariableBytecode4 [
 
 	| jump1 jump7 jumpNext t1 jump6 jump3 currentBlock t0 jump5 jump2 jumpTrue live t2 jump4 |
 	live := 0.
+	self annotateBytecode: self Label.
 	self ensureReceiverResultRegContainsSelf.
 	t0 := self
 		      allocateRegNotConflictingWith: live
@@ -8012,7 +8025,6 @@ DruidJIT >> gen_StoreAndPopReceiverVariableBytecode4 [
 	self MoveR: t0 R: TempReg.
 	backEnd saveAndRestoreLinkRegAround: [
 		self CallRT: ceStoreCheckTrampoline ].
-	self annotateBytecode: self Label.
 	self TstCq: 7 R: t1.
 	jump6 := self JumpNonZero: 0.
 	jump7 := self JumpZero: 0.
@@ -8079,7 +8091,6 @@ DruidJIT >> gen_StoreAndPopReceiverVariableBytecode4 [
 	self MoveR: t0 R: TempReg.
 	backEnd saveAndRestoreLinkRegAround: [
 		self CallRT: ceStoreCheckTrampoline ].
-	self annotateBytecode: self Label.
 	currentBlock := self Label.
 	jump6 jmpTarget: currentBlock.
 	jump4 jmpTarget: currentBlock.
@@ -8098,6 +8109,7 @@ DruidJIT >> gen_StoreAndPopReceiverVariableBytecode5 [
 
 	| jump1 jump7 jumpNext t1 jump6 jump3 currentBlock t0 jump5 jump2 jumpTrue live t2 jump4 |
 	live := 0.
+	self annotateBytecode: self Label.
 	self ensureReceiverResultRegContainsSelf.
 	t0 := self
 		      allocateRegNotConflictingWith: live
@@ -8158,7 +8170,6 @@ DruidJIT >> gen_StoreAndPopReceiverVariableBytecode5 [
 	self MoveR: t0 R: TempReg.
 	backEnd saveAndRestoreLinkRegAround: [
 		self CallRT: ceStoreCheckTrampoline ].
-	self annotateBytecode: self Label.
 	self TstCq: 7 R: t1.
 	jump6 := self JumpNonZero: 0.
 	jump7 := self JumpZero: 0.
@@ -8225,7 +8236,6 @@ DruidJIT >> gen_StoreAndPopReceiverVariableBytecode5 [
 	self MoveR: t0 R: TempReg.
 	backEnd saveAndRestoreLinkRegAround: [
 		self CallRT: ceStoreCheckTrampoline ].
-	self annotateBytecode: self Label.
 	currentBlock := self Label.
 	jump6 jmpTarget: currentBlock.
 	jump4 jmpTarget: currentBlock.
@@ -8244,6 +8254,7 @@ DruidJIT >> gen_StoreAndPopReceiverVariableBytecode6 [
 
 	| jump1 jump7 jumpNext t1 jump6 jump3 currentBlock t0 jump5 jump2 jumpTrue live t2 jump4 |
 	live := 0.
+	self annotateBytecode: self Label.
 	self ensureReceiverResultRegContainsSelf.
 	t0 := self
 		      allocateRegNotConflictingWith: live
@@ -8304,7 +8315,6 @@ DruidJIT >> gen_StoreAndPopReceiverVariableBytecode6 [
 	self MoveR: t0 R: TempReg.
 	backEnd saveAndRestoreLinkRegAround: [
 		self CallRT: ceStoreCheckTrampoline ].
-	self annotateBytecode: self Label.
 	self TstCq: 7 R: t1.
 	jump6 := self JumpNonZero: 0.
 	jump7 := self JumpZero: 0.
@@ -8371,7 +8381,6 @@ DruidJIT >> gen_StoreAndPopReceiverVariableBytecode6 [
 	self MoveR: t0 R: TempReg.
 	backEnd saveAndRestoreLinkRegAround: [
 		self CallRT: ceStoreCheckTrampoline ].
-	self annotateBytecode: self Label.
 	currentBlock := self Label.
 	jump6 jmpTarget: currentBlock.
 	jump4 jmpTarget: currentBlock.
@@ -8390,6 +8399,7 @@ DruidJIT >> gen_StoreAndPopReceiverVariableBytecode7 [
 
 	| jump1 jump7 jumpNext t1 jump6 jump3 currentBlock t0 jump5 jump2 jumpTrue live t2 jump4 |
 	live := 0.
+	self annotateBytecode: self Label.
 	self ensureReceiverResultRegContainsSelf.
 	t0 := self
 		      allocateRegNotConflictingWith: live
@@ -8450,7 +8460,6 @@ DruidJIT >> gen_StoreAndPopReceiverVariableBytecode7 [
 	self MoveR: t0 R: TempReg.
 	backEnd saveAndRestoreLinkRegAround: [
 		self CallRT: ceStoreCheckTrampoline ].
-	self annotateBytecode: self Label.
 	self TstCq: 7 R: t1.
 	jump6 := self JumpNonZero: 0.
 	jump7 := self JumpZero: 0.
@@ -8517,7 +8526,6 @@ DruidJIT >> gen_StoreAndPopReceiverVariableBytecode7 [
 	self MoveR: t0 R: TempReg.
 	backEnd saveAndRestoreLinkRegAround: [
 		self CallRT: ceStoreCheckTrampoline ].
-	self annotateBytecode: self Label.
 	currentBlock := self Label.
 	jump6 jmpTarget: currentBlock.
 	jump4 jmpTarget: currentBlock.

--- a/smalltalksrc/VMMaker/DruidJIT.class.st
+++ b/smalltalksrc/VMMaker/DruidJIT.class.st
@@ -398,30 +398,14 @@ DruidJIT class >> bytecodeTable [
 		  #branch. #isBranchFalse. #isMapped. #v3:ShortForward:Branch:Distance: }.
 		  { 1. 199. 199. #gen_ShortConditionalJumpFalse7.
 		  #branch. #isBranchFalse. #isMapped. #v3:ShortForward:Branch:Distance: }.
-		  { 1. 200. 200. #gen_StoreAndPopReceiverVariableBytecode0.
-		  #isInstVarRef. #is1ByteInstVarStore. #isMappedIfImmutability.
-		  #needsFrameIfImmutability:.  -1 }.
-		  { 1. 201. 201. #gen_StoreAndPopReceiverVariableBytecode1.
-		  #isInstVarRef. #is1ByteInstVarStore. #isMappedIfImmutability.
-		  #needsFrameIfImmutability:.  -1 }.
-		  { 1. 202. 202. #gen_StoreAndPopReceiverVariableBytecode2.
-		  #isInstVarRef. #is1ByteInstVarStore. #isMappedIfImmutability.
-		  #needsFrameIfImmutability:.  -1 }.
-		  { 1. 203. 203. #gen_StoreAndPopReceiverVariableBytecode3.
-		  #isInstVarRef. #is1ByteInstVarStore. #isMappedIfImmutability.
-		  #needsFrameIfImmutability:.  -1 }.
-		  { 1. 204. 204. #gen_StoreAndPopReceiverVariableBytecode4.
-		  #isInstVarRef. #is1ByteInstVarStore. #isMappedIfImmutability.
-		  #needsFrameIfImmutability:.  -1 }.
-		  { 1. 205. 205. #gen_StoreAndPopReceiverVariableBytecode5.
-		  #isInstVarRef. #is1ByteInstVarStore. #isMappedIfImmutability.
-		  #needsFrameIfImmutability:.  -1 }.
-		  { 1. 206. 206. #gen_StoreAndPopReceiverVariableBytecode6.
-		  #isInstVarRef. #is1ByteInstVarStore. #isMappedIfImmutability.
-		  #needsFrameIfImmutability:.  -1 }.
-		  { 1. 207. 207. #gen_StoreAndPopReceiverVariableBytecode7.
-		  #isInstVarRef. #is1ByteInstVarStore. #isMappedIfImmutability.
-		  #needsFrameIfImmutability:.  -1 }.
+		  { 1. 200. 200. #unknownBytecode }.
+		  { 1. 201. 201. #unknownBytecode }.
+		  { 1. 202. 202. #unknownBytecode }.
+		  { 1. 203. 203. #unknownBytecode }.
+		  { 1. 204. 204. #unknownBytecode }.
+		  { 1. 205. 205. #unknownBytecode }.
+		  { 1. 206. 206. #unknownBytecode }.
+		  { 1. 207. 207. #unknownBytecode }.
 		  { 1. 208. 208. #gen_StoreAndPopTemporaryVariableBytecode0 }.
 		  { 1. 209. 209. #gen_StoreAndPopTemporaryVariableBytecode1 }.
 		  { 1. 210. 210. #gen_StoreAndPopTemporaryVariableBytecode2 }.
@@ -454,10 +438,9 @@ DruidJIT class >> bytecodeTable [
 		  { 2. 233. 233. #gen_ExtPushCharacterBytecode.
 		  #needsFrameNever:. 1 }.
 		  { 2. 234. 234. #gen_ExtSendBytecode. #isMapped }.
-		  { 2. 235. 235. #gen_ExtSendSuperBytecode. #isMapped }.
+		  { 2. 235. 235. #unknownBytecode }.
 		  { 2. 236. 236. #unknownBytecode }.
-		  { 2. 237. 237. #gen_ExtUnconditionalJump. #branch. #isMapped.
-		  #v4:Long:Branch:Distance: }.
+		  { 2. 237. 237. #unknownBytecode }.
 		  { 2. 238. 238. #gen_ExtJumpIfTrue. #branch. #isBranchTrue.
 		  #isMapped. #v4:Long:Branch:Distance: }.
 		  { 2. 239. 239. #gen_ExtJumpIfFalse. #branch. #isBranchFalse.

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -2685,6 +2685,8 @@ StackInterpreter >> booleanValueOf: obj [
 StackInterpreter >> bytecodePrimAdd [
 
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
+	
 	| rcvr arg |
 	rcvr := self stackValue: 1.
 	arg := self stackValue: 0.
@@ -2748,6 +2750,8 @@ StackInterpreter >> bytecodePrimAt [
 StackInterpreter >> bytecodePrimAtEnd [
 
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
+	
 	self normalSendSpecialSelector: 21 argumentCount: 0
 ]
 
@@ -2797,6 +2801,8 @@ StackInterpreter >> bytecodePrimAtPut [
 StackInterpreter >> bytecodePrimBitAnd [
 
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
+	
 	self druidIgnore: [
 		self initPrimCall.
 		self primitiveBitAnd.
@@ -2810,6 +2816,8 @@ StackInterpreter >> bytecodePrimBitAnd [
 StackInterpreter >> bytecodePrimBitOr [
 
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
+	
 	self druidIgnore: [
 		self initPrimCall.
 		self primitiveBitOr.
@@ -2823,6 +2831,8 @@ StackInterpreter >> bytecodePrimBitOr [
 StackInterpreter >> bytecodePrimBitShift [
 
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
+	
 	self druidIgnore: [
 		self initPrimCall.
 		self primitiveBitShift.
@@ -2846,6 +2856,8 @@ StackInterpreter >> bytecodePrimClass [
 StackInterpreter >> bytecodePrimDiv [
 
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
+	
 	self druidIgnore: [
 		| quotient |
 		self initPrimCall.
@@ -2863,6 +2875,8 @@ StackInterpreter >> bytecodePrimDiv [
 StackInterpreter >> bytecodePrimDivide [
 
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
+	
 	self druidIgnore: [
 		| rcvr arg result |
 		rcvr := self stackValue: 1.
@@ -2889,6 +2903,8 @@ StackInterpreter >> bytecodePrimDivide [
 StackInterpreter >> bytecodePrimDo [
 
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
+	
 	self normalSendSpecialSelector: 27 argumentCount: 1
 ]
 
@@ -2896,6 +2912,7 @@ StackInterpreter >> bytecodePrimDo [
 StackInterpreter >> bytecodePrimEqualSistaV1 [
 
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
 	
 	self druidIgnore: [
 		| rcvr arg aBool |
@@ -2915,6 +2932,8 @@ StackInterpreter >> bytecodePrimEqualSistaV1 [
 StackInterpreter >> bytecodePrimGreaterOrEqualSistaV1 [
 
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
+	
 	self druidIgnore: [
 		| rcvr arg aBool |
 		rcvr := self stackValue: 1.
@@ -2938,6 +2957,8 @@ StackInterpreter >> bytecodePrimGreaterOrEqualSistaV1 [
 StackInterpreter >> bytecodePrimGreaterThanSistaV1 [
 
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
+	
 	self druidIgnore: [
 		| rcvr arg aBool |
 		rcvr := self stackValue: 1.
@@ -2961,6 +2982,8 @@ StackInterpreter >> bytecodePrimGreaterThanSistaV1 [
 StackInterpreter >> bytecodePrimIdenticalSistaV1 [
 	<compilationInfo: #notMapped>
 	<needsFrameNever: -1>
+	<druidInfo: #hasSend>
+	
 	| rcvr arg |
 	rcvr := self stackValue: 1.
 	arg := self stackValue: 0.
@@ -2975,6 +2998,8 @@ StackInterpreter >> bytecodePrimIdenticalSistaV1 [
 StackInterpreter >> bytecodePrimLessOrEqualSistaV1 [
 
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
+	
 	self druidIgnore: [
 		| rcvr arg aBool |
 		rcvr := self stackValue: 1.
@@ -2998,6 +3023,8 @@ StackInterpreter >> bytecodePrimLessOrEqualSistaV1 [
 StackInterpreter >> bytecodePrimLessThanSistaV1 [
 
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
+	
 	self druidIgnore: [
 		| rcvr arg aBool |
 		rcvr := self stackValue: 1.
@@ -3021,6 +3048,8 @@ StackInterpreter >> bytecodePrimLessThanSistaV1 [
 StackInterpreter >> bytecodePrimMakePoint [
 
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
+	
 	self druidIgnore: [ "Inline primitiveMakePoint for the benefit of the interpreter. Externalizing the
 	 sp & fp, then internalizing and testign for primitive failure add much overhead.
 	 So simply inline the relatively small ammount of code directly."
@@ -3045,6 +3074,8 @@ StackInterpreter >> bytecodePrimMakePoint [
 StackInterpreter >> bytecodePrimMod [
 
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
+	
 	self druidIgnore: [
 		| mod |
 		self initPrimCall.
@@ -3062,6 +3093,8 @@ StackInterpreter >> bytecodePrimMod [
 StackInterpreter >> bytecodePrimMultiply [
 
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
+	
 	self druidIgnore: [
 		| rcvr arg result overflow oop |
 		rcvr := self stackValue: 1.
@@ -3094,6 +3127,8 @@ StackInterpreter >> bytecodePrimMultiply [
 StackInterpreter >> bytecodePrimNew [
 
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
+	
 	self normalSendSpecialSelector: 28 argumentCount: 0
 ]
 
@@ -3101,6 +3136,8 @@ StackInterpreter >> bytecodePrimNew [
 StackInterpreter >> bytecodePrimNewWithArg [
 
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
+	
 	self normalSendSpecialSelector: 29 argumentCount: 1
 ]
 
@@ -3108,6 +3145,8 @@ StackInterpreter >> bytecodePrimNewWithArg [
 StackInterpreter >> bytecodePrimNext [
 
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
+	
 	self normalSendSpecialSelector: 19 argumentCount: 0
 ]
 
@@ -3115,6 +3154,8 @@ StackInterpreter >> bytecodePrimNext [
 StackInterpreter >> bytecodePrimNextPut [
 
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
+	
 	self normalSendSpecialSelector: 20 argumentCount: 1
 ]
 
@@ -3122,6 +3163,8 @@ StackInterpreter >> bytecodePrimNextPut [
 StackInterpreter >> bytecodePrimNotEqualSistaV1 [
 
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
+	
 	self druidIgnore: [
 		| rcvr arg aBool |
 		rcvr := self stackValue: 1.
@@ -3141,6 +3184,8 @@ StackInterpreter >> bytecodePrimNotIdenticalSistaV1 [
 
 	<compilationInfo: #notMapped>
 	<needsFrameNever: -1>
+	<druidInfo: #hasSend>
+	
 	| rcvr arg |
 	rcvr := self stackValue: 1.
 	arg := self stackValue: 0.
@@ -3155,6 +3200,8 @@ StackInterpreter >> bytecodePrimNotIdenticalSistaV1 [
 StackInterpreter >> bytecodePrimPointX [
 
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
+	
 	self druidIgnore: [
 		| rcvr |
 		self initPrimCall.
@@ -3173,6 +3220,8 @@ StackInterpreter >> bytecodePrimPointX [
 StackInterpreter >> bytecodePrimPointY [
 
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
+	
 	self druidIgnore: [
 		| rcvr |
 		self initPrimCall.
@@ -3191,6 +3240,8 @@ StackInterpreter >> bytecodePrimPointY [
 StackInterpreter >> bytecodePrimSize [
 
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
+	
 	self druidIgnore: [
 		| rcvr sz isString isArray |
 		self initPrimCall.
@@ -3225,6 +3276,8 @@ StackInterpreter >> bytecodePrimSpecialSelector24 [
 StackInterpreter >> bytecodePrimSubtract [
 
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
+	
 	self druidIgnore: [
 		| rcvr arg result |
 		rcvr := self stackValue: 1.
@@ -3247,6 +3300,8 @@ StackInterpreter >> bytecodePrimSubtract [
 StackInterpreter >> bytecodePrimValue [
 
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
+	
 	self druidIgnore: [
 		| rcvr isBlock |
 		rcvr := self stackTop.
@@ -3265,6 +3320,8 @@ StackInterpreter >> bytecodePrimValue [
 StackInterpreter >> bytecodePrimValueWithArg [
 
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
+	
 	self druidIgnore: [
 		| rcvr isBlock |
 		rcvr := self stackValue: 1.
@@ -5376,6 +5433,8 @@ StackInterpreter >> extSendBytecode [
 	"238		11101110	i i i i i j j j	Send Literal Selector #iiiii (+ Extend A * 32) with jjj (+ Extend B * 8) Arguments"
 
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
+	
 	| byte messageSelectorIndex messageArgumentCount |
 	byte := self fetchByte.
 	messageSelectorIndex := byte >> 3 + (extA << 5).
@@ -5395,6 +5454,7 @@ StackInterpreter >> extSendSuperBytecode [
 			ifTrue: [Send To Superclass Literal Selector #iiiii (+ Extend A * 32) with jjj (+ Extend B * 8) Arguments]
 			ifFalse: [Send To Superclass of Stacked Class Literal Selector #iiiii (+ Extend A * 32) with jjj (+ (Extend B bitAnd: 63) * 8) Arguments]"
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
 
 	| byte selectorIndex numArgs |
 	byte := self fetchByte.
@@ -13266,6 +13326,8 @@ StackInterpreter >> sendLiteralSelector0ArgsBytecode [
 	"Can use any of the first 16 literals for the selector."
 
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
+	
 	self
 		normalLiteralSelectorAt: (currentBytecode bitAnd: 16rF)
 		argumentCount: 0
@@ -13276,6 +13338,8 @@ StackInterpreter >> sendLiteralSelector1ArgBytecode [
 	"Can use any of the first 16 literals for the selector."
 
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
+	
 	self
 		normalLiteralSelectorAt: (currentBytecode bitAnd: 16rF)
 		argumentCount: 1
@@ -13286,6 +13350,8 @@ StackInterpreter >> sendLiteralSelector2ArgsBytecode [
 	"Can use any of the first 16 literals for the selector."
 
 	<compilationInfo: #isMapped>
+	<druidInfo: #hasSend>
+	
 	self
 		normalLiteralSelectorAt: (currentBytecode bitAnd: 16rF)
 		argumentCount: 2

--- a/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
+++ b/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
@@ -3442,6 +3442,7 @@ StackToRegisterMappingCogit >> initializeFixup: fixup [
 	 Initially a fixup's target is just a flag.  Later on it is replaced with a proper instruction."
 	<var: #fixup type: #'BytecodeFixup *'>
 	<inline: true>
+
 	fixup
 		simStackPtr: simStackPtr;
 		becomeMergeFixup;

--- a/smalltalksrc/VMMakerTests/VMJittedPrimitivesTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJittedPrimitivesTest.class.st
@@ -59,8 +59,6 @@ VMJittedPrimitivesTest >> executePrimitiveWithReceiver: receiverOop withArgument
 		arguments: (aCollection collect: [ :arg | self twoComplementFor: arg ])
 		method: 0.
 
-
-
 	self runUntilReturn
 ]
 


### PR DESCRIPTION
- Added new pragma `<druidInfo: #hasSend>` for bytecodes with message send
- Generated new `DruidJIT` model fixing the `annotateBytecode`

#### TODO
- [ ] There are failing `Kernel*` tests due to inst var assignation (maybe IMMUTABILITY check?)