### PR TITLE
Change custom command in ‘vmmaker.cmake’ to take into account that the ‘CMAKE_CURRENT_BINARY_DIR_TO_OUT’ can contain spaces

### DIFF
--- a/cmake/vmmaker.cmake
+++ b/cmake/vmmaker.cmake
@@ -144,7 +144,7 @@ if(GENERATE_SOURCES)
     #Custom command that generates the vm source code from VMMaker into the generated folder
     add_custom_command(
         OUTPUT ${VMSOURCEFILES} ${PLUGIN_GENERATED_FILES}
-        COMMAND ${VMMAKER_VM} --headless ${VMMAKER_IMAGE} --no-default-preferences eval \"PharoVMMaker generate: \#\'${FLAVOUR}\' outputDirectory: \'${CMAKE_CURRENT_BINARY_DIR_TO_OUT}\' imageFormat: \'${IMAGE_FORMAT}\'\"
+        COMMAND ${VMMAKER_VM} --headless ${VMMAKER_IMAGE} --no-default-preferences perform PharoVMMaker generate:outputDirectory:imageFormat: ${FLAVOUR} ${CMAKE_CURRENT_BINARY_DIR_TO_OUT} ${IMAGE_FORMAT}
         DEPENDS vmmaker ${VMMAKER_IMAGE} ${VMMAKER_VM}
         COMMENT "Generating VM files for flavour: ${FLAVOUR}")
 


### PR DESCRIPTION
This pull request changes the custom command in ‘vmmaker.cmake’ to take into account that the `CMAKE_CURRENT_BINARY_DIR_TO_OUT` can contain spaces.

I was using a directory on an external SSD with a name containing spaces. The command failed because the path `/Volumes/External SSD/…` got passed in the message to PharoVMMaker as the string `'/Volumes/External\ SSD/…'`, so with a backslash before the space. The [send of `#ensureCreateDirectory`](https://github.com/pharo-project/pharo-vm/blob/79fe4f326de43124edca33e81282a27e5da8a44d/smalltalksrc/Slang/VMMaker.class.st#L1180) in `#sourceDirectoryName:` on VMMaker then failed because creating a directory in `/Volumes` is not permitted (“PrimitiveFailed: primitive #createDirectory: in MacStore failed”).

I’m not sure how to fix it without also changing the first argument from a symbol to a string, but that shouldn’t be a problem for the [`#generate:outputDirectory:imageFormat:` method](https://github.com/pharo-project/pharo-vm/blob/79fe4f326de43124edca33e81282a27e5da8a44d/smalltalksrc/VMMakerCompatibilityForPharo6/PharoVMMaker.class.st#L68-L85).