### PR TITLE
Add library with function to spawn a process connected to a pseudo-terminal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -571,6 +571,10 @@ add_subdirectory(ffiTestLibrary ${CMAKE_CURRENT_BINARY_DIR}/build/ffiTestLibrary
 # Handling Third party dependencies
 add_third_party_dependencies_per_platform()
 
+if (UNIX)
+    addIndependentLibraryWithRPATH(tty ${CMAKE_CURRENT_SOURCE_DIR}/tty/tty.c)
+endif()
+
 # Packaging Setup
 include(cmake/packaging.cmake)
 

--- a/tty/tty.c
+++ b/tty/tty.c
@@ -10,18 +10,19 @@
 #include <stdio.h>
 #include <sys/ioctl.h>
 
+#define STATUS_ERROR 127
 #define CHECK_NULL(exp) \
     if ((exp) == NULL) { \
-        exit(1); \
+        exit(STATUS_ERROR); \
     }
 #define CHECK_ERROR(exp) \
     if ((exp) == -1) { \
-        exit(1); \
+        exit(STATUS_ERROR); \
     }
 #define CHECK_ERROR_PRINT(exp) \
     if ((exp) == -1) { \
         printf("Error in %s at %s: %s\n", __func__, #exp, strerror(errno)); \
-        exit(1); \
+        exit(STATUS_ERROR); \
     }
 
 pid_t tty_spawn(int fdm, const char *path, char *const argv[], char *const envp[])
@@ -35,9 +36,9 @@ pid_t tty_spawn(int fdm, const char *path, char *const argv[], char *const envp[
         should be given as expected by 'execve'. The process ID of the
         new process is returned, or -1 if one could not be created. If
         the process is created but fails to open the slave device, or
-        set up the standard file descriptors, it exits with status 1.
+        set up the standard file descriptors, it exits with status 127.
         If it fails to create the session, set the controlling
-        terminal or execute the file, it exits with status 1 after
+        terminal or execute the file, it exits with status 127 after
         printing an error message on the terminal that indicates the
         call that failed.
         

--- a/tty/tty.c
+++ b/tty/tty.c
@@ -1,0 +1,30 @@
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/ioctl.h>
+
+#define CHECK_ERROR(exp) if ((exp) == -1) { printf("Error in %s at %s: %s\n", __func__, #exp, strerror(errno)); exit(1); }
+
+pid_t tty_spawn(int fdm, const char *path, char *const argv[], char *const envp[])
+{
+    pid_t pid = fork();
+    if (pid == 0)
+    {
+        int fds = open(ptsname(fdm), O_RDWR);
+        close(fdm);
+        close(0);
+        close(1);
+        close(2);
+        dup(fds);
+        dup(fds);
+        dup(fds);
+        close(fds);
+        CHECK_ERROR(setsid());
+        CHECK_ERROR(ioctl(0, TIOCSCTTY, 0));
+        CHECK_ERROR(execve(path, argv, envp));
+    }
+    return pid;
+}

--- a/tty/tty.c
+++ b/tty/tty.c
@@ -1,5 +1,5 @@
 #ifndef _XOPEN_SOURCE
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 700
 #endif
 
 #include <errno.h>
@@ -13,16 +13,16 @@
 #define STATUS_ERROR 127
 #define CHECK_NULL(exp) \
     if ((exp) == NULL) { \
-        exit(STATUS_ERROR); \
+        _exit(STATUS_ERROR); \
     }
 #define CHECK_ERROR(exp) \
     if ((exp) == -1) { \
-        exit(STATUS_ERROR); \
+        _exit(STATUS_ERROR); \
     }
 #define CHECK_ERROR_PRINT(exp) \
     if ((exp) == -1) { \
-        printf("Error in %s at %s: %s\n", __func__, #exp, strerror(errno)); \
-        exit(STATUS_ERROR); \
+        dprintf(2, "Error in %s at %s: %s\n", __func__, #exp, strerror(errno)); \
+        _exit(STATUS_ERROR); \
     }
 
 pid_t tty_spawn(int fdm, const char *path, char *const argv[], char *const envp[])

--- a/tty/tty.c
+++ b/tty/tty.c
@@ -1,3 +1,7 @@
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE 500
+#endif
+
 #include <errno.h>
 #include <string.h>
 #include <unistd.h>

--- a/tty/tty.c
+++ b/tty/tty.c
@@ -10,7 +10,19 @@
 #include <stdio.h>
 #include <sys/ioctl.h>
 
-#define CHECK_ERROR(exp) if ((exp) == -1) { printf("Error in %s at %s: %s\n", __func__, #exp, strerror(errno)); exit(1); }
+#define CHECK_NULL(exp) \
+    if ((exp) == NULL) { \
+        exit(1); \
+    }
+#define CHECK_ERROR(exp) \
+    if ((exp) == -1) { \
+        exit(1); \
+    }
+#define CHECK_ERROR_PRINT(exp) \
+    if ((exp) == -1) { \
+        printf("Error in %s at %s: %s\n", __func__, #exp, strerror(errno)); \
+        exit(1); \
+    }
 
 pid_t tty_spawn(int fdm, const char *path, char *const argv[], char *const envp[])
     /*
@@ -22,10 +34,12 @@ pid_t tty_spawn(int fdm, const char *path, char *const argv[], char *const envp[
         device as returned by 'posix_openpt'. The next three arguments
         should be given as expected by 'execve'. The process ID of the
         new process is returned, or -1 if one could not be created. If
-        the process is created but fails to create the session, set
-        the controlling terminal or execute the file, it exits with
-        status 1 after printing an error message on the terminal that
-        indicates the call that failed.
+        the process is created but fails to open the slave device, or
+        set up the standard file descriptors, it exits with status 1.
+        If it fails to create the session, set the controlling
+        terminal or execute the file, it exits with status 1 after
+        printing an error message on the terminal that indicates the
+        call that failed.
         
         Provided through a library included with the VM to support
         Pharo terminal emulators: it can only be partially replicated
@@ -36,18 +50,21 @@ pid_t tty_spawn(int fdm, const char *path, char *const argv[], char *const envp[
     pid_t pid = fork();
     if (pid == 0)
     {
-        int fds = open(ptsname(fdm), O_RDWR);
-        close(fdm);
-        close(0);
-        close(1);
-        close(2);
-        dup(fds);
-        dup(fds);
-        dup(fds);
-        close(fds);
-        CHECK_ERROR(setsid());
-        CHECK_ERROR(ioctl(0, TIOCSCTTY, 0));
-        CHECK_ERROR(execve(path, argv, envp));
+        char *sname;
+        CHECK_NULL(sname = ptsname(fdm));
+        int fds;
+        CHECK_ERROR(fds = open(sname, O_RDWR));
+        CHECK_ERROR(close(fdm));
+        CHECK_ERROR(close(0));
+        CHECK_ERROR(close(1));
+        CHECK_ERROR(close(2));
+        CHECK_ERROR(dup(fds));
+        CHECK_ERROR(dup(fds));
+        CHECK_ERROR(dup(fds));
+        CHECK_ERROR(close(fds));
+        CHECK_ERROR_PRINT(setsid());
+        CHECK_ERROR_PRINT(ioctl(0, TIOCSCTTY, 0));
+        CHECK_ERROR_PRINT(execve(path, argv, envp));
     }
     return pid;
 }

--- a/tty/tty.c
+++ b/tty/tty.c
@@ -9,6 +9,25 @@
 #define CHECK_ERROR(exp) if ((exp) == -1) { printf("Error in %s at %s: %s\n", __func__, #exp, strerror(errno)); exit(1); }
 
 pid_t tty_spawn(int fdm, const char *path, char *const argv[], char *const envp[])
+    /*
+        Spawns a process as a session leader with a pseudo-terminal as
+        its controlling terminal, its standard file descriptors
+        referring to the terminal, and executing a file with the given
+        arguments and environment. The first argument is expected to
+        be a file descriptor referring to a master pseudo-terminal
+        device as returned by 'posix_openpt'. The next three arguments
+        should be given as expected by 'execve'. The process ID of the
+        new process is returned, or -1 if one could not be created. If
+        the process is created but fails to create the session, set
+        the controlling terminal or execute the file, it exits with
+        status 1 after printing an error message on the terminal that
+        indicates the call that failed.
+        
+        Provided through a library included with the VM to support
+        Pharo terminal emulators: it can only be partially replicated
+        through the FFI by using 'posix_spawn', as that seems to lack
+        a way to set the controlling terminal of the new process.
+    */
 {
     pid_t pid = fork();
     if (pid == 0)


### PR DESCRIPTION
This pull request adds a small library with a function to spawn a process connected to a pseudo-terminal. As discussed in [pavel-krivanek/terminal issue #2](https://github.com/pavel-krivanek/terminal/issues/2) and [PTerm issue #58](https://github.com/lxsang/PTerm/issues/58), it’s not entirely possible to replicate this function in-image using `posix_spawn`. The function calls `setsid` and `ioctl` with `TIOCSCTTY` in the spawned process. For the `setsid` call, the attribute flag `POSIX_SPAWN_SETSID` can be passed to `posix_spawn` (nonstandard but supported by the GNU C Library and macOS). But for the `ioctl` call there is, as far as I know, no corresponding attribute or file action that can be passed.

The new File Browser that is being adopted (see: [Pharo pull request #16084](https://github.com/pharo-project/pharo/pull/16084)) offers a context menu item ‘Open terminal here’. That currently does not allow using PTerm ([PTerm issue #62](https://github.com/lxsang/PTerm/issues/62)), but it would be nice if it did and if the VM made that convenient to use by providing the necessary supporting library.
