### PR TITLE
small change in copyWithoutReturn to handle CCoerce

### DIFF
--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -1354,6 +1354,7 @@ SlangBasicTranslationTest >> testInlineWithCoerceAsArgument [
 	tMethod := self getTMethodFrom:
 		           #methodCallingInSendMethodWithCCoerceInReturn.
 	tMethod recordDeclarationsIn: generator.
+
 	generator doBasicInlining: true.
 
 	translation := self translate: tMethod.
@@ -1368,6 +1369,57 @@ methodCallingInSendMethodWithCCoerceInReturn(void)
 {
 	method(((sqInt) (method()) ));
 	return 0;
+}'
+]
+
+{ #category : 'tests-inlinemethod' }
+SlangBasicTranslationTest >> testInlineWithCoerceAsExpressionInAssignment [
+	"the cast is still in an expression, so inlining does not supress it"
+
+	| translation tMethod |
+	tMethod := self getTMethodFrom:
+		           #methodCallingInAssignemtMethodWithCCoerceInReturn.
+	tMethod recordDeclarationsIn: generator.
+	generator doBasicInlining: true.
+
+	translation := self translate: tMethod.
+	translation := translation trimBoth.
+
+	self
+		assert: translation
+		equals:
+			'/* SlangBasicTranslationTestClass>>#methodCallingInAssignemtMethodWithCCoerceInReturn */
+static sqInt
+methodCallingInAssignemtMethodWithCCoerceInReturn(void)
+{
+	sqInt i;
+
+	i = ((sqInt) (method()) );
+	return 0;
+}'
+]
+
+{ #category : 'tests-inlinemethod' }
+SlangBasicTranslationTest >> testInlineWithCoerceAsExpressionInReturn [
+	"the cast is still in an expression, so inlining does not supress it"
+
+	| translation tMethod |
+	tMethod := self getTMethodFrom:
+		           #methodCallingInReturnMethodWithCCoerceInReturn.
+	tMethod recordDeclarationsIn: generator.
+	generator doBasicInlining: true.
+
+	translation := self translate: tMethod.
+	translation := translation trimBoth.
+
+	self
+		assert: translation
+		equals:
+			'/* SlangBasicTranslationTestClass>>#methodCallingInReturnMethodWithCCoerceInReturn */
+static sqInt
+methodCallingInReturnMethodWithCCoerceInReturn(void)
+{
+	return ((sqInt) (method()) );
 }'
 ]
 

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -1346,6 +1346,31 @@ SlangBasicTranslationTest >> testInlineNodeWithSharedLabelInCase [
 }'
 ]
 
+{ #category : 'tests-inlinemethod' }
+SlangBasicTranslationTest >> testInlineWithUnecessaryCoerce [
+	"the cast isn't in an expression anymore, so inlining supress it. If it we keep the cast we would have the line '(sqInt) method;' which would produce an 'unused expression result' warning."
+
+	| translation tMethod |
+	tMethod := self getTMethodFrom:
+		           #methodCallingMethodWithCCoerceInReturn.
+	tMethod recordDeclarationsIn: generator.
+	generator doBasicInlining: true.
+
+	translation := self translate: tMethod.
+	translation := translation trimBoth.
+
+	self
+		assert: translation
+		equals:
+			'/* SlangBasicTranslationTestClass>>#methodCallingMethodWithCCoerceInReturn */
+static sqInt
+methodCallingMethodWithCCoerceInReturn(void)
+{
+	method();
+	return 0;
+}'
+]
+
 { #category : 'tests-labels' }
 SlangBasicTranslationTest >> testLabel [
 

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -1347,6 +1347,31 @@ SlangBasicTranslationTest >> testInlineNodeWithSharedLabelInCase [
 ]
 
 { #category : 'tests-inlinemethod' }
+SlangBasicTranslationTest >> testInlineWithCoerceAsArgument [
+	"the cast is still in an expression, so inlining does not supress it"
+
+	| translation tMethod |
+	tMethod := self getTMethodFrom:
+		           #methodCallingInSendMethodWithCCoerceInReturn.
+	tMethod recordDeclarationsIn: generator.
+	generator doBasicInlining: true.
+
+	translation := self translate: tMethod.
+	translation := translation trimBoth.
+
+	self
+		assert: translation
+		equals:
+			'/* SlangBasicTranslationTestClass>>#methodCallingInSendMethodWithCCoerceInReturn */
+static sqInt
+methodCallingInSendMethodWithCCoerceInReturn(void)
+{
+	method(((sqInt) (method()) ));
+	return 0;
+}'
+]
+
+{ #category : 'tests-inlinemethod' }
 SlangBasicTranslationTest >> testInlineWithUnecessaryCoerce [
 	"the cast isn't in an expression anymore, so inlining supress it. If it we keep the cast we would have the line '(sqInt) method;' which would produce an 'unused expression result' warning."
 

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
@@ -41,6 +41,12 @@ SlangBasicTranslationTestClass >> initializationOptions [
 ]
 
 { #category : 'inline' }
+SlangBasicTranslationTestClass >> methodCallingInSendMethodWithCCoerceInReturn [
+
+	self method: self methodWithCCoerceInReturn
+]
+
+{ #category : 'inline' }
 SlangBasicTranslationTestClass >> methodCallingMethodWithCCoerceInReturn [
 
 	self methodWithCCoerceInReturn

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
@@ -41,6 +41,19 @@ SlangBasicTranslationTestClass >> initializationOptions [
 ]
 
 { #category : 'inline' }
+SlangBasicTranslationTestClass >> methodCallingInAssignemtMethodWithCCoerceInReturn [
+
+	| i |
+	i := self methodWithCCoerceInReturn
+]
+
+{ #category : 'inline' }
+SlangBasicTranslationTestClass >> methodCallingInReturnMethodWithCCoerceInReturn [
+
+	^ self methodWithCCoerceInReturn
+]
+
+{ #category : 'inline' }
 SlangBasicTranslationTestClass >> methodCallingInSendMethodWithCCoerceInReturn [
 
 	self method: self methodWithCCoerceInReturn

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
@@ -41,6 +41,12 @@ SlangBasicTranslationTestClass >> initializationOptions [
 ]
 
 { #category : 'inline' }
+SlangBasicTranslationTestClass >> methodCallingMethodWithCCoerceInReturn [
+
+	self methodWithCCoerceInReturn
+]
+
+{ #category : 'inline' }
 SlangBasicTranslationTestClass >> methodCallingMethodWithInlinePragma [
 
 	self methodWithoutInlinePragma.
@@ -113,6 +119,11 @@ SlangBasicTranslationTestClass >> methodWithAnOptionPragma [
 
 	<option: #OPTION>
 	
+]
+
+{ #category : 'inline' }
+SlangBasicTranslationTestClass >> methodWithCCoerceInReturn [
+	^ self cCoerce: self method to: #sqInt 
 ]
 
 { #category : 'inline' }

--- a/smalltalksrc/Slang/TMethod.class.st
+++ b/smalltalksrc/Slang/TMethod.class.st
@@ -1426,7 +1426,6 @@ TMethod >> inlineConditional: aSendNode in: aCodeGen [
 
 { #category : 'inlining' }
 TMethod >> inlineFunctionCall: aSendNode in: aCodeGen [
-
 	"Answer the body of the called function, substituting the actual
 	 parameters for the formal argument variables in the method body.
 	 Assume caller has established that:
@@ -1440,21 +1439,22 @@ TMethod >> inlineFunctionCall: aSendNode in: aCodeGen [
 	doNotRename := Set withAll: args.
 	argsForInlining := aSendNode argumentsForInliningCodeGenerator:
 		                   aCodeGen.
-	meth args with: argsForInlining do: [ :argName :exprNode | 
+	meth args with: argsForInlining do: [ :argName :exprNode |
 		exprNode isLeaf ifTrue: [ doNotRename add: argName ] ].
-	(meth statements size = 2 and: [ 
-		 meth statements first isSend and: [ 
-			 meth statements first selector == #flag: ] ]) ifTrue: [ 
+	(meth statements size = 2 and: [
+		 meth statements first isSend and: [
+			 meth statements first selector == #flag: ] ]) ifTrue: [
 		meth statements removeFirst ].
 	meth renameVarsForInliningInto: self except: doNotRename in: aCodeGen.
 	meth renameLabelsForInliningInto: self.
 	self addVarsDeclarationsAndLabelsOf: meth except: doNotRename.
 	substitutionDict := Dictionary new: meth args size * 2.
-	meth args with: argsForInlining do: [ :argName :exprNode | 
+	meth args with: argsForInlining do: [ :argName :exprNode |
 		substitutionDict at: argName put: exprNode.
-		(doNotRename includes: argName) ifFalse: [ 
+		(doNotRename includes: argName) ifFalse: [
 			self removeLocal: argName ] ].
 	meth parseTree bindVariablesIn: substitutionDict.
+	meth parseTree parent: aSendNode parent.
 	^ meth parseTree endsWithReturn
 		  ifTrue: [ meth parseTree copyWithoutReturn ]
 		  ifFalse: [ meth parseTree ]
@@ -1601,7 +1601,6 @@ TMethod >> inlineReturningConditional: aSendNode in: aCodeGen [
 
 { #category : 'inlining' }
 TMethod >> inlineSend: aSendNode directReturn: directReturn exitVar: exitVar in: aCodeGen [
-
 	"Answer a collection of statements to replace the given send.  directReturn indicates
 	 that the send is the expression in a return statement, so returns can be left in the
 	 body of the inlined method. If exitVar is nil, the value returned by the send is not
@@ -1618,49 +1617,51 @@ TMethod >> inlineSend: aSendNode directReturn: directReturn exitVar: exitVar in:
 	"convenient for debugging..."
 	aCodeGen maybeBreakForInlineOf: aSendNode in: self.
 	elidedArgs := #(  ).
-	(methArgs notEmpty and: [ methArgs first beginsWith: 'self_in_' ]) 
+	(methArgs notEmpty and: [ methArgs first beginsWith: 'self_in_' ])
 		ifTrue: [ "If the first arg is not used we can and should elide it."
 			| varNode |
 			varNode := TVariableNode new setName: methArgs first.
-			(meth parseTree noneSatisfy: [ :node | varNode isSameAs: node ]) 
+			(meth parseTree noneSatisfy: [ :node | varNode isSameAs: node ])
 				ifTrue: [ elidedArgs := { methArgs first } ].
 			methArgs := methArgs allButFirst ].
 	methArgs size = aSendNode arguments size ifFalse: [ ^ nil ].
 	meth := meth copy.
 
-	(meth statements size > 1 and: [ 
-		 meth statements first isSend and: [ 
-			 meth statements first selector == #flag: ] ]) ifTrue: [ 
+	(meth statements size > 1 and: [
+		 meth statements first isSend and: [
+			 meth statements first selector == #flag: ] ]) ifTrue: [
 		meth statements removeFirst ].
 
 	"Propagate the return type of an inlined method"
-	(directReturn or: [ exitVar notNil ]) ifTrue: [ 
+	(directReturn or: [ exitVar notNil ]) ifTrue: [
 		exitType := directReturn
 			            ifTrue: [ returnType ]
-			            ifFalse: [ 
+			            ifFalse: [
 			            (self typeFor: exitVar in: aCodeGen) ifNil: [ #sqInt ] ].
-		(exitType = #void or: [ exitType = meth returnType ]) ifFalse: [ 
+		(exitType = #void or: [ exitType = meth returnType ]) ifFalse: [
 			meth propagateReturnIn: aCodeGen ] ].
 
 	"Propagate any unusual argument types to untyped argument variables"
-	methArgs with: aSendNode arguments do: [ :formal :actual | 
-		(meth declarationAt: formal ifAbsent: nil) ifNil: [ | type |
-			(actual isVariable and: [ (type := self typeFor: actual name in: aCodeGen) notNil ])
-			 ifTrue: [
-				type ~= #sqInt ifTrue: [ 
-					meth declarationAt: formal put: (type last = $*
-							 ifTrue: [ type , formal ]
-							 ifFalse: [ type , ' ' , formal ]) ] ] ] ].
+	methArgs with: aSendNode arguments do: [ :formal :actual |
+		(meth declarationAt: formal ifAbsent: nil) ifNil: [
+			| type |
+			(actual isVariable and: [
+				 (type := self typeFor: actual name in: aCodeGen) notNil ])
+				ifTrue: [
+					type ~= #sqInt ifTrue: [
+						meth declarationAt: formal put: (type last = $*
+								 ifTrue: [ type , formal ]
+								 ifFalse: [ type , ' ' , formal ]) ] ] ] ].
 
 	meth renameVarsForInliningInto: self except: elidedArgs in: aCodeGen.
 	meth renameLabelsForInliningInto: self.
 	self addVarsDeclarationsAndLabelsOf: meth except: elidedArgs.
-	meth hasReturn ifTrue: [ 
-		directReturn ifFalse: [ 
+	meth hasReturn ifTrue: [
+		directReturn ifFalse: [
 			exitLabel := self unusedLabelForInliningInto: self.
 			(meth exitVar: exitVar label: exitLabel)
 				ifTrue: [ labels add: exitLabel ]
-				ifFalse: [ exitLabel := nil ] "is label used?" ] ].
+				ifFalse: [ "is label used?" exitLabel := nil ] ] ].
 	(inlineStmts := OrderedCollection new:
 			                meth statements size + meth args size + 2)
 		add: (label := TLabeledCommentNode new setComment: 'begin ' , sel);
@@ -1670,18 +1671,19 @@ TMethod >> inlineSend: aSendNode directReturn: directReturn exitVar: exitVar in:
 				 except: elidedArgs
 				 in: aCodeGen);
 		addAll: meth statements. "method body"
-	directReturn ifTrue: [ 
+	directReturn ifTrue: [
+		meth parseTree parent: aSendNode parent.
 		meth endsWithReturn
-			ifTrue: [ 
+			ifTrue: [
 				exitVar ifNotNil: [ "don't remove the returns if being invoked in the context of a return"
 					inlineStmts
 						at: inlineStmts size
 						put: inlineStmts last copyWithoutReturn ] ]
-			ifFalse: [ 
+			ifFalse: [
 				inlineStmts add:
 					(TReturnNode new setExpression:
 						 (TVariableNode new setName: 'nil')) ] ].
-	exitLabel ifNotNil: [ 
+	exitLabel ifNotNil: [
 		inlineStmts add: (TLabeledCommentNode new
 				 setLabel: exitLabel
 				 comment: 'end ' , meth selector) ].

--- a/smalltalksrc/Slang/TParseNode.class.st
+++ b/smalltalksrc/Slang/TParseNode.class.st
@@ -278,6 +278,15 @@ TParseNode >> isNonNullCCode [
 ]
 
 { #category : 'testing' }
+TParseNode >> isNotExpression [
+
+	^ parent isNil or: [
+		  parent isTMethod or: [
+			  parent isSend not and: [
+				  parent isReturn not and: [ parent isAssignment not ] ] ] ]
+]
+
+{ #category : 'testing' }
 TParseNode >> isReturn [
 
 	^false

--- a/smalltalksrc/Slang/TReturnNode.class.st
+++ b/smalltalksrc/Slang/TReturnNode.class.st
@@ -107,7 +107,10 @@ TReturnNode >> children [
 
 { #category : 'transformations' }
 TReturnNode >> copyWithoutReturn [
-	^expression
+
+	(expression isSend and: [ expression selector beginsWith: #cCoerce ])
+		ifTrue: [ ^ expression arguments first ].
+	^ expression
 ]
 
 { #category : 'testing' }

--- a/smalltalksrc/Slang/TReturnNode.class.st
+++ b/smalltalksrc/Slang/TReturnNode.class.st
@@ -110,7 +110,8 @@ TReturnNode >> copyWithoutReturn [
 	"called when inlining happens, if the expression is in a cast, it may be no longer needed and will produce a warning by the C compiler if the expression isn't use as an expression anymore"
 
 	((parent isTMethod or: [
-		  parent isSend not and: [ parent isReturn not ] ]) and: [
+		  parent isSend not and: [
+			  parent isReturn not and: [ parent isAssignment not ] ] ]) and: [
 		 expression isSend and: [ expression selector beginsWith: #cCoerce ] ])
 		ifTrue: [ ^ expression arguments first ].
 	^ expression

--- a/smalltalksrc/Slang/TReturnNode.class.st
+++ b/smalltalksrc/Slang/TReturnNode.class.st
@@ -107,8 +107,11 @@ TReturnNode >> children [
 
 { #category : 'transformations' }
 TReturnNode >> copyWithoutReturn [
+	"called when inlining happens, if the expression is in a cast, it may be no longer needed and will produce a warning by the C compiler if the expression isn't use as an expression anymore"
 
-	(expression isSend and: [ expression selector beginsWith: #cCoerce ])
+	((parent isTMethod or: [
+		  parent isSend not and: [ parent isReturn not ] ]) and: [
+		 expression isSend and: [ expression selector beginsWith: #cCoerce ] ])
 		ifTrue: [ ^ expression arguments first ].
 	^ expression
 ]

--- a/smalltalksrc/Slang/TReturnNode.class.st
+++ b/smalltalksrc/Slang/TReturnNode.class.st
@@ -109,7 +109,7 @@ TReturnNode >> children [
 TReturnNode >> copyWithoutReturn [
 	"called when inlining happens, if the expression is in a cast, it may be no longer needed and will produce a warning by the C compiler if the expression isn't use as an expression anymore"
 
-	((parent isTMethod or: [
+	(((parent isNil or: [ parent isTMethod ]) or: [
 		  parent isSend not and: [
 			  parent isReturn not and: [ parent isAssignment not ] ] ]) and: [
 		 expression isSend and: [ expression selector beginsWith: #cCoerce ] ])

--- a/smalltalksrc/Slang/TReturnNode.class.st
+++ b/smalltalksrc/Slang/TReturnNode.class.st
@@ -109,9 +109,7 @@ TReturnNode >> children [
 TReturnNode >> copyWithoutReturn [
 	"called when inlining happens, if the expression is in a cast, it may be no longer needed and will produce a warning by the C compiler if the expression isn't use as an expression anymore"
 
-	(((parent isNil or: [ parent isTMethod ]) or: [
-		  parent isSend not and: [
-			  parent isReturn not and: [ parent isAssignment not ] ] ]) and: [
+	(self isNotExpression and: [
 		 expression isSend and: [ expression selector beginsWith: #cCoerce ] ])
 		ifTrue: [ ^ expression arguments first ].
 	^ expression

--- a/smalltalksrc/Slang/TStatementListNode.class.st
+++ b/smalltalksrc/Slang/TStatementListNode.class.st
@@ -306,13 +306,16 @@ TStatementListNode >> children [
 
 { #category : 'transformations' }
 TStatementListNode >> copyWithoutReturn [
+
 	self assert: self endsWithReturn.
-	statements size = 1 ifTrue:
-		[^statements last copyWithoutReturn].
-	^self class new
-		setArguments: arguments
-			statements: statements allButLast, {statements last copyWithoutReturn};
-		yourself
+	statements size = 1 ifTrue: [
+		statements last parent: self parent.
+		^ statements last copyWithoutReturn ].
+	^ self class new
+		  setArguments: arguments
+		  statements:
+			  statements allButLast , { statements last copyWithoutReturn };
+		  yourself
 ]
 
 { #category : 'declarations' }

--- a/smalltalksrc/Slang/TStatementListNode.class.st
+++ b/smalltalksrc/Slang/TStatementListNode.class.st
@@ -308,7 +308,7 @@ TStatementListNode >> children [
 TStatementListNode >> copyWithoutReturn [
 	self assert: self endsWithReturn.
 	statements size = 1 ifTrue:
-		[^statements last expression].
+		[^statements last copyWithoutReturn].
 	^self class new
 		setArguments: arguments
 			statements: statements allButLast, {statements last copyWithoutReturn};


### PR DESCRIPTION
Suppress cCoerce at the top of return expression when we suppress return in inlining.

cCoerce can be found in returns to make them match their method return type.
During inlining we can create a copy of parts of the AST without their return. If there is a cCoerce at the top of their expression, it may be no longer needed and can produce a 'warning: expression result unused'.