### PR TITLE
remove unused cast and expression

### DIFF
--- a/extracted/plugins/B2DPlugin/src/common/B2DPlugin.c
+++ b/extracted/plugins/B2DPlugin/src/common/B2DPlugin.c
@@ -13643,7 +13643,6 @@ stepToNextWideBezierInat(sqInt bezier, sqInt yValue)
 		updateData[GBUpdateY] = lastY;
 		updateData[GBUpdateDX] = fwDx;
 		updateData[GBUpdateDY] = fwDy;
-		((signed)lastX >> 8);
 	}
 	else {
 
@@ -13673,7 +13672,7 @@ stepToNextWideBezierInat(sqInt bezier, sqInt yValue)
 	updateData1[GBUpdateY] = lastY1;
 	updateData1[GBUpdateDX] = fwDx1;
 	updateData1[GBUpdateDY] = fwDy1;
-	((signed)lastX1 >> 8);
+	
 	computeFinalWideBezierValueswidth(bezier, lineWidth);
 	return 0;
 }

--- a/extracted/plugins/UnixOSProcessPlugin/src/common/UnixOSProcessPlugin.c
+++ b/extracted/plugins/UnixOSProcessPlugin/src/common/UnixOSProcessPlugin.c
@@ -4887,7 +4887,7 @@ transientCStringFromString(sqInt aString)
 
 	/* Point to the actual C string. */
 	cString = arrayValueOf(newString);
-	(char *)strncpy(cString, stringPtr, len);
+	strncpy(cString, stringPtr, len);
 	cString[len] = 0;
 	return cString;
 }


### PR DESCRIPTION
remove manually unused cast and expression in the extracted folder, https://github.com/pharo-project/pharo-vm/pull/836 should prevent some of it to appear in the generated folder