### PR TITLE
Profile vm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ option(BUILD_WITH_GRAPHVIZ              "Generate dependency graphs" ON)
 
 set(APPNAME			"Pharo"         CACHE STRING                 "VM Application name")
 set(FLAVOUR			"CoInterpreter" CACHE STRING                 "The kind of VM to generate. Possible values: StackVM, CoInterpreter")
+set(PROFILE			"None" CACHE STRING                 "What do you want to profile? Possible values: None, Bytecode")
 set(PHARO_LIBRARY_PATH		"@executable_path/Plugins" CACHE STRING      "The RPATH to use in the build")
 set(ICEBERG_DEFAULT_REMOTE	"scpUrl"        CACHE STRING                 "If Iceberg uses HTTPS (httpsUrl) or tries first with SSH (scpUrl)")
 set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0")
@@ -308,6 +309,12 @@ else()
 	set(DEBUGVM 0)
 endif()
 
+if (PROFILE MATCHES "Bytecode")
+	set(PROFILEBYTECODEVM 1)
+else()
+	set(PROFILEBYTECODEVM 0)
+endif()
+
 add_compile_options(
 	${OPTIMIZATION_LEVEL}
     -Wno-sometimes-uninitialized
@@ -332,6 +339,7 @@ add_compile_options(
 
 add_compile_definitions(
     IMMUTABILITY=1
+    PROFILE_CURRENT_BYTECODE=${PROFILEBYTECODEVM}
     COGMTVM=0
     PharoVM=1
     DEBUGVM=${DEBUGVM}

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -4892,9 +4892,9 @@ StackInterpreter >> currentBytecode: anInteger [
 
 	<inline: true>
 	currentBytecode := anInteger.
+	
+	self profileCurrentBytecode
 
-	self printNum: currentBytecode.
-	self cr
 ]
 
 { #category : #initialization }
@@ -12538,6 +12538,15 @@ StackInterpreter >> processesInProcessListDo: aBlock [
 					        withInitialValue: ctxt ].
 			(self isLiveContext: ctxt) ifTrue: [ aBlock value: proc ].
 			proc := objectMemory fetchPointer: NextLinkIndex ofObject: proc ] ]
+]
+
+{ #category : #accessing }
+StackInterpreter >> profileCurrentBytecode [
+
+	<inline: true>
+	self cppIf: #PROFILE_CURRENT_BYTECODE ifTrue: [
+		self printNum: currentBytecode.
+		self cr ]
 ]
 
 { #category : #'as yet unclassified' }

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -1869,7 +1869,7 @@ StackInterpreter >> activateNewMethod [
 StackInterpreter >> activeProcess [
 	"Answer the current activeProcess."
 	<api> "useful for VM debugging"
-	^objectMemory memoryActiveProcess
+	^objectMemory memoryActiveProcess 
 ]
 
 { #category : #'process primitive support' }
@@ -2598,7 +2598,7 @@ StackInterpreter >> booleanCheatFalse [
 		^ self jump: offset ].
 
 	"not followed by a jumpIfFalse; (un)do instruction fetch and push boolean result"
-	currentBytecode := bytecode.
+	self currentBytecode: bytecode.
 	self push: objectMemory falseObject
 ]
 
@@ -2619,7 +2619,7 @@ StackInterpreter >> booleanCheatFalseSistaV1 [
 		^ self jump: offset ].
 
 	"not followed by a jumpIfFalse; (un)do instruction fetch and push boolean result"
-	currentBytecode := bytecode.
+	self currentBytecode: bytecode.
 	self push: objectMemory falseObject
 ]
 
@@ -2640,7 +2640,7 @@ StackInterpreter >> booleanCheatFalseV4 [
 		^ self jump: offset ].
 
 	"not followed by a jumpIfFalse; (un)do instruction fetch and push boolean result"
-	currentBytecode := bytecode.
+	self currentBytecode: bytecode.
 	self push: objectMemory falseObject
 ]
 
@@ -2674,7 +2674,7 @@ StackInterpreter >> booleanCheatTrue [
 			^ self jump: offset ] ].
 
 	"not followed by a jumpIfFalse; (un)do instruction fetch and push boolean result"
-	currentBytecode := bytecode.
+	self currentBytecode: bytecode.
 	self push: objectMemory trueObject
 ]
 
@@ -2698,7 +2698,7 @@ StackInterpreter >> booleanCheatTrueSistaV1 [
 			^ self jump: offset ] ].
 
 	"not followed by a jumpIfFalse; (un)do instruction fetch and push boolean result"
-	currentBytecode := bytecode.
+	self currentBytecode: bytecode.
 	self push: objectMemory trueObject
 ]
 
@@ -2722,7 +2722,7 @@ StackInterpreter >> booleanCheatTrueV4 [
 			^ self jump: offset ] ].
 
 	"not followed by a jumpIfFalse; (un)do instruction fetch and push boolean result"
-	currentBytecode := bytecode.
+	self currentBytecode: bytecode.
 	self push: objectMemory trueObject
 ]
 
@@ -4886,6 +4886,17 @@ StackInterpreter >> currentBytecode [
 	^ currentBytecode
 ]
 
+{ #category : #accessing }
+StackInterpreter >> currentBytecode: anInteger [
+	"Use this setter to change the current bytecode, so we can profile."
+
+	<inline: true>
+	currentBytecode := anInteger.
+
+	self printNum: currentBytecode.
+	self cr
+]
+
 { #category : #initialization }
 StackInterpreter >> defaultNumStackPages [
 	"Return the default number of stack pages allocate at startup.
@@ -5793,7 +5804,7 @@ StackInterpreter >> fetchNextBytecode [
 
 	"This method fetches the next instruction (bytecode). Each bytecode method is responsible for fetching the next bytecode, preferably as early as possible to allow the memory system time to process the request before the next dispatch."
 
-	currentBytecode := self fetchByte
+	self currentBytecode: self fetchByte
 ]
 
 { #category : #'frame access' }
@@ -8387,7 +8398,7 @@ StackInterpreter >> itemporary: offset in: theFP put: valueOop [
 StackInterpreter >> jump: offset [
 
 	instructionPointer := instructionPointer + offset + 1.
-	currentBytecode := objectMemory byteAtPointer: instructionPointer
+	self currentBytecode: (objectMemory byteAtPointer: instructionPointer)
 ]
 
 { #category : #'sista bytecodes' }

--- a/smalltalksrc/VMMaker/StackInterpreterSimulator.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreterSimulator.class.st
@@ -415,11 +415,6 @@ StackInterpreterSimulator >> cr [
 	traceOn ifTrue: [ transcript cr; flush ].
 ]
 
-{ #category : #accessing }
-StackInterpreterSimulator >> currentBytecode: anInteger [ 
-	currentBytecode := anInteger
-]
-
 { #category : #UI }
 StackInterpreterSimulator >> desiredDisplayExtent [
 	^(savedWindowSize


### PR DESCRIPTION
We (@guillep @jordanmontt @doste @RenaudFondeur and me in the VMDojo) make a small change to profile the bytecode numbers executed by the interpreter.

A `PROFILE` option to _cmake_ was added, so we can control the profiling easily without editing the code :)

For now there is only `Bytecode` as accepted value (or `None` as default for a _normal, non-profiling_ VM). We are thinking to add more options like _Profile message sends_.