### PR TITLE
Bump to MacOS 11 and above

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,7 +260,7 @@ elseif(UNIX)
         set(OS_TYPE "Mac OS")
         set(VM_TARGET_OS "1000") # Used to recognise OS X
 
-        set(COMMON_FLAGS "-stdlib=libc++ -mmacosx-version-min=10.7 ${COMMON_FLAGS}")
+        set(COMMON_FLAGS "-mmacosx-version-min=11.0 ${COMMON_FLAGS}")
 
     elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
         set(VM_TARGET_OS "linux-gnu")
@@ -325,7 +325,6 @@ add_compile_options(
     -Wno-unknown-pragmas
     -Wno-pointer-sign
     -Wno-constant-conversion
-    -Wno-tautological-pointer-compare
     -Wno-deprecated-declarations
     -Wno-pointer-to-int-cast
     -Wno-compare-distinct-pointer-types


### PR DESCRIPTION
New VMs do not build in MacOS <=10.7, bump min sdk version required to 11.