### PR TITLE
Fix ‘doReport’ to take into account that ‘fopen’ can return NULL

### DIFF
--- a/src/debugUnix.c
+++ b/src/debugUnix.c
@@ -58,12 +58,16 @@ void doReport(char* fault, ucontext_t *uap){
 	crashdumpFileName[0] = 0;
 	getCrashDumpFilenameInto(crashdumpFileName);
 	crashDumpFile = fopen(crashdumpFileName, "a+");
-	vm_setVMOutputStream(crashDumpFile);
-
-	reportStackState(fault, ctimebuf, 1, uap, crashDumpFile);
+	if (crashDumpFile != NULL) {
+		vm_setVMOutputStream(crashDumpFile);
+	
+		reportStackState(fault, ctimebuf, 1, uap, crashDumpFile);
+	}
 
 	vm_setVMOutputStream(stderr);
-	fclose(crashDumpFile);
+	if (crashDumpFile != NULL) {
+		fclose(crashDumpFile);
+	}
 
 	reportStackState(fault, ctimebuf, 1, uap, stderr);
 


### PR DESCRIPTION
This pull request fixes ‘doReport’ to take into account that ‘fopen’ can return NULL.

It’s a fix for [Pharo issue #13773](https://github.com/pharo-project/pharo/issues/13773) (“Diagnostics signal crashes Pharo when opened through Finder”).