### PR TITLE
Do not retain any selectors in CogAbstractInstruction

### DIFF
--- a/smalltalksrc/VMMaker/CogAbstractInstruction.class.st
+++ b/smalltalksrc/VMMaker/CogAbstractInstruction.class.st
@@ -290,12 +290,12 @@ CogAbstractInstruction class >> registerMaskFor: reg1 and: reg2 and: reg3 and: r
 
 { #category : #translation }
 CogAbstractInstruction class >> requiredMethodNames: options [
-	^self selectors reject:
+	^ super requiredMethodNames: options"self selectors reject:
 		[:s| | m |
 		(self isAccessor: s)
 		or: [((m := self compiledMethodAt: s) isQuick and: [m pragmas isEmpty])
 		or: [(m pragmaAt: #doNotGenerate) notNil
-		or: [(m pragmaAt: #inline:) notNil and: [(m pragmaAt: #inline:) arguments first == true]]]]]
+		or: [(m pragmaAt: #inline:) notNil and: [(m pragmaAt: #inline:) arguments first == true]]]]]"
 ]
 
 { #category : #verification }

--- a/smalltalksrc/VMMaker/CogAbstractInstruction.class.st
+++ b/smalltalksrc/VMMaker/CogAbstractInstruction.class.st
@@ -288,16 +288,6 @@ CogAbstractInstruction class >> registerMaskFor: reg1 and: reg2 and: reg3 and: r
 	^Cogit basicNew registerMaskFor: reg1 and: reg2 and: reg3 and: reg4 and: reg5 and: reg6 and: reg7 and: reg8 and: reg9 and: reg10
 ]
 
-{ #category : #translation }
-CogAbstractInstruction class >> requiredMethodNames: options [
-	^ super requiredMethodNames: options"self selectors reject:
-		[:s| | m |
-		(self isAccessor: s)
-		or: [((m := self compiledMethodAt: s) isQuick and: [m pragmas isEmpty])
-		or: [(m pragmaAt: #doNotGenerate) notNil
-		or: [(m pragmaAt: #inline:) notNil and: [(m pragmaAt: #inline:) arguments first == true]]]]]"
-]
-
 { #category : #verification }
 CogAbstractInstruction class >> specificOpcodes [
 	^self subclassResponsibility


### PR DESCRIPTION
`CogAbstractInstruction` implements an overly conservative version of `requiredMethodNames:`.
This provokes the retaining of lots of methods that should not be retained.

Fix https://github.com/pharo-project/pharo-vm/issues/786