### PR TITLE
Extend macOS implementation of SqueakSSL plugin to support setting a certificate on the SSL session context

### DIFF
--- a/extracted/plugins/SqueakSSL/include/common/SqueakSSL.h
+++ b/extracted/plugins/SqueakSSL/include/common/SqueakSSL.h
@@ -60,6 +60,7 @@
 #define SQSSL_PROP_PEERNAME 0
 #define SQSSL_PROP_CERTNAME 1
 #define SQSSL_PROP_SERVERNAME 2
+#define SQSSL_PROP_CERTPASS 3
 
 /* sqCreateSSL: Creates a new SSL instance.
 	Arguments: None.

--- a/extracted/plugins/SqueakSSL/src/osx/sqMacSSL.c
+++ b/extracted/plugins/SqueakSSL/src/osx/sqMacSSL.c
@@ -626,7 +626,7 @@ sqInt sqAcceptSSL(sqInt handle, char* srcBuf, sqInt srcLen, char* dstBuf,
     }
     /* We are connected. Verify the cert. */
     ssl->state = SQSSL_CONNECTED;
-        return SQSSL_OK;
+    return ssl->outLen;
 }
 
 /* sqEncryptSSL: Encrypt data for SSL transmission.


### PR DESCRIPTION
This pull request extends the macOS implementation of the SqueakSSL plugin to support setting a certificate on the SSL session context. The certificate and private key can be given by setting the ‘CERTNAME’ property to the path of a PKCS#12 file (the [Windows implementation](https://github.com/pharo-project/pharo-vm/blob/aeba90c8141d4a7b35c6e47dfc9b8e0c886c61dc/extracted/plugins/SqueakSSL/src/win/sqWin32SSL.c#L177) expects the property to be set to the name of a certificate in a certificate store, while the [Unix implementation](https://github.com/pharo-project/pharo-vm/blob/aeba90c8141d4a7b35c6e47dfc9b8e0c886c61dc/extracted/plugins/SqueakSSL/src/unix/sqUnixSSL.c#L278) expects the path to a PEM file). The function [‘SecPKCS12Import’](https://developer.apple.com/documentation/security/1396915-secpkcs12import?language=objc) that is used to read the PKCS#12 file seems to require it to have a non-empty password, so a property ‘CERTPASS’ for giving the password is added. Commit 3d9d9004f7c305c2 also fixes a bug in ‘sqAcceptSSL’.

This can be used to set up a [ZnSecureServer](https://github.com/svenvc/zinc/tree/bd1f945c7aec7981b3e2b7494613fb580841c3e5/repository/Zinc-Zodiac-Core.package/ZnSecureServer.class) on macOS as follows (which assumes `#certificatePassword:` has been implemented similarly to the implementation of `#certificate:` and `#certificateName:` on ZdcPluginSSLSession):

```smalltalk
"Generate a private key and certificate for a certificate authority:"
result1 := LibC resultOfCommand: 'cd /tmp && /usr/bin/openssl ' ,
	'req -x509 -newkey rsa -nodes -keyout ca-key -out ca-cert ' ,
	'-subj "/CN=ZnSecureServer Test CA Certificate" 2>&1'.

"Generate a private key and certificate for the server:"
result2 := LibC resultOfCommand: 'cd /tmp && /usr/bin/openssl ' ,
	'req -x509 -newkey rsa -nodes -keyout s-key -out s-cert1 ' ,
	'-subj "/CN=ZnSecureServer Test Server Certificate" ' ,
	'-addext subjectAltName=DNS:localhost 2>&1'.

"Generate a certificate for the server signed by the certificate authority:"
result3 := LibC resultOfCommand: 'cd /tmp && /usr/bin/openssl ' ,
	'x509 -in s-cert1 -out s-cert2 ' ,
	'-CAkey ca-key -CA ca-cert -CAserial ca-srl -CAcreateserial 2>&1'.

"Put the server private key and the certificate signed by the certificate authority in a PKCS#12 file:"
result4 := LibC resultOfCommand: 'cd /tmp && /usr/bin/openssl ' ,
	'pkcs12 -export -inkey s-key -in s-cert2 ' ,
	'-out s-pkcs12 -password pass:password123 2>&1'.

"Add the certificate authority’s certificate as trusted to the ‘login’ keychain (needs confirmation):"
result5 := LibC resultOfCommand: 'cd /tmp && /usr/bin/security ' ,
	'add-trusted-cert -k ~/Library/Keychains/login.keychain-db ca-cert 2>&1'.

"Start a ZnSecureServer with the PKCS#12 file and password:"
(server := ZnSecureServer on: 1443)
	certificate: '/tmp/s-pkcs12';
	certificatePassword: 'password123';
	logToTranscript;
	start.

"Get ‘/’ from the server:"
response := ZnEasy get: 'https://localhost:1443'.
```

Browsing ‘https://localhost:1443’ works with Chrome and Firefox. With Safari, a ConnectionClosed is signaled while performing `#accept` on a ZdcSecureSocketStream, I haven’t tried to find the cause yet.

A point I’m not sure about is whether the ‘items’ array assigned by ‘SecPKCS12Import’ should be released or not, though I assumed not as the function doesn’t have ‘Create’ or ‘Copy’ in its name (see ‘The Create Rule’ in the [‘Memory Management Programming Guide for Core Foundation’](https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFMemoryMgmt/CFMemoryMgmt.html)).

There’s a corresponding issue that I had opened about this in the OpenSmalltalk VM repository: [OpenSmalltalk VM issue #680](https://github.com/OpenSmalltalk/opensmalltalk-vm/issues/680).