### PR TITLE
Extend macOS implementation of SqueakSSL plugin to support setting a certificate on the SSL session context

### DIFF
--- a/extracted/plugins/SqueakSSL/src/osx/sqMacSSL.c
+++ b/extracted/plugins/SqueakSSL/src/osx/sqMacSSL.c
@@ -626,7 +626,7 @@ sqInt sqAcceptSSL(sqInt handle, char* srcBuf, sqInt srcLen, char* dstBuf,
     }
     /* We are connected. Verify the cert. */
     ssl->state = SQSSL_CONNECTED;
-        return SQSSL_OK;
+    return ssl->outLen;
 }
 
 /* sqEncryptSSL: Encrypt data for SSL transmission.

--- a/extracted/plugins/SqueakSSL/src/osx/sqMacSSL.c
+++ b/extracted/plugins/SqueakSSL/src/osx/sqMacSSL.c
@@ -206,6 +206,40 @@ OSStatus sqSetupSSL(sqSSL* ssl, int isServer)
         }
     }
 
+    if (ssl->certName) {
+        CFStringRef certName = CFStringCreateWithCString(kCFAllocatorDefault, ssl->certName, kCFStringEncodingASCII);
+        if (certName == NULL)
+            return SQSSL_GENERIC_ERROR;
+        CFMutableDictionaryRef query = CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+        if (query == NULL) {
+            CFRelease(certName);
+            return SQSSL_GENERIC_ERROR;
+        }
+        CFDictionarySetValue(query, kSecMatchLimit, kSecMatchLimitOne);
+        CFDictionarySetValue(query, kSecReturnRef, kCFBooleanTrue);
+        CFDictionarySetValue(query, kSecClass, kSecClassIdentity);
+        CFDictionarySetValue(query, kSecMatchSubjectWholeString, certName);
+        CFDictionarySetValue(query, kSecMatchValidOnDate, kCFNull);
+        CFRelease(certName);
+        SecIdentityRef identity;
+        status = SecItemCopyMatching(query, (CFTypeRef*) &identity);
+        CFRelease(query);
+        if (status != noErr) {
+            logStatus(status, status == errSecItemNotFound ? "SecItemCopyMatching had no results" : "SecItemCopyMatching failed");
+            return status;
+        }
+        CFArrayRef certs = CFArrayCreate(kCFAllocatorDefault, (const void **)&identity, 1, &kCFTypeArrayCallBacks);
+        CFRelease(identity);
+        if (certs == NULL)
+            return SQSSL_GENERIC_ERROR;
+        status = SSLSetCertificate(ssl->ctx, certs);
+        CFRelease(certs);
+        if (status != noErr) {
+            logStatus(status, "SSLSetCertificate failed");
+            return status;
+        }
+    }
+
     return status;
 }
 


### PR DESCRIPTION
This pull request extends the macOS implementation of the SqueakSSL plugin to support setting a certificate on the SSL session context. It differs from pull request #812 in that the ‘CERTNAME’ property is used to identify a certificate and private key in a keychain rather than as the path to a file containing the certificate and private key. Commit 539aedd1d4 in this pull request corresponds to commit 3d9d9004f7 in the earlier pull request and fixes a bug in ‘sqAcceptSSL’.

This can be used to set up a [ZnSecureServer](https://github.com/svenvc/zinc/tree/a340624b238ca7aee0722033bbf64ea42c7e6fd2/repository/Zinc-Zodiac-Core.package/ZnSecureServer.class) on macOS as follows:

```smalltalk
"Generate a private key and certificate for a certificate authority:"
result1 := LibC resultOfCommand: 'cd /tmp && /usr/bin/openssl ' ,
	'req -x509 -newkey rsa -nodes -keyout ca-key -out ca-cert ' ,
	'-subj "/CN=ZnSecureServer Test CA Certificate" 2>&1'.

"Generate a private key and certificate for the server:"
result2 := LibC resultOfCommand: 'cd /tmp && /usr/bin/openssl ' ,
	'req -x509 -newkey rsa -nodes -keyout s-key -out s-cert1 ' ,
	'-subj "/CN=ZnSecureServer Test Server Certificate" ' ,
	'-addext subjectAltName=DNS:localhost 2>&1'.

"Generate a certificate for the server signed by the certificate authority:"
result3 := LibC resultOfCommand: 'cd /tmp && /usr/bin/openssl ' ,
	'x509 -in s-cert1 -out s-cert2 ' ,
	'-CAkey ca-key -CA ca-cert -CAserial ca-srl -CAcreateserial 2>&1'.

"Add the server certificate signed by the certificate authority to the ‘login’ keychain:"
result4 := LibC resultOfCommand: 'cd /tmp && /usr/bin/security ' ,
	'add-certificates -k ~/Library/Keychains/login.keychain-db s-cert2 2>&1'.

"Add the server private key to the ‘login’ keychain:"
result5 := LibC resultOfCommand: 'cd /tmp && /usr/bin/security ' ,
	'import s-key -k ~/Library/Keychains/login.keychain-db 2>&1'.

"Add the certificate authority’s certificate as trusted to the ‘login’ keychain (needs confirmation):"
result6 := LibC resultOfCommand: 'cd /tmp && /usr/bin/security ' ,
	'add-trusted-cert -k ~/Library/Keychains/login.keychain-db ca-cert 2>&1'.

"Start a ZnSecureServer with ‘certificate’ set to the common name of the server certificate’s subject:"
(server := ZnSecureServer on: 1443)
	certificate: 'ZnSecureServer Test Server Certificate';
	logToTranscript;
	start.

"Get ‘/’ from the server (needs permission to use the private key, use the button to always allow):"
response := ZnEasy get: 'https://localhost:1443'.
```

Browsing ‘https://localhost:1443’ works with Chrome and Firefox. As noted [in the earlier pull request](https://github.com/pharo-project/pharo-vm/pull/812#issuecomment-2146255573), with Safari, there’s a problem which seems to be related to the use of IPv4 rather than IPv6.

The earlier pull request was closed, and this new one opened, following comments given in [OpenSmalltalk VM issue #680](https://github.com/OpenSmalltalk/opensmalltalk-vm/issues/680). As mentioned there, a concern now could be that there can be multiple certificates for the same subject, which one is then used is not really specified, except that expired certificates are excluded from the search performed through [‘SecItemCopyMatching’](https://developer.apple.com/documentation/security/1398306-secitemcopymatching?language=objc) by using [‘kSecMatchValidOnDate’](https://developer.apple.com/documentation/security/ksecmatchvalidondate?language=objc) in the query.