### PR TITLE
Ignoring EAGAIN in epoll_wait

### DIFF
--- a/extracted/vm/src/unix/aio.c
+++ b/extracted/vm/src/unix/aio.c
@@ -308,7 +308,7 @@ aio_handle_events(long microSecondsTimeout){
 	aio_flush_pipe(signal_pipe_fd[0]);
 
 	if(epollReturn == -1){
-		if(errno != EINTR){
+		if(errno != EINTR && errno != EAGAIN){
 			logErrorFromErrno("epoll_wait");
 		}
 		return 0;


### PR DESCRIPTION
We need to ignore this error and just retry later.