### PR TITLE
Change calling convention on closures

### DIFF
--- a/smalltalksrc/VMMaker/CoInterpreter.class.st
+++ b/smalltalksrc/VMMaker/CoInterpreter.class.st
@@ -2718,14 +2718,27 @@ CoInterpreter >> executeFullCogBlock: cogMethod closure: closure mayContextSwitc
 	 register arguments to blocks. Instead, the machine code block value primitives
 	 push the reg args if necessary before dispatching to the block.  Hence here, only
 	 the receiver gets pushed. See genPrimitiveClosureValue"
+
 	<var: #cogMethod type: #'CogMethod *'>
 	cogit assertCStackWellAligned.
-	self assertValidExecutionPointe: instructionPointer r: framePointer s: stackPointer.
+	self
+		assertValidExecutionPointe: instructionPointer
+		r: framePointer
+		s: stackPointer.
 	self ensurePushedInstructionPointer.
-	self push: cogMethod asInteger 
-		+ (mayContextSwitch
-				ifTrue: [cogit fullBlockEntryOffset]
-				ifFalse: [cogit fullBlockNoContextSwitchEntryOffset]).
+
+	cogit numRegArgs > 0 ifTrue: [ "dont use and: so as to get Slang to inline cogit numRegArgs > 0"
+		cogMethod cmNumArgs <= cogit numRegArgs ifTrue: [
+			self
+				callRegisterArgCogMethod: cogMethod
+				at: (mayContextSwitch
+						 ifTrue: [ cogit fullBlockEntryOffset ]
+						 ifFalse: [ cogit fullBlockNoContextSwitchEntryOffset ])
+				receiver: closure ] ].
+
+	self push: cogMethod asInteger + (mayContextSwitch
+			 ifTrue: [ cogit fullBlockEntryOffset ]
+			 ifFalse: [ cogit fullBlockNoContextSwitchEntryOffset ]).
 	self push: closure.
 	self callEnilopmart: #ceCallCogCodePopReceiverReg.
 	self unreachable

--- a/smalltalksrc/VMMaker/CoInterpreter.class.st
+++ b/smalltalksrc/VMMaker/CoInterpreter.class.st
@@ -2734,7 +2734,8 @@ CoInterpreter >> executeFullCogBlock: cogMethod closure: closure mayContextSwitc
 				at: (mayContextSwitch
 						 ifTrue: [ cogit fullBlockEntryOffset ]
 						 ifFalse: [ cogit fullBlockNoContextSwitchEntryOffset ])
