### PR TITLE
Revert "Bump to MacOS 11 and above"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,7 +260,7 @@ elseif(UNIX)
         set(OS_TYPE "Mac OS")
         set(VM_TARGET_OS "1000") # Used to recognise OS X
 
-        set(COMMON_FLAGS "-mmacosx-version-min=11.0 ${COMMON_FLAGS}")
+        set(COMMON_FLAGS "-stdlib=libc++ -mmacosx-version-min=10.7 ${COMMON_FLAGS}")
 
     elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
         set(VM_TARGET_OS "linux-gnu")
@@ -325,6 +325,7 @@ add_compile_options(
     -Wno-unknown-pragmas
     -Wno-pointer-sign
     -Wno-constant-conversion
+    -Wno-tautological-pointer-compare
     -Wno-deprecated-declarations
     -Wno-pointer-to-int-cast
     -Wno-compare-distinct-pointer-types


### PR DESCRIPTION
This does not build (yet) on our CI that uses MacOSX

Reverts pharo-project/pharo-vm#774