### PR TITLE
Remove StackInterpreter interruptPending instance variable

### DIFF
--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -336,7 +336,6 @@ Class {
 		'reenterInterpreter',
 		'nextWakeupUsecs',
 		'nextPollUsecs',
-		'interruptPending',
 		'savedWindowSize',
 		'imageHeaderFlags',
 		'fullScreenFlag',
@@ -3899,14 +3898,6 @@ StackInterpreter >> checkForEventsMayContextSwitch: mayContextSwitch [
 		 nextPollUsecs := now + 20000
 		 "Note that strictly speaking we might need to update 'now' at this point since
 		 ioProcessEvents could take a very long time on some platforms" ].
-
-	interruptPending ifTrue:
-		[interruptPending := false.
-		 "reset interrupt flag"
-		 sema := objectMemory splObj: TheInterruptSemaphore.
-		 (sema ~= objectMemory nilObject
-		  and: [self synchronousSignal: sema]) ifTrue:
-			[switched := true]].
 
 	nextWakeupUsecs ~= 0 ifTrue:
 		[now >= nextWakeupUsecs ifTrue:


### PR DESCRIPTION
The instance variable `interruptPending` from the `StackInterpreter` class is only used in this method and it's **never** initialized (see the file changed from this PR). When this code gets compiled to C we get the following.

```c
/* StackInterpreter>>#checkForEventsMayContextSwitch: */
static sqInt NoDbgRegParms
checkForEventsMayContextSwitch(sqInt mayContextSwitch)

sqInt interruptPending;

/* more code ... */

	if (GIV(interruptPending)) {
		GIV(interruptPending) = 0;
		
		
		sema = unsignedLongAt((GIV(specialObjectsOop) + BaseHeaderSize) + ((sqInt) (((usqInt) TheInterruptSemaphore ) << (shiftForWord())) ));
		if ((sema != GIV(nilObj)) && (synchronousSignal(sema))) {
			switched = 1;
		}
	}
	
/* more code ... */
```

The variable get declared like this `sqInt interruptPending;` but it's **never** initialized. So, the conditional `if (GIV(interruptPending))` will never be true as the variable was never initialized.

As the `interruptPending` variable is only used in that method and never initialized, I propose to delete that code snipped as it's never reached and it will never be true.