### PR TITLE
Primitive to compare bytes

### DIFF
--- a/smalltalksrc/Melchor/VMClass.class.st
+++ b/smalltalksrc/Melchor/VMClass.class.st
@@ -809,6 +809,15 @@ VMClass >> malloc: size [
 ]
 
 { #category : #'C library simulation' }
+VMClass >> memcmp: array1 _: array2 _: length [
+
+	<doNotGenerate>
+	0 to: length - 1 do: [ :i |
+	(array1 at: i) = (array2 at: i) ifFalse: [ ^ 999 "Not 0" ] ].
+	^ 0
+]
+
+{ #category : #'C library simulation' }
 VMClass >> memcpy: dest _: src _: bytes [
 	<doNotGenerate>
 	"implementation of memcpy(3). N.B. If ranges overlap, must use memmove."

--- a/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
@@ -1250,7 +1250,7 @@ InterpreterPrimitives >> primitiveCompareBytes [
 	argumentCount = 1 ifFalse:[self primitiveFail. ^self].
 	arg1 := self stackValue: 1.
 	arg2 := self stackValue: 0.
-	((objectMemory isBytes: arg1) and:[objectMemory isBytes: arg2]) 
+	((objectMemory isWordsOrBytes: arg1) and:[objectMemory isWordsOrBytes: arg2]) 
 		ifFalse:[self primitiveFail. ^self].
 	"Quick identity test"
 	(arg1 = arg2) ifTrue:[^self pop: 2 thenPush: objectMemory trueObject].
@@ -1275,7 +1275,7 @@ InterpreterPrimitives >> primitiveCompareBytes2 [
 		^ self ].
 	arg1 := self stackValue: 1.
 	arg2 := self stackValue: 0.
-	((objectMemory isBytes: arg1) and: [ objectMemory isBytes: arg2 ])
+	((objectMemory isWordsOrBytes: arg1) and: [ objectMemory isWordsOrBytes: arg2 ])
 		ifFalse: [
 			self primitiveFail.
 			^ self ].

--- a/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
@@ -1264,6 +1264,39 @@ InterpreterPrimitives >> primitiveCompareBytes [
 
 ]
 
+{ #category : #'indexing primitives' }
+InterpreterPrimitives >> primitiveCompareBytes2 [
+	"Primitive. Compare two byte-indexed objects for equality"
+
+	<export: true>
+	| arg1 arg2 len1 len2 result |
+	argumentCount = 1 ifFalse: [
+		self primitiveFail.
+		^ self ].
+	arg1 := self stackValue: 1.
+	arg2 := self stackValue: 0.
+	((objectMemory isBytes: arg1) and: [ objectMemory isBytes: arg2 ])
+		ifFalse: [
+			self primitiveFail.
+			^ self ].
+	"Quick identity test"
+	arg1 = arg2 ifTrue: [
+		^ self pop: 2 thenPush: objectMemory trueObject ].
+	len1 := objectMemory byteSizeOf: arg1.
+	len2 := objectMemory byteSizeOf: arg2.
+	len1 = len2 ifFalse: [
+		^ self pop: 2 thenPush: objectMemory falseObject ].
+
+	result := self
+		          memcmp: (objectMemory firstIndexableField: arg1)
+		          _: (objectMemory firstIndexableField: arg2)
+		          _: len1.
+
+	result = 0
+		ifTrue: [ self pop: 2 thenPush: objectMemory trueObject ]
+		ifFalse: [ self pop: 2 thenPush: objectMemory falseObject ]
+]
+
 { #category : #'sound primitives' }
 InterpreterPrimitives >> primitiveConstantFill [
 	"Fill the receiver, which must be an indexable non-pointer

--- a/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
@@ -1242,61 +1242,6 @@ InterpreterPrimitives >> primitiveCoarseUTCMicrosecondClock [
 	self pop: 1 thenPush: (self positive64BitIntegerFor: self ioUTCMicroseconds)
 ]
 
-{ #category : #'indexing primitives' }
-InterpreterPrimitives >> primitiveCompareBytes [
-	"Primitive. Compare two byte-indexed objects for equality"
-	| arg1 arg2 len1 len2 |
-	<export: true>
-	argumentCount = 1 ifFalse:[self primitiveFail. ^self].
-	arg1 := self stackValue: 1.
-	arg2 := self stackValue: 0.
-	((objectMemory isWordsOrBytes: arg1) and:[objectMemory isWordsOrBytes: arg2]) 
-		ifFalse:[self primitiveFail. ^self].
-	"Quick identity test"
-	(arg1 = arg2) ifTrue:[^self pop: 2 thenPush: objectMemory trueObject].
-	len1 := objectMemory byteSizeOf: arg1.
-	len2 := objectMemory byteSizeOf: arg2.
-	len1 = len2 ifFalse:[^self pop: 2 thenPush: objectMemory falseObject].
-	0 to: len1-1 do:[:i|
-		(objectMemory fetchByte: i ofObject: arg1) = (objectMemory fetchByte: i ofObject: arg2) 
-			ifFalse:[^self pop: 2 thenPush: objectMemory falseObject]].
-	self pop: 2 thenPush: objectMemory trueObject.
-
-]
-
-{ #category : #'indexing primitives' }
-InterpreterPrimitives >> primitiveCompareBytes2 [
-	"Primitive. Compare two byte-indexed objects for equality"
-
-	<export: true>
-	| arg1 arg2 len1 len2 result |
-	argumentCount = 1 ifFalse: [
-		self primitiveFail.
-		^ self ].
-	arg1 := self stackValue: 1.
-	arg2 := self stackValue: 0.
-	((objectMemory isWordsOrBytes: arg1) and: [ objectMemory isWordsOrBytes: arg2 ])
-		ifFalse: [
-			self primitiveFail.
-			^ self ].
-	"Quick identity test"
-	arg1 = arg2 ifTrue: [
-		^ self pop: 2 thenPush: objectMemory trueObject ].
-	len1 := objectMemory byteSizeOf: arg1.
-	len2 := objectMemory byteSizeOf: arg2.
-	len1 = len2 ifFalse: [
-		^ self pop: 2 thenPush: objectMemory falseObject ].
-
-	result := self
-		          memcmp: (objectMemory firstIndexableField: arg1)
-		          _: (objectMemory firstIndexableField: arg2)
-		          _: len1.
-
-	result = 0
-		ifTrue: [ self pop: 2 thenPush: objectMemory trueObject ]
-		ifFalse: [ self pop: 2 thenPush: objectMemory falseObject ]
-]
-
 { #category : #'sound primitives' }
 InterpreterPrimitives >> primitiveConstantFill [
 	"Fill the receiver, which must be an indexable non-pointer

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -1202,7 +1202,8 @@ StackInterpreter class >> initializePrimitiveTable [
 		(149 primitiveGetAttribute)
 
 		"Were File Primitives (150-169) - NO LONGER INDEXED"
-		(150 157 primitiveFail)
+		(150 156 primitiveFail)
+		(157 primitiveCompareBytes)
 		(158 primitiveStringCompareWith)
 		(159 primitiveHashMultiply)
 		(160 primitiveAdoptInstance)
@@ -1489,9 +1490,6 @@ StackInterpreter class >> isObjectAccessor: selector [
 	^(InterpreterProxy whichCategoryIncludesSelector: selector) = #'object access'
 	 or: [(SpurMemoryManager whichCategoryIncludesSelector: selector) = #'object access']
 
-	"This for checking.  The above two protocols are somewhat disjoint."
-	"(InterpreterProxy allMethodsInCategory: #'object access') copyWithoutAll: (SpurMemoryManager allMethodsInCategory: #'object access')"
-	"(SpurMemoryManager allMethodsInCategory: #'object access') copyWithoutAll: (InterpreterProxy allMethodsInCategory: #'object access')"
 ]
 
 { #category : #'spur compilation support' }

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -1204,7 +1204,7 @@ StackInterpreter class >> initializePrimitiveTable [
 		"Were File Primitives (150-169) - NO LONGER INDEXED"
 		(150 155 primitiveFail)
 		(156 primitiveCompareBytes)
-		(157 primitiveCompareBytes2)
+		(157 primitiveFail)
 		(158 primitiveStringCompareWith)
 		(159 primitiveHashMultiply)
 		(160 primitiveAdoptInstance)
@@ -10892,6 +10892,58 @@ StackInterpreter >> primitiveAccessorDepthForExternalPrimitiveMethod: methodObj 
 		(objectMemory
 			fetchPointer: 2
 			ofObject: (self literal: 0 ofMethod: methodObj))
+]
+
+{ #category : #'indexing primitives' }
+StackInterpreter >> primitiveCompareBytes [
+	"Primitive. Compare two word or byte indexed objects for equality.
+	This version uses memcmp for comparison.
+	It is specialized for equality and thus it performs an unordered comparison, not caring about element order.
+	This can be used for:
+	 - ByteArray
+	 - ByteString
+	 - FloatArray
+	 ..."
+
+	<export: true>
+	| arg1 arg2 len1 len2 result boolean |
+
+	argumentCount < 1 ifTrue: [ ^ self primitiveFail ].
+
+	arg1 := self stackValue: 1.
+	arg2 := self stackValue: 0.
+
+	"Quick identity test to avoid checking object contents when they are the same one\"
+	arg1 = arg2 ifTrue: [
+		^ self pop: 2 thenPush: objectMemory trueObject ].
+	
+	"This primitive only works for bytes and words objects.
+	The check below does not even let pass forwarders.
+	Below, we assume that the two compared objects are indexable and can be compared."
+	((objectMemory isWordsOrBytes: arg1) and: [
+		 objectMemory isWordsOrBytes: arg2 ]) ifFalse: [
+		^ self primitiveFail ].
+
+	"Two arrays of different lenght can never be equal"
+	len1 := objectMemory byteSizeOf: arg1.
+	len2 := objectMemory byteSizeOf: arg2.
+	len1 = len2 ifFalse: [
+		^ self pop: 2 thenPush: objectMemory falseObject ].
+
+	"Use memcmp to compare the array contents.
+	Our benchmarks showed that 
+	 - it is 3x faster than doing it directly in Pharo when the compared bytes are few
+	 - it is hundreds of times faster when comparing thousands of bytes.
+	The alternative word-by-word comparison implemented purely in slang is also better than the baseline but it is 10x slower than memcmp for large comparisons"
+	result := self
+		          memcmp: (objectMemory firstIndexableField: arg1)
+		          _: (objectMemory firstIndexableField: arg2)
+		          _: len1.
+
+	boolean := result = 0
+		           ifTrue: [ objectMemory trueObject ]
+		           ifFalse: [ objectMemory falseObject ].
+	self pop: 2 thenPush: boolean
 ]
 
 { #category : #'process primitives' }

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -1202,8 +1202,9 @@ StackInterpreter class >> initializePrimitiveTable [
 		(149 primitiveGetAttribute)
 
 		"Were File Primitives (150-169) - NO LONGER INDEXED"
-		(150 156 primitiveFail)
-		(157 primitiveCompareBytes)
+		(150 155 primitiveFail)
+		(156 primitiveCompareBytes)
+		(157 primitiveCompareBytes2)
 		(158 primitiveStringCompareWith)
 		(159 primitiveHashMultiply)
 		(160 primitiveAdoptInstance)

--- a/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
@@ -1254,7 +1254,7 @@ VMPrimitiveTest >> testPrimitiveClassReturnsAClass [
 	
 ]
 
-{ #category : #'tests - primitiveDivide' }
+{ #category : #'tests - primitiveCompareBytes' }
 VMPrimitiveTest >> testPrimitiveCompareBytes2 [
 
 	| array1 array2 |
@@ -1270,7 +1270,7 @@ VMPrimitiveTest >> testPrimitiveCompareBytes2 [
 	self assert: interpreter stackTop equals: memory trueObject
 ]
 
-{ #category : #'tests - primitiveDivide' }
+{ #category : #'tests - primitiveCompareBytes' }
 VMPrimitiveTest >> testPrimitiveCompareBytesEmpty [
 
 	| array1 array2 |
@@ -1286,7 +1286,7 @@ VMPrimitiveTest >> testPrimitiveCompareBytesEmpty [
 	self assert: interpreter stackTop equals: memory trueObject
 ]
 
-{ #category : #'tests - primitiveDivide' }
+{ #category : #'tests - primitiveCompareBytes' }
 VMPrimitiveTest >> testPrimitiveCompareBytesWithDifferentSize1 [
 
 	| array1 array2 size |
@@ -1309,7 +1309,7 @@ VMPrimitiveTest >> testPrimitiveCompareBytesWithDifferentSize1 [
 	self assert: interpreter stackTop equals: memory falseObject
 ]
 
-{ #category : #'tests - primitiveDivide' }
+{ #category : #'tests - primitiveCompareBytes' }
 VMPrimitiveTest >> testPrimitiveCompareBytesWithDifferentSize2 [
 
 	| array1 array2 size |
@@ -1332,7 +1332,7 @@ VMPrimitiveTest >> testPrimitiveCompareBytesWithDifferentSize2 [
 	self assert: interpreter stackTop equals: memory falseObject
 ]
 
-{ #category : #'tests - primitiveDivide' }
+{ #category : #'tests - primitiveCompareBytes' }
 VMPrimitiveTest >> testPrimitiveCompareBytesWithDifferentValues [
 
 	| array1 array2 size |
@@ -1353,7 +1353,7 @@ VMPrimitiveTest >> testPrimitiveCompareBytesWithDifferentValues [
 	self assert: interpreter stackTop equals: memory falseObject
 ]
 
-{ #category : #'tests - primitiveDivide' }
+{ #category : #'tests - primitiveCompareBytes' }
 VMPrimitiveTest >> testPrimitiveCompareBytesWithLastDifferentValue [
 
 	| array1 array2 size |
@@ -1375,7 +1375,7 @@ VMPrimitiveTest >> testPrimitiveCompareBytesWithLastDifferentValue [
 	self assert: interpreter stackTop equals: memory falseObject
 ]
 
-{ #category : #'tests - primitiveDivide' }
+{ #category : #'tests - primitiveCompareBytes' }
 VMPrimitiveTest >> testPrimitiveCompareBytesWithNonByteArgument [
 
 	| array1 size |
@@ -1394,7 +1394,7 @@ VMPrimitiveTest >> testPrimitiveCompareBytesWithNonByteArgument [
 	self assert: interpreter failed 
 ]
 
-{ #category : #'tests - primitiveDivide' }
+{ #category : #'tests - primitiveCompareBytes' }
 VMPrimitiveTest >> testPrimitiveCompareBytesWithNonByteReceiver [
 
 	| array1 size |
@@ -1413,7 +1413,7 @@ VMPrimitiveTest >> testPrimitiveCompareBytesWithNonByteReceiver [
 	self assert: interpreter failed 
 ]
 
-{ #category : #'tests - primitiveDivide' }
+{ #category : #'tests - primitiveCompareBytes' }
 VMPrimitiveTest >> testPrimitiveCompareBytesWithNonByteReceiverShouldLeaveTheSameStack [
 
 	| array1 size |
@@ -1433,7 +1433,7 @@ VMPrimitiveTest >> testPrimitiveCompareBytesWithNonByteReceiverShouldLeaveTheSam
 	self assert: (interpreter stackValue: 1) equals: memory nilObject
 ]
 
-{ #category : #'tests - primitiveDivide' }
+{ #category : #'tests - primitiveCompareBytes' }
 VMPrimitiveTest >> testPrimitiveCompareBytesWithSize [
 
 	| array1 array2 size |

--- a/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
@@ -1255,6 +1255,22 @@ VMPrimitiveTest >> testPrimitiveClassReturnsAClass [
 ]
 
 { #category : #'tests - primitiveDivide' }
+VMPrimitiveTest >> testPrimitiveCompareBytes2 [
+
+	| array1 array2 |
+	array1 := self new8BitIndexableOfSize: 0.
+	array2 := self new8BitIndexableOfSize: 0.
+
+	interpreter push: array1.
+	interpreter push: array2.
+
+	interpreter argumentCount: 1.
+	interpreter primitiveCompareBytes2.
+
+	self assert: interpreter stackTop equals: memory trueObject
+]
+
+{ #category : #'tests - primitiveDivide' }
 VMPrimitiveTest >> testPrimitiveCompareBytesEmpty [
 
 	| array1 array2 |

--- a/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
@@ -1271,6 +1271,24 @@ VMPrimitiveTest >> testPrimitiveCompareBytes2 [
 ]
 
 { #category : #'tests - primitiveCompareBytes' }
+VMPrimitiveTest >> testPrimitiveCompareBytesArgCountLessThanOne [
+
+	| array1 size |
+	size := 1.
+	array1 := self new8BitIndexableOfSize: size.
+
+	1 to: size do: [ :i |
+	memory storeByte: i - 1 ofObject: array1 withValue: 0 ].
+
+	interpreter push: array1.
+
+	interpreter argumentCount: 0.
+	interpreter primitiveCompareBytes.
+
+	self assert: interpreter failed
+]
+
+{ #category : #'tests - primitiveCompareBytes' }
 VMPrimitiveTest >> testPrimitiveCompareBytesEmpty [
 
 	| array1 array2 |
@@ -1281,6 +1299,26 @@ VMPrimitiveTest >> testPrimitiveCompareBytesEmpty [
 	interpreter push: array2.
 
 	interpreter argumentCount: 1.
+	interpreter primitiveCompareBytes.
+
+	self assert: interpreter stackTop equals: memory trueObject
+]
+
+{ #category : #'tests - primitiveCompareBytes' }
+VMPrimitiveTest >> testPrimitiveCompareBytesIdentity [
+
+	| array1 size |
+	size := 1.
+	array1 := self new8BitIndexableOfSize: size.
+
+	1 to: size do: [ :i |
+	memory storeByte: i - 1 ofObject: array1 withValue: 0 ].
+
+	interpreter push: array1.
+	interpreter push: array1.
+
+	interpreter argumentCount: 1.
+
 	interpreter primitiveCompareBytes.
 
 	self assert: interpreter stackTop equals: memory trueObject

--- a/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
@@ -1255,22 +1255,6 @@ VMPrimitiveTest >> testPrimitiveClassReturnsAClass [
 ]
 
 { #category : #'tests - primitiveCompareBytes' }
-VMPrimitiveTest >> testPrimitiveCompareBytes2 [
-
-	| array1 array2 |
-	array1 := self new8BitIndexableOfSize: 0.
-	array2 := self new8BitIndexableOfSize: 0.
-
-	interpreter push: array1.
-	interpreter push: array2.
-
-	interpreter argumentCount: 1.
-	interpreter primitiveCompareBytes2.
-
-	self assert: interpreter stackTop equals: memory trueObject
-]
-
-{ #category : #'tests - primitiveCompareBytes' }
 VMPrimitiveTest >> testPrimitiveCompareBytesArgCountLessThanOne [
 
 	| array1 size |

--- a/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
@@ -1254,6 +1254,190 @@ VMPrimitiveTest >> testPrimitiveClassReturnsAClass [
 	
 ]
 
+{ #category : #'tests - primitiveDivide' }
+VMPrimitiveTest >> testPrimitiveCompareBytesEmpty [
+
+	| array1 array2 |
+	array1 := self new8BitIndexableOfSize: 0.
+	array2 := self new8BitIndexableOfSize: 0.
+
+	interpreter push: array1.
+	interpreter push: array2.
+
+	interpreter argumentCount: 1.
+	interpreter primitiveCompareBytes.
+
+	self assert: interpreter stackTop equals: memory trueObject
+]
+
+{ #category : #'tests - primitiveDivide' }
+VMPrimitiveTest >> testPrimitiveCompareBytesWithDifferentSize1 [
+
+	| array1 array2 size |
+	size := 1.
+	array1 := self new8BitIndexableOfSize: size.
+	array2 := self new8BitIndexableOfSize: size + 1.
+
+	1 to: size do: [ :i |
+		memory storeByte: i - 1 ofObject: array1 withValue: 0.
+		memory storeByte: i - 1 ofObject: array2 withValue: 0 ].
+	memory storeByte: size - 1 ofObject: array2 withValue: 0.
+
+	"Arg > Receiver"
+	interpreter push: array1.
+	interpreter push: array2.
+
+	interpreter argumentCount: 1.
+	interpreter primitiveCompareBytes.
+
+	self assert: interpreter stackTop equals: memory falseObject
+]
+
+{ #category : #'tests - primitiveDivide' }
+VMPrimitiveTest >> testPrimitiveCompareBytesWithDifferentSize2 [
+
+	| array1 array2 size |
+	size := 1.
+	array1 := self new8BitIndexableOfSize: size.
+	array2 := self new8BitIndexableOfSize: size + 1.
+
+	1 to: size do: [ :i |
+		memory storeByte: i - 1 ofObject: array1 withValue: 0.
+		memory storeByte: i - 1 ofObject: array2 withValue: 0 ].
+	memory storeByte: size - 1 ofObject: array2 withValue: 0.
+
+	"Receiver > Arg"
+	interpreter push: array2.
+	interpreter push: array1.
+
+	interpreter argumentCount: 1.
+	interpreter primitiveCompareBytes.
+
+	self assert: interpreter stackTop equals: memory falseObject
+]
+
+{ #category : #'tests - primitiveDivide' }
+VMPrimitiveTest >> testPrimitiveCompareBytesWithDifferentValues [
+
+	| array1 array2 size |
+	size := 2.
+	array1 := self new8BitIndexableOfSize: size.
+	array2 := self new8BitIndexableOfSize: size.
+
+	1 to: size do: [ :i |
+		memory storeByte: i - 1 ofObject: array1 withValue: 0.
+		memory storeByte: i - 1 ofObject: array2 withValue: 1 ].
+
+	interpreter push: array1.
+	interpreter push: array2.
+
+	interpreter argumentCount: 1.
+	interpreter primitiveCompareBytes.
+
+	self assert: interpreter stackTop equals: memory falseObject
+]
+
+{ #category : #'tests - primitiveDivide' }
+VMPrimitiveTest >> testPrimitiveCompareBytesWithLastDifferentValue [
+
+	| array1 array2 size |
+	size := 2.
+	array1 := self new8BitIndexableOfSize: size.
+	array2 := self new8BitIndexableOfSize: size.
+
+	1 to: size do: [ :i |
+		memory storeByte: i - 1 ofObject: array1 withValue: 0.
+		memory storeByte: i - 1 ofObject: array2 withValue: 0 ].
+	memory storeByte: size - 1 ofObject: array2 withValue: 1.
+
+	interpreter push: array1.
+	interpreter push: array2.
+
+	interpreter argumentCount: 1.
+	interpreter primitiveCompareBytes.
+
+	self assert: interpreter stackTop equals: memory falseObject
+]
+
+{ #category : #'tests - primitiveDivide' }
+VMPrimitiveTest >> testPrimitiveCompareBytesWithNonByteArgument [
+
+	| array1 size |
+	size := 2.
+	array1 := self new8BitIndexableOfSize: size.
+
+	1 to: size do: [ :i |
+	memory storeByte: i - 1 ofObject: array1 withValue: 0 ].
+
+	interpreter push: array1.
+	interpreter push: memory nilObject.
+
+	interpreter argumentCount: 1.
+	interpreter primitiveCompareBytes.
+
+	self assert: interpreter failed 
+]
+
+{ #category : #'tests - primitiveDivide' }
+VMPrimitiveTest >> testPrimitiveCompareBytesWithNonByteReceiver [
+
+	| array1 size |
+	size := 2.
+	array1 := self new8BitIndexableOfSize: size.
+
+	1 to: size do: [ :i |
+	memory storeByte: i - 1 ofObject: array1 withValue: 0 ].
+
+	interpreter push: memory nilObject.
+	interpreter push: array1.
+
+	interpreter argumentCount: 1.
+	interpreter primitiveCompareBytes.
+
+	self assert: interpreter failed 
+]
+
+{ #category : #'tests - primitiveDivide' }
+VMPrimitiveTest >> testPrimitiveCompareBytesWithNonByteReceiverShouldLeaveTheSameStack [
+
+	| array1 size |
+	size := 2.
+	array1 := self new8BitIndexableOfSize: size.
+
+	1 to: size do: [ :i |
+	memory storeByte: i - 1 ofObject: array1 withValue: 0 ].
+
+	interpreter push: memory nilObject.
+	interpreter push: array1.
+
+	interpreter argumentCount: 1.
+	interpreter primitiveCompareBytes.
+
+	self assert: (interpreter stackValue: 0) equals: array1.
+	self assert: (interpreter stackValue: 1) equals: memory nilObject
+]
+
+{ #category : #'tests - primitiveDivide' }
+VMPrimitiveTest >> testPrimitiveCompareBytesWithSize [
+
+	| array1 array2 size |
+	size := 1.
+	array1 := self new8BitIndexableOfSize: size.
+	array2 := self new8BitIndexableOfSize: size.
+
+	1 to: size do: [ :i |
+		memory storeByte: i - 1 ofObject: array1 withValue: 0.
+		memory storeByte: i - 1 ofObject: array2 withValue: 0 ].
+
+	interpreter push: array1.
+	interpreter push: array2.
+
+	interpreter argumentCount: 1.
+	interpreter primitiveCompareBytes.
+
+	self assert: interpreter stackTop equals: memory trueObject
+]
+
 { #category : #'tests - primitiveDiv' }
 VMPrimitiveTest >> testPrimitiveDiv [
 


### PR DESCRIPTION
Redo of https://github.com/pharo-project/pharo-vm/pull/611

This pull request introduces a new primitive to compare bytes.

 In the mentioned PR,  two implementations were proposed, one using a loop in 'pure Pharo'  and the other memcmp and thus relying on the C implementation.

We made a couple of benchmarks and we saw that the memcmp implementation:
	 - is 3x faster than doing it directly in Pharo when the compared bytes are few.
	 - is hundreds of times faster when comparing thousands of bytes.
	
  The alternative word-by-word comparison implemented purely in slang is also better than the baseline but it is 10x slower than memcmp for large comparisons.
