### PR TITLE
Constant conversion warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,8 +324,11 @@ add_compile_options(
     -Wno-pointer-integer-compare
     -Wno-unknown-pragmas
     -Wno-pointer-sign
+<<<<<<< HEAD
     -Wno-constant-conversion
     -Wno-tautological-pointer-compare
+=======
+>>>>>>> 66015f0470 (Re-enable warnings)
     -Wno-deprecated-declarations
     -Wno-pointer-to-int-cast
     -Wno-compare-distinct-pointer-types

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -2004,7 +2004,7 @@ SpurMemoryManager >> allocateNewSpaceSlots: numSlots format: formatField classIn
 		ifTrue: "for header parsing we put a saturated slot count in the prepended overflow size word"
 			[self flag: #endianness.
 			 self long32At: freeStart put: numSlots.
-			 self long32At: freeStart + 4 put: self numSlotsMask << self numSlotsHalfShift.
+			 self long32At: freeStart + 4 put: (self cCoerceSimple: (self numSlotsMask << self numSlotsHalfShift) to: #int).
 			 self long64At: newObj put: (self headerForSlots: self numSlotsMask format: formatField classIndex: classIndex)]
 		ifFalse:
 			[self long64At: newObj put: (self headerForSlots: numSlots format: formatField classIndex: classIndex)].


### PR DESCRIPTION
Cast constant to int to avoid warning and re enable warning