-				receiver: closure ] ].
+				receiver: closure.
+			self unreachable ] ].
 
 	self push: cogMethod asInteger + (mayContextSwitch
 			 ifTrue: [ cogit fullBlockEntryOffset ]

--- a/smalltalksrc/VMMaker/CoInterpreter.class.st
+++ b/smalltalksrc/VMMaker/CoInterpreter.class.st
@@ -2727,6 +2727,8 @@ CoInterpreter >> executeFullCogBlock: cogMethod closure: closure mayContextSwitc
 		s: stackPointer.
 	self ensurePushedInstructionPointer.
 
+	"If arguments fit on registers, they should not be passed on the stack.
+	Call the trampoline that is on charge of pop'ing them to respect the machine code calling convention"
 	cogit numRegArgs > 0 ifTrue: [ "dont use and: so as to get Slang to inline cogit numRegArgs > 0"
 		cogMethod cmNumArgs <= cogit numRegArgs ifTrue: [
 			self

--- a/smalltalksrc/VMMaker/SimpleStackBasedCogit.class.st
+++ b/smalltalksrc/VMMaker/SimpleStackBasedCogit.class.st
@@ -1784,7 +1784,6 @@ SimpleStackBasedCogit >> genPrimReturnEnterCogCodeEnilopmart: profiling [
 
 { #category : #'primitive generators' }
 SimpleStackBasedCogit >> genPrimitiveFullClosureValue [
-
 	"Check the argument count.  Fail if wrong.
 	 Get the method from the outerContext and see if it is cogged.  If so, jump to the
 	 block entry or the no-context-switch entry, as appropriate, and we're done.  If not,
@@ -1836,11 +1835,13 @@ SimpleStackBasedCogit >> genPrimitiveFullClosureValue [
 	jumpBCMethod jmpTarget:
 		(jumpFailImmediateMethod jmpTarget:
 			 (jumpFail4 jmpTarget: self Label)).
+
 	(result := self
 		           compileInterpreterPrimitive: primitiveRoutine
 		           flags: (self
 				            primitivePropertyFlags: primitiveIndex
-				            primitiveDescriptor: self primitiveDescriptor)) < 0 ifTrue: [ ^ result ].
+				            primitiveDescriptor: self primitiveDescriptor)) < 0
+		ifTrue: [ ^ result ].
 	jumpFailNArgs jmpTarget: self Label.
 	^ CompletePrimitive
 ]

--- a/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
+++ b/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
@@ -1016,6 +1016,13 @@ StackToRegisterMappingCogit >> compileCogMethod: selector [
 ]
 
 { #category : #'compile abstract instructions' }
+StackToRegisterMappingCogit >> compileEntireFullBlockMethod: numCopied [
+
+	regArgsHaveBeenPushed := false.
+	^ super compileEntireFullBlockMethod: numCopied
+]
+
+{ #category : #'compile abstract instructions' }
 StackToRegisterMappingCogit >> compileEntireMethod [
 	"Compile the abstract instructions for the entire method, including blocks."
 	regArgsHaveBeenPushed := false.
@@ -1052,6 +1059,8 @@ StackToRegisterMappingCogit >> compileFullBlockFramelessEntry: numCopied [
 { #category : #'compile abstract instructions' }
 StackToRegisterMappingCogit >> compileFullBlockMethodFrameBuild: numCopied [
 	<option: #SistaV1BytecodeSet>
+	"We push the call arguments (receiver and arguments) to the stack, regardless of it being a frameful or frameless method"
+	self genPushRegisterArgs.
 	useTwoPaths ifTrue: 
 		[ "method with only inst var store, we compile only slow path for now" 
 		 useTwoPaths := false.
@@ -2121,14 +2130,6 @@ StackToRegisterMappingCogit >> genPrimReturn [
 ]
 
 { #category : #'primitive generators' }
-StackToRegisterMappingCogit >> genPrimitiveFullClosureValue [
-	"Override to push the register args first."
-	<option: #SistaV1BytecodeSet>
-	self genPushRegisterArgs.
-	^super genPrimitiveFullClosureValue
-]
-
-{ #category : #'primitive generators' }
 StackToRegisterMappingCogit >> genPrimitivePerform [
 	"Generate an in-line perform primitive.  The lookup code requires the selector to be in Arg0Reg.
 	 adjustArgumentsForPerform: adjusts the arguments once genLookupForPerformNumArgs:
@@ -2370,13 +2371,17 @@ StackToRegisterMappingCogit >> genPushReceiverVariable: index [
 { #category : #'compile abstract instructions' }
 StackToRegisterMappingCogit >> genPushRegisterArgs [
 	"Ensure that the register args are pushed before the retpc for methods with arity <= self numRegArgs."
+
 	"This won't be as clumsy on a RISC.  But putting the receiver and
 	 args above the return address means the CoInterpreter has a
 	 single machine-code frame format which saves us a lot of work."
-	(regArgsHaveBeenPushed
-	 or: [methodOrBlockNumArgs > self numRegArgs]) ifFalse:
-		[backEnd genPushRegisterArgsForNumArgs: methodOrBlockNumArgs scratchReg: SendNumArgsReg.
-		regArgsHaveBeenPushed := true]
+
+	(regArgsHaveBeenPushed or: [ methodOrBlockNumArgs > self numRegArgs ])
+		ifFalse: [
+			backEnd
+				genPushRegisterArgsForNumArgs: methodOrBlockNumArgs
+				scratchReg: SendNumArgsReg.
+			regArgsHaveBeenPushed := true ]
 ]
 
 { #category : #'bytecode generator support' }

--- a/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
+++ b/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
@@ -1018,6 +1018,7 @@ StackToRegisterMappingCogit >> compileCogMethod: selector [
 { #category : #'compile abstract instructions' }
 StackToRegisterMappingCogit >> compileEntireFullBlockMethod: numCopied [
 
+	"Initialize regArgsHaveBeenPushed so each compilation is clean"
 	regArgsHaveBeenPushed := false.
 	^ super compileEntireFullBlockMethod: numCopied
 ]


### PR DESCRIPTION
This PR changes the calling convention of closure activation on JIT compilation.
The interpreter->JIT closure activation has been revised too.

This PR depends on https://github.com/pharo-project/pharo-vm/pull/760.

Benchmarks show no noticeable degradation/improvement on ARM64 (on the order of +-1% systematically).

### Before:

It was the caller's responsibility to push the closure's receiver/arguments to the stack before activating a closure.
The receiver/argument push was made on the primitiveFullBlockClosure, thus all closures shared the code making the push.
This made JIT compiled closures shorter by a couple of push instructions each.

### Now:

Closures follow the method calling convention.
Closures with <=2 arguments will have their arguments passed on registers, and otherwise on the stack.
In the first case, it's the callee's responsibility (i.e., the closure) to push the arguments, otherwise it's the caller's responsibility.
This makes JIT compiled closures slightly larger by a couple of push instructions.

At the same time, this opens the possibility of frameless closures and eventually unify the code activating closures and methods.