### PR TITLE
Removed Cogit>>#voidNSSendCache: 

### DIFF
--- a/smalltalksrc/VMMaker/Cogit.class.st
+++ b/smalltalksrc/VMMaker/Cogit.class.st
@@ -12150,12 +12150,6 @@ Cogit >> voidCogCompiledCode [
 	methodZone clearCogCompiledCode
 ]
 
-{ #category : #'in-line cacheing' }
-Cogit >> voidNSSendCache: nsSendCache [
-	<inline: true>
-	nsSendCache classTag: objectRepresentation illegalClassTag; enclosingObject: 0; target: 0
-]
-
 { #category : #'debug printing' }
 Cogit >> warnMultiple: cogMethod selectors: aSelectorOop [
 	<inline: true>


### PR DESCRIPTION
Removed Cogit>>#voidNSSendCache: method as it has no senders and it has a call to a non existing method.

<img width="1097" alt="image" src="https://github.com/pharo-project/pharo-vm/assets/33934979/696b4ec8-a0e3-49e6-886c-1ba8ff723ce8">
