### PR TITLE
add tests for type harmonization

### DIFF
--- a/smalltalksrc/Slang-Tests/SLTypeHarmonizationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SLTypeHarmonizationTest.class.st
@@ -1,0 +1,464 @@
+Class {
+	#name : #SLTypeHarmonizationTest,
+	#superclass : #SlangAbstractTestCase,
+	#instVars : [
+		'types'
+	],
+	#category : #'Slang-Tests'
+}
+
+{ #category : #running }
+SLTypeHarmonizationTest >> setUp [
+	super setUp.
+	types := Set new.
+]
+
+{ #category : #harmonizeOneType }
+SLTypeHarmonizationTest >> testHarmonizedChar [
+	"cast a char to an int"
+	| result |
+	types add: #char.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #sqInt ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeTwoType }
+SLTypeHarmonizationTest >> testHarmonizedCharAndInt [
+	| result |
+	types add: #int.
+	types add: #char.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #sqInt ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeTwoType }
+SLTypeHarmonizationTest >> testHarmonizedCharAndUnknown [
+	| result |
+	types add: #unknown.
+	types add: #char.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #sqInt ; add: #unknown ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeOnePointer }
+SLTypeHarmonizationTest >> testHarmonizedCharPtr [
+	"doesn't change the type"
+	| result |
+	types add: #'char *'.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #'char *' ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeOneType }
+SLTypeHarmonizationTest >> testHarmonizedEmptyRetrunType [
+	"unknowned type doesn't get any transformation"
+	| result |
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new ).
+	
+	
+]
+
+{ #category : #harmonizeOneType }
+SLTypeHarmonizationTest >> testHarmonizedInt [
+	| result |
+	types add: #int.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #sqInt ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeTwoType }
+SLTypeHarmonizationTest >> testHarmonizedIntAndLongNotWorking [
+	"the type are not merged"
+	| result |
+	types add: #int.
+	types add: #long.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #sqInt ; add: #long ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeTwoType }
+SLTypeHarmonizationTest >> testHarmonizedIntAndLonglongNotWorking [
+	"the type are not merged"
+	| result |
+	types add: #int.
+	types add: #'long long'.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #sqInt ; add: #sqLong ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeTwoType }
+SLTypeHarmonizationTest >> testHarmonizedIntAndShort [
+	| result |
+	types add: #int.
+	types add: #short.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #sqInt ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeTwoType }
+SLTypeHarmonizationTest >> testHarmonizedIntAndUnsignedIntAndLonglongNotAndUnsignedlonglongWorking [
+	"default to signed type"
+	| result |
+	types add: #int.
+	types add: #'unsigned int'.
+	types add: #'long long'.
+	types add: #'unsigned long long'.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #sqInt ; add: #sqLong ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeThreeType }
+SLTypeHarmonizationTest >> testHarmonizedIntAndUnsignedIntAndLonglongNotWorking [
+	"default to signed type"
+	| result |
+	types add: #int.
+	types add: #'unsigned int'.
+	types add: #'long long'.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #sqInt ; add: #sqLong ; add: #usqInt ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeTwoType }
+SLTypeHarmonizationTest >> testHarmonizedIntAndUnsignedIntNotWorking [
+	"default to signed type"
+	| result |
+	types add: #int.
+	types add: #'unsigned int'.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #sqInt ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeOnePointer }
+SLTypeHarmonizationTest >> testHarmonizedIntPtr [
+	"doesn't change the type"
+	| result |
+	types add: #'int *'.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #'int *' ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeThreeType }
+SLTypeHarmonizationTest >> testHarmonizedKnownTypeAndNotKnownAndUnsignedIntNotWorking [
+	"if at least one of the type isn't in #(char short int #'long long' #'unsigned char' #'unsigned short' #'unsigned int' #'unsigned long long') then it will remain unmerged"
+	| result |
+	types add: #int.
+	types add: #'unsigned int'.
+	types add: #unknown.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #sqInt ; add: #unknown ; add: #usqInt ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeThreeType }
+SLTypeHarmonizationTest >> testHarmonizedKnownTypeAndNotKnownNotWorking [
+	"if at least one of the type isn't in #(char short int #'long long' #'unsigned char' #'unsigned short' #'unsigned int' #'unsigned long long') then it will remain unmerged"
+	| result |
+	types add: #int.
+	types add: #short.
+	types add: #unknown.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #sqInt ; add: #unknown ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeOneType }
+SLTypeHarmonizationTest >> testHarmonizedLong [
+	"long type doesn't get any transformation, it counts as unknown"
+	| result |
+	types add: #long.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #long ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeTwoType }
+SLTypeHarmonizationTest >> testHarmonizedLongAndUnsignedLongNotWorking [
+	"doesn't merge the type"
+	| result |
+	types add: #long.
+	types add: #'unsigned long'.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #long ; add: #'unsigned long' ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeOnePointer }
+SLTypeHarmonizationTest >> testHarmonizedLongPtr [
+	"doesn't change the type"
+	| result |
+	types add: #'long *'.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #'long *' ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeOneType }
+SLTypeHarmonizationTest >> testHarmonizedLonglong [
+	| result |
+	types add: #'long long'.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #sqLong ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeOnePointer }
+SLTypeHarmonizationTest >> testHarmonizedLonglongPtr [
+	"doesn't change the type"
+	| result |
+	types add: #'long long*'.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #'long long*' ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeOneType }
+SLTypeHarmonizationTest >> testHarmonizedNumber [
+	| result |
+	types add: 7.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #sqInt ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeTwoType }
+SLTypeHarmonizationTest >> testHarmonizedNumberAndAnythingNotWorking [
+	"return anything"
+	| result |
+	types add: 7.
+	types add: #anything.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #anything ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeTwoType }
+SLTypeHarmonizationTest >> testHarmonizedNumbers [
+	| result |
+	types add: 7.
+	types add: 8.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #sqInt ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeTwoType }
+SLTypeHarmonizationTest >> testHarmonizedNumbersNotWorking [
+	"the type always default to int"
+	| result |
+	types add: 7.
+	types add: -2147483648.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #sqInt ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeOneType }
+SLTypeHarmonizationTest >> testHarmonizedShort [
+	"cast short to int"
+	| result |
+	types add: #short.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #sqInt ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeOnePointer }
+SLTypeHarmonizationTest >> testHarmonizedShortPtr [
+	"doesn't change the type"
+	| result |
+	types add: #'short *'.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #'short *' ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeSignedAndUnsigned }
+SLTypeHarmonizationTest >> testHarmonizedSignedUnsignedIntNotWorking [
+	| result |
+	types add: #int.
+	types add: #'unsigned int'.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #sqInt ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeSignedAndUnsigned }
+SLTypeHarmonizationTest >> testHarmonizedSignedUnsignedNotWorking [
+	"ignore the unsigned long long in the merge operation"
+	| result |
+	types add: #int.
+	types add: #'unsigned int'.
+	types add: #'unsigned long long'.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #sqInt ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeOneType }
+SLTypeHarmonizationTest >> testHarmonizedUnknown [
+	"unknowned type doesn't get any transformation"
+	| result |
+	types add: #unknown.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #unknown ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeOnePointer }
+SLTypeHarmonizationTest >> testHarmonizedUnknownPtr [
+	"doesn't change the type"
+	| result |
+	types add: #'unknown *'.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #'unknown *' ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeOnePointer }
+SLTypeHarmonizationTest >> testHarmonizedUnsignedIntPtr [
+	"doesn't change the type"
+	| result |
+	types add: #'unsigned int *'.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #'unsigned int *' ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeOneType }
+SLTypeHarmonizationTest >> testHarmonizedUnsignedchar [
+	"cast an unsigned char to an usqInt"
+	| result |
+	types add: #'unsigned char'.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #'usqInt' ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeOnePointer }
+SLTypeHarmonizationTest >> testHarmonizedUnsignedcharPtr [
+	"doesn't change the type"
+	| result |
+	types add: #'unsigned char *'.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #'unsigned char *' ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeOneType }
+SLTypeHarmonizationTest >> testHarmonizedUnsignedint [
+	| result |
+	types add: #'unsigned int'.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #usqInt ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeOneType }
+SLTypeHarmonizationTest >> testHarmonizedUnsignedlong [
+	"unsigned long type doesn't get any transformation, it counts as unknown"
+	| result |
+	types add: #'unsigned long'.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #'unsigned long' ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeOnePointer }
+SLTypeHarmonizationTest >> testHarmonizedUnsignedlongPtr [
+	"doesn't change the type"
+	| result |
+	types add: #'unsigned long *'.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #'unsigned long *' ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeOneType }
+SLTypeHarmonizationTest >> testHarmonizedUnsignedlonglong [
+	| result |
+	types add: #'unsigned long long'.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #'usqLong' ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeOnePointer }
+SLTypeHarmonizationTest >> testHarmonizedUnsignedlonglongPtr [
+	"doesn't change the type"
+	| result |
+	types add: #'unsigned long long*'.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #'unsigned long long*' ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeOneType }
+SLTypeHarmonizationTest >> testHarmonizedUnsignedshort [
+	| result |
+	types add: #'unsigned short'.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #usqInt ; yourself ).
+	
+	
+]
+
+{ #category : #harmonizeOnePointer }
+SLTypeHarmonizationTest >> testHarmonizedUnsignedshortPtr [
+	"doesn't change the type"
+	| result |
+	types add: #'unsigned short *'.
+	result := ccg harmonizeReturnTypesIn: types.
+	self assert: result equals: (Set new add: #'unsigned short *' ; yourself ).
+	
+	
+]

--- a/smalltalksrc/Slang-Tests/SlangBasicTypeInferenceTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTypeInferenceTest.class.st
@@ -213,6 +213,48 @@ SlangBasicTypeInferenceTest >> testReturnANilMessageSend [
 	self assert: tMethod returnType equals: #sqInt.
 ]
 
+{ #category : #'experiment-return-signed' }
+SlangBasicTypeInferenceTest >> testReturnASignIntFromAnUnsigneNotWorking [
+	"the type here  is wrong, we get an unsigned int instead of an int"
+	| tMethod |
+	tMethod := ccg methodNamed: #returnASignIntFromAnUnsignedNotWorking:.
+	
+	self assert: tMethod isNotNil.
+	self assert: (ccg typeFor: tMethod statements first in: tMethod) equals: #'unsigned int'.
+	self assert: tMethod returnType equals: #usqInt
+]
+
+{ #category : #'experiment-return-signed' }
+SlangBasicTypeInferenceTest >> testReturnASignIntFromAnUnsigned [
+	| tMethod |
+	tMethod := ccg methodNamed: #returnASignIntFromAnUnsigned.
+	
+	self assert: tMethod isNotNil.
+	self assert: (ccg typeFor: tMethod statements first in: tMethod) equals: #int.
+	self assert: tMethod returnType equals: #sqInt
+]
+
+{ #category : #'experiment-return-signed' }
+SlangBasicTypeInferenceTest >> testReturnASignIntFromAnUnsignedShouldNotWork [
+	"the type here  is wrong, we get an unsigned int instead of an int"
+	| tMethod |
+	tMethod := ccg methodNamed: #returnASignIntFromAnUnsignedShouldNotWork:.
+	
+	self assert: tMethod isNotNil.
+	self assert: (ccg typeFor: tMethod statements first in: tMethod) equals: #'unsigned int'.
+	self assert: tMethod returnType equals: #usqInt
+]
+
+{ #category : #'experiment-return-signed' }
+SlangBasicTypeInferenceTest >> testReturnASignIntFromAnUnsignedWork [
+	| tMethod |
+	tMethod := ccg methodNamed: #returnASignIntFromAnUnsigned:.
+	
+	self assert: tMethod isNotNil.
+	self assert: (ccg typeFor: tMethod statements first in: tMethod) equals: #int.
+	self assert: tMethod returnType equals: #sqInt
+]
+
 { #category : #'return-constant' }
 SlangBasicTypeInferenceTest >> testReturnASmallNegativeIntegerConstantNode [
 	| tMethod |
@@ -545,6 +587,102 @@ SlangBasicTypeInferenceTest >> testReturnFloatConstantNode [
 	self assert: (ccg typeFor: tMethod statements first in: tMethod) equals: #double.
 	self assert: tMethod returnType equals: #double
 	
+]
+
+{ #category : #'experiment-return-long-int' }
+SlangBasicTypeInferenceTest >> testReturnLongIntInVariable [
+	| tMethod |
+	tMethod := ccg methodNamed: #returnLongIntInVariable.
+	
+	self assert: tMethod isNotNil.
+	self assert: tMethod returnType equals: #'usqInt'
+]
+
+{ #category : #'experiment-return-long-int' }
+SlangBasicTypeInferenceTest >> testReturnLongIntIsntWorking [
+	| tMethod |
+	tMethod := ccg methodNamed: #returnLongInt.
+	
+	self assert: tMethod isNotNil.
+	self assert: tMethod returnType equals: #'sqInt'
+]
+
+{ #category : #'experiment-return-long-int' }
+SlangBasicTypeInferenceTest >> testReturnMultipleLongInt [
+	| tMethod |
+	tMethod := ccg methodNamed: #returnMultipleLongInt.
+	
+	self assert: tMethod isNotNil.
+	self assert: tMethod returnType equals: #'usqInt'
+]
+
+{ #category : #'experiment-return-long-int' }
+SlangBasicTypeInferenceTest >> testReturnMultipleLongIntAnnotation [
+	| tMethod |
+	tMethod := ccg methodNamed: #returnMultipleLongIntAnnotation:.
+	
+	self assert: tMethod isNotNil.
+	self assert: tMethod returnType equals: #'usqInt'
+]
+
+{ #category : #'experiment-return-long-int' }
+SlangBasicTypeInferenceTest >> testReturnMultipleLongIntNotWorking [
+	"should have return a long int"
+	| tMethod |
+	tMethod := ccg methodNamed: #returnMultipleLongIntNotWorking.
+	
+	self assert: tMethod isNotNil.
+	self assert: tMethod returnType equals: #'sqInt'
+]
+
+{ #category : #'experiment-return-multiple-type' }
+SlangBasicTypeInferenceTest >> testReturnStringAndIntIfTrue1 [
+	"only one type is returned and 'char *' seems to be always chosen"
+	| tMethod |
+	tMethod := ccg methodNamed: #returnStringAndIntInIfTrue1.
+	
+	self assert: tMethod isNotNil.
+	self assert: tMethod returnType equals: #'char *'
+]
+
+{ #category : #'experiment-return-multiple-type' }
+SlangBasicTypeInferenceTest >> testReturnStringAndIntIfTrue2 [
+	"only one type is returned and 'char *' seems to be always chosen"
+	| tMethod |
+	tMethod := ccg methodNamed: #returnStringAndIntInIfTrue2.
+	
+	self assert: tMethod isNotNil.
+	self assert: tMethod returnType equals: #'char *'
+]
+
+{ #category : #'experiment-return-multiple-type' }
+SlangBasicTypeInferenceTest >> testReturnStringAndIntInIfTrueifFalse1 [
+	"only one type is returned and 'char *' seems to be always chosen"
+	| tMethod |
+	tMethod := ccg methodNamed: #returnStringAndIntInIfTrueifFalse1.
+	
+	self assert: tMethod isNotNil.
+	self assert: tMethod returnType equals: #'char *'
+]
+
+{ #category : #'experiment-return-multiple-type' }
+SlangBasicTypeInferenceTest >> testReturnStringAndIntInIfTrueifFalse2 [
+	"only one type is returned and 'char *' seems to be always chosen"
+	| tMethod |
+	tMethod := ccg methodNamed: #returnStringAndIntInIfTrueifFalse2.
+	
+	self assert: tMethod isNotNil.
+	self assert: tMethod returnType equals: #'char *'
+]
+
+{ #category : #'experiment-return-multiple-type' }
+SlangBasicTypeInferenceTest >> testReturnStringAndIntInIfTrueifFalse3 [
+	"in this case, the type obtained is int"
+	| tMethod |
+	tMethod := ccg methodNamed: #returnStringAndIntInIfTrueifFalse3.
+	
+	self assert: tMethod isNotNil.
+	self assert: tMethod returnType equals: #sqInt
 ]
 
 { #category : #'return-temp-assigned-const' }

--- a/smalltalksrc/Slang-Tests/SlangBasicTypeInferenceTestClass.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTypeInferenceTestClass.class.st
@@ -105,6 +105,46 @@ SlangBasicTypeInferenceTestClass >> returnANilMessageSend [
 	^ self returnANilConstantNode
 ]
 
+{ #category : #'experiment-return-signed' }
+SlangBasicTypeInferenceTestClass >> returnASignIntFromAnUnsigned [
+
+	"<var: #i type: #'unsigned int'>"
+	| i |
+	i := 2.
+	i < 1 whileTrue: [ i := i + 1 ].
+	^ i
+]
+
+{ #category : #'experiment-return-signed' }
+SlangBasicTypeInferenceTestClass >> returnASignIntFromAnUnsigned: j [
+
+	<var: #j type: #'unsigned int'>
+	| i |
+	i := j.
+	i < 0 whileTrue: [ i := i + 1 ].
+	^ i
+]
+
+{ #category : #'experiment-return-signed' }
+SlangBasicTypeInferenceTestClass >> returnASignIntFromAnUnsignedNotWorking: j [
+
+	<var: #j type: #'unsigned int'>
+	| i |
+	i := j.
+	i < 1 whileTrue: [ i := i + 1 ].
+	^ i
+]
+
+{ #category : #'experiment-return-signed' }
+SlangBasicTypeInferenceTestClass >> returnASignIntFromAnUnsignedShouldNotWork: j [
+
+	<var: #j type: #'unsigned int'>
+	| i |
+	i := j.
+	i < 1 whileTrue: [ i := i + 1 ].
+	^ i
+]
+
 { #category : #'return-constant' }
 SlangBasicTypeInferenceTestClass >> returnASmallNegativeIntegerConstantNode [
 	^ -30
@@ -280,6 +320,150 @@ SlangBasicTypeInferenceTestClass >> returnExplicitTempUnsignedLongLong [
 	<var:#t type:#'unsigned long long'>
 	| t |
 	^ t
+]
+
+{ #category : #'experiment-return-long-int' }
+SlangBasicTypeInferenceTestClass >> returnLongInt [
+	^ 2147483648
+	
+
+]
+
+{ #category : #'experiment-return-long-int' }
+SlangBasicTypeInferenceTestClass >> returnLongIntInVariable [
+	| i |
+	i := 2147483648.
+	^ i
+	
+
+]
+
+{ #category : #'experiment-return-long-int' }
+SlangBasicTypeInferenceTestClass >> returnMultipleLongInt [
+	| i |
+	i := 2147483648.
+	i = 2147483648
+	ifTrue: [  
+		^ i
+	]
+	ifFalse: [ 
+		^ 5
+	].
+	
+
+]
+
+{ #category : #'experiment-return-long-int' }
+SlangBasicTypeInferenceTestClass >> returnMultipleLongIntAnnotation [
+	| i |
+	i := 2147483648.
+	i = 2147483648
+	ifTrue: [  
+		^ i
+	]
+	ifFalse: [ 
+		^ 5
+	].
+	
+
+]
+
+{ #category : #'experiment-return-long-int' }
+SlangBasicTypeInferenceTestClass >> returnMultipleLongIntAnnotation: i [
+	<var: #i type: #'unsigned int'>
+	i = 6
+	ifTrue: [  
+		^ i
+	]
+	ifFalse: [ 
+		^ 5
+	].
+	
+
+]
+
+{ #category : #'experiment-return-long-int' }
+SlangBasicTypeInferenceTestClass >> returnMultipleLongIntNotWorking [
+	| i |
+	i := 2147483648.
+	i = 2147483648
+	ifTrue: [  
+		^ 2147483648
+	]
+	ifFalse: [ 
+		^ 2147483649
+	].
+	
+
+]
+
+{ #category : #'experiment-return-multiple-type' }
+SlangBasicTypeInferenceTestClass >> returnStringAndIntInIfTrue1 [ 
+	| i |
+	i := 3.
+	i = 3
+	ifTrue: [  
+		^ 5
+	].
+	^ 'aa'
+]
+
+{ #category : #'experiment-return-multiple-type' }
+SlangBasicTypeInferenceTestClass >> returnStringAndIntInIfTrue2 [
+	| i |
+	i := 3.
+	i = 3
+	ifTrue: [  
+		^ 'aa'
+	].
+	^ 5
+]
+
+{ #category : #'experiment-return-multiple-type' }
+SlangBasicTypeInferenceTestClass >> returnStringAndIntInIfTrueifFalse1 [ 
+	| i |
+	i := 3.
+	i = 3
+	ifTrue: [  
+		^ 5
+	]
+	ifFalse: [ 
+		^ 'aa'
+	].
+	
+
+]
+
+{ #category : #'experiment-return-multiple-type' }
+SlangBasicTypeInferenceTestClass >> returnStringAndIntInIfTrueifFalse2 [
+	| i |
+	i := 3.
+	i = 3
+	ifTrue: [  
+		^ 'aa'
+	]
+	ifFalse: [ 
+		^ 5
+	].
+	
+
+]
+
+{ #category : #'experiment-return-multiple-type' }
+SlangBasicTypeInferenceTestClass >> returnStringAndIntInIfTrueifFalse3 [
+	| i |
+	i := 3.
+	i = 3
+	ifTrue: [  
+		^ i
+	]
+	ifFalse: [ 
+		^ 'aa'
+	].
+	^ 7
+
+	
+
 ]
 
 { #category : #'return-temp-assigned-const' }

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -4637,6 +4637,7 @@ CCodeGenerator >> shouldGenerateHeader [
 
 { #category : #utilities }
 CCodeGenerator >> shouldGenerateMethod: aTMethod [
+
 	^(self isBuiltinSelector: aTMethod selector)
 		ifTrue: [requiredSelectors includes: aTMethod selector]
 		ifFalse: [aTMethod inline ~~ #always]


### PR DESCRIPTION
add tests for the harmonizeReturnTypesIn: method use by SlangTyper to harmonized types