### PR TITLE
a better comment support for Slang

### DIFF
--- a/smalltalksrc/CAST/CASTEqualityTests.class.st
+++ b/smalltalksrc/CAST/CASTEqualityTests.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #CASTEqualityTests,
-	#superclass : #TestCase,
-	#category : #'CAST-Tests'
+	#name : 'CASTEqualityTests',
+	#superclass : 'TestCase',
+	#category : 'CAST-Tests',
+	#package : 'CAST',
+	#tag : 'Tests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 CASTEqualityTests >> testArrayDeclaratorNodeEquality [
 
 	self
@@ -12,7 +14,7 @@ CASTEqualityTests >> testArrayDeclaratorNodeEquality [
 		equals: (CArrayDeclaratorNode identifier: 'aLiteralArray')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 CASTEqualityTests >> testArrayDeclaratorNodeInEquality [
 
 	self
@@ -20,7 +22,7 @@ CASTEqualityTests >> testArrayDeclaratorNodeInEquality [
 		equals: (CArrayDeclaratorNode identifier: 'toto')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 CASTEqualityTests >> testAssignmentNodeDefaultOperatorInEquality [
 
 	self
@@ -33,7 +35,7 @@ CASTEqualityTests >> testAssignmentNodeDefaultOperatorInEquality [
 			rvalue: (CConstantNode value: 2))
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 CASTEqualityTests >> testAssignmentNodeEquality [
 
 	self
@@ -45,7 +47,7 @@ CASTEqualityTests >> testAssignmentNodeEquality [
 			rvalue: (CConstantNode value: 2))
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 CASTEqualityTests >> testAssignmentNodeLvalueInEquality [
 
 	self
@@ -57,7 +59,7 @@ CASTEqualityTests >> testAssignmentNodeLvalueInEquality [
 			rvalue: (CConstantNode value: 2))
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 CASTEqualityTests >> testAssignmentNodeRvalueInEquality [
 
 	self
@@ -69,7 +71,7 @@ CASTEqualityTests >> testAssignmentNodeRvalueInEquality [
 			rvalue: (CConstantNode value: 3))
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 CASTEqualityTests >> testAssignmentNodeWithSpecialAndDefaultOperatorEquality [
 
 	self
@@ -82,7 +84,7 @@ CASTEqualityTests >> testAssignmentNodeWithSpecialAndDefaultOperatorEquality [
 			rvalue: (CConstantNode value: 2))
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 CASTEqualityTests >> testAssignmentNodeWithSpecialOperatorEquality [
 
 	self
@@ -96,7 +98,7 @@ CASTEqualityTests >> testAssignmentNodeWithSpecialOperatorEquality [
 			rvalue: (CConstantNode value: 2))
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 CASTEqualityTests >> testAssignmentNodeWithSpecialOperatorLvalueInEquality [
 
 	self
@@ -110,7 +112,7 @@ CASTEqualityTests >> testAssignmentNodeWithSpecialOperatorLvalueInEquality [
 			rvalue: (CConstantNode value: 2))
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 CASTEqualityTests >> testAssignmentNodeWithSpecialOperatorOperatorInEquality [
 
 	self
@@ -124,7 +126,7 @@ CASTEqualityTests >> testAssignmentNodeWithSpecialOperatorOperatorInEquality [
 			rvalue: (CConstantNode value: 3))
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 CASTEqualityTests >> testAssignmentNodeWithSpecialOperatorRvalueInEquality [
 
 	self
@@ -138,7 +140,7 @@ CASTEqualityTests >> testAssignmentNodeWithSpecialOperatorRvalueInEquality [
 			rvalue: (CConstantNode value: 3))
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 CASTEqualityTests >> testConstantNodeEquality [
 
 	self
@@ -146,7 +148,7 @@ CASTEqualityTests >> testConstantNodeEquality [
 		equals: (CConstantNode value: 1)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 CASTEqualityTests >> testConstantNodeInEquality [
 
 	self
@@ -154,7 +156,7 @@ CASTEqualityTests >> testConstantNodeInEquality [
 		equals: (CConstantNode value: 2)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 CASTEqualityTests >> testGoToEquality [
 
 	self
@@ -162,7 +164,7 @@ CASTEqualityTests >> testGoToEquality [
 		equals: (CGotoStatementNode identifier: 'toto')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 CASTEqualityTests >> testGoToInequality [
 
 	self
@@ -170,7 +172,7 @@ CASTEqualityTests >> testGoToInequality [
 		equals: (CGotoStatementNode identifier: 'toto')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 CASTEqualityTests >> testIdentifierNodeEquality [
 
 	self
@@ -178,7 +180,7 @@ CASTEqualityTests >> testIdentifierNodeEquality [
 		equals: (CIdentifierNode name: 'toto')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 CASTEqualityTests >> testIdentifierNodeInEquality [
 
 	self
@@ -186,7 +188,7 @@ CASTEqualityTests >> testIdentifierNodeInEquality [
 		equals: (CIdentifierNode name: 'toto2')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 CASTEqualityTests >> testInitDeclaratorNodeEquality [
 
 	self
@@ -198,7 +200,7 @@ CASTEqualityTests >> testInitDeclaratorNodeEquality [
 			initializer: (CConstantNode value: '1'))
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 CASTEqualityTests >> testInitDeclaratorNodeWithDeclaratorInEquality [
 
 	self
@@ -210,7 +212,7 @@ CASTEqualityTests >> testInitDeclaratorNodeWithDeclaratorInEquality [
 			initializer: (CConstantNode value: '1'))
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 CASTEqualityTests >> testInitDeclaratorNodeWithInitializerInEquality [
 
 	self
@@ -222,7 +224,7 @@ CASTEqualityTests >> testInitDeclaratorNodeWithInitializerInEquality [
 			initializer: (CConstantNode value: '2'))
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 CASTEqualityTests >> testInitializerNodeEquality [
 
 	self
@@ -230,7 +232,7 @@ CASTEqualityTests >> testInitializerNodeEquality [
 		equals: (CGLRInitializerNode initializers: { CConstantNode value: 1 })
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 CASTEqualityTests >> testInitializerNodeInEquality [
 
 	self

--- a/smalltalksrc/CAST/CASTParser.class.st
+++ b/smalltalksrc/CAST/CASTParser.class.st
@@ -2,17 +2,19 @@
 I am a C GLR Parser
 "
 Class {
-	#name : #CASTParser,
-	#superclass : #SmaCCGLRParser,
-	#category : #'CAST-Parser'
+	#name : 'CASTParser',
+	#superclass : 'SmaCCGLRParser',
+	#category : 'CAST-Parser',
+	#package : 'CAST',
+	#tag : 'Parser'
 }
 
-{ #category : #'generated-accessing' }
+{ #category : 'generated-accessing' }
 CASTParser class >> cacheId [
 	^'2017-12-13T09:32:38.213967+01:00'
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTParser class >> definitionComment [
 "<H>
 	: [a-fA-F0-9]
@@ -423,17 +425,17 @@ identifier: <IDENTIFIER> 'symbol' {{}};
 typename: <IDENTIFIER> 'symbol' {{}};"
 ]
 
-{ #category : #'generated-accessing' }
+{ #category : 'generated-accessing' }
 CASTParser class >> scannerClass [
 	^CASTScanner
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTParser class >> startingStateFortranslationUnit [
 	^ 1
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTParser >> ambiguousTransitions [
 ^#(
 #[ 0 26 0 30] 
@@ -446,7 +448,7 @@ CASTParser >> ambiguousTransitions [
 	).
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForabstract_declarator1: nodes [
 	| result |
 	result := CGLRAbstractDeclaratorNode new.
@@ -455,7 +457,7 @@ CASTParser >> reduceActionForabstract_declarator1: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForabstract_declarator2: nodes [
 	| result |
 	result := CGLRAbstractDeclaratorNode new.
@@ -463,7 +465,7 @@ CASTParser >> reduceActionForabstract_declarator2: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForabstract_declarator3: nodes [
 	| result |
 	result := CGLRAbstractDeclaratorNode new.
@@ -473,7 +475,7 @@ CASTParser >> reduceActionForabstract_declarator3: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForassignment_expression2: nodes [
 	| result |
 	result := CAssignmentNode new.
@@ -483,7 +485,7 @@ CASTParser >> reduceActionForassignment_expression2: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForcast_expression2: nodes [
 	| result |
 	result := CCastExpressionNode new.
@@ -492,14 +494,14 @@ CASTParser >> reduceActionForcast_expression2: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForcompound_statement1: nodes [
 	| result |
 	result := CCompoundStatementNode new.
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForcompound_statement2: nodes [
 	| result |
 	result := CCompoundStatementNode new.
@@ -507,7 +509,7 @@ CASTParser >> reduceActionForcompound_statement2: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForcompound_statement3: nodes [
 	| result |
 	result := CCompoundStatementNode new.
@@ -515,7 +517,7 @@ CASTParser >> reduceActionForcompound_statement3: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForcompound_statement4: nodes [
 	| result |
 	result := CCompoundStatementNode new.
@@ -524,7 +526,7 @@ CASTParser >> reduceActionForcompound_statement4: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForconditional_expression2: nodes [
 	| result |
 	result := CTernaryNode new.
@@ -534,7 +536,7 @@ CASTParser >> reduceActionForconditional_expression2: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionFordeclaration1: nodes [
 	| result |
 	result := CDeclarationNode new.
@@ -542,7 +544,7 @@ CASTParser >> reduceActionFordeclaration1: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionFordeclaration2: nodes [
 	| result |
 	result := CDeclarationNode new.
@@ -551,7 +553,7 @@ CASTParser >> reduceActionFordeclaration2: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionFordeclaration_specifiers1: nodes [
 	| result |
 	result := OrderedCollection new: 2.
@@ -559,7 +561,7 @@ CASTParser >> reduceActionFordeclaration_specifiers1: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionFordeclaration_specifiers2: nodes [
 	| result |
 	result := nodes at: 2.
@@ -567,7 +569,7 @@ CASTParser >> reduceActionFordeclaration_specifiers2: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionFordeclarator1: nodes [
 	| result |
 	result := CPointerDeclaratorNode new.
@@ -577,20 +579,20 @@ CASTParser >> reduceActionFordeclarator1: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionFordeclarator2: nodes [
 
 	^ nodes at: 1
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionFordirect_abstract_declarator2: nodes [
 	| result |
 	result := CArrayDeclaratorNode new.
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionFordirect_abstract_declarator3: nodes [
 	| result |
 	result := CArrayDeclaratorNode new.
@@ -598,14 +600,14 @@ CASTParser >> reduceActionFordirect_abstract_declarator3: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionFordirect_abstract_declarator6: nodes [
 	| result |
 	result := CFunctionDeclaratorNode new.
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionFordirect_abstract_declarator7: nodes [
 	| result |
 	result := CFunctionDeclaratorNode new.
@@ -614,13 +616,13 @@ CASTParser >> reduceActionFordirect_abstract_declarator7: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionFordirect_declarator3: nodes [
 	
 	^ nodes at: 2
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionFordirect_declarator4: nodes [
 	| result |
 	result := CArrayDeclaratorNode new.
@@ -629,7 +631,7 @@ CASTParser >> reduceActionFordirect_declarator4: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionFordirect_declarator5: nodes [
 	| result |
 	result := CArrayDeclaratorNode new.
@@ -637,7 +639,7 @@ CASTParser >> reduceActionFordirect_declarator5: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionFordirect_declarator6: nodes [
 	| result |
 	result := CFunctionDeclaratorNode new.
@@ -647,7 +649,7 @@ CASTParser >> reduceActionFordirect_declarator6: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionFordirect_declarator7: nodes [
 	| result |
 	result := CFunctionDeclaratorNode new.
@@ -656,13 +658,13 @@ CASTParser >> reduceActionFordirect_declarator7: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionFordirect_declarator8: nodes [
 	
 	^ nodes at: 1
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForenum_specifier1: nodes [
 	| result |
 	result := CGLREnumNode new.
@@ -670,7 +672,7 @@ CASTParser >> reduceActionForenum_specifier1: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForenum_specifier2: nodes [
 	| result |
 	result := CGLREnumNode new.
@@ -679,7 +681,7 @@ CASTParser >> reduceActionForenum_specifier2: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForenum_specifier3: nodes [
 	| result |
 	result := CGLREnumNode new.
@@ -687,7 +689,7 @@ CASTParser >> reduceActionForenum_specifier3: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForenumerator1: nodes [
 	| result |
 	result := CGLREnumeratorNode new.
@@ -695,7 +697,7 @@ CASTParser >> reduceActionForenumerator1: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForenumerator2: nodes [
 	| result |
 	result := CGLREnumeratorNode new.
@@ -704,31 +706,31 @@ CASTParser >> reduceActionForenumerator2: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForexpression1: nodes [
 
 	^ nodes at: 1
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForexpression2: nodes [
 	
 	^ (nodes at: 1), (nodes at: 3)
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForexpression_statement1: nodes [
 
 	^ CEmptyStatementNode new
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForexpression_statement2: nodes [
 
 	^ nodes at: 1
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForfunction_definition1: nodes [
 	| result |
 	result := CFunctionDefinitionNode new.
@@ -739,7 +741,7 @@ CASTParser >> reduceActionForfunction_definition1: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForfunction_definition2: nodes [
 	| result |
 	result := CFunctionDefinitionNode new.
@@ -749,7 +751,7 @@ CASTParser >> reduceActionForfunction_definition2: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForfunction_definition3: nodes [
 	| result |
 	result := CFunctionDefinitionNode new.
@@ -759,7 +761,7 @@ CASTParser >> reduceActionForfunction_definition3: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForfunction_definition4: nodes [
 	| result |
 	result := CFunctionDefinitionNode new.
@@ -768,7 +770,7 @@ CASTParser >> reduceActionForfunction_definition4: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForidentifier1: nodes [
 	| result |
 	result := CIdentifierNode new.
@@ -776,7 +778,7 @@ CASTParser >> reduceActionForidentifier1: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForinit_declaration1: nodes [
 	| result |
 	result := Array new: 3.
@@ -789,13 +791,13 @@ CASTParser >> reduceActionForinit_declaration1: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForinit_declarator1: nodes [
 	
 	^ nodes at: 1
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForinit_declarator2: nodes [
 	| result |
 	result := CInitDeclaratorNode new.
@@ -804,7 +806,7 @@ CASTParser >> reduceActionForinit_declarator2: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForinit_declarator_list2: nodes [
 	| result |
 	result := nodes at: 1.
@@ -813,7 +815,7 @@ CASTParser >> reduceActionForinit_declarator_list2: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForinitializer2: nodes [
 	| result |
 	result := CGLRInitializerNode new.
@@ -821,7 +823,7 @@ CASTParser >> reduceActionForinitializer2: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForinitializer3: nodes [
 	| result |
 	result := CGLRInitializerNode new.
@@ -829,7 +831,7 @@ CASTParser >> reduceActionForinitializer3: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForiteration_statement1: nodes [
 	| result |
 	result := CWhileStatementNode new.
@@ -838,7 +840,7 @@ CASTParser >> reduceActionForiteration_statement1: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForiteration_statement2: nodes [
 	| result |
 	result := CDoStatementNode new.
@@ -847,7 +849,7 @@ CASTParser >> reduceActionForiteration_statement2: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForiteration_statement3: nodes [
 	| result |
 	result := CForStatementNode new.
@@ -857,7 +859,7 @@ CASTParser >> reduceActionForiteration_statement3: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForiteration_statement4: nodes [
 	| result |
 	result := CForStatementNode new.
@@ -868,7 +870,7 @@ CASTParser >> reduceActionForiteration_statement4: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForjump_statement1: nodes [
 	| result |
 	result := CGotoStatementNode new.
@@ -876,28 +878,28 @@ CASTParser >> reduceActionForjump_statement1: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForjump_statement2: nodes [
 	| result |
 	result := CGLRContinueStatementNode new.
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForjump_statement3: nodes [
 	| result |
 	result := CBreakStatementNode new.
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForjump_statement4: nodes [
 	| result |
 	result := CReturnStatementNode new.
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForjump_statement5: nodes [
 	| result |
 	result := CReturnStatementNode new.
@@ -905,7 +907,7 @@ CASTParser >> reduceActionForjump_statement5: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForlabeled_statement1: nodes [
 	| result |
 	result := CLabeledStatementNode new.
@@ -914,7 +916,7 @@ CASTParser >> reduceActionForlabeled_statement1: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForlabeled_statement2: nodes [
 	| result |
 	result := CLabeledStatementNode new.
@@ -923,7 +925,7 @@ CASTParser >> reduceActionForlabeled_statement2: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForlabeled_statement3: nodes [
 	| result |
 	result := CLabeledStatementNode new.
@@ -932,7 +934,7 @@ CASTParser >> reduceActionForlabeled_statement3: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionFormultiplicative_expression3: nodes [
 	| result |
 	result := CBinaryOperatorNode new.
@@ -942,7 +944,7 @@ CASTParser >> reduceActionFormultiplicative_expression3: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForparameter_declaration1: nodes [
 	| result |
 	result := CParameterDeclarationNode new.
@@ -951,7 +953,7 @@ CASTParser >> reduceActionForparameter_declaration1: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForparameter_declaration3: nodes [
 	| result |
 	result := CParameterDeclarationNode new.
@@ -959,7 +961,7 @@ CASTParser >> reduceActionForparameter_declaration3: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForparameter_type_list1: nodes [
 	| result |
 	result := Array new: 3.
@@ -970,7 +972,7 @@ CASTParser >> reduceActionForparameter_type_list1: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForparameter_type_list2: nodes [
 	| result |
 	result := Array new: 3.
@@ -983,7 +985,7 @@ CASTParser >> reduceActionForparameter_type_list2: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForpointer1: nodes [
 	| result |
 	result := Array new: 2.
@@ -993,7 +995,7 @@ CASTParser >> reduceActionForpointer1: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForpointer2: nodes [
 	| result |
 	result := Array new: 2.
@@ -1004,7 +1006,7 @@ CASTParser >> reduceActionForpointer2: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForpointer3: nodes [
 	| result |
 	result := nodes at: 2.
@@ -1012,7 +1014,7 @@ CASTParser >> reduceActionForpointer3: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForpointer4: nodes [
 	| result |
 	result := nodes at: 3.
@@ -1021,7 +1023,7 @@ CASTParser >> reduceActionForpointer4: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForpostfix_expression2: nodes [
 	| result |
 	result := CArrayAccessNode new.
@@ -1030,7 +1032,7 @@ CASTParser >> reduceActionForpostfix_expression2: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForpostfix_expression3: nodes [
 	| result |
 	result := CCallNode new.
@@ -1038,7 +1040,7 @@ CASTParser >> reduceActionForpostfix_expression3: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForpostfix_expression4: nodes [
 	| result |
 	result := CCallNode new.
@@ -1047,7 +1049,7 @@ CASTParser >> reduceActionForpostfix_expression4: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForpostfix_expression5: nodes [
 	| result |
 	result := CMemberAccessNode new.
@@ -1056,7 +1058,7 @@ CASTParser >> reduceActionForpostfix_expression5: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForpostfix_expression6: nodes [
 	| result |
 	result := CStructurePointerAccessNode new.
@@ -1065,7 +1067,7 @@ CASTParser >> reduceActionForpostfix_expression6: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForpostfix_expression7: nodes [
 	| result |
 	result := CIncrementNode new.
@@ -1074,7 +1076,7 @@ CASTParser >> reduceActionForpostfix_expression7: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForpostfix_expression8: nodes [
 	| result |
 	result := CDecrementNode new.
@@ -1082,13 +1084,13 @@ CASTParser >> reduceActionForpostfix_expression8: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForprimary_expression1: nodes [
 
 	^ nodes at: 1
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForprimary_expression2: nodes [
 	| result |
 	result := CConstantNode new.
@@ -1096,7 +1098,7 @@ CASTParser >> reduceActionForprimary_expression2: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForprimary_expression3: nodes [
 	| result |
 	result := CStringLiteralNode new.
@@ -1104,13 +1106,13 @@ CASTParser >> reduceActionForprimary_expression3: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForprimary_expression4: nodes [
 
 	^ nodes at: 2
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForselection_statement1: nodes [
 	| result |
 	result := CIfStatementNode new.
@@ -1119,7 +1121,7 @@ CASTParser >> reduceActionForselection_statement1: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForselection_statement2: nodes [
 	| result |
 	result := CIfStatementNode new.
@@ -1129,7 +1131,7 @@ CASTParser >> reduceActionForselection_statement2: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForselection_statement3: nodes [
 	| result |
 	result := CSwitchStatementNode new.
@@ -1138,7 +1140,7 @@ CASTParser >> reduceActionForselection_statement3: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForspecifier_qualifier_list3: nodes [
 	| result |
 	result := nodes at: 2.
@@ -1146,7 +1148,7 @@ CASTParser >> reduceActionForspecifier_qualifier_list3: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForspecifier_qualifier_list4: nodes [
 	| result |
 	result := Array new: 2.
@@ -1156,7 +1158,7 @@ CASTParser >> reduceActionForspecifier_qualifier_list4: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForstruct_declaration1: nodes [
 	| result |
 	result := CGLRStructDeclarationNode new.
@@ -1166,7 +1168,7 @@ CASTParser >> reduceActionForstruct_declaration1: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForstruct_declarator1: nodes [
 	| result |
 	result := CGLRStructDeclaratorNode new.
@@ -1174,7 +1176,7 @@ CASTParser >> reduceActionForstruct_declarator1: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForstruct_declarator2: nodes [
 	| result |
 	result := CGLRStructDeclaratorNode new.
@@ -1182,7 +1184,7 @@ CASTParser >> reduceActionForstruct_declarator2: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForstruct_declarator3: nodes [
 	| result |
 	result := CGLRStructDeclaratorNode new.
@@ -1191,7 +1193,7 @@ CASTParser >> reduceActionForstruct_declarator3: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForstruct_or_union_specifier1: nodes [
 	| result |
 	result := CGLRStructOrUnionSpecifierNode new.
@@ -1201,7 +1203,7 @@ CASTParser >> reduceActionForstruct_or_union_specifier1: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForstruct_or_union_specifier2: nodes [
 	| result |
 	result := CGLRStructOrUnionSpecifierNode new.
@@ -1210,7 +1212,7 @@ CASTParser >> reduceActionForstruct_or_union_specifier2: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForstruct_or_union_specifier3: nodes [
 	| result |
 	result := CGLRStructOrUnionSpecifierNode new.
@@ -1219,7 +1221,7 @@ CASTParser >> reduceActionForstruct_or_union_specifier3: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionFortranslationUnit1: nodes [
 	| result |
 	result := CGLRTranslationUnitNode new.
@@ -1227,7 +1229,7 @@ CASTParser >> reduceActionFortranslationUnit1: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionFortranslationUnit2: nodes [
 	| result |
 	result := nodes at: 1.
@@ -1235,7 +1237,7 @@ CASTParser >> reduceActionFortranslationUnit2: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionFortype_name1: nodes [
 	| result |
 	result := CGLRTypeNode new.
@@ -1244,7 +1246,7 @@ CASTParser >> reduceActionFortype_name1: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionFortype_name2: nodes [
 	| result |
 	result := CGLRTypeNode new.
@@ -1254,12 +1256,12 @@ CASTParser >> reduceActionFortype_name2: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionFortype_qualifier1: nodes [
 	^ nodes at: 1
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionFortype_qualifier_list2: nodes [
 	| result |
 	result := nodes at: 1.
@@ -1267,7 +1269,7 @@ CASTParser >> reduceActionFortype_qualifier_list2: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionFortypename1: nodes [
 	| result |
 	result := CTypeNameNode new.
@@ -1275,7 +1277,7 @@ CASTParser >> reduceActionFortypename1: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForunary_expression3: nodes [
 	| result |
 	result := CUnaryOperatorNode new.
@@ -1284,7 +1286,7 @@ CASTParser >> reduceActionForunary_expression3: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForunary_expression5: nodes [
 	| result |
 	result := CSizeofNode new.
@@ -1292,7 +1294,7 @@ CASTParser >> reduceActionForunary_expression5: nodes [
 	^ result
 ]
 
-{ #category : #'generated-reduction actions' }
+{ #category : 'generated-reduction actions' }
 CASTParser >> reduceActionForunary_expression6: nodes [
 	| result |
 	result := CSizeofNode new.
@@ -1300,7 +1302,7 @@ CASTParser >> reduceActionForunary_expression6: nodes [
 	^ result
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTParser >> reduceTable [
 ^#(
 	#(127 1 #reduceActionForpointer1:) 
@@ -1467,17 +1469,17 @@ CASTParser >> reduceTable [
 	).
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTParser >> symbolNames [
 	^ #('"^"' '"|"' '"=="' '"!="' '"&&"' '">"' '"<="' '">="' '"||"' '"%="' '"+="' '"*="' '"return"' '">>"' '"?"' '":"' '"="' '"<"' '"-="' '"--"' '","' '"->"' '"++"' '"sizeof"' '"("' '")"' '"."' '"&"' '"/"' '"%"' '"~"' '"!"' '"<<"' '"*"' '"+"' '"-"' '"/="' '"case"' '"default"' '"const"' '"volatile"' '"if"' '"struct"' '"union"' '"<<="' '"else"' '"continue"' '"break"' '"for"' '"goto"' '"enum"' '"switch"' '"while"' '"do"' '"unsigned"' '"signed"' '"typedef"' '"extern"' '"|="' '"double"' '"static"' '">>="' '"&="' '"^="' '";"' '"long"' '"float"' '"short"' '"int"' '"auto"' '"register"' '"void"' '"char"' '<ELLIPSIS>' '<comment>' '<IDENTIFIER>' '<CONSTANT>' '<STRING_LITERAL>' '<LEFT_BLOCK>' '<RIGHT_BLOCK>' '<LEFT_BRACE>' '<RIGHT_BRACE>' '<whitespace>' 'primary_expression' 'argument_expression_list' 'assignment_expression' 'unary_expression' 'unary_operator' 'cast_expression' 'type_name' 'multiplicative_expression' 'additive_expression' 'shift_expression' 'relational_expression' 'equality_expression' 'and_expression' 'exclusive_or_expression' 'inclusive_or_expression' 'logical_and_expression' 'logical_or_expression' 'conditional_expression' 'assignment_operator' 'constant_expression' 'declaration_specifiers' 'init_declaration' 'declaration' 'init_declarator_list' 'storage_class_specifier' 'type_specifier' 'type_qualifier' 'init_declarator' 'declarator' 'initializer' 'struct_or_union_specifier' 'enum_specifier' 'typename' 'struct_or_union' 'expression' 'struct_declaration_list' 'identifier' 'struct_declaration' 'specifier_qualifier_list' 'struct_declarator_list' 'struct_declarator' 'enumerator_list' 'enumerator' 'pointer' 'direct_declarator' 'parameter_type_list' 'identifier_list' 'type_qualifier_list' 'parameter_list' 'postfix_expression' 'parameter_declaration' 'abstract_declarator' 'direct_abstract_declarator' 'initializer_list' 'labeled_statement' 'compound_statement' 'expression_statement' 'selection_statement' 'iteration_statement' 'jump_statement' 'statement' 'statement_list' 'declaration_list' 'function_definition' 'translationUnit' 'E O F' 'error' 'external_declaration' 'B e g i n')
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTParser >> symbolTypes [
 	^ #(#SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #SmaCCToken #CGLRAbstractNode #OrderedCollection #CGLRAbstractNode #CGLRAbstractNode #SmaCCToken #CGLRAbstractNode #CGLRTypeNode #CGLRAbstractNode #CGLRAbstractNode #CGLRAbstractNode #CGLRAbstractNode #CGLRAbstractNode #CGLRAbstractNode #CGLRAbstractNode #CGLRAbstractNode #CGLRAbstractNode #CGLRAbstractNode #CGLRAbstractNode #SmaCCToken #CGLRAbstractNode #OrderedCollection #OrderedCollection #CDeclarationNode #OrderedCollection #SmaCCToken #Object #SmaCCToken #CInitDeclaratorNode #CPointerDeclaratorNode #CGLRAbstractNode #CGLRStructOrUnionSpecifierNode #CGLREnumNode #CTypeNameNode #SmaCCToken #CExpressionNode #OrderedCollection #CIdentifierNode #CGLRStructDeclarationNode #OrderedCollection #OrderedCollection #CGLRStructDeclaratorNode #OrderedCollection #CGLREnumeratorNode #OrderedCollection #CGLRAbstractNode #OrderedCollection #OrderedCollection #OrderedCollection #OrderedCollection #CGLRAbstractNode #CParameterDeclarationNode #CGLRAbstractDeclaratorNode #CGLRAbstractNode #OrderedCollection #CLabeledStatementNode #CCompoundStatementNode #CGLRExpressionStatementNode #CGLRAbstractNode #CGLRAbstractNode #CGLRAbstractNode #CGLRAbstractNode #OrderedCollection #OrderedCollection #CFunctionDefinitionNode #CGLRTranslationUnitNode #SmaCCToken #SmaCCToken #CGLRAbstractNode #CGLRTranslationUnitNode)
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTParser >> transitionTable [
 ^#(
 #[1 0 9 0 25 0 13 0 34 0 17 0 40 0 21 0 41 0 25 0 43 0 29 0 44 0 33 0 51 0 37 0 55 0 41 0 56 0 45 0 57 0 49 0 58 0 53 0 60 0 57 0 61 0 61 0 66 0 65 0 67 0 69 0 68 0 73 0 69 0 77 0 70 0 81 0 71 0 85 0 72 0 89 0 73 0 93 0 76 0 97 0 104 0 101 0 105 0 105 0 106 0 109 0 108 0 113 0 109 0 117 0 110 0 121 0 112 0 125 0 114 0 129 0 115 0 133 0 116 0 137 0 117 0 141 0 120 0 145 0 127 0 149 0 128 0 153 0 147 0 157 0 148 0 161 0 151] 

--- a/smalltalksrc/CAST/CASTParserTests.class.st
+++ b/smalltalksrc/CAST/CASTParserTests.class.st
@@ -4,12 +4,14 @@ A few tests to explore the ambiguity of a GLR grammar.
 
 "
 Class {
-	#name : #CASTParserTests,
-	#superclass : #TestCase,
-	#category : #'CAST-Tests'
+	#name : 'CASTParserTests',
+	#superclass : 'TestCase',
+	#category : 'CAST-Tests',
+	#package : 'CAST',
+	#tag : 'Tests'
 }
 
-{ #category : #examples }
+{ #category : 'examples' }
 CASTParserTests class >> ambiguityAsAttribute [
 	<example>
 	| block |
@@ -33,7 +35,7 @@ CASTParserTests class >> ambiguityAsAttribute [
 			ex resume: results first ]
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 CASTParserTests class >> ambiguityAsAttribute2 [
 	<example>
 	| block |
@@ -53,7 +55,7 @@ CASTParserTests class >> ambiguityAsAttribute2 [
 			ex resume: results first ]
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 CASTParserTests class >> ambiguityAsAttribute3 [
 	<example>
 	| block |
@@ -75,7 +77,7 @@ CASTParserTests class >> ambiguityAsAttribute3 [
 			ex resume: results first ]
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 CASTParserTests class >> inspectingAmbiguousNotification [
 	<example>
 	[ CASTParser
@@ -89,7 +91,7 @@ CASTParserTests class >> inspectingAmbiguousNotification [
 			ex resume: ex tag first ]
 ]
 
-{ #category : #examples }
+{ #category : 'examples' }
 CASTParserTests class >> inspectingAmbiguousNotificationWithHalt [
 	<example>
 	[ CASTParser
@@ -104,7 +106,7 @@ void f() {
 			ex resume: ex tag first ]
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 CASTParserTests >> parseDeclaration: aStratement [
 
 	| unit |
@@ -115,14 +117,14 @@ CASTParserTests >> parseDeclaration: aStratement [
 	^ unit declarations first declarations first
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 CASTParserTests >> parseExpression: anExpression [
 
 	
 	^ self parseStatement: anExpression, ';'
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 CASTParserTests >> parseStatement: aStratement [
 
 	| unit |
@@ -133,7 +135,7 @@ CASTParserTests >> parseStatement: aStratement [
 	^ unit declarations first statements first
 ]
 
-{ #category : #'tests-assignment' }
+{ #category : 'tests-assignment' }
 CASTParserTests >> testParseAccumulatingAssignment [
 
 	| assignment |
@@ -144,7 +146,7 @@ CASTParserTests >> testParseAccumulatingAssignment [
 	self assert: assignment operator equals: '+='.
 ]
 
-{ #category : #'tests-binary operators' }
+{ #category : 'tests-binary operators' }
 CASTParserTests >> testParseAddition [
 
 	| expression |
@@ -155,7 +157,7 @@ CASTParserTests >> testParseAddition [
 	self assert: expression operator equals: '+'
 ]
 
-{ #category : #'tests-binary operators' }
+{ #category : 'tests-binary operators' }
 CASTParserTests >> testParseAdditionPrecedence [
 
 	| expression |
@@ -177,7 +179,7 @@ CASTParserTests >> testParseAdditionPrecedence [
 
 ]
 
-{ #category : #'tests-binary operators' }
+{ #category : 'tests-binary operators' }
 CASTParserTests >> testParseAdressOf [
 
 	| expression |
@@ -187,7 +189,7 @@ CASTParserTests >> testParseAdressOf [
 	self assert: expression operator equals: '&'
 ]
 
-{ #category : #'tests-declarators' }
+{ #category : 'tests-declarators' }
 CASTParserTests >> testParseArrayDeclarationWithInitializer [
 
 	| declaration declarator |
@@ -207,7 +209,7 @@ CASTParserTests >> testParseArrayDeclarationWithInitializer [
 	self assert: declarator declarator name equals: 'a'.
 ]
 
-{ #category : #'tests-declarators' }
+{ #category : 'tests-declarators' }
 CASTParserTests >> testParseArrayDeclarationWithSize [
 
 	| declaration declarator |
@@ -222,7 +224,7 @@ CASTParserTests >> testParseArrayDeclarationWithSize [
 	self assert: declarator declarator name equals: 'a'.
 ]
 
-{ #category : #'tests-basic expressions' }
+{ #category : 'tests-basic expressions' }
 CASTParserTests >> testParseArrayNode [
 
 	| expression |
@@ -234,7 +236,7 @@ CASTParserTests >> testParseArrayNode [
 	self assert: expression index value equals: '1'.
 ]
 
-{ #category : #'tests-assignment' }
+{ #category : 'tests-assignment' }
 CASTParserTests >> testParseAssignment [
 
 	| assignment |
@@ -245,7 +247,7 @@ CASTParserTests >> testParseAssignment [
 	self assert: assignment operator equals: '='.
 ]
 
-{ #category : #'tests-calls' }
+{ #category : 'tests-calls' }
 CASTParserTests >> testParseCall [
 
 	| expression |
@@ -257,7 +259,7 @@ CASTParserTests >> testParseCall [
 	self assert: expression arguments isEmpty.
 ]
 
-{ #category : #'tests-calls' }
+{ #category : 'tests-calls' }
 CASTParserTests >> testParseCallWithArguments [
 
 	| expression |
@@ -271,7 +273,7 @@ CASTParserTests >> testParseCallWithArguments [
 	self assert: expression arguments third isBinaryOperation.
 ]
 
-{ #category : #'tests-control flow' }
+{ #category : 'tests-control flow' }
 CASTParserTests >> testParseCastExpression [
 
 	| statement |
@@ -281,7 +283,7 @@ CASTParserTests >> testParseCastExpression [
 	self assert: statement type equals: 'int'
 ]
 
-{ #category : #'tests-basic expressions' }
+{ #category : 'tests-basic expressions' }
 CASTParserTests >> testParseCommaSeparatedExpression [
 
 	| expression commaSeparatedExpression |
@@ -294,7 +296,7 @@ CASTParserTests >> testParseCommaSeparatedExpression [
 	self assert: commaSeparatedExpression expressions third isBinaryOperation.
 ]
 
-{ #category : #'tests-compound statements' }
+{ #category : 'tests-compound statements' }
 CASTParserTests >> testParseCompoundStatement [
 
 	| statement |
@@ -310,7 +312,7 @@ CASTParserTests >> testParseCompoundStatement [
 	self assert: statement statements third value equals: '3'.
 ]
 
-{ #category : #'tests-assignment' }
+{ #category : 'tests-assignment' }
 CASTParserTests >> testParseDecrementingAssignment [
 
 	| assignment |
@@ -321,7 +323,7 @@ CASTParserTests >> testParseDecrementingAssignment [
 	self assert: assignment operator equals: '-='.
 ]
 
-{ #category : #'tests-assignment' }
+{ #category : 'tests-assignment' }
 CASTParserTests >> testParseDividingAssignment [
 
 	| assignment |
@@ -332,7 +334,7 @@ CASTParserTests >> testParseDividingAssignment [
 	self assert: assignment operator equals: '/='.
 ]
 
-{ #category : #'tests-compound statements' }
+{ #category : 'tests-compound statements' }
 CASTParserTests >> testParseEmptyCompoundStatement [
 
 	| statement |
@@ -343,7 +345,7 @@ CASTParserTests >> testParseEmptyCompoundStatement [
 	self assert: statement statements isEmpty
 ]
 
-{ #category : #'tests-basic expressions' }
+{ #category : 'tests-basic expressions' }
 CASTParserTests >> testParseEmptyStatement [
 
 	| unit |
@@ -351,7 +353,7 @@ CASTParserTests >> testParseEmptyStatement [
 	self assert: unit declarations first statements first isEmptyStatement.
 ]
 
-{ #category : #'tests-numbers' }
+{ #category : 'tests-numbers' }
 CASTParserTests >> testParseFloatingPointConstant [
 
 	| unit firstStatement |
@@ -366,7 +368,7 @@ CASTParserTests >> testParseFloatingPointConstant [
 	self assert: firstStatement value equals: '17.2333'.
 ]
 
-{ #category : #'tests-declarators' }
+{ #category : 'tests-declarators' }
 CASTParserTests >> testParseFunctionDeclarator [
 
 	| declaration declarator |
@@ -381,7 +383,7 @@ CASTParserTests >> testParseFunctionDeclarator [
 	self assert: declarator parameters size equals: 1.
 ]
 
-{ #category : #'tests-declarators' }
+{ #category : 'tests-declarators' }
 CASTParserTests >> testParseFunctionPointerDeclarator [
 
 	| declaration declarator |
@@ -396,7 +398,7 @@ CASTParserTests >> testParseFunctionPointerDeclarator [
 	self assert: declarator declarator declarator name equals: 'pf'.
 ]
 
-{ #category : #'tests-numbers' }
+{ #category : 'tests-numbers' }
 CASTParserTests >> testParseGoTo [
 
 	| unit firstStatement |
@@ -411,7 +413,7 @@ CASTParserTests >> testParseGoTo [
 	self assert: firstStatement label name equals: 'toto'.
 ]
 
-{ #category : #'tests-numbers' }
+{ #category : 'tests-numbers' }
 CASTParserTests >> testParseHexadecimalIntegerConstantConstant [
 
 	| unit firstStatement |
@@ -426,7 +428,7 @@ CASTParserTests >> testParseHexadecimalIntegerConstantConstant [
 	self assert: firstStatement value equals: '0x7'.
 ]
 
-{ #category : #'tests-numbers' }
+{ #category : 'tests-numbers' }
 CASTParserTests >> testParseHexadecimalIntegerConstantConstant2 [
 
 	| unit firstStatement |
@@ -441,7 +443,7 @@ CASTParserTests >> testParseHexadecimalIntegerConstantConstant2 [
 	self assert: firstStatement value equals: '0X7'.
 ]
 
-{ #category : #'tests-basic expressions' }
+{ #category : 'tests-basic expressions' }
 CASTParserTests >> testParseIdentifier [
 
 	| expression |
@@ -452,7 +454,7 @@ CASTParserTests >> testParseIdentifier [
 	self assert: expression name equals: 'a'.
 ]
 
-{ #category : #'tests-control flow' }
+{ #category : 'tests-control flow' }
 CASTParserTests >> testParseIfElse [
 
 	| statement |
@@ -462,7 +464,7 @@ CASTParserTests >> testParseIfElse [
 	self assert: statement else notNil
 ]
 
-{ #category : #'tests-control flow' }
+{ #category : 'tests-control flow' }
 CASTParserTests >> testParseIfNoElse [
 
 	| statement |
@@ -472,7 +474,7 @@ CASTParserTests >> testParseIfNoElse [
 	self assert: statement else isNil
 ]
 
-{ #category : #'tests-numbers' }
+{ #category : 'tests-numbers' }
 CASTParserTests >> testParseIntegerConstant [
 
 	| unit firstStatement |
@@ -487,7 +489,7 @@ CASTParserTests >> testParseIntegerConstant [
 	self assert: firstStatement value equals: '17'.
 ]
 
-{ #category : #'tests-control flow' }
+{ #category : 'tests-control flow' }
 CASTParserTests >> testParseLabelledEmptyStatement [
 
 	| statement |
@@ -499,7 +501,7 @@ CASTParserTests >> testParseLabelledEmptyStatement [
 	self assert: statement statement isEmptyStatement
 ]
 
-{ #category : #'tests-control flow' }
+{ #category : 'tests-control flow' }
 CASTParserTests >> testParseLabelledStatement [
 
 	| statement |
@@ -511,7 +513,7 @@ CASTParserTests >> testParseLabelledStatement [
 	self assert: statement statement isBinaryOperation
 ]
 
-{ #category : #'tests-numbers' }
+{ #category : 'tests-numbers' }
 CASTParserTests >> testParseLongIntegerConstantConstant [
 
 	| unit firstStatement |
@@ -526,7 +528,7 @@ CASTParserTests >> testParseLongIntegerConstantConstant [
 	self assert: firstStatement value equals: '7L'.
 ]
 
-{ #category : #'tests-numbers' }
+{ #category : 'tests-numbers' }
 CASTParserTests >> testParseLongIntegerConstantConstant2 [
 
 	| unit firstStatement |
@@ -541,7 +543,7 @@ CASTParserTests >> testParseLongIntegerConstantConstant2 [
 	self assert: firstStatement value equals: '7l'.
 ]
 
-{ #category : #'tests-binary operators' }
+{ #category : 'tests-binary operators' }
 CASTParserTests >> testParseMultiplication [
 
 	| expression |
@@ -552,7 +554,7 @@ CASTParserTests >> testParseMultiplication [
 	self assert: expression operator equals: '*'
 ]
 
-{ #category : #'tests-binary operators' }
+{ #category : 'tests-binary operators' }
 CASTParserTests >> testParseMultiplicationPrecedenceOverAddition [
 
 	| expression |
@@ -574,7 +576,7 @@ CASTParserTests >> testParseMultiplicationPrecedenceOverAddition [
 
 ]
 
-{ #category : #'tests-assignment' }
+{ #category : 'tests-assignment' }
 CASTParserTests >> testParseMultiplyingAssignment [
 
 	| assignment |
@@ -585,7 +587,7 @@ CASTParserTests >> testParseMultiplyingAssignment [
 	self assert: assignment operator equals: '*='.
 ]
 
-{ #category : #'tests-binary operators' }
+{ #category : 'tests-binary operators' }
 CASTParserTests >> testParseNot [
 
 	| expression |
@@ -596,7 +598,7 @@ CASTParserTests >> testParseNot [
 	self assert: expression operator equals: '!'
 ]
 
-{ #category : #'tests-numbers' }
+{ #category : 'tests-numbers' }
 CASTParserTests >> testParseOctalIntegerConstantConstant [
 
 	| unit firstStatement |
@@ -611,7 +613,7 @@ CASTParserTests >> testParseOctalIntegerConstantConstant [
 	self assert: firstStatement value equals: '07'.
 ]
 
-{ #category : #'tests-basic expressions' }
+{ #category : 'tests-basic expressions' }
 CASTParserTests >> testParseParenthesizedExpression [
 
 	| expression |
@@ -620,7 +622,7 @@ CASTParserTests >> testParseParenthesizedExpression [
 	self assert: expression isExpression.
 ]
 
-{ #category : #'tests-declarators' }
+{ #category : 'tests-declarators' }
 CASTParserTests >> testParsePointerDeclarator [
 
 	| declaration declarator |
@@ -634,7 +636,7 @@ CASTParserTests >> testParsePointerDeclarator [
 	self assert: declarator declarator name equals: 'a'.
 ]
 
-{ #category : #'tests-binary operators' }
+{ #category : 'tests-binary operators' }
 CASTParserTests >> testParsePostIncrement [
 
 	| expression |
@@ -643,7 +645,7 @@ CASTParserTests >> testParsePostIncrement [
 	self assert: expression isIncrement.
 ]
 
-{ #category : #'tests-control flow' }
+{ #category : 'tests-control flow' }
 CASTParserTests >> testParseReturnWithExpression [
 
 	| statement |
@@ -653,7 +655,7 @@ CASTParserTests >> testParseReturnWithExpression [
 	self assert: statement expression notNil
 ]
 
-{ #category : #'tests-control flow' }
+{ #category : 'tests-control flow' }
 CASTParserTests >> testParseReturnWithoutExpression [
 
 	| statement |
@@ -663,7 +665,7 @@ CASTParserTests >> testParseReturnWithoutExpression [
 	self assert: statement expression isNil
 ]
 
-{ #category : #'tests-declarators' }
+{ #category : 'tests-declarators' }
 CASTParserTests >> testParseSequenceOfDeclarators [
 
 	| declaration declarator |
@@ -683,7 +685,7 @@ CASTParserTests >> testParseSequenceOfDeclarators [
 	self assert: declarator declarator name equals: 'b'.
 ]
 
-{ #category : #'tests-declarators' }
+{ #category : 'tests-declarators' }
 CASTParserTests >> testParseSimpleArrayDeclaration [
 
 	| declaration declarator |
@@ -698,7 +700,7 @@ CASTParserTests >> testParseSimpleArrayDeclaration [
 	self assert: declarator declarator name equals: 'a'.
 ]
 
-{ #category : #'tests-control flow' }
+{ #category : 'tests-control flow' }
 CASTParserTests >> testParseSizeofExpression [
 
 	| statement |
@@ -710,7 +712,7 @@ CASTParserTests >> testParseSizeofExpression [
 	self assert: statement child expression isIdentifier.
 ]
 
-{ #category : #'tests-control flow' }
+{ #category : 'tests-control flow' }
 CASTParserTests >> testParseSizeofTypeInt [
 
 	| statement |
@@ -721,7 +723,7 @@ CASTParserTests >> testParseSizeofTypeInt [
 	self assert: statement child specifiers first value equals: 'int'
 ]
 
-{ #category : #'tests-declarators' }
+{ #category : 'tests-declarators' }
 CASTParserTests >> testParseStructDeclarator [
 
 	| declaration declarator |
@@ -736,7 +738,7 @@ CASTParserTests >> testParseStructDeclarator [
 	self assert: declarator parameters size equals: 1.
 ]
 
-{ #category : #'tests-structures' }
+{ #category : 'tests-structures' }
 CASTParserTests >> testParseStructureAndUnionAccess [
 
 	| expression |
@@ -748,7 +750,7 @@ CASTParserTests >> testParseStructureAndUnionAccess [
 	self assert: expression member name equals: 'field'.
 ]
 
-{ #category : #'tests-structures' }
+{ #category : 'tests-structures' }
 CASTParserTests >> testParseStructurePointerAccess [
 
 	| expression |
@@ -760,7 +762,7 @@ CASTParserTests >> testParseStructurePointerAccess [
 	self assert: expression member name equals: 'field'.
 ]
 
-{ #category : #'tests-control flow' }
+{ #category : 'tests-control flow' }
 CASTParserTests >> testParseSwitch [
 
 	| statement case0 case1 |
@@ -786,7 +788,7 @@ CASTParserTests >> testParseSwitch [
 	self assert: statement statement statements second isBreakStatement.
 ]
 
-{ #category : #'tests-control flow' }
+{ #category : 'tests-control flow' }
 CASTParserTests >> testParseSwitchWithDefaultCase [
 
 	| statement case0 |
@@ -805,7 +807,7 @@ CASTParserTests >> testParseSwitchWithDefaultCase [
 	self assert: statement statement statements second case value equals: 'default'.
 ]
 
-{ #category : #'tests-control flow' }
+{ #category : 'tests-control flow' }
 CASTParserTests >> testParseTernary [
 
 	| statement |
@@ -816,7 +818,7 @@ CASTParserTests >> testParseTernary [
 	self assert: statement else isConstant
 ]
 
-{ #category : #'tests-declarators' }
+{ #category : 'tests-declarators' }
 CASTParserTests >> testParseUnionDeclarator [
 
 	| declaration declarator |
@@ -831,7 +833,7 @@ CASTParserTests >> testParseUnionDeclarator [
 	self assert: declarator parameters size equals: 1.
 ]
 
-{ #category : #'tests-numbers' }
+{ #category : 'tests-numbers' }
 CASTParserTests >> testParseUnsignedIntegerConstantConstant [
 
 	| unit firstStatement |
@@ -846,7 +848,7 @@ CASTParserTests >> testParseUnsignedIntegerConstantConstant [
 	self assert: firstStatement value equals: '7U'.
 ]
 
-{ #category : #'tests-numbers' }
+{ #category : 'tests-numbers' }
 CASTParserTests >> testParseUnsignedIntegerConstantConstant2 [
 
 	| unit firstStatement |
@@ -861,7 +863,7 @@ CASTParserTests >> testParseUnsignedIntegerConstantConstant2 [
 	self assert: firstStatement value equals: '7u'.
 ]
 
-{ #category : #'tests-control flow' }
+{ #category : 'tests-control flow' }
 CASTParserTests >> testParseWhile [
 
 	| statement |
@@ -870,7 +872,7 @@ CASTParserTests >> testParseWhile [
 	self assert: statement isWhile
 ]
 
-{ #category : #'tests-control flow' }
+{ #category : 'tests-control flow' }
 CASTParserTests >> testSwitchStatement [
 
 	| statement |

--- a/smalltalksrc/CAST/CASTScanner.class.st
+++ b/smalltalksrc/CAST/CASTScanner.class.st
@@ -2,12 +2,14 @@
 I am a GLR based C scanner.
 "
 Class {
-	#name : #CASTScanner,
-	#superclass : #SmaCCScanner,
-	#category : #'CAST-Parser'
+	#name : 'CASTScanner',
+	#superclass : 'SmaCCScanner',
+	#category : 'CAST-Parser',
+	#package : 'CAST',
+	#tag : 'Parser'
 }
 
-{ #category : #'generated-initialization' }
+{ #category : 'generated-initialization' }
 CASTScanner class >> initializeKeywordMap [
 	keywordMap := Dictionary new.
 	#(#(76 'auto' 70) #(76 'break' 48) #(76 'case' 38) #(76 'char' 73) #(76 'const' 40) #(76 'continue' 47) #(76 'default' 39) #(76 'do' 54) #(76 'double' 60) #(76 'else' 46) #(76 'enum' 51) #(76 'extern' 58) #(76 'float' 67) #(76 'for' 49) #(76 'goto' 50) #(76 'if' 42) #(76 'int' 69) #(76 'long' 66) #(76 'register' 71) #(76 'return' 13) #(76 'short' 68) #(76 'signed' 56) #(76 'sizeof' 24) #(76 'static' 61) #(76 'struct' 43) #(76 'switch' 52) #(76 'typedef' 57) #(76 'union' 44) #(76 'unsigned' 55) #(76 'void' 72) #(76 'volatile' 41) #(76 'while' 53))
@@ -18,17 +20,17 @@ CASTScanner class >> initializeKeywordMap [
 	^ keywordMap
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> emptySymbolTokenId [
 	^ 149
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> errorTokenId [
 	^ 150
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> scan1 [
 	[ self step.
 	currentCharacter == $"
@@ -39,7 +41,7 @@ CASTScanner >> scan1 [
 	true ] whileTrue
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> scan10 [
 	[ self recordMatch: #(77).
 	self step.
@@ -53,7 +55,7 @@ CASTScanner >> scan10 [
 	^ self reportLastMatch
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> scan2 [
 	self step.
 	currentCharacter == $\
@@ -65,7 +67,7 @@ CASTScanner >> scan2 [
 	^ self reportLastMatch
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> scan3 [
 	[ self step.
 	currentCharacter == $'
@@ -89,13 +91,13 @@ CASTScanner >> scan3 [
 	^ self reportLastMatch
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> scan4 [
 	self step.
 	^ self scan3
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> scan5 [
 	[ self recordMatch: #(77).
 	self step.
@@ -107,7 +109,7 @@ CASTScanner >> scan5 [
 	^ self reportLastMatch
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> scan6 [
 	self step.
 	('+-' includes: currentCharacter)
@@ -117,7 +119,7 @@ CASTScanner >> scan6 [
 	^ self reportLastMatch
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> scan7 [
 	[ self recordMatch: #(77).
 	self step.
@@ -127,7 +129,7 @@ CASTScanner >> scan7 [
 	^ self reportLastMatch
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> scan8 [
 	[ self step.
 	currentCharacter == $*
@@ -139,7 +141,7 @@ CASTScanner >> scan8 [
 	true ] whileTrue
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> scan9 [
 	self step.
 	(currentCharacter between: $0 and: $9)
@@ -147,7 +149,7 @@ CASTScanner >> scan9 [
 	^ self reportLastMatch
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> scanForToken [
 	self step.
 	currentCharacter == $!
@@ -176,7 +178,7 @@ CASTScanner >> scanForToken [
 	^ self scanForTokenX20
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> scanForTokenX1 [
 	self recordMatch: #(77).
 	self step.
@@ -204,7 +206,7 @@ CASTScanner >> scanForTokenX1 [
 	^ self reportLastMatch
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> scanForTokenX10 [
 	self recordMatch: #(35).
 	self step.
@@ -215,7 +217,7 @@ CASTScanner >> scanForTokenX10 [
 	^ self reportLastMatch
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> scanForTokenX11 [
 	self recordMatch: #(28).
 	self step.
@@ -226,7 +228,7 @@ CASTScanner >> scanForTokenX11 [
 	^ self reportLastMatch
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> scanForTokenX12 [
 	self recordMatch: #(30).
 	self step.
@@ -237,7 +239,7 @@ CASTScanner >> scanForTokenX12 [
 	^ self reportLastMatch
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> scanForTokenX13 [
 	[ self recordMatch: #(83).
 	self step.
@@ -246,7 +248,7 @@ CASTScanner >> scanForTokenX13 [
 	^ self reportLastMatch
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> scanForTokenX14 [
 	self recordMatch: #(1).
 	self step.
@@ -255,7 +257,7 @@ CASTScanner >> scanForTokenX14 [
 	^ self reportLastMatch
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> scanForTokenX15 [
 	self recordMatch: #(17).
 	self step.
@@ -264,7 +266,7 @@ CASTScanner >> scanForTokenX15 [
 	^ self reportLastMatch
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> scanForTokenX16 [
 	self recordMatch: #(16).
 	self step.
@@ -273,7 +275,7 @@ CASTScanner >> scanForTokenX16 [
 	^ self reportLastMatch
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> scanForTokenX17 [
 	self recordMatch: #(34).
 	self step.
@@ -282,7 +284,7 @@ CASTScanner >> scanForTokenX17 [
 	^ self reportLastMatch
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> scanForTokenX18 [
 	self recordMatch: #(32).
 	self step.
@@ -291,7 +293,7 @@ CASTScanner >> scanForTokenX18 [
 	^ self reportLastMatch
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> scanForTokenX19 [
 	currentCharacter == $[
 		ifTrue: [ ^ self recordAndReportMatch: #(79) ].
@@ -321,7 +323,7 @@ CASTScanner >> scanForTokenX19 [
 	^ self reportLastMatch
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> scanForTokenX2 [
 	self recordMatch: #(76).
 	self step.
@@ -341,7 +343,7 @@ CASTScanner >> scanForTokenX2 [
 	^ self reportLastMatch
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> scanForTokenX20 [
 	currentCharacter == $,
 		ifTrue: [ ^ self recordAndReportMatch: #(21) ].
@@ -379,7 +381,7 @@ CASTScanner >> scanForTokenX20 [
 	^ self scanForTokenX19
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> scanForTokenX3 [
 	self recordMatch: #(18).
 	self step.
@@ -398,7 +400,7 @@ CASTScanner >> scanForTokenX3 [
 	^ self reportLastMatch
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> scanForTokenX4 [
 	[ self recordMatch: #(76).
 	self step.
@@ -408,7 +410,7 @@ CASTScanner >> scanForTokenX4 [
 		whileTrue
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> scanForTokenX5 [
 	self recordMatch: #(27).
 	self step.
@@ -422,7 +424,7 @@ CASTScanner >> scanForTokenX5 [
 	^ self reportLastMatch
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> scanForTokenX6 [
 	self recordMatch: #(36).
 	self step.
@@ -435,7 +437,7 @@ CASTScanner >> scanForTokenX6 [
 	^ self reportLastMatch
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> scanForTokenX7 [
 	self recordMatch: #(6).
 	self step.
@@ -449,7 +451,7 @@ CASTScanner >> scanForTokenX7 [
 	^ self reportLastMatch
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> scanForTokenX8 [
 	self recordMatch: #(2).
 	self step.
@@ -460,7 +462,7 @@ CASTScanner >> scanForTokenX8 [
 	^ self reportLastMatch
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> scanForTokenX9 [
 	self recordMatch: #(29).
 	self step.
@@ -471,7 +473,7 @@ CASTScanner >> scanForTokenX9 [
 	^ self reportLastMatch
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CASTScanner >> tokenActions [
 	^ #(nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil #comment nil nil nil nil nil nil nil #whitespace)
 ]

--- a/smalltalksrc/CAST/CAbstractDeclaratorNode.class.st
+++ b/smalltalksrc/CAST/CAbstractDeclaratorNode.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #CAbstractDeclaratorNode,
-	#superclass : #CGLRAbstractNode,
+	#name : 'CAbstractDeclaratorNode',
+	#superclass : 'CGLRAbstractNode',
 	#instVars : [
 		'declarator'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractDeclaratorNode class >> declarator: aDeclarator [
 	
 	^ self new
@@ -15,13 +17,13 @@ CAbstractDeclaratorNode class >> declarator: aDeclarator [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CAbstractDeclaratorNode class >> identifier: aString [ 
 	
 	^ self declarator: (CIdentifierNode name: aString)
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CAbstractDeclaratorNode >> = anObject [
 
 	"Answer whether the receiver and anObject represent the same object."
@@ -31,18 +33,18 @@ CAbstractDeclaratorNode >> = anObject [
 	^ declarator = anObject declarator1
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractDeclaratorNode >> declarator [
 	^ declarator
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CAbstractDeclaratorNode >> declarator1 [
 
 	^ declarator
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractDeclaratorNode >> declarator: aCGLRAbstractNode [
 	self declarator notNil
 		ifTrue: [ self declarator parent: nil ].
@@ -51,7 +53,7 @@ CAbstractDeclaratorNode >> declarator: aCGLRAbstractNode [
 		ifTrue: [ self declarator parent: self ]
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CAbstractDeclaratorNode >> hash [
 
 	"Answer an integer value that is related to the identity of the receiver."

--- a/smalltalksrc/CAST/CAbstractNodeVisitor.class.st
+++ b/smalltalksrc/CAST/CAbstractNodeVisitor.class.st
@@ -1,270 +1,272 @@
 Class {
-	#name : #CAbstractNodeVisitor,
-	#superclass : #Object,
-	#category : #'CAST-Visitor'
+	#name : 'CAbstractNodeVisitor',
+	#superclass : 'Object',
+	#category : 'CAST-Visitor',
+	#package : 'CAST',
+	#tag : 'Visitor'
 }
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitAbstract: anAbstract [
 	^ self visitSmaCCParseNode: anAbstract
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitAbstractDeclarator: anAbstractDeclarator [
 	^ self visitAbstract: anAbstractDeclarator
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitArray: anArray [
 	^ self visitAbstract: anArray
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitArrayDeclarator: anArrayDeclarator [
 	^ self visitAbstract: anArrayDeclarator
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitArrow: anArrow [
 	^ self visitAbstract: anArrow
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitAssignment: anAssignment [
 	^ self visitAbstract: anAssignment
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitBinary: aBinary [
 	^ self visitAbstract: aBinary
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitBreakStatement: aBreakStatement [
 	^ self visitAbstract: aBreakStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitCall: aCall [
 	^ self visitAbstract: aCall
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitCastExpression: aCastExpression [
 	^ self visitAbstract: aCastExpression
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitComment: aComment [
 	^ self visitAbstract: aComment
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitCompoundStatement: aCompoundStatement [
 	^ self visitAbstract: aCompoundStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitConstant: aConstant [
 	^ self visitAbstract: aConstant
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitContinueStatement: aContinueStatement [
 	^ self visitAbstract: aContinueStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitDeclaration: aDeclaration [
 	^ self visitAbstract: aDeclaration
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitDeclarator: aDeclarator [
 	^ self visitAbstract: aDeclarator
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitDecrement: aDecrement [
 	^ self visitAbstract: aDecrement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitDoStatement: aDoStatement [
 	^ self visitAbstract: aDoStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitEmptyStatement: anEmptyStatement [
 	^ self visitAbstract: anEmptyStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitEnum: anEnum [
 	^ self visitAbstract: anEnum
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitEnumerator: anEnumerator [
 	^ self visitAbstract: anEnumerator
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitExpression: anExpression [
 	^ self visitAbstract: anExpression
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitExpressionList: anExpressionList [
 	^ self visitAbstract: anExpressionList
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitExpressionStatement: anExpressionStatement [
 	^ self visitAbstract: anExpressionStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitForStatement: aForStatement [
 	^ self visitAbstract: aForStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitFunctionDeclarator: aFunctionDeclarator [
 	^ self visitAbstract: aFunctionDeclarator
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitFunctionDefinition: aFunctionDefinition [
 	^ self visitAbstract: aFunctionDefinition
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitFunctionPointerDeclarator: aFunctionPointerDeclarator [
 	^ self visitAbstract: aFunctionPointerDeclarator
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitGotoStatement: aGotoStatement [
 	^ self visitAbstract: aGotoStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitIdentifier: anIdentifier [
 	^ self visitAbstract: anIdentifier
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitIdentifierExpression: anIdentifierExpression [
 	^ self visitAbstract: anIdentifierExpression
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitIfStatement: aSelectionStatement [
 	^ self visitAbstract: aSelectionStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitIncrement: anIncrement [
 	^ self visitAbstract: anIncrement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitInitDeclarator: anInitDeclarator [
 	^ self visitAbstract: anInitDeclarator
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitInitializer: anInitializer [
 	^ self visitAbstract: anInitializer
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitLabeledStatement: aLabeledStatement [
 	^ self visitAbstract: aLabeledStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitParameterDeclaration: aParameterDeclaration [
 	^ self visitAbstract: aParameterDeclaration
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitParenthesizedExpression: aParenthesizedExpression [
 	^ self visitAbstract: aParenthesizedExpression
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitPoint: aPoint [
 	^ self visitAbstract: aPoint
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitPreprocessorDefine: aPreprocessorDefine [
 	^ self visitAbstract: aPreprocessorDefine
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitPreprocessorIf: anArrayDeclarator [
 	^ self visitAbstract: anArrayDeclarator
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitReturnStatement: aReturnStatement [
 	^ self visitAbstract: aReturnStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitStringLiteral: aStringLiteral [
 	^ self visitAbstract: aStringLiteral
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitStructDeclaration: aStructDeclaration [
 	^ self visitAbstract: aStructDeclaration
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitStructDeclarator: aStructDeclarator [
 	^ self visitAbstract: aStructDeclarator
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitStructOrUnionSpecifier: aStructOrUnionSpecifier [
 	^ self visitAbstract: aStructOrUnionSpecifier
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitSwitchStatement: aSwitchStatement [
 	^ self visitAbstract: aSwitchStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitTernary: aTernary [
 	^ self visitAbstract: aTernary
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitTranslationUnit: aTranslationUnit [
 	^ self visitAbstract: aTranslationUnit
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitTypeName: aTypeName [
 	^ self visitAbstract: aTypeName
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitTypename: aTypename [
 	^ self visitAbstract: aTypename
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitUnaryOperator: anUnaryExpression [
 	^ self visitAbstract: anUnaryExpression
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAbstractNodeVisitor >> visitWhileStatement: aWhileStatement [
 	^ self visitAbstract: aWhileStatement
 ]

--- a/smalltalksrc/CAST/CArrayAccessNode.class.st
+++ b/smalltalksrc/CAST/CArrayAccessNode.class.st
@@ -1,14 +1,16 @@
 Class {
-	#name : #CArrayAccessNode,
-	#superclass : #CExpressionNode,
+	#name : 'CArrayAccessNode',
+	#superclass : 'CExpressionNode',
 	#instVars : [
 		'array',
 		'index'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CArrayAccessNode class >> array: anIdentifierNode index: anExpressionNode [
 
 	^ self new
@@ -17,17 +19,17 @@ CArrayAccessNode class >> array: anIdentifierNode index: anExpressionNode [
 		  yourself
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CArrayAccessNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitArray: self
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CArrayAccessNode >> array [
 	^ array
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CArrayAccessNode >> array: aCGLRAbstractNode [
 	self assertExpression: aCGLRAbstractNode.
 	
@@ -38,12 +40,12 @@ CArrayAccessNode >> array: aCGLRAbstractNode [
 		ifTrue: [ self array parent: self ]
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CArrayAccessNode >> index [
 	^ index
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CArrayAccessNode >> index: aCGLRExpressionNode [
 	self assertExpression: aCGLRExpressionNode.
 	
@@ -54,7 +56,7 @@ CArrayAccessNode >> index: aCGLRExpressionNode [
 		ifTrue: [ self index parent: self ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CArrayAccessNode >> isArrayAccessNode [
 	
 	^ true

--- a/smalltalksrc/CAST/CArrayDeclaratorNode.class.st
+++ b/smalltalksrc/CAST/CArrayDeclaratorNode.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #CArrayDeclaratorNode,
-	#superclass : #CAbstractDeclaratorNode,
+	#name : 'CArrayDeclaratorNode',
+	#superclass : 'CAbstractDeclaratorNode',
 	#instVars : [
 		'size'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CArrayDeclaratorNode >> = anObject [
 
 	"Answer whether the receiver and anObject represent the same object."
@@ -17,12 +19,12 @@ CArrayDeclaratorNode >> = anObject [
 	^ size = anObject size and: [ declarator = anObject declarator ]
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CArrayDeclaratorNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitArrayDeclarator: self
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CArrayDeclaratorNode >> hash [
 
 	"Answer an integer value that is related to the identity of the receiver."
@@ -30,18 +32,18 @@ CArrayDeclaratorNode >> hash [
 	^ size hash bitXor: declarator hash
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CArrayDeclaratorNode >> isArrayDeclarator [
 	
 	^ true
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CArrayDeclaratorNode >> size [
 	^ size
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CArrayDeclaratorNode >> size: aCGLRAbstractNode [
 	self size notNil
 		ifTrue: [ self size parent: nil ].

--- a/smalltalksrc/CAST/CAssignmentNode.class.st
+++ b/smalltalksrc/CAST/CAssignmentNode.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #CAssignmentNode,
-	#superclass : #CExpressionNode,
+	#name : 'CAssignmentNode',
+	#superclass : 'CExpressionNode',
 	#instVars : [
 		'lvalue',
 		'rvalue',
 		'operator'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CAssignmentNode class >> lvalue: lvalue operator: aString rvalue: rvalue [
 	
 	^ self new
@@ -19,13 +21,13 @@ CAssignmentNode class >> lvalue: lvalue operator: aString rvalue: rvalue [
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CAssignmentNode class >> lvalue: lValue rvalue: rValue [
 
 	^ self lvalue: lValue operator: '=' rvalue: rValue
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CAssignmentNode >> = anObject [
 
 	"Answer whether the receiver and anObject represent the same object."
@@ -36,12 +38,12 @@ CAssignmentNode >> = anObject [
 		  operator = anObject operator and: [ lvalue = anObject lvalue ] ]
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAssignmentNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitAssignment: self
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CAssignmentNode >> hash [
 
 	"Answer an integer value that is related to the identity of the receiver."
@@ -49,12 +51,12 @@ CAssignmentNode >> hash [
 	^ rvalue hash bitXor: (operator hash bitXor: lvalue hash)
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAssignmentNode >> lvalue [
 	^ lvalue
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAssignmentNode >> lvalue: aCGLRAbstractNode [
 	self lvalue notNil
 		ifTrue: [ self lvalue parent: nil ].
@@ -63,22 +65,22 @@ CAssignmentNode >> lvalue: aCGLRAbstractNode [
 		ifTrue: [ self lvalue parent: self ]
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAssignmentNode >> operator [
 	^ operator
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAssignmentNode >> operator: aSmaCCToken [
 	operator := aSmaCCToken
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAssignmentNode >> rvalue [
 	^ rvalue
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CAssignmentNode >> rvalue: aCGLRAbstractNode [
 	self assertExpression: aCGLRAbstractNode.
 

--- a/smalltalksrc/CAST/CBinaryOperatorNode.class.st
+++ b/smalltalksrc/CAST/CBinaryOperatorNode.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #CBinaryOperatorNode,
-	#superclass : #CExpressionNode,
+	#name : 'CBinaryOperatorNode',
+	#superclass : 'CExpressionNode',
 	#instVars : [
 		'left',
 		'right',
 		'operator'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CBinaryOperatorNode class >> operator: aString left: lexpression right: rexpression [
 	
 	^ self new
@@ -19,23 +21,23 @@ CBinaryOperatorNode class >> operator: aString left: lexpression right: rexpress
 		yourself
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CBinaryOperatorNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitBinary: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CBinaryOperatorNode >> isBinaryOperation [
 	
 	^ true
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CBinaryOperatorNode >> left [
 	^ left
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CBinaryOperatorNode >> left: aCGLRAbstractNode [
 	self assertExpression: aCGLRAbstractNode.
 	
@@ -46,22 +48,22 @@ CBinaryOperatorNode >> left: aCGLRAbstractNode [
 		ifTrue: [ self left parent: self ]
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CBinaryOperatorNode >> operator [
 	^ operator
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CBinaryOperatorNode >> operator: aSmaCCToken [
 	operator := aSmaCCToken
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CBinaryOperatorNode >> right [
 	^ right
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CBinaryOperatorNode >> right: aCGLRAbstractNode [
 	self assertExpression: aCGLRAbstractNode.
 	

--- a/smalltalksrc/CAST/CBreakStatementNode.class.st
+++ b/smalltalksrc/CAST/CBreakStatementNode.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #CBreakStatementNode,
-	#superclass : #CGLRAbstractNode,
-	#category : #'CAST-Nodes'
+	#name : 'CBreakStatementNode',
+	#superclass : 'CGLRAbstractNode',
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #generated }
+{ #category : 'generated' }
 CBreakStatementNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitBreakStatement: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CBreakStatementNode >> isBreakStatement [
 
 	^true

--- a/smalltalksrc/CAST/CCallNode.class.st
+++ b/smalltalksrc/CAST/CCallNode.class.st
@@ -1,20 +1,22 @@
 Class {
-	#name : #CCallNode,
-	#superclass : #CExpressionNode,
+	#name : 'CCallNode',
+	#superclass : 'CExpressionNode',
 	#instVars : [
 		'arguments',
 		'identifier'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CCallNode class >> identifier: anIndentifier [
 	
 	^ self identifier: anIndentifier arguments: #()
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CCallNode class >> identifier: anIndentifier arguments: anOrderdList [
 	
 	^ self new
@@ -23,17 +25,17 @@ CCallNode class >> identifier: anIndentifier arguments: anOrderdList [
 		yourself
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CCallNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitCall: self
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CCallNode >> arguments [
 	^ arguments
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CCallNode >> arguments: anOrderedCollection [
 	self assertListOfExpressions: anOrderedCollection.
 
@@ -42,12 +44,12 @@ CCallNode >> arguments: anOrderedCollection [
 	self setParents: self arguments to: self
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CCallNode >> identifier [
 	^ identifier
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CCallNode >> identifier: aCGLRAbstractNode [
 	self identifier notNil
 		ifTrue: [ self identifier parent: nil ].
@@ -56,13 +58,13 @@ CCallNode >> identifier: aCGLRAbstractNode [
 		ifTrue: [ self identifier parent: self ]
 ]
 
-{ #category : #'generated-initialize-release' }
+{ #category : 'generated-initialize-release' }
 CCallNode >> initialize [
 	super initialize.
 	arguments := OrderedCollection new: 2.
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CCallNode >> isFunctionCall [
 	
 	^ true

--- a/smalltalksrc/CAST/CCastExpressionNode.class.st
+++ b/smalltalksrc/CAST/CCastExpressionNode.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #CCastExpressionNode,
-	#superclass : #CExpressionNode,
+	#name : 'CCastExpressionNode',
+	#superclass : 'CExpressionNode',
 	#instVars : [
 		'expr',
 		'type',
 		'leftParenToken',
 		'rightParenToken'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CCastExpressionNode class >> type: aType expression: anExpression [
 
 	^ self new
@@ -19,17 +21,17 @@ CCastExpressionNode class >> type: aType expression: anExpression [
 		  yourself
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CCastExpressionNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitCastExpression: self
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CCastExpressionNode >> expression [
 	^ expr
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CCastExpressionNode >> expression: aCGLRAbstractNode [
 
 	self assertExpression: aCGLRAbstractNode.
@@ -41,17 +43,17 @@ CCastExpressionNode >> expression: aCGLRAbstractNode [
 		ifTrue: [ self expression parent: self ]
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CCastExpressionNode >> isCastExpression [
 	^ true
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CCastExpressionNode >> type [
 	^ type
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CCastExpressionNode >> type: aCGLRTypeNameNode [
 	self type notNil
 		ifTrue: [ self type parent: nil ].

--- a/smalltalksrc/CAST/CCommentNode.class.st
+++ b/smalltalksrc/CAST/CCommentNode.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #CCommentNode,
-	#superclass : #CGLRAbstractNode,
+	#name : 'CCommentNode',
+	#superclass : 'CGLRAbstractNode',
 	#instVars : [
 		'comment'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CCommentNode class >> comment: aString [
 
 	^ self new
@@ -15,37 +17,37 @@ CCommentNode class >> comment: aString [
 		  yourself
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CCommentNode >> acceptVisitor: anAbstractVisitor [
 
 	^ anAbstractVisitor visitComment: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CCommentNode >> comment [
 
 	^ comment
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CCommentNode >> comment: aComment [
 
 	comment := aComment
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CCommentNode >> isComment [
 
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CCommentNode >> needsSeparator [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CCommentNode >> needsTrailingSemicolon [
 
 	^ false

--- a/smalltalksrc/CAST/CCompoundStatementNode.class.st
+++ b/smalltalksrc/CAST/CCompoundStatementNode.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #CCompoundStatementNode,
-	#superclass : #CGLRAbstractNode,
+	#name : 'CCompoundStatementNode',
+	#superclass : 'CGLRAbstractNode',
 	#instVars : [
 		'declarations',
 		'statements',
 		'needsBrackets'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CCompoundStatementNode class >> declarations: declarations statements: statements [
 
 	^ self new
@@ -18,7 +20,7 @@ CCompoundStatementNode class >> declarations: declarations statements: statement
 		yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CCompoundStatementNode class >> statements: statements [
 
 	^ self new
@@ -26,7 +28,7 @@ CCompoundStatementNode class >> statements: statements [
 		  yourself
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CCompoundStatementNode >> = anObject [
 
 	"Answer whether the receiver and anObject represent the same object."
@@ -37,36 +39,42 @@ CCompoundStatementNode >> = anObject [
 		  declarations = anObject declarations ]
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CCompoundStatementNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitCompoundStatement: self
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 CCompoundStatementNode >> add: aStatement [
 
 	statements add: aStatement
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 CCompoundStatementNode >> addAll: aCompoundStatement [
 
 	statements addAll: aCompoundStatement statements
 ]
 
-{ #category : #generated }
+{ #category : 'accessing' }
+CCompoundStatementNode >> comment [
+
+	^ self statements first comment
+]
+
+{ #category : 'generated' }
 CCompoundStatementNode >> declarations [
 	^ declarations
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CCompoundStatementNode >> declarations: anOrderedCollection [
 	self setParents: self declarations to: nil.
 	declarations := anOrderedCollection.
 	self setParents: self declarations to: self
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CCompoundStatementNode >> hash [
 
 	"Answer an integer value that is related to the identity of the receiver."
@@ -74,7 +82,7 @@ CCompoundStatementNode >> hash [
 	^ statements hash bitXor: declarations hash
 ]
 
-{ #category : #'generated-initialize-release' }
+{ #category : 'generated-initialize-release' }
 CCompoundStatementNode >> initialize [
 	super initialize.
 	statements := OrderedCollection new: 2.
@@ -83,19 +91,25 @@ CCompoundStatementNode >> initialize [
 	needsSeparator := false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
+CCompoundStatementNode >> isComment [
+
+	^ self statements size = 1 and: [ self statements first isComment ]
+]
+
+{ #category : 'testing' }
 CCompoundStatementNode >> isCompoundStatement [
 	
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CCompoundStatementNode >> isEmpty [
 	
 	^ statements isEmpty or: [ statements allSatisfy: [ :e | e isEmpty ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CCompoundStatementNode >> last [
 	"For some unknown reason, the some compound can be empty."
 	[ statements last isEmpty ] whileTrue: [ statements removeAt: statements size ].
@@ -103,7 +117,7 @@ CCompoundStatementNode >> last [
 	^ statements last last
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CCompoundStatementNode >> last: aCReturnStatementNode [ 
 	
 	"We rewrite the tree recursively.
@@ -114,30 +128,30 @@ CCompoundStatementNode >> last: aCReturnStatementNode [
 		put: (statements last last: aCReturnStatementNode)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CCompoundStatementNode >> needsBrackets [
 
 	^ needsBrackets
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CCompoundStatementNode >> needsBrackets: anObject [
 
 	needsBrackets := anObject
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CCompoundStatementNode >> needsTrailingSemicolon [
 
 	^ false
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CCompoundStatementNode >> statements [
 	^ statements
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CCompoundStatementNode >> statements: anOrderedCollection [
 	self setParents: self statements to: nil.
 	statements := anOrderedCollection.

--- a/smalltalksrc/CAST/CConstantNode.class.st
+++ b/smalltalksrc/CAST/CConstantNode.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #CConstantNode,
-	#superclass : #CExpressionNode,
+	#name : 'CConstantNode',
+	#superclass : 'CExpressionNode',
 	#instVars : [
 		'value'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CConstantNode class >> value: aValue [
 
 	^ self new
@@ -15,7 +17,7 @@ CConstantNode class >> value: aValue [
 		yourself
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CConstantNode >> = anObject [
 
 	"Answer whether the receiver and anObject represent the same object."
@@ -25,12 +27,12 @@ CConstantNode >> = anObject [
 	^ value = anObject value
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CConstantNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitConstant: self
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CConstantNode >> hash [
 
 	"Answer an integer value that is related to the identity of the receiver."
@@ -38,24 +40,24 @@ CConstantNode >> hash [
 	^ value hash
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CConstantNode >> isConstant [
 	
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CConstantNode >> isLeaf [
 	
 	^ true
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CConstantNode >> value [
 	^ value
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CConstantNode >> value: aSmaCCToken [
 	value := aSmaCCToken
 ]

--- a/smalltalksrc/CAST/CDeclarationNode.class.st
+++ b/smalltalksrc/CAST/CDeclarationNode.class.st
@@ -1,22 +1,24 @@
 Class {
-	#name : #CDeclarationNode,
-	#superclass : #CGLRAbstractNode,
+	#name : 'CDeclarationNode',
+	#superclass : 'CGLRAbstractNode',
 	#instVars : [
 		'specifiers',
 		'declarators',
 		'hasRawPrototype',
 		'isFunctionPrototype'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CDeclarationNode class >> specifiers: specifiers declarator: aDeclarator [
 	
 	^ self specifiers: specifiers declarators: {aDeclarator}
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CDeclarationNode class >> specifiers: specifiers declarators: declarators [
 	
 	^ self new
@@ -25,7 +27,7 @@ CDeclarationNode class >> specifiers: specifiers declarators: declarators [
 		yourself
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CDeclarationNode >> = anObject [
 
 	"Answer whether the receiver and anObject represent the same object."
@@ -36,36 +38,36 @@ CDeclarationNode >> = anObject [
 		  declarators = anObject declarators ]
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CDeclarationNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitDeclaration: self
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CDeclarationNode >> declarators [
 	^ declarators
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CDeclarationNode >> declarators: anOrderedCollection [
 	self setParents: self declarators to: nil.
 	declarators := anOrderedCollection.
 	self setParents: self declarators to: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CDeclarationNode >> hasRawPrototype [
 
 	^ hasRawPrototype
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CDeclarationNode >> hasRawPrototype: aBoolean [
 	
 	hasRawPrototype := aBoolean
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CDeclarationNode >> hash [
 
 	"Answer an integer value that is related to the identity of the receiver."
@@ -73,7 +75,7 @@ CDeclarationNode >> hash [
 	^ specifiers hash bitXor: declarators hash
 ]
 
-{ #category : #'generated-initialize-release' }
+{ #category : 'generated-initialize-release' }
 CDeclarationNode >> initialize [
 
 	super initialize.
@@ -83,24 +85,24 @@ CDeclarationNode >> initialize [
 	declarators := OrderedCollection new: 2
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CDeclarationNode >> isFunctionPrototype [
 	"Return true if this declaration is a function prototype."
 	^ isFunctionPrototype
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CDeclarationNode >> isFunctionPrototype: aBoolean [
 	
 	isFunctionPrototype := aBoolean
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CDeclarationNode >> specifiers [
 	^ specifiers
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CDeclarationNode >> specifiers: anOrderedCollection [
 	specifiers := anOrderedCollection
 ]

--- a/smalltalksrc/CAST/CDecrementNode.class.st
+++ b/smalltalksrc/CAST/CDecrementNode.class.st
@@ -1,47 +1,49 @@
 Class {
-	#name : #CDecrementNode,
-	#superclass : #CGLRAbstractNode,
+	#name : 'CDecrementNode',
+	#superclass : 'CGLRAbstractNode',
 	#instVars : [
 		'object',
 		'prefix'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CDecrementNode class >> object: aVariable [
 	
 	^self new object: aVariable; prefix: false; yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CDecrementNode class >> object: aVariable prefix: boolean [
 	
 	^self new object: aVariable; prefix: boolean; yourself
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CDecrementNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitDecrement: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CDecrementNode >> isDecrement [
 
 	^ true
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CDecrementNode >> nodeVariables [
 	^ #(#object)
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CDecrementNode >> object [
 	^ object
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CDecrementNode >> object: aCGLRAbstractNode [
 	self object notNil
 		ifTrue: [ self object parent: nil ].
@@ -50,13 +52,13 @@ CDecrementNode >> object: aCGLRAbstractNode [
 		ifTrue: [ self object parent: self ]
 ]
 
-{ #category : #acccessing }
+{ #category : 'acccessing' }
 CDecrementNode >> prefix [
 
 	^ prefix
 ]
 
-{ #category : #acccessing }
+{ #category : 'acccessing' }
 CDecrementNode >> prefix: boolean [
 
 	prefix := boolean

--- a/smalltalksrc/CAST/CDoStatementNode.class.st
+++ b/smalltalksrc/CAST/CDoStatementNode.class.st
@@ -1,14 +1,16 @@
 Class {
-	#name : #CDoStatementNode,
-	#superclass : #CGLRAbstractNode,
+	#name : 'CDoStatementNode',
+	#superclass : 'CGLRAbstractNode',
 	#instVars : [
 		'statement',
 		'while'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CDoStatementNode class >> while: aConditionExpression statement: aStatement [
 
 	^ self new
@@ -17,23 +19,23 @@ CDoStatementNode class >> while: aConditionExpression statement: aStatement [
 		  yourself
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CDoStatementNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitDoStatement: self
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CDoStatementNode >> isDoWhile [
 
 	^true
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CDoStatementNode >> statement [
 	^ statement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CDoStatementNode >> statement: aCGLRAbstractNode [
 	self statement notNil
 		ifTrue: [ self statement parent: nil ].
@@ -42,12 +44,12 @@ CDoStatementNode >> statement: aCGLRAbstractNode [
 		ifTrue: [ self statement parent: self ]
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CDoStatementNode >> while [
 	^ while
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CDoStatementNode >> while: aCGLRExpressionNode [
 	self while notNil
 		ifTrue: [ self while parent: nil ].

--- a/smalltalksrc/CAST/CEmptyStatementNode.class.st
+++ b/smalltalksrc/CAST/CEmptyStatementNode.class.st
@@ -1,21 +1,23 @@
 Class {
-	#name : #CEmptyStatementNode,
-	#superclass : #CGLRAbstractNode,
-	#category : #'CAST-Nodes'
+	#name : 'CEmptyStatementNode',
+	#superclass : 'CGLRAbstractNode',
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 CEmptyStatementNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitEmptyStatement: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CEmptyStatementNode >> isEmpty [
 	
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CEmptyStatementNode >> isEmptyStatement [
 	
 	^ true

--- a/smalltalksrc/CAST/CExpressionListNode.class.st
+++ b/smalltalksrc/CAST/CExpressionListNode.class.st
@@ -1,32 +1,34 @@
 Class {
-	#name : #CExpressionListNode,
-	#superclass : #CExpressionNode,
+	#name : 'CExpressionListNode',
+	#superclass : 'CExpressionNode',
 	#instVars : [
 		'expressions',
 		'printOnMultipleLines'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #adding }
+{ #category : 'adding' }
 CExpressionListNode >> , anotherExpression [
 	
 	self add: anotherExpression.
 	^ self
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 CExpressionListNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitExpressionList: self
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 CExpressionListNode >> add: anExpression [
 	
 	expressions add: anExpression
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 CExpressionListNode >> combineWithExpression: firstExpression [
 	
 	| result |
@@ -39,12 +41,12 @@ CExpressionListNode >> combineWithExpression: firstExpression [
 	^ result
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CExpressionListNode >> expressions [
 	^ expressions
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CExpressionListNode >> expressions: anOrderedCollection [
 	self assertListOfExpressions: anOrderedCollection.
 
@@ -53,26 +55,26 @@ CExpressionListNode >> expressions: anOrderedCollection [
 	self setParents: self expressions to: self
 ]
 
-{ #category : #'generated-initialize-release' }
+{ #category : 'generated-initialize-release' }
 CExpressionListNode >> initialize [
 	super initialize.
 	expressions := OrderedCollection new: 2.
 	printOnMultipleLines := false.
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CExpressionListNode >> isCommaSeparatedExpression [
 
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CExpressionListNode >> printOnMultipleLines [
 
 	^ printOnMultipleLines
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CExpressionListNode >> printOnMultipleLines: aBoolean [
 
 	printOnMultipleLines := aBoolean

--- a/smalltalksrc/CAST/CExpressionNode.class.st
+++ b/smalltalksrc/CAST/CExpressionNode.class.st
@@ -1,24 +1,26 @@
 Class {
-	#name : #CExpressionNode,
-	#superclass : #CGLRAbstractNode,
+	#name : 'CExpressionNode',
+	#superclass : 'CGLRAbstractNode',
 	#instVars : [
 		'needsParentheses'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #combining }
+{ #category : 'combining' }
 CExpressionNode >> , anotherExpression [
 	
 	^ anotherExpression combineWithExpression: self
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CExpressionNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitExpression: self
 ]
 
-{ #category : #combining }
+{ #category : 'combining' }
 CExpressionNode >> combineWithExpression: firstExpression [
 	
 	| result |
@@ -30,25 +32,25 @@ CExpressionNode >> combineWithExpression: firstExpression [
 	^ result
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 CExpressionNode >> initialize [
 	super initialize.
 	needsParentheses := false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CExpressionNode >> isExpression [
 
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CExpressionNode >> needsParentheses [
 
 	^ needsParentheses
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CExpressionNode >> needsParentheses: aBoolean [
 
 	needsParentheses := aBoolean

--- a/smalltalksrc/CAST/CForStatementNode.class.st
+++ b/smalltalksrc/CAST/CForStatementNode.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #CForStatementNode,
-	#superclass : #CGLRAbstractNode,
+	#name : 'CForStatementNode',
+	#superclass : 'CGLRAbstractNode',
 	#instVars : [
 		'init',
 		'until',
 		'statement',
 		'step'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CForStatementNode class >> init: initialization until: condition step: aStep statement: aStatement [
 
 	^ self new
@@ -21,17 +23,17 @@ CForStatementNode class >> init: initialization until: condition step: aStep sta
 		  yourself
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CForStatementNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitForStatement: self
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CForStatementNode >> init [
 	^ init
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CForStatementNode >> init: anOrderedCollection [
 	self assertListOfExpressions: anOrderedCollection.
 	
@@ -40,18 +42,18 @@ CForStatementNode >> init: anOrderedCollection [
 	self setParents: self init to: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CForStatementNode >> isForStatement [
 
 	^true
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CForStatementNode >> statement [
 	^ statement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CForStatementNode >> statement: aCGLRAbstractNode [
 	self statement notNil
 		ifTrue: [ self statement parent: nil ].
@@ -60,12 +62,12 @@ CForStatementNode >> statement: aCGLRAbstractNode [
 		ifTrue: [ self statement parent: self ]
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CForStatementNode >> step [
 	^ step
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CForStatementNode >> step: anOrderedCollection [
 	self assertListOfExpressions: anOrderedCollection.
 	
@@ -74,12 +76,12 @@ CForStatementNode >> step: anOrderedCollection [
 	self setParents: self step to: self
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CForStatementNode >> until [
 	^ until
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CForStatementNode >> until: aCGLRExpressionStatementNode [
 	self assertExpression: aCGLRExpressionStatementNode.
 

--- a/smalltalksrc/CAST/CFunctionDeclaratorNode.class.st
+++ b/smalltalksrc/CAST/CFunctionDeclaratorNode.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #CFunctionDeclaratorNode,
-	#superclass : #CAbstractDeclaratorNode,
+	#name : 'CFunctionDeclaratorNode',
+	#superclass : 'CAbstractDeclaratorNode',
 	#instVars : [
 		'identifiers',
 		'parameters',
 		'ellipsis',
 		'isPrototype'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CFunctionDeclaratorNode class >> declarator: aDeclarator parameters: parameters [
 
 	^ self new
@@ -19,7 +21,7 @@ CFunctionDeclaratorNode class >> declarator: aDeclarator parameters: parameters 
 		  yourself
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CFunctionDeclaratorNode >> = anObject [
 
 	"Answer whether the receiver and anObject represent the same object."
@@ -32,22 +34,22 @@ CFunctionDeclaratorNode >> = anObject [
 				  declarator = anObject declarator ] ] ]
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CFunctionDeclaratorNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitFunctionDeclarator: self
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CFunctionDeclaratorNode >> compositeNodeVariables [
 	^ #(#parameters #identifiers)
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CFunctionDeclaratorNode >> declarator [
 	^ declarator
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CFunctionDeclaratorNode >> declarator: aCGLRAbstractNode [
 	self declarator notNil
 		ifTrue: [ self declarator parent: nil ].
@@ -56,17 +58,17 @@ CFunctionDeclaratorNode >> declarator: aCGLRAbstractNode [
 		ifTrue: [ self declarator parent: self ]
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CFunctionDeclaratorNode >> ellipsis [
 	^ ellipsis
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CFunctionDeclaratorNode >> ellipsis: aSmaCCToken [
 	ellipsis := aSmaCCToken
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CFunctionDeclaratorNode >> hash [
 
 	"Answer an integer value that is related to the identity of the receiver."
@@ -75,19 +77,19 @@ CFunctionDeclaratorNode >> hash [
 		  (identifiers hash bitXor: (ellipsis hash bitXor: declarator hash))
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CFunctionDeclaratorNode >> identifiers [
 	^ identifiers
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CFunctionDeclaratorNode >> identifiers: anOrderedCollection [
 	self setParents: self identifiers to: nil.
 	identifiers := anOrderedCollection.
 	self setParents: self identifiers to: self
 ]
 
-{ #category : #'generated-initialize-release' }
+{ #category : 'generated-initialize-release' }
 CFunctionDeclaratorNode >> initialize [
 
 	super initialize.
@@ -96,30 +98,30 @@ CFunctionDeclaratorNode >> initialize [
 	isPrototype := false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CFunctionDeclaratorNode >> isFunctionDeclarator [
 	
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CFunctionDeclaratorNode >> isPrototype [
 
 	^ isPrototype
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CFunctionDeclaratorNode >> isPrototype: aBoolean [
 
 	isPrototype := aBoolean
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CFunctionDeclaratorNode >> parameters [
 	^ parameters
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CFunctionDeclaratorNode >> parameters: anOrderedCollection [
 	self setParents: self parameters to: nil.
 	parameters := anOrderedCollection.

--- a/smalltalksrc/CAST/CFunctionDefinitionNode.class.st
+++ b/smalltalksrc/CAST/CFunctionDefinitionNode.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #CFunctionDefinitionNode,
-	#superclass : #CGLRAbstractNode,
+	#name : 'CFunctionDefinitionNode',
+	#superclass : 'CGLRAbstractNode',
 	#instVars : [
 		'declarator',
 		'body',
@@ -8,10 +8,12 @@ Class {
 		'arguments',
 		'hasRawPrototype'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CFunctionDefinitionNode class >> declarator: aDeclarator body: aBlock specifiers: specifiers [
 
 	^ self new
@@ -21,7 +23,7 @@ CFunctionDefinitionNode class >> declarator: aDeclarator body: aBlock specifiers
 		  yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CFunctionDefinitionNode class >> declarator: aDeclarator body: aBlock specifiers: specifiers arguments: arguments [
 
 	^ self new
@@ -32,7 +34,7 @@ CFunctionDefinitionNode class >> declarator: aDeclarator body: aBlock specifiers
 		  yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CFunctionDefinitionNode class >> declarator: aDeclarator specifiers: specifiers [
 
 	^ self new
@@ -41,7 +43,7 @@ CFunctionDefinitionNode class >> declarator: aDeclarator specifiers: specifiers 
 		  yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CFunctionDefinitionNode class >> declarator: aDeclarator specifiers: specifiers arguments: arguments [
 
 	^ self new
@@ -51,29 +53,29 @@ CFunctionDefinitionNode class >> declarator: aDeclarator specifiers: specifiers 
 		  yourself
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CFunctionDefinitionNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitFunctionDefinition: self
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CFunctionDefinitionNode >> arguments [
 	^ arguments
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CFunctionDefinitionNode >> arguments: anOrderedCollection [
 	self setParents: self arguments to: nil.
 	arguments := anOrderedCollection.
 	self setParents: self arguments to: self
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CFunctionDefinitionNode >> body [
 	^ body
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CFunctionDefinitionNode >> body: aCGLRCompoundStatementNode [
 	self body notNil
 		ifTrue: [ self body parent: nil ].
@@ -82,18 +84,18 @@ CFunctionDefinitionNode >> body: aCGLRCompoundStatementNode [
 		ifTrue: [ self body parent: self ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CFunctionDefinitionNode >> declarations [
 	
 	^ body declarations
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CFunctionDefinitionNode >> declarator [
 	^ declarator
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CFunctionDefinitionNode >> declarator: aCGLRDeclaratorNode [
 	self declarator notNil
 		ifTrue: [ self declarator parent: nil ].
@@ -102,19 +104,19 @@ CFunctionDefinitionNode >> declarator: aCGLRDeclaratorNode [
 		ifTrue: [ self declarator parent: self ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CFunctionDefinitionNode >> hasRawPrototype [
 
 	^ hasRawPrototype
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CFunctionDefinitionNode >> hasRawPrototype: aBoolean [
 
 	hasRawPrototype := aBoolean
 ]
 
-{ #category : #'generated-initialize-release' }
+{ #category : 'generated-initialize-release' }
 CFunctionDefinitionNode >> initialize [
 	super initialize.
 	hasRawPrototype := false.
@@ -122,29 +124,29 @@ CFunctionDefinitionNode >> initialize [
 	arguments := OrderedCollection new: 2.
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CFunctionDefinitionNode >> needsSeparator [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CFunctionDefinitionNode >> needsTrailingSemicolon [
 
 	^ false
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CFunctionDefinitionNode >> specifiers [
 	^ specifiers
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CFunctionDefinitionNode >> specifiers: anOrderedCollection [
 	specifiers := anOrderedCollection
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CFunctionDefinitionNode >> statements [
 	
 	^ body statements 

--- a/smalltalksrc/CAST/CFunctionPointerDeclaratorNode.class.st
+++ b/smalltalksrc/CAST/CFunctionPointerDeclaratorNode.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #CFunctionPointerDeclaratorNode,
-	#superclass : #CAbstractDeclaratorNode,
-	#category : #'CAST-Nodes'
+	#name : 'CFunctionPointerDeclaratorNode',
+	#superclass : 'CAbstractDeclaratorNode',
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CFunctionPointerDeclaratorNode >> = anObject [
 
 	"Answer whether the receiver and anObject represent the same object."
@@ -14,18 +16,18 @@ CFunctionPointerDeclaratorNode >> = anObject [
 	^ declarator = anObject declarator2
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CFunctionPointerDeclaratorNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitFunctionPointerDeclarator: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CFunctionPointerDeclaratorNode >> declarator2 [
 
 	^ declarator
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CFunctionPointerDeclaratorNode >> hash [
 
 	"Answer an integer value that is related to the identity of the receiver."

--- a/smalltalksrc/CAST/CGLRAbstractDeclaratorNode.class.st
+++ b/smalltalksrc/CAST/CGLRAbstractDeclaratorNode.class.st
@@ -1,25 +1,26 @@
 Class {
-	#name : #CGLRAbstractDeclaratorNode,
-	#superclass : #CGLRAbstractNode,
+	#name : 'CGLRAbstractDeclaratorNode',
+	#superclass : 'CGLRAbstractNode',
 	#instVars : [
 		'pointers',
 		'qualifiers',
 		'direct'
 	],
-	#category : #CAST
+	#category : 'CAST',
+	#package : 'CAST'
 }
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRAbstractDeclaratorNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitAbstractDeclarator: self
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRAbstractDeclaratorNode >> direct [
 	^ direct
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRAbstractDeclaratorNode >> direct: aCGLRAbstractNode [
 	self direct notNil
 		ifTrue: [ self direct parent: nil ].
@@ -28,29 +29,29 @@ CGLRAbstractDeclaratorNode >> direct: aCGLRAbstractNode [
 		ifTrue: [ self direct parent: self ]
 ]
 
-{ #category : #'generated-initialize-release' }
+{ #category : 'generated-initialize-release' }
 CGLRAbstractDeclaratorNode >> initialize [
 	super initialize.
 	pointers := OrderedCollection new: 2.
 	qualifiers := OrderedCollection new: 2.
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRAbstractDeclaratorNode >> pointers [
 	^ pointers
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRAbstractDeclaratorNode >> pointers: anOrderedCollection [
 	pointers := anOrderedCollection
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRAbstractDeclaratorNode >> qualifiers [
 	^ qualifiers
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRAbstractDeclaratorNode >> qualifiers: anOrderedCollection [
 	qualifiers := anOrderedCollection
 ]

--- a/smalltalksrc/CAST/CGLRAbstractNode.class.st
+++ b/smalltalksrc/CAST/CGLRAbstractNode.class.st
@@ -1,18 +1,19 @@
 Class {
-	#name : #CGLRAbstractNode,
-	#superclass : #SmaCCParseNode,
+	#name : 'CGLRAbstractNode',
+	#superclass : 'SmaCCParseNode',
 	#instVars : [
 		'needsSeparator'
 	],
-	#category : #CAST
+	#category : 'CAST',
+	#package : 'CAST'
 }
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRAbstractNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitAbstract: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CGLRAbstractNode >> ambiguous: aNode [
 	(aNode class == self class
 		and: [ self children size = aNode children size ])
@@ -24,135 +25,140 @@ CGLRAbstractNode >> ambiguous: aNode [
 				do: [ :n1 :n2 | n1 ambiguous: n2 ] ]
 ]
 
-{ #category : #asserting }
+{ #category : 'asserting' }
 CGLRAbstractNode >> assertExpression: aNode [
 
 	self assert: aNode isExpression
 ]
 
-{ #category : #asserting }
+{ #category : 'asserting' }
 CGLRAbstractNode >> assertListOfExpressions: aCollection [ 
 	
 	self assert: (aCollection allSatisfy: [ :e | e isExpression ])
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CGLRAbstractNode >> comments [
 
 	^ super comments ifNil: [ #() ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CGLRAbstractNode >> initialize [
 
 	super initialize.
 	needsSeparator := true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CGLRAbstractNode >> isBinaryOperation [
 	
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CGLRAbstractNode >> isCastExpression [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
+CGLRAbstractNode >> isComment [ 
+	^ false
+]
+
+{ #category : 'testing' }
 CGLRAbstractNode >> isCompoundStatement [
 	
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CGLRAbstractNode >> isConstant [
 	
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CGLRAbstractNode >> isEmpty [
 	
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CGLRAbstractNode >> isEmptyStatement [
 	
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CGLRAbstractNode >> isExpression [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CGLRAbstractNode >> isFunctionCall [
 	
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CGLRAbstractNode >> isFunctionDeclarator [
 	
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CGLRAbstractNode >> isIdentifier [
 	
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CGLRAbstractNode >> isLeaf [
 	
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CGLRAbstractNode >> isReturn [
 	
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CGLRAbstractNode >> isUnaryOperation [
 	
 	^ false
 ]
 
-{ #category : #rewriting }
+{ #category : 'rewriting' }
 CGLRAbstractNode >> last [
 	"I'm the last statement of myself"
 	^ self
 ]
 
-{ #category : #rewriting }
+{ #category : 'rewriting' }
 CGLRAbstractNode >> last: aReplacement [
 	
 	"I replace myself by the node as argument"
 	^ aReplacement
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CGLRAbstractNode >> needsSeparator [
 
 	^ needsSeparator
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CGLRAbstractNode >> needsSeparator: aBoolean [
 
 	needsSeparator := aBoolean
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CGLRAbstractNode >> needsTrailingSemicolon [ 
 	
 	^ true

--- a/smalltalksrc/CAST/CGLRContinueStatementNode.class.st
+++ b/smalltalksrc/CAST/CGLRContinueStatementNode.class.st
@@ -1,10 +1,11 @@
 Class {
-	#name : #CGLRContinueStatementNode,
-	#superclass : #CGLRAbstractNode,
-	#category : #CAST
+	#name : 'CGLRContinueStatementNode',
+	#superclass : 'CGLRAbstractNode',
+	#category : 'CAST',
+	#package : 'CAST'
 }
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRContinueStatementNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitContinueStatement: self
 ]

--- a/smalltalksrc/CAST/CGLREnumNode.class.st
+++ b/smalltalksrc/CAST/CGLREnumNode.class.st
@@ -1,41 +1,42 @@
 Class {
-	#name : #CGLREnumNode,
-	#superclass : #CGLRAbstractNode,
+	#name : 'CGLREnumNode',
+	#superclass : 'CGLRAbstractNode',
 	#instVars : [
 		'enumerators',
 		'identifier'
 	],
-	#category : #CAST
+	#category : 'CAST',
+	#package : 'CAST'
 }
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLREnumNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitEnum: self
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLREnumNode >> compositeNodeVariables [
 	^ #(#enumerators)
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLREnumNode >> enumerators [
 	^ enumerators
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLREnumNode >> enumerators: anOrderedCollection [
 	self setParents: self enumerators to: nil.
 	enumerators := anOrderedCollection.
 	self setParents: self enumerators to: self
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLREnumNode >> identifier [
 	^ identifier
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLREnumNode >> identifier: aCGLRIdentifierNode [
 	self identifier notNil
 		ifTrue: [ self identifier parent: nil ].
@@ -44,13 +45,13 @@ CGLREnumNode >> identifier: aCGLRIdentifierNode [
 		ifTrue: [ self identifier parent: self ]
 ]
 
-{ #category : #'generated-initialize-release' }
+{ #category : 'generated-initialize-release' }
 CGLREnumNode >> initialize [
 	super initialize.
 	enumerators := OrderedCollection new: 2.
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLREnumNode >> nodeVariables [
 	^ #(#identifier)
 ]

--- a/smalltalksrc/CAST/CGLREnumeratorNode.class.st
+++ b/smalltalksrc/CAST/CGLREnumeratorNode.class.st
@@ -1,24 +1,25 @@
 Class {
-	#name : #CGLREnumeratorNode,
-	#superclass : #CGLRAbstractNode,
+	#name : 'CGLREnumeratorNode',
+	#superclass : 'CGLRAbstractNode',
 	#instVars : [
 		'symbol',
 		'expr'
 	],
-	#category : #CAST
+	#category : 'CAST',
+	#package : 'CAST'
 }
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLREnumeratorNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitEnumerator: self
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLREnumeratorNode >> expression [
 	^ expr
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLREnumeratorNode >> expression: aCGLRAbstractNode [
 	self expression notNil
 		ifTrue: [ self expression parent: nil ].
@@ -27,12 +28,12 @@ CGLREnumeratorNode >> expression: aCGLRAbstractNode [
 		ifTrue: [ self expression parent: self ]
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLREnumeratorNode >> symbol [
 	^ symbol
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLREnumeratorNode >> symbol: aCGLRIdentifierNode [
 	self symbol notNil
 		ifTrue: [ self symbol parent: nil ].

--- a/smalltalksrc/CAST/CGLRInitializerNode.class.st
+++ b/smalltalksrc/CAST/CGLRInitializerNode.class.st
@@ -1,13 +1,14 @@
 Class {
-	#name : #CGLRInitializerNode,
-	#superclass : #CGLRAbstractNode,
+	#name : 'CGLRInitializerNode',
+	#superclass : 'CGLRAbstractNode',
 	#instVars : [
 		'initializers'
 	],
-	#category : #CAST
+	#category : 'CAST',
+	#package : 'CAST'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CGLRInitializerNode class >> initializers: aCollection [ 
 	
 	^ self new
@@ -15,7 +16,7 @@ CGLRInitializerNode class >> initializers: aCollection [
 		yourself
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CGLRInitializerNode >> = anObject [
 
 	"Answer whether the receiver and anObject represent the same object."
@@ -25,12 +26,12 @@ CGLRInitializerNode >> = anObject [
 	^ initializers = anObject initializers
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRInitializerNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitInitializer: self
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CGLRInitializerNode >> hash [
 
 	"Answer an integer value that is related to the identity of the receiver."
@@ -38,18 +39,18 @@ CGLRInitializerNode >> hash [
 	^ initializers hash
 ]
 
-{ #category : #'generated-initialize-release' }
+{ #category : 'generated-initialize-release' }
 CGLRInitializerNode >> initialize [
 	super initialize.
 	initializers := OrderedCollection new: 2.
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRInitializerNode >> initializers [
 	^ initializers
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRInitializerNode >> initializers: anOrderedCollection [
 	self setParents: self initializers to: nil.
 	initializers := anOrderedCollection.

--- a/smalltalksrc/CAST/CGLRStructDeclarationNode.class.st
+++ b/smalltalksrc/CAST/CGLRStructDeclarationNode.class.st
@@ -1,32 +1,33 @@
 Class {
-	#name : #CGLRStructDeclarationNode,
-	#superclass : #CGLRAbstractNode,
+	#name : 'CGLRStructDeclarationNode',
+	#superclass : 'CGLRAbstractNode',
 	#instVars : [
 		'declarators',
 		'specifiers',
 		'qualifiers'
 	],
-	#category : #CAST
+	#category : 'CAST',
+	#package : 'CAST'
 }
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRStructDeclarationNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitStructDeclaration: self
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRStructDeclarationNode >> declarators [
 	^ declarators
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRStructDeclarationNode >> declarators: anOrderedCollection [
 	self setParents: self declarators to: nil.
 	declarators := anOrderedCollection.
 	self setParents: self declarators to: self
 ]
 
-{ #category : #'generated-initialize-release' }
+{ #category : 'generated-initialize-release' }
 CGLRStructDeclarationNode >> initialize [
 	super initialize.
 	specifiers := OrderedCollection new: 2.
@@ -34,22 +35,22 @@ CGLRStructDeclarationNode >> initialize [
 	declarators := OrderedCollection new: 2.
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRStructDeclarationNode >> qualifiers [
 	^ qualifiers
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRStructDeclarationNode >> qualifiers: anOrderedCollection [
 	qualifiers := anOrderedCollection
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRStructDeclarationNode >> specifiers [
 	^ specifiers
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRStructDeclarationNode >> specifiers: anOrderedCollection [
 	specifiers := anOrderedCollection
 ]

--- a/smalltalksrc/CAST/CGLRStructDeclaratorNode.class.st
+++ b/smalltalksrc/CAST/CGLRStructDeclaratorNode.class.st
@@ -1,24 +1,25 @@
 Class {
-	#name : #CGLRStructDeclaratorNode,
-	#superclass : #CGLRAbstractNode,
+	#name : 'CGLRStructDeclaratorNode',
+	#superclass : 'CGLRAbstractNode',
 	#instVars : [
 		'declarator',
 		'_size'
 	],
-	#category : #CAST
+	#category : 'CAST',
+	#package : 'CAST'
 }
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRStructDeclaratorNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitStructDeclarator: self
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRStructDeclaratorNode >> declarator [
 	^ declarator
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRStructDeclaratorNode >> declarator: aCGLRDeclaratorNode [
 	self declarator notNil
 		ifTrue: [ self declarator parent: nil ].
@@ -27,12 +28,12 @@ CGLRStructDeclaratorNode >> declarator: aCGLRDeclaratorNode [
 		ifTrue: [ self declarator parent: self ]
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRStructDeclaratorNode >> size [
 	^ _size
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRStructDeclaratorNode >> size: aCGLRAbstractNode [
 	self size notNil
 		ifTrue: [ self size parent: nil ].

--- a/smalltalksrc/CAST/CGLRStructOrUnionSpecifierNode.class.st
+++ b/smalltalksrc/CAST/CGLRStructOrUnionSpecifierNode.class.st
@@ -1,58 +1,59 @@
 Class {
-	#name : #CGLRStructOrUnionSpecifierNode,
-	#superclass : #CGLRAbstractNode,
+	#name : 'CGLRStructOrUnionSpecifierNode',
+	#superclass : 'CGLRAbstractNode',
 	#instVars : [
 		'prefix',
 		'symbol',
 		'members'
 	],
-	#category : #CAST
+	#category : 'CAST',
+	#package : 'CAST'
 }
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRStructOrUnionSpecifierNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitStructOrUnionSpecifier: self
 ]
 
-{ #category : #'generated-initialize-release' }
+{ #category : 'generated-initialize-release' }
 CGLRStructOrUnionSpecifierNode >> initialize [
 	super initialize.
 	members := OrderedCollection new: 2.
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRStructOrUnionSpecifierNode >> members [
 	^ members
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRStructOrUnionSpecifierNode >> members: anOrderedCollection [
 	self setParents: self members to: nil.
 	members := anOrderedCollection.
 	self setParents: self members to: self
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRStructOrUnionSpecifierNode >> nodeVariables [
 	^ #(#symbol)
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRStructOrUnionSpecifierNode >> prefix [
 	^ prefix
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRStructOrUnionSpecifierNode >> prefix: aSmaCCToken [
 	prefix := aSmaCCToken
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRStructOrUnionSpecifierNode >> symbol [
 	^ symbol
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRStructOrUnionSpecifierNode >> symbol: aCGLRIdentifierNode [
 	self symbol notNil
 		ifTrue: [ self symbol parent: nil ].

--- a/smalltalksrc/CAST/CGLRTranslationUnitNode.class.st
+++ b/smalltalksrc/CAST/CGLRTranslationUnitNode.class.st
@@ -1,30 +1,31 @@
 Class {
-	#name : #CGLRTranslationUnitNode,
-	#superclass : #CGLRAbstractNode,
+	#name : 'CGLRTranslationUnitNode',
+	#superclass : 'CGLRAbstractNode',
 	#instVars : [
 		'declarations'
 	],
-	#category : #CAST
+	#category : 'CAST',
+	#package : 'CAST'
 }
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRTranslationUnitNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitTranslationUnit: self
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRTranslationUnitNode >> declarations [
 	^ declarations
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRTranslationUnitNode >> declarations: anOrderedCollection [
 	self setParents: self declarations to: nil.
 	declarations := anOrderedCollection.
 	self setParents: self declarations to: self
 ]
 
-{ #category : #'generated-initialize-release' }
+{ #category : 'generated-initialize-release' }
 CGLRTranslationUnitNode >> initialize [
 	super initialize.
 	declarations := OrderedCollection new: 2.

--- a/smalltalksrc/CAST/CGLRTypeNode.class.st
+++ b/smalltalksrc/CAST/CGLRTypeNode.class.st
@@ -1,20 +1,21 @@
 Class {
-	#name : #CGLRTypeNode,
-	#superclass : #CGLRAbstractNode,
+	#name : 'CGLRTypeNode',
+	#superclass : 'CGLRAbstractNode',
 	#instVars : [
 		'qualifiers',
 		'specifiers',
 		'abstract'
 	],
-	#category : #CAST
+	#category : 'CAST',
+	#package : 'CAST'
 }
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRTypeNode >> abstract [
 	^ abstract
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRTypeNode >> abstract: aCGLRAbstractDeclaratorNode [
 	self abstract notNil
 		ifTrue: [ self abstract parent: nil ].
@@ -23,39 +24,39 @@ CGLRTypeNode >> abstract: aCGLRAbstractDeclaratorNode [
 		ifTrue: [ self abstract parent: self ]
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRTypeNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitTypeName: self
 ]
 
-{ #category : #'generated-initialize-release' }
+{ #category : 'generated-initialize-release' }
 CGLRTypeNode >> initialize [
 	super initialize.
 	specifiers := OrderedCollection new: 2.
 	qualifiers := OrderedCollection new: 2.
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRTypeNode >> isTypeNode [
 	^ true
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRTypeNode >> qualifiers [
 	^ qualifiers
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRTypeNode >> qualifiers: anOrderedCollection [
 	qualifiers := anOrderedCollection
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRTypeNode >> specifiers [
 	^ specifiers
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGLRTypeNode >> specifiers: anOrderedCollection [
 	specifiers := anOrderedCollection
 ]

--- a/smalltalksrc/CAST/CGotoStatementNode.class.st
+++ b/smalltalksrc/CAST/CGotoStatementNode.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #CGotoStatementNode,
-	#superclass : #CGLRAbstractNode,
+	#name : 'CGotoStatementNode',
+	#superclass : 'CGLRAbstractNode',
 	#instVars : [
 		'label'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGotoStatementNode class >> identifier: id [
 
 	^ self new
@@ -15,7 +17,7 @@ CGotoStatementNode class >> identifier: id [
 		  yourself
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CGotoStatementNode >> = anObject [
 
 	"Answer whether the receiver and anObject represent the same object."
@@ -25,12 +27,12 @@ CGotoStatementNode >> = anObject [
 	^ label = anObject label
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGotoStatementNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitGotoStatement: self
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CGotoStatementNode >> hash [
 
 	"Answer an integer value that is related to the identity of the receiver."
@@ -38,17 +40,17 @@ CGotoStatementNode >> hash [
 	^ label hash
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CGotoStatementNode >> isGoTo [
 	^ true.
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGotoStatementNode >> label [
 	^ label
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CGotoStatementNode >> label: aCGLRIdentifierNode [
 	self label notNil
 		ifTrue: [ self label parent: nil ].

--- a/smalltalksrc/CAST/CIdentifierNode.class.st
+++ b/smalltalksrc/CAST/CIdentifierNode.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #CIdentifierNode,
-	#superclass : #CExpressionNode,
+	#name : 'CIdentifierNode',
+	#superclass : 'CExpressionNode',
 	#instVars : [
 		'name'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CIdentifierNode class >> name: aString [ 
 	
 	^ self new
@@ -15,7 +17,7 @@ CIdentifierNode class >> name: aString [
 		yourself
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CIdentifierNode >> = anObject [
 
 	"Answer whether the receiver and anObject represent the same object."
@@ -25,12 +27,12 @@ CIdentifierNode >> = anObject [
 	^ name = anObject name
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CIdentifierNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitIdentifier: self
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CIdentifierNode >> hash [
 
 	"Answer an integer value that is related to the identity of the receiver."
@@ -38,25 +40,25 @@ CIdentifierNode >> hash [
 	^ name hash
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CIdentifierNode >> isIdentifier [
 	
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CIdentifierNode >> isLeaf [
 	
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CIdentifierNode >> name [
 	
 	^ name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CIdentifierNode >> name: aName [
 	
 	name := aName

--- a/smalltalksrc/CAST/CIfStatementNode.class.st
+++ b/smalltalksrc/CAST/CIfStatementNode.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #CIfStatementNode,
-	#superclass : #CGLRAbstractNode,
+	#name : 'CIfStatementNode',
+	#superclass : 'CGLRAbstractNode',
 	#instVars : [
 		'then',
 		'else',
 		'if'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CIfStatementNode class >> if: aCondition then: anExpression [
 
 	^ self new
@@ -18,7 +20,7 @@ CIfStatementNode class >> if: aCondition then: anExpression [
 		  yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CIfStatementNode class >> if: aCondition then: anExpression else: anOtherExpression [
 
 	^ self new
@@ -28,17 +30,17 @@ CIfStatementNode class >> if: aCondition then: anExpression else: anOtherExpress
 		  yourself
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CIfStatementNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitIfStatement: self
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CIfStatementNode >> else [
 	^ else
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CIfStatementNode >> else: aCGLRAbstractNode [
 	self else notNil
 		ifTrue: [ self else parent: nil ].
@@ -47,12 +49,12 @@ CIfStatementNode >> else: aCGLRAbstractNode [
 		ifTrue: [ self else parent: self ]
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CIfStatementNode >> if [
 	^ if
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CIfStatementNode >> if: aCGLRExpressionNode [
 	self assertExpression: aCGLRExpressionNode.
 	
@@ -63,30 +65,30 @@ CIfStatementNode >> if: aCGLRExpressionNode [
 		ifTrue: [ self if parent: self ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CIfStatementNode >> isIf [
 	
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CIfStatementNode >> needsSeparator [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CIfStatementNode >> needsTrailingSemicolon [
 
 	^ false
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CIfStatementNode >> then [
 	^ then
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CIfStatementNode >> then: aCGLRAbstractNode [
 	self then notNil
 		ifTrue: [ self then parent: nil ].

--- a/smalltalksrc/CAST/CIncrementNode.class.st
+++ b/smalltalksrc/CAST/CIncrementNode.class.st
@@ -1,41 +1,43 @@
 Class {
-	#name : #CIncrementNode,
-	#superclass : #CExpressionNode,
+	#name : 'CIncrementNode',
+	#superclass : 'CExpressionNode',
 	#instVars : [
 		'object',
 		'prefix'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CIncrementNode class >> object: aVariable [
 	
 	^self new object: aVariable; prefix: false; yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CIncrementNode class >> object: aVariable prefix: boolean [
 	
 	^self new object: aVariable; prefix: boolean; yourself
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CIncrementNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitIncrement: self
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CIncrementNode >> isIncrement [
 	^ true
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CIncrementNode >> object [
 	^ object
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CIncrementNode >> object: aCGLRAbstractNode [
 	self assertExpression: aCGLRAbstractNode.
 	
@@ -46,13 +48,13 @@ CIncrementNode >> object: aCGLRAbstractNode [
 		ifTrue: [ self object parent: self ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CIncrementNode >> prefix [
 
 	^ prefix
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CIncrementNode >> prefix: boolean [
 
 	prefix := boolean

--- a/smalltalksrc/CAST/CInitDeclaratorNode.class.st
+++ b/smalltalksrc/CAST/CInitDeclaratorNode.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #CInitDeclaratorNode,
-	#superclass : #CAbstractDeclaratorNode,
+	#name : 'CInitDeclaratorNode',
+	#superclass : 'CAbstractDeclaratorNode',
 	#instVars : [
 		'initializer'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CInitDeclaratorNode class >> declarator: aDeclarator initializer: anInitializer [
 	
 	^ self new
@@ -16,7 +18,7 @@ CInitDeclaratorNode class >> declarator: aDeclarator initializer: anInitializer 
 		yourself
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CInitDeclaratorNode >> = anObject [
 
 	"Answer whether the receiver and anObject represent the same object."
@@ -27,12 +29,12 @@ CInitDeclaratorNode >> = anObject [
 		  declarator = anObject declarator ]
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CInitDeclaratorNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitInitDeclarator: self
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CInitDeclaratorNode >> hash [
 
 	"Answer an integer value that is related to the identity of the receiver."
@@ -40,12 +42,12 @@ CInitDeclaratorNode >> hash [
 	^ initializer hash bitXor: declarator hash
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CInitDeclaratorNode >> initializer [
 	^ initializer
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CInitDeclaratorNode >> initializer: aCGLRAbstractNode [
 	self initializer notNil
 		ifTrue: [ self initializer parent: nil ].
@@ -54,7 +56,7 @@ CInitDeclaratorNode >> initializer: aCGLRAbstractNode [
 		ifTrue: [ self initializer parent: self ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CInitDeclaratorNode >> isInitializerDeclarator [
 	
 	^ true

--- a/smalltalksrc/CAST/CLabeledStatementNode.class.st
+++ b/smalltalksrc/CAST/CLabeledStatementNode.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #CLabeledStatementNode,
-	#superclass : #CGLRAbstractNode,
+	#name : 'CLabeledStatementNode',
+	#superclass : 'CGLRAbstractNode',
 	#instVars : [
 		'label',
 		'statement',
 		'case'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #generated }
+{ #category : 'generated' }
 CLabeledStatementNode class >> case: aCase statement: aStatement [
 
 	^ self new
@@ -18,39 +20,39 @@ CLabeledStatementNode class >> case: aCase statement: aStatement [
 		yourself
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CLabeledStatementNode class >> defaultDoing: aCompoundStatement [
 
 	^ self case: 'default' statement: aCompoundStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CLabeledStatementNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitLabeledStatement: self
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CLabeledStatementNode >> case [
 	^ case
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CLabeledStatementNode >> case: anObject [
 	case := anObject
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CLabeledStatementNode >> isLabelledStatement [
 	
 	^ true
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CLabeledStatementNode >> label [
 	^ label
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CLabeledStatementNode >> label: aCGLRIdentifierNode [
 	self label notNil
 		ifTrue: [ self label parent: nil ].
@@ -59,7 +61,7 @@ CLabeledStatementNode >> label: aCGLRIdentifierNode [
 		ifTrue: [ self label parent: self ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CLabeledStatementNode >> needsSeparator [
 
 	"The labeled statement node is a case:.
@@ -68,12 +70,12 @@ CLabeledStatementNode >> needsSeparator [
 	^ false
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CLabeledStatementNode >> statement [
 	^ statement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CLabeledStatementNode >> statement: aCGLRAbstractNode [
 	self statement notNil
 		ifTrue: [ self statement parent: nil ].

--- a/smalltalksrc/CAST/CMemberAccessNode.class.st
+++ b/smalltalksrc/CAST/CMemberAccessNode.class.st
@@ -1,14 +1,16 @@
 Class {
-	#name : #CMemberAccessNode,
-	#superclass : #CExpressionNode,
+	#name : 'CMemberAccessNode',
+	#superclass : 'CExpressionNode',
 	#instVars : [
 		'object',
 		'member'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CMemberAccessNode class >> object: anObject member: aMember [
 
 	^ self new
@@ -17,23 +19,23 @@ CMemberAccessNode class >> object: anObject member: aMember [
 		  yourself
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CMemberAccessNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitPoint: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CMemberAccessNode >> isMemberAccess [
 	
 	^ true
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CMemberAccessNode >> member [
 	^ member
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CMemberAccessNode >> member: aCGLRIdentifierNode [
 	self member notNil
 		ifTrue: [ self member parent: nil ].
@@ -42,12 +44,12 @@ CMemberAccessNode >> member: aCGLRIdentifierNode [
 		ifTrue: [ self member parent: self ]
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CMemberAccessNode >> object [
 	^ object
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CMemberAccessNode >> object: aCGLRAbstractNode [
 
 	self assertExpression: aCGLRAbstractNode.

--- a/smalltalksrc/CAST/CParameterDeclarationNode.class.st
+++ b/smalltalksrc/CAST/CParameterDeclarationNode.class.st
@@ -1,21 +1,23 @@
 Class {
-	#name : #CParameterDeclarationNode,
-	#superclass : #CGLRAbstractNode,
+	#name : 'CParameterDeclarationNode',
+	#superclass : 'CGLRAbstractNode',
 	#instVars : [
 		'specifiers',
 		'declarator',
 		'rawDeclaration'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CParameterDeclarationNode class >> declarator: aString [
 
 	^ self new declarator: aString
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CParameterDeclarationNode class >> declarator: aString cDeclaration: cDecleration [
 
 	^ self new
@@ -24,7 +26,7 @@ CParameterDeclarationNode class >> declarator: aString cDeclaration: cDecleratio
 		  yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CParameterDeclarationNode class >> declarator: aString specifiers: anOrderedCollection [
 
 	^ self new
@@ -33,17 +35,17 @@ CParameterDeclarationNode class >> declarator: aString specifiers: anOrderedColl
 		  yourself
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CParameterDeclarationNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitParameterDeclaration: self
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CParameterDeclarationNode >> declarator [
 	^ declarator
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CParameterDeclarationNode >> declarator: aCGLRAbstractNode [
 	self declarator notNil
 		ifTrue: [ self declarator parent: nil ].
@@ -52,30 +54,30 @@ CParameterDeclarationNode >> declarator: aCGLRAbstractNode [
 		ifTrue: [ self declarator parent: self ]
 ]
 
-{ #category : #'generated-initialize-release' }
+{ #category : 'generated-initialize-release' }
 CParameterDeclarationNode >> initialize [
 	super initialize.
 	specifiers := OrderedCollection new: 2.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CParameterDeclarationNode >> rawDeclaration [
 
 	^ rawDeclaration
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CParameterDeclarationNode >> rawDeclaration: anObject [
 
 	rawDeclaration := anObject
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CParameterDeclarationNode >> specifiers [
 	^ specifiers
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CParameterDeclarationNode >> specifiers: anOrderedCollection [
 	specifiers := anOrderedCollection
 ]

--- a/smalltalksrc/CAST/CPointerDeclaratorNode.class.st
+++ b/smalltalksrc/CAST/CPointerDeclaratorNode.class.st
@@ -1,14 +1,16 @@
 Class {
-	#name : #CPointerDeclaratorNode,
-	#superclass : #CAbstractDeclaratorNode,
+	#name : 'CPointerDeclaratorNode',
+	#superclass : 'CAbstractDeclaratorNode',
 	#instVars : [
 		'pointers',
 		'qualifiers'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 CPointerDeclaratorNode class >> declarator: aDeclarator pointers: numberOfPointers [
 	
 	^ (self declarator: aDeclarator)
@@ -16,7 +18,7 @@ CPointerDeclaratorNode class >> declarator: aDeclarator pointers: numberOfPointe
 		yourself
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CPointerDeclaratorNode >> = anObject [
 
 	"Answer whether the receiver and anObject represent the same object."
@@ -28,18 +30,18 @@ CPointerDeclaratorNode >> = anObject [
 			  declarator = anObject declarator2 ] ]
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CPointerDeclaratorNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitDeclarator: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CPointerDeclaratorNode >> declarator2 [
 
 	^ declarator
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 CPointerDeclaratorNode >> hash [
 
 	"Answer an integer value that is related to the identity of the receiver."
@@ -47,35 +49,35 @@ CPointerDeclaratorNode >> hash [
 	^ qualifiers hash bitXor: (pointers hash bitXor: declarator hash)
 ]
 
-{ #category : #'generated-initialize-release' }
+{ #category : 'generated-initialize-release' }
 CPointerDeclaratorNode >> initialize [
 	super initialize.
 	pointers := OrderedCollection new: 2.
 	qualifiers := OrderedCollection new: 2.
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CPointerDeclaratorNode >> isPointerDeclarator [
 	
 	^ true
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CPointerDeclaratorNode >> pointers [
 	^ pointers
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CPointerDeclaratorNode >> pointers: anOrderedCollection [
 	pointers := anOrderedCollection
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CPointerDeclaratorNode >> qualifiers [
 	^ qualifiers
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CPointerDeclaratorNode >> qualifiers: anOrderedCollection [
 	qualifiers := anOrderedCollection
 ]

--- a/smalltalksrc/CAST/CPreprocessorDefineNode.class.st
+++ b/smalltalksrc/CAST/CPreprocessorDefineNode.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #CPreprocessorDefineNode,
-	#superclass : #CGLRAbstractNode,
+	#name : 'CPreprocessorDefineNode',
+	#superclass : 'CGLRAbstractNode',
 	#instVars : [
 		'token',
 		'expression',
 		'rawMacro'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CPreprocessorDefineNode class >> token: anIdentifier expression: anExpression [
 
 	^ self new
@@ -18,7 +20,7 @@ CPreprocessorDefineNode class >> token: anIdentifier expression: anExpression [
 		  yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CPreprocessorDefineNode class >> token: anIdentifier rawMacro: aString [
 
 	^ self new
@@ -27,42 +29,42 @@ CPreprocessorDefineNode class >> token: anIdentifier rawMacro: aString [
 		  yourself
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CPreprocessorDefineNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitPreprocessorDefine: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CPreprocessorDefineNode >> expression [
 
 	^ expression
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CPreprocessorDefineNode >> expression: anObject [
 
 	expression := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CPreprocessorDefineNode >> rawMacro [
 
 	^ rawMacro
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CPreprocessorDefineNode >> rawMacro: anObject [
 
 	rawMacro := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CPreprocessorDefineNode >> token [
 
 	^ token
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CPreprocessorDefineNode >> token: anObject [
 
 	token := anObject

--- a/smalltalksrc/CAST/CPreprocessorIfNode.class.st
+++ b/smalltalksrc/CAST/CPreprocessorIfNode.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #CPreprocessorIfNode,
-	#superclass : #CExpressionNode,
+	#name : 'CPreprocessorIfNode',
+	#superclass : 'CExpressionNode',
 	#instVars : [
 		'then',
 		'else',
 		'if',
 		'isArgument'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CPreprocessorIfNode class >> if: aCondition then: anExpression [
 
 	^ self new
@@ -19,7 +21,7 @@ CPreprocessorIfNode class >> if: aCondition then: anExpression [
 		  yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CPreprocessorIfNode class >> if: aCondition then: anExpression asArgument: asArgument [
 
 	^ self new
@@ -29,7 +31,7 @@ CPreprocessorIfNode class >> if: aCondition then: anExpression asArgument: asArg
 		  yourself
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CPreprocessorIfNode class >> if: aCondition then: anExpression else: anOtherExpression [
 
 	^ self new
@@ -39,67 +41,67 @@ CPreprocessorIfNode class >> if: aCondition then: anExpression else: anOtherExpr
 		  yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CPreprocessorIfNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitPreprocessorIf: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CPreprocessorIfNode >> else [
 
 	^ else
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CPreprocessorIfNode >> else: aStatement [
 
 	else := aStatement
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CPreprocessorIfNode >> if [
 
 	^ if
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CPreprocessorIfNode >> if: aStatement [
 
 	if := aStatement
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 CPreprocessorIfNode >> initialize [ 
 
 	super initialize.
 	isArgument := false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CPreprocessorIfNode >> isArgument [
 
 	^ isArgument
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CPreprocessorIfNode >> isArgument: aBoolean [
 
 	isArgument := aBoolean
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CPreprocessorIfNode >> needsSeparator [
 
 	^ false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CPreprocessorIfNode >> then [
 
 	^ then
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CPreprocessorIfNode >> then: aStatement [
 
 	then := aStatement

--- a/smalltalksrc/CAST/CRawCodeNode.class.st
+++ b/smalltalksrc/CAST/CRawCodeNode.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #CRawCodeNode,
-	#superclass : #CExpressionNode,
+	#name : 'CRawCodeNode',
+	#superclass : 'CExpressionNode',
 	#instVars : [
 		'code'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CRawCodeNode class >> code: aString [
 
 	^ self new
@@ -15,18 +17,18 @@ CRawCodeNode class >> code: aString [
 		  yourself
 ]
 
-{ #category : #visiting }
+{ #category : 'visiting' }
 CRawCodeNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitRawCode: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CRawCodeNode >> code [
 
 	^ code
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CRawCodeNode >> code: anObject [
 
 	code := anObject

--- a/smalltalksrc/CAST/CReturnStatementNode.class.st
+++ b/smalltalksrc/CAST/CReturnStatementNode.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #CReturnStatementNode,
-	#superclass : #CGLRAbstractNode,
+	#name : 'CReturnStatementNode',
+	#superclass : 'CGLRAbstractNode',
 	#instVars : [
 		'expr'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CReturnStatementNode class >> expression: anExpression [
 
 	^ self new
@@ -15,17 +17,17 @@ CReturnStatementNode class >> expression: anExpression [
 		yourself
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CReturnStatementNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitReturnStatement: self
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CReturnStatementNode >> expression [
 	^ expr
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CReturnStatementNode >> expression: aCGLRExpressionNode [
 
 	self assertExpression: aCGLRExpressionNode.
@@ -37,7 +39,7 @@ CReturnStatementNode >> expression: aCGLRExpressionNode [
 		ifTrue: [ self expression parent: self ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CReturnStatementNode >> isReturn [
 	
 	^ true

--- a/smalltalksrc/CAST/CSizeofNode.class.st
+++ b/smalltalksrc/CAST/CSizeofNode.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #CSizeofNode,
-	#superclass : #CExpressionNode,
+	#name : 'CSizeofNode',
+	#superclass : 'CExpressionNode',
 	#instVars : [
 		'child'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CSizeofNode class >> operator: anOperator expression: anExpression [
 
 	^ self new
@@ -16,25 +18,25 @@ CSizeofNode class >> operator: anOperator expression: anExpression [
 		  yourself
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CSizeofNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitSizeof: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CSizeofNode >> child [
 
 	^ child
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CSizeofNode >> child: anObject [
 	self assertExpression: anObject.
 	
 	child := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CSizeofNode >> isSizeof [ 
 
 	^ true

--- a/smalltalksrc/CAST/CStringLiteralNode.class.st
+++ b/smalltalksrc/CAST/CStringLiteralNode.class.st
@@ -1,14 +1,16 @@
 Class {
-	#name : #CStringLiteralNode,
-	#superclass : #CExpressionNode,
+	#name : 'CStringLiteralNode',
+	#superclass : 'CExpressionNode',
 	#instVars : [
 		'value',
 		'needsDoubleQuotes'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CStringLiteralNode class >> value: aString [
 
 	^ self new
@@ -17,35 +19,35 @@ CStringLiteralNode class >> value: aString [
 		  yourself
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CStringLiteralNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitStringLiteral: self
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CStringLiteralNode >> isLeaf [
 
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CStringLiteralNode >> needsDoubleQuotes [
 
 	^ needsDoubleQuotes
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CStringLiteralNode >> needsDoubleQuotes: aBoolean [
 
 	needsDoubleQuotes := aBoolean
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CStringLiteralNode >> value [
 	^ value
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CStringLiteralNode >> value: aSmaCCToken [
 	value := aSmaCCToken
 ]

--- a/smalltalksrc/CAST/CStructurePointerAccessNode.class.st
+++ b/smalltalksrc/CAST/CStructurePointerAccessNode.class.st
@@ -1,14 +1,16 @@
 Class {
-	#name : #CStructurePointerAccessNode,
-	#superclass : #CExpressionNode,
+	#name : 'CStructurePointerAccessNode',
+	#superclass : 'CExpressionNode',
 	#instVars : [
 		'member',
 		'structurePointer'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CStructurePointerAccessNode class >> structurePointer: aPointer member: aMember [
 
 	^ self new
@@ -17,23 +19,23 @@ CStructurePointerAccessNode class >> structurePointer: aPointer member: aMember 
 		  yourself
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CStructurePointerAccessNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitArrow: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CStructurePointerAccessNode >> isStructPointerAccess [
 	
 	^ true
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CStructurePointerAccessNode >> member [
 	^ member
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CStructurePointerAccessNode >> member: aCGLRIdentifierNode [
 	self member notNil
 		ifTrue: [ self member parent: nil ].
@@ -42,13 +44,13 @@ CStructurePointerAccessNode >> member: aCGLRIdentifierNode [
 		ifTrue: [ self member parent: self ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CStructurePointerAccessNode >> structurePointer [
 	
 	^ structurePointer
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CStructurePointerAccessNode >> structurePointer: aCGLRAbstractNode [
 	self assertExpression: aCGLRAbstractNode.
 

--- a/smalltalksrc/CAST/CSwitchStatementNode.class.st
+++ b/smalltalksrc/CAST/CSwitchStatementNode.class.st
@@ -1,14 +1,16 @@
 Class {
-	#name : #CSwitchStatementNode,
-	#superclass : #CGLRAbstractNode,
+	#name : 'CSwitchStatementNode',
+	#superclass : 'CGLRAbstractNode',
 	#instVars : [
 		'statement',
 		'if'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CSwitchStatementNode class >> if: anExpression statement: aStatement [
 
 	^ self new
@@ -17,17 +19,17 @@ CSwitchStatementNode class >> if: anExpression statement: aStatement [
 		yourself
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CSwitchStatementNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitSwitchStatement: self
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CSwitchStatementNode >> if [
 	^ if
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CSwitchStatementNode >> if: aCGLRExpressionNode [
 	self assertExpression: aCGLRExpressionNode.
 	
@@ -38,24 +40,24 @@ CSwitchStatementNode >> if: aCGLRExpressionNode [
 		ifTrue: [ self if parent: self ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CSwitchStatementNode >> isSwitch [
 	
 	^ true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CSwitchStatementNode >> needsSeparator [
 
 	^ false
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CSwitchStatementNode >> statement [
 	^ statement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CSwitchStatementNode >> statement: aCGLRAbstractNode [
 	self statement notNil
 		ifTrue: [ self statement parent: nil ].

--- a/smalltalksrc/CAST/CTernaryNode.class.st
+++ b/smalltalksrc/CAST/CTernaryNode.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #CTernaryNode,
-	#superclass : #CExpressionNode,
+	#name : 'CTernaryNode',
+	#superclass : 'CExpressionNode',
 	#instVars : [
 		'condition',
 		'else',
 		'then',
 		'printOnMultipleLines'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CTernaryNode class >> condition: aCondition then: thenExpression else: elseExpression [
 
 	^ self new
@@ -21,17 +23,17 @@ CTernaryNode class >> condition: aCondition then: thenExpression else: elseExpre
 		  yourself
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CTernaryNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitTernary: self
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CTernaryNode >> condition [
 	^ condition
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CTernaryNode >> condition: aCGLRExpressionNode [
 	self assertExpression: aCGLRExpressionNode.
 	
@@ -42,12 +44,12 @@ CTernaryNode >> condition: aCGLRExpressionNode [
 		ifTrue: [ self condition parent: self ]
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CTernaryNode >> else [
 	^ else
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CTernaryNode >> else: aCGLRExpressionNode [
 	self assertExpression: aCGLRExpressionNode.
 	
@@ -58,29 +60,29 @@ CTernaryNode >> else: aCGLRExpressionNode [
 		ifTrue: [ self else parent: self ]
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CTernaryNode >> isTernary [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CTernaryNode >> printOnMultipleLines [
 
 	^ printOnMultipleLines
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CTernaryNode >> printOnMultipleLines: aBoolean [
 
 	printOnMultipleLines := aBoolean
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CTernaryNode >> then [
 	^ then
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CTernaryNode >> then: aCGLRExpressionNode [
 	self assertExpression: aCGLRExpressionNode.
 	

--- a/smalltalksrc/CAST/CTypeNameNode.class.st
+++ b/smalltalksrc/CAST/CTypeNameNode.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #CTypeNameNode,
-	#superclass : #CGLRAbstractNode,
+	#name : 'CTypeNameNode',
+	#superclass : 'CGLRAbstractNode',
 	#instVars : [
 		'symbol'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CTypeNameNode class >> symbol: aType [
 
 	^ self new
@@ -15,23 +17,23 @@ CTypeNameNode class >> symbol: aType [
 		  yourself
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CTypeNameNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitTypename: self
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CTypeNameNode >> isTypeName [
 
 	^ true
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CTypeNameNode >> symbol [
 	^ symbol
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CTypeNameNode >> symbol: aSmaCCToken [
 	symbol := aSmaCCToken
 ]

--- a/smalltalksrc/CAST/CUnaryOperatorNode.class.st
+++ b/smalltalksrc/CAST/CUnaryOperatorNode.class.st
@@ -1,14 +1,16 @@
 Class {
-	#name : #CUnaryOperatorNode,
-	#superclass : #CExpressionNode,
+	#name : 'CUnaryOperatorNode',
+	#superclass : 'CExpressionNode',
 	#instVars : [
 		'expr',
 		'operator'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CUnaryOperatorNode class >> operator: anOperator expression: anExpression [
 
 	^ self new
@@ -17,34 +19,34 @@ CUnaryOperatorNode class >> operator: anOperator expression: anExpression [
 		  yourself
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CUnaryOperatorNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitUnaryOperator: self
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CUnaryOperatorNode >> expression [
 	^ expr
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CUnaryOperatorNode >> expression: aCGLRAbstractNode [
 	self assertExpression: aCGLRAbstractNode.
 	
 	expr := aCGLRAbstractNode
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CUnaryOperatorNode >> isUnaryOperation [
 	^ true
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CUnaryOperatorNode >> operator [
 	^ operator
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CUnaryOperatorNode >> operator: aSmaCCToken [
 	operator := aSmaCCToken
 ]

--- a/smalltalksrc/CAST/CWhileStatementNode.class.st
+++ b/smalltalksrc/CAST/CWhileStatementNode.class.st
@@ -1,14 +1,16 @@
 Class {
-	#name : #CWhileStatementNode,
-	#superclass : #CGLRAbstractNode,
+	#name : 'CWhileStatementNode',
+	#superclass : 'CGLRAbstractNode',
 	#instVars : [
 		'statement',
 		'while'
 	],
-	#category : #'CAST-Nodes'
+	#category : 'CAST-Nodes',
+	#package : 'CAST',
+	#tag : 'Nodes'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CWhileStatementNode class >> while: aBooleanExpression statement: aStatement [
 
 	^ self new
@@ -17,23 +19,23 @@ CWhileStatementNode class >> while: aBooleanExpression statement: aStatement [
 		  yourself
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CWhileStatementNode >> acceptVisitor: anAbstractVisitor [
 	^ anAbstractVisitor visitWhileStatement: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CWhileStatementNode >> isWhile [
 	
 	^ true
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CWhileStatementNode >> statement [
 	^ statement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CWhileStatementNode >> statement: aCGLRAbstractNode [
 	self statement notNil
 		ifTrue: [ self statement parent: nil ].
@@ -42,12 +44,12 @@ CWhileStatementNode >> statement: aCGLRAbstractNode [
 		ifTrue: [ self statement parent: self ]
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CWhileStatementNode >> while [
 	^ while
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 CWhileStatementNode >> while: aCGLRExpressionNode [
 	self assertExpression: aCGLRExpressionNode.
 	

--- a/smalltalksrc/CAST/package.st
+++ b/smalltalksrc/CAST/package.st
@@ -1,1 +1,1 @@
-Package { #name : #CAST }
+Package { #name : 'CAST' }

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -1359,12 +1359,11 @@ SlangBasicTranslationTest >> testInlineNodeWithSharedLabelInCase [
 }'
 ]
 
-{ #category : 'tests-inlinemethod' }
+{ #category : 'test-inline-comment' }
 SlangBasicTranslationTest >> testInlinedCommentInExpression [
 
 	| translation tMethod |
-	tMethod := self getTMethodFrom:
-		           #methodCallingMethodWithInlinePragmaExpressionList.
+	tMethod := self getTMethodFrom: #methodCallingMethodExpressionList.
 	tMethod recordDeclarationsIn: generator.
 	generator doBasicInlining: true.
 
@@ -1374,14 +1373,85 @@ SlangBasicTranslationTest >> testInlinedCommentInExpression [
 	self
 		assert: translation
 		equals:
-			'/* SlangBasicTranslationTestClass>>#methodCallingMethodWithInlinePragmaExpressionList */
+			'/* SlangBasicTranslationTestClass>>#methodCallingMethodExpressionList */
 static sqInt
-methodCallingMethodWithInlinePragmaExpressionList(void)
+methodCallingMethodExpressionList(void)
 {
 	sqInt i;
 
 	i == ((/* begin emptyMethod */ /* end emptyMethod */, bodyOfMethodWithoutInlinePragma(), /* begin methodWithoutInlinePragmaAndEmptyMethodCall */ /* begin emptyMethod */ /* end emptyMethod */, bodyOfMethodWithoutInlinePragma() /* end methodWithoutInlinePragmaAndEmptyMethodCall */, /* begin methodWithInlinePragma */ bodyOfMethodWithInlinePragma() /* end methodWithInlinePragma */));
 	return 0;
+}'
+]
+
+{ #category : 'test-inline-comment' }
+SlangBasicTranslationTest >> testInlinedCommentInSwitch [
+
+	| translation tMethod |
+	tMethod := self getTMethodFrom: #switch.
+	tMethod prepareMethodIn: generator.
+	tMethod recordDeclarationsIn: generator.
+	generator doBasicInlining: true.
+
+	translation := self translate: tMethod.
+	translation := translation trimBoth.
+
+	self
+		assert: translation
+		equals:
+			'/* SlangBasicTranslationTestClass>>#switch */
+static sqInt
+switch(void)
+{
+	switch (1) {
+		case 4:
+		{
+			/* begin methodWithoutInlinePragmaAndEmptyMethodCall */
+			/* begin emptyMethod */
+			/* end emptyMethod */
+			bodyOfMethodWithoutInlinePragma();
+			/* end methodWithoutInlinePragmaAndEmptyMethodCall */
+		}
+		break;
+		default:
+		error("Case not found and no otherwise clause");
+	}
+	return 0;
+}'
+]
+
+{ #category : 'test-inline-comment' }
+SlangBasicTranslationTest >> testInlinedCommentInSwitchAsExpression [
+
+	| translation tMethod |
+	tMethod := self getTMethodFrom: #switchInReturn.
+	tMethod prepareMethodIn: generator.
+	tMethod recordDeclarationsIn: generator.
+	generator doBasicInlining: true.
+	translation := self translate: tMethod.
+	translation := translation trimBoth.
+
+	self
+		assert: translation
+		equals: '/* SlangBasicTranslationTestClass>>#switchInReturn */
+static sqInt
+switchInReturn(void)
+{
+	sqInt switch0;
+
+	switch (1) {
+		case 4:
+		{
+			/* begin methodWithoutInlinePragmaAndEmptyMethodCall */
+			/* begin emptyMethod */
+			/* end emptyMethod */
+			return bodyOfMethodWithoutInlinePragma();
+			/* end methodWithoutInlinePragmaAndEmptyMethodCall */
+		}
+		default:
+		error("Case not found and no otherwise clause");
+		return -1;
+	}
 }'
 ]
 

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -1380,7 +1380,7 @@ methodCallingMethodWithInlinePragmaExpressionList(void)
 {
 	sqInt i;
 
-	i == ((/* begin methodWithoutInlinePragma */ bodyOfMethodWithoutInlinePragma() /* end methodWithoutInlinePragma */, /* begin methodWithInlinePragma */ bodyOfMethodWithInlinePragma() /* end methodWithInlinePragma */));
+	i == ((/* begin emptyMethod */ /* end emptyMethod */, bodyOfMethodWithoutInlinePragma(), /* begin methodWithoutInlinePragmaAndEmptyMethodCall */ /* begin emptyMethod */ /* end emptyMethod */, bodyOfMethodWithoutInlinePragma() /* end methodWithoutInlinePragmaAndEmptyMethodCall */, /* begin methodWithInlinePragma */ bodyOfMethodWithInlinePragma() /* end methodWithInlinePragma */));
 	return 0;
 }'
 ]

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -1360,68 +1360,8 @@ SlangBasicTranslationTest >> testInlineNodeWithSharedLabelInCase [
 ]
 
 { #category : 'test-inline-comment' }
-SlangBasicTranslationTest >> testInlinedCommentInExpression [
-
-	| translation tMethod |
-	tMethod := self getTMethodFrom: #methodCallingMethodExpressionList.
-	tMethod recordDeclarationsIn: generator.
-	generator doBasicInlining: true.
-
-	translation := self translate: tMethod.
-	translation := translation trimBoth.
-
-	self
-		assert: translation
-		equals:
-			'/* SlangBasicTranslationTestClass>>#methodCallingMethodExpressionList */
-static sqInt
-methodCallingMethodExpressionList(void)
-{
-	sqInt i;
-
-	i == ((/* begin emptyMethod */ /* end emptyMethod */, bodyOfMethodWithoutInlinePragma(), /* begin methodWithoutInlinePragmaAndEmptyMethodCall */ /* begin emptyMethod */ /* end emptyMethod */, bodyOfMethodWithoutInlinePragma() /* end methodWithoutInlinePragmaAndEmptyMethodCall */, /* begin methodWithInlinePragma */ bodyOfMethodWithInlinePragma() /* end methodWithInlinePragma */));
-	return 0;
-}'
-]
-
-{ #category : 'test-inline-comment' }
-SlangBasicTranslationTest >> testInlinedCommentInSwitch [
-
-	| translation tMethod |
-	tMethod := self getTMethodFrom: #switch.
-	tMethod prepareMethodIn: generator.
-	tMethod recordDeclarationsIn: generator.
-	generator doBasicInlining: true.
-
-	translation := self translate: tMethod.
-	translation := translation trimBoth.
-
-	self
-		assert: translation
-		equals:
-			'/* SlangBasicTranslationTestClass>>#switch */
-static sqInt
-switch(void)
-{
-	switch (1) {
-		case 4:
-		{
-			/* begin methodWithoutInlinePragmaAndEmptyMethodCall */
-			/* begin emptyMethod */
-			/* end emptyMethod */
-			bodyOfMethodWithoutInlinePragma();
-			/* end methodWithoutInlinePragmaAndEmptyMethodCall */
-		}
-		break;
-		default:
-		error("Case not found and no otherwise clause");
-	}
-	return 0;
-}'
-]
-
-{ #category : 'test-inline-comment' }
 SlangBasicTranslationTest >> testInlinedCommentInSwitchAsExpression [
+	"comments in Slang are related to inlining, they should only be in list of Statement (use as argument or expression but list of statement anyway) at the start or end of a list of statement. when use as an expression we need to be careful of where to put comma to respect semantics/not produce errors. here the return need to be moved to the switch at the location of the actual last statement "
 
 	| translation tMethod |
 	tMethod := self getTMethodFrom: #switchInReturn.
@@ -1452,6 +1392,32 @@ switchInReturn(void)
 		error("Case not found and no otherwise clause");
 		return -1;
 	}
+}'
+]
+
+{ #category : 'test-inline-comment' }
+SlangBasicTranslationTest >> testInlinedMethodCommentInExpression [
+	"comments in Slang are related to inlining, they should only be in list of Statement (use as argument or expression but list of statement anyway) at the start or end of a list of statement. when use as an expression we need to be careful of where to put comma to respect semantics/not produce errors "
+
+	| translation tMethod |
+	tMethod := self getTMethodFrom: #methodCallingMethodExpressionList.
+	tMethod recordDeclarationsIn: generator.
+	generator doBasicInlining: true.
+
+	translation := self translate: tMethod.
+	translation := translation trimBoth.
+
+	self
+		assert: translation
+		equals:
+			'/* SlangBasicTranslationTestClass>>#methodCallingMethodExpressionList */
+static sqInt
+methodCallingMethodExpressionList(void)
+{
+	sqInt i;
+
+	i == ((/* begin emptyMethod */ /* end emptyMethod */, bodyOfMethodWithoutInlinePragma(), /* begin methodWithoutInlinePragmaAndEmptyMethodCall */ /* begin emptyMethod */ /* end emptyMethod */, bodyOfMethodWithoutInlinePragma() /* end methodWithoutInlinePragmaAndEmptyMethodCall */, /* begin methodWithInlinePragma */ bodyOfMethodWithInlinePragma() /* end methodWithInlinePragma */));
+	return 0;
 }'
 ]
 
@@ -6403,6 +6369,105 @@ SlangBasicTranslationTest >> testSwitchStatementWithNoDefaultStatement [
 	default:
 	error("Case not found and no otherwise clause");
 }'
+]
+
+{ #category : 'test-inline-comment' }
+SlangBasicTranslationTest >> testTStatementAddAllLastWithComment [
+	"comments in Slang are related to inlining, they should only be in list of Statement (use as argument or expression but list of statement anyway). When there is a comment a the end of list it must stay at the end after addition was done"
+
+	| tStatementWithNoComment comment |
+	comment := TLabeledCommentNode new comment: #comment.
+	tStatementWithNoComment := TStatementListNode new statements: {
+			                           (TAssignmentNode new
+				                            setVariable:
+				                            (TVariableNode new setName: #i)
+				                            expression:
+				                            (TConstantNode new setValue: 5)).
+			                           (TConstantNode new setValue: 6).
+			                           comment.
+			                           comment }.
+	tStatementWithNoComment addAllLast:
+		{ (TReturnNode new expression: (TConstantNode new setValue: 9)) }.
+
+	self assert: (tStatementWithNoComment isSameAs:
+			 (TStatementListNode new statements: {
+					  (TAssignmentNode new
+						   setVariable: (TVariableNode new setName: #i)
+						   expression: (TConstantNode new setValue: 5)).
+					  (TConstantNode new setValue: 6).
+					  (TReturnNode new expression: (TConstantNode new setValue: 9)).
+					  comment.
+					  comment }))
+]
+
+{ #category : 'test-inline-comment' }
+SlangBasicTranslationTest >> testTStatementAddAllLastWithoutComment [
+	"comments in Slang are related to inlining, they should only be in list of Statement (use as argument or expression but list of statement anyway). When there is a comment a the end of list it must stay at the end after addition was done"
+
+	| tStatementWithNoComment |
+	tStatementWithNoComment := TStatementListNode new statements: {
+			                           (TAssignmentNode new
+				                            setVariable:
+				                            (TVariableNode new setName: #i)
+				                            expression:
+				                            (TConstantNode new setValue: 5)).
+			                           (TConstantNode new setValue: 6) }.
+	tStatementWithNoComment addAllLast:
+		{ (TReturnNode new expression: (TConstantNode new setValue: 9)) }.
+
+	self assert: (tStatementWithNoComment isSameAs:
+			 (TStatementListNode new statements: {
+					  (TAssignmentNode new
+						   setVariable: (TVariableNode new setName: #i)
+						   expression: (TConstantNode new setValue: 5)).
+					  (TConstantNode new setValue: 6).
+					  (TReturnNode new expression: (TConstantNode new setValue: 9)) }))
+]
+
+{ #category : 'test-inline-comment' }
+SlangBasicTranslationTest >> testTStatementAllButLastNonCommentStatementWithComment [
+	"comments in Slang are related to inlining, they should only be in list of Statement (use as argument or expression but list of statement anyway). When we want to remove the last expression we need to ignore comments at the end"
+
+	| tStatementWithNoComment comment |
+	comment := TLabeledCommentNode new comment: #comment.
+	tStatementWithNoComment := TStatementListNode new statements: {
+			                           (TAssignmentNode new
+				                            setVariable:
+				                            (TVariableNode new setName: #i)
+				                            expression:
+				                            (TConstantNode new setValue: 5)).
+			                           (TConstantNode new setValue: 6).
+			                           comment.
+			                           comment }.
+	tStatementWithNoComment statements:
+		tStatementWithNoComment allButLastNonCommentStatement.
+	self assert: (tStatementWithNoComment isSameAs:
+			 (TStatementListNode new statements: {
+					  (TAssignmentNode new
+						   setVariable: (TVariableNode new setName: #i)
+						   expression: (TConstantNode new setValue: 5)).
+					  comment.
+					  comment }))
+]
+
+{ #category : 'test-inline-comment' }
+SlangBasicTranslationTest >> testTStatementAllButLastNonCommentStatementWithoutComment [
+	"comments in Slang are related to inlining, they should only be in list of Statement (use as argument or expression but list of statement anyway). When we want to remove the last expression we need to ignore comments at the end "
+
+	| tStatementWithNoComment |
+	tStatementWithNoComment := TStatementListNode new statements: {
+			                           (TAssignmentNode new
+				                            setVariable:
+				                            (TVariableNode new setName: #i)
+				                            expression:
+				                            (TConstantNode new setValue: 5)).
+			                           (TConstantNode new setValue: 6) }.
+	tStatementWithNoComment statements:
+		tStatementWithNoComment allButLastNonCommentStatement.
+	self assert: (tStatementWithNoComment isSameAs:
+			 (TStatementListNode new statements: { (TAssignmentNode new
+					   setVariable: (TVariableNode new setName: #i)
+					   expression: (TConstantNode new setValue: 5)) }))
 ]
 
 { #category : 'tests-assignment' }

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -1359,6 +1359,32 @@ SlangBasicTranslationTest >> testInlineNodeWithSharedLabelInCase [
 }'
 ]
 
+{ #category : 'tests-inlinemethod' }
+SlangBasicTranslationTest >> testInlinedCommentInExpression [
+
+	| translation tMethod |
+	tMethod := self getTMethodFrom:
+		           #methodCallingMethodWithInlinePragmaExpressionList.
+	tMethod recordDeclarationsIn: generator.
+	generator doBasicInlining: true.
+
+	translation := self translate: tMethod.
+	translation := translation trimBoth.
+
+	self
+		assert: translation
+		equals:
+			'/* SlangBasicTranslationTestClass>>#methodCallingMethodWithInlinePragmaExpressionList */
+static sqInt
+methodCallingMethodWithInlinePragmaExpressionList(void)
+{
+	sqInt i;
+
+	i == ((/* begin methodWithoutInlinePragma */ bodyOfMethodWithoutInlinePragma() /* end methodWithoutInlinePragma */, /* begin methodWithInlinePragma */ bodyOfMethodWithInlinePragma() /* end methodWithInlinePragma */));
+	return 0;
+}'
+]
+
 { #category : 'tests-labels' }
 SlangBasicTranslationTest >> testLabel [
 

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -1360,8 +1360,8 @@ SlangBasicTranslationTest >> testInlineNodeWithSharedLabelInCase [
 ]
 
 { #category : 'test-inline-comment' }
-SlangBasicTranslationTest >> testInlinedCommentInSwitchAsExpression [
-	"comments in Slang are related to inlining, they should only be in list of Statement (use as argument or expression but list of statement anyway) at the start or end of a list of statement. when use as an expression we need to be careful of where to put comma to respect semantics/not produce errors. here the return need to be moved to the switch at the location of the actual last statement "
+SlangBasicTranslationTest >> testInlinedCommentInExpressionMoveReturn [
+	"comments in Slang are related to inlining, they should only be in list of Statement (use as argument or expression but list of statement anyway) at the start or end of a list of statement. Here the return need to be moved to the switch at the location of the actual last statement "
 
 	| translation tMethod |
 	tMethod := self getTMethodFrom: #switchInReturn.
@@ -6425,7 +6425,7 @@ SlangBasicTranslationTest >> testTStatementAddAllLastWithoutComment [
 ]
 
 { #category : 'test-inline-comment' }
-SlangBasicTranslationTest >> testTStatementAllButLastNonCommentStatementWithComment [
+SlangBasicTranslationTest >> testTStatementAllButLastNonCommentWithComment [
 	"comments in Slang are related to inlining, they should only be in list of Statement (use as argument or expression but list of statement anyway). When we want to remove the last expression we need to ignore comments at the end"
 
 	| tStatementWithNoComment comment |
@@ -6451,7 +6451,7 @@ SlangBasicTranslationTest >> testTStatementAllButLastNonCommentStatementWithComm
 ]
 
 { #category : 'test-inline-comment' }
-SlangBasicTranslationTest >> testTStatementAllButLastNonCommentStatementWithoutComment [
+SlangBasicTranslationTest >> testTStatementAllButLastNonCommentWithoutComment [
 	"comments in Slang are related to inlining, they should only be in list of Statement (use as argument or expression but list of statement anyway). When we want to remove the last expression we need to ignore comments at the end "
 
 	| tStatementWithNoComment |

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -229,16 +229,19 @@ methodCallingMethodWithInlinePragma(void)
 	methodWithoutInlinePragma();
 	/* begin methodWithInlinePragma */
 	bodyOfMethodWithInlinePragma();
-	
+	/* end methodWithInlinePragma */
+	/* begin methodWithoutInlinePragmaAndBlock: */
 	{
 		blockBody1();
 		blockBody2();
 	}
-	
+	/* end methodWithoutInlinePragmaAndBlock: */
+	/* begin methodWithInlinePragmaAndBlock: */
 	{
 		blockBody3();
 		blockBody4();
 	}
+	/* end methodWithInlinePragmaAndBlock: */
 	return 0;
 }'
 ]
@@ -265,16 +268,19 @@ methodCallingMethodWithInlinePragma(void)
 	methodWithoutInlinePragma();
 	/* begin methodWithInlinePragma */
 	bodyOfMethodWithInlinePragma();
-	
+	/* end methodWithInlinePragma */
+	/* begin methodWithoutInlinePragmaAndBlock: */
 	{
 		blockBody1();
 		blockBody2();
 	}
-	
+	/* end methodWithoutInlinePragmaAndBlock: */
+	/* begin methodWithInlinePragmaAndBlock: */
 	{
 		blockBody3();
 		blockBody4();
 	}
+	/* end methodWithInlinePragmaAndBlock: */
 	return 0;
 }'
 ]
@@ -305,11 +311,13 @@ methodCallingMethodWithInlinePragma(void)
 		blockBody1();
 		blockBody2();
 	}
-	
+	/* end methodWithoutInlinePragmaAndBlock: */
+	/* begin methodWithInlinePragmaAndBlock: */
 	{
 		blockBody3();
 		blockBody4();
 	}
+	/* end methodWithInlinePragmaAndBlock: */
 	return 0;
 }'
 ]
@@ -364,18 +372,22 @@ methodCallingMethodWithInlinePragma(void)
 {
 	/* begin methodWithoutInlinePragma */
 	bodyOfMethodWithoutInlinePragma();
-	
+	/* end methodWithoutInlinePragma */
+	/* begin methodWithInlinePragma */
 	bodyOfMethodWithInlinePragma();
-	
+	/* end methodWithInlinePragma */
+	/* begin methodWithoutInlinePragmaAndBlock: */
 	{
 		blockBody1();
 		blockBody2();
 	}
-	
+	/* end methodWithoutInlinePragmaAndBlock: */
+	/* begin methodWithInlinePragmaAndBlock: */
 	{
 		blockBody3();
 		blockBody4();
 	}
+	/* end methodWithInlinePragmaAndBlock: */
 	return 0;
 }'
 ]
@@ -1395,14 +1407,15 @@ SlangBasicTranslationTest >> testLabelWithComment [
 SlangBasicTranslationTest >> testLabelWithCommentWithPreviousCommentMarkingAnInline [
 
 	| label translation |
-	
-	"If the previous comment marked an inline, do not output anything"
+	"If the previous comment marked an inline, do not output anything""the method tested is responsible for the disparition of a lot of comment marking inlining, not sure of its purpose"
 	generator previousCommentMarksInlining: true.
-	
+
 	label := TLabeledCommentNode withComment: 'some comment'.
 	translation := self translate: label.
 
-	self assert: translation equals: ''
+	"self assert: translation equals: ''"
+
+	self assert: translation equals: '/* some comment */'
 ]
 
 { #category : 'tests-method' }

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -520,20 +520,21 @@ SlangBasicTranslationTest >> testBlockValueAsArgument [
 SlangBasicTranslationTest >> testBlockValueAsArgumentWithComment [
 
 	| translation expression |
-	expression := TStatementListNode new setArguments: #(  ) statements: { 
-		TLabeledCommentNode withComment: 'yes!'.
-		TConstantNode value: 17. }.
+	expression := TStatementListNode new
+		              setArguments: #(  )
+		              statements: {
+				              (TLabeledCommentNode withComment: 'yes!').
+				              (TConstantNode value: 17).
+				              (TLabeledCommentNode withComment: 'no!') }.
 	translation := self translate: (TAssignmentNode
-		variable: (TVariableNode named: 'v')
-		expression: (TSendNode
-			receiver: (TVariableNode named: 'v')
-			selector: #ifTrue: 
-			arguments: {expression})).
+			                variable: (TVariableNode named: 'v')
+			                expression: (TSendNode
+					                 receiver: (TVariableNode named: 'v')
+					                 selector: #ifTrue:
+					                 arguments: { expression })).
 
-	self
-		assert: translation trimBoth
-		equals: 'v = ((v)
-	 ? (/* yes! */ 17)
+	self assert: translation trimBoth equals: 'v = ((v)
+	 ? (/* yes! */ 17 /* no! */)
 	 : 0)'
 ]
 

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
@@ -45,17 +45,8 @@ SlangBasicTranslationTestClass >> initializationOptions [
 	^ nil
 ]
 
-{ #category : 'inline' }
-SlangBasicTranslationTestClass >> methodCallingMethodWithInlinePragma [
-
-	self methodWithoutInlinePragma.
-	self methodWithInlinePragma.
-	self methodWithoutInlinePragmaAndBlock: [ self blockBody1. self blockBody2 ].
-	self methodWithInlinePragmaAndBlock: [ self blockBody3. self blockBody4 ].
-]
-
-{ #category : 'inline' }
-SlangBasicTranslationTestClass >> methodCallingMethodWithInlinePragmaExpressionList [
+{ #category : 'inline-comment' }
+SlangBasicTranslationTestClass >> methodCallingMethodExpressionList [
 
 	| i |
 	i = [
@@ -63,6 +54,15 @@ SlangBasicTranslationTestClass >> methodCallingMethodWithInlinePragmaExpressionL
 	self bodyOfMethodWithoutInlinePragma.
 	self methodWithoutInlinePragmaAndEmptyMethodCall.
 	self methodWithInlinePragma ]
+]
+
+{ #category : 'inline' }
+SlangBasicTranslationTestClass >> methodCallingMethodWithInlinePragma [
+
+	self methodWithoutInlinePragma.
+	self methodWithInlinePragma.
+	self methodWithoutInlinePragmaAndBlock: [ self blockBody1. self blockBody2 ].
+	self methodWithInlinePragmaAndBlock: [ self blockBody3. self blockBody4 ].
 ]
 
 { #category : 'inline' }
@@ -83,6 +83,12 @@ SlangBasicTranslationTestClass >> methodDefiningSingleStaticVariable [
 SlangBasicTranslationTestClass >> methodDefiningSingleVariable [
 
 	| foo |
+]
+
+{ #category : 'inline-comment' }
+SlangBasicTranslationTestClass >> methodInlinineSwitch [
+
+	self switch
 ]
 
 { #category : 'inline' }
@@ -231,4 +237,18 @@ SlangBasicTranslationTestClass >> methodWithoutInlinePragmaAndEmptyMethodCall [
 SlangBasicTranslationTestClass >> methodWithoutReturn [
 
 	<returnTypeC: #sqInt>
+]
+
+{ #category : 'inline-comment' }
+SlangBasicTranslationTestClass >> switch [
+
+	true caseOf:
+		  { ([ 4 ] -> [ self methodWithoutInlinePragmaAndEmptyMethodCall ]) }
+]
+
+{ #category : 'inline-comment' }
+SlangBasicTranslationTestClass >> switchInReturn [
+
+	^ true caseOf:
+		  { ([ 4 ] -> [ self methodWithoutInlinePragmaAndEmptyMethodCall ]) }
 ]

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
@@ -24,6 +24,11 @@ SlangBasicTranslationTestClass class >> objectMemoryClass [
 ]
 
 { #category : 'inline' }
+SlangBasicTranslationTestClass >> emptyMethod [
+	self cCode: [  ] inSmalltalk: [  ]
+]
+
+{ #category : 'inline' }
 SlangBasicTranslationTestClass >> first: param1 second: param2 [
 	"Method with several parameters"
 ]

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
@@ -50,6 +50,15 @@ SlangBasicTranslationTestClass >> methodCallingMethodWithInlinePragma [
 ]
 
 { #category : 'inline' }
+SlangBasicTranslationTestClass >> methodCallingMethodWithInlinePragmaExpressionList [
+
+	| i |
+	i = [
+	self methodWithoutInlinePragma.
+	self methodWithInlinePragma ]
+]
+
+{ #category : 'inline' }
 SlangBasicTranslationTestClass >> methodDefiningSingleExternVariable [
 
 	<var: 'foo' type: #'extern int' >

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
@@ -240,13 +240,6 @@ SlangBasicTranslationTestClass >> methodWithoutReturn [
 ]
 
 { #category : 'inline-comment' }
-SlangBasicTranslationTestClass >> switch [
-
-	true caseOf:
-		  { ([ 4 ] -> [ self methodWithoutInlinePragmaAndEmptyMethodCall ]) }
-]
-
-{ #category : 'inline-comment' }
 SlangBasicTranslationTestClass >> switchInReturn [
 
 	^ true caseOf:

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
@@ -54,7 +54,9 @@ SlangBasicTranslationTestClass >> methodCallingMethodWithInlinePragmaExpressionL
 
 	| i |
 	i = [
-	self methodWithoutInlinePragma.
+	self emptyMethod.
+	self bodyOfMethodWithoutInlinePragma.
+	self methodWithoutInlinePragmaAndEmptyMethodCall.
 	self methodWithInlinePragma ]
 ]
 
@@ -212,6 +214,12 @@ SlangBasicTranslationTestClass >> methodWithoutInlinePragma [
 SlangBasicTranslationTestClass >> methodWithoutInlinePragmaAndBlock: aBlock [
 
 	aBlock value
+]
+
+{ #category : 'inline' }
+SlangBasicTranslationTestClass >> methodWithoutInlinePragmaAndEmptyMethodCall [
+	self emptyMethod.
+	self bodyOfMethodWithoutInlinePragma.
 ]
 
 { #category : 'inline' }

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -1735,13 +1735,17 @@ CCodeGenerator >> generateCASTDivide: tast [
 { #category : 'CAST translation' }
 CCodeGenerator >> generateCASTDoWhile: boolean loop: tast [
 
-	| block  cond|
-	block := TStatementListNode statements: tast receiver statements allButLast.
+	| block cond |
+	block := TStatementListNode statements:
+		         tast receiver allButLastNonCommentStatement.
 	block addDeclarations: tast receiver declarations.
 	block := block asCASTIn: self.
-	cond := (tast receiver statements last asCASTExpressionIn: self).
+	cond := tast receiver lastNonCommentStatement asCASTExpressionIn:
+		        self.
 	^ CDoStatementNode
-		  while: (boolean ifTrue: [ cond ] ifFalse: [ CUnaryOperatorNode operator: #! expression: cond ])
+		  while: (boolean
+				   ifTrue: [ cond ]
+				   ifFalse: [ CUnaryOperatorNode operator: #! expression: cond ])
 		  statement: block
 ]
 
@@ -2935,16 +2939,23 @@ CCodeGenerator >> generateCASTWhileFalse: tast [
 CCodeGenerator >> generateCASTWhileForeverBreakIf: boolean loop: tast [
 
 	| block if cond |
-	cond := (tast receiver statements last asCASTExpressionIn: self).
-	if := CIfStatementNode if: (boolean ifTrue: [ cond ] ifFalse: [ CUnaryOperatorNode operator: #! expression: cond ]) then: (CBreakStatementNode new).
-	block := TStatementListNode statements: tast receiver statements allButLast.
+	cond := tast receiver lastNonCommentStatement asCASTExpressionIn:
+		        self.
+	if := CIfStatementNode
+		      if: (boolean
+				       ifTrue: [ cond ]
+				       ifFalse: [
+				       CUnaryOperatorNode operator: #! expression: cond ])
+		      then: CBreakStatementNode new.
+	block := TStatementListNode statements:
+		         tast receiver allButLastNonCommentStatement.
 	block addDeclarations: tast receiver declarations.
-	block addDeclarations:  tast arguments first declarations.
+	block addDeclarations: tast arguments first declarations.
 	block := block asCASTIn: self.
 	block add: if.
 	block addAll: (tast arguments first asCASTIn: self).
 
-	^ CWhileStatementNode 
+	^ CWhileStatementNode
 		  while: (CConstantNode value: 1)
 		  statement: block
 ]

--- a/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
+++ b/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
@@ -260,7 +260,7 @@ CSlangPrettyPrinter >> visitExpressionList: anExpressionList [
 	anExpressionList expressions
 		do: [ :e |
 			e acceptVisitor: self.
-			lastRequiredSeparator := e isEmpty not or: [ e isLabel not ] ]
+			lastRequiredSeparator := e isEmpty not or: [ e comments isNotEmpty  ] ]
 		separatedBy: [
 			lastRequiredSeparator
 				ifFalse: [ stream nextPutAll: ' ' ]

--- a/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
+++ b/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
@@ -16,6 +16,38 @@ CSlangPrettyPrinter >> contents [
 	^ stream contents
 ]
 
+{ #category : 'testing' }
+CSlangPrettyPrinter >> expressionListNeedAComma: expressions current: e futureIndex: futureIndex commentSeries: commentSeries [
+	"handle space, comma and comment in visitExpressionList, comments only comes from inlining in an expressionList. ensure comments are not considered as element of the list and are linked to theirs respective methods. if the list contains an empty inlined method we can have a potential series of comments  that shouldn't be considered as element, hence the boolean commentSeries. Return if a comma is needed and if the comment series continue/start.
+	"
+
+	| next currentRequiredEndSeparator futureRequireBeginningSeparator continueCommentSeries currentIsEndComment nextIsBeginComment |
+	futureIndex > expressions size ifTrue: [ ^ { false. false } ].
+	next := expressions at: futureIndex.
+
+	currentIsEndComment := e isComment and: [
+		                       e comment beginsWith: #' end' ].
+	nextIsBeginComment := next isComment and: [
+		                      next comment beginsWith: #' begin' ].
+
+	(currentIsEndComment and: [
+		 nextIsBeginComment and: [ commentSeries ] ]) ifTrue: [
+		^ { false. true } ].
+
+	continueCommentSeries := e isComment and: [ next isComment ].
+	currentRequiredEndSeparator := e isEmpty not and: [
+		                               e isComment not or: [
+			                               currentIsEndComment ] ].
+	futureRequireBeginningSeparator := next isEmpty not and: [
+		                                   next isComment not or: [
+			                                   nextIsBeginComment ] ].
+
+	^ {
+		  (currentRequiredEndSeparator and: [
+			   futureRequireBeginningSeparator ]).
+		  continueCommentSeries }
+]
+
 { #category : 'initialization' }
 CSlangPrettyPrinter >> initialize [
 
@@ -255,29 +287,23 @@ CSlangPrettyPrinter >> visitEmptyStatement: anEmptyStatement [
 { #category : 'generated' }
 CSlangPrettyPrinter >> visitExpressionList: anExpressionList [
 
-	| lastRequiredSeparator futureRequireBeginningSeparator futureIndex size expressions |
+	| needCommaAndCommentSeries futureIndex expressions commentSeries |
 	stream nextPut: $(.
 	futureIndex := 1.
 	expressions := anExpressionList expressions.
-	size := expressions size.
+	commentSeries := true.
 	expressions
 		do: [ :e |
 			e acceptVisitor: self.
-			lastRequiredSeparator := e isEmpty not and: [
-				                         e isComment not or: [
-					                         e comment beginsWith: #' end' ] ].
 			futureIndex := futureIndex + 1.
-			futureRequireBeginningSeparator := futureIndex <= size and: [
-				                                   | next |
-				                                   next := expressions at:
-					                                           futureIndex.
-				                                   next isEmpty not and: [
-					                                   next isComment not or: [
-						                                   lastRequiredSeparator and: [
-							                                   next comment beginsWith:
-								                                   #' begin' ] ] ] ] ]
+			needCommaAndCommentSeries := self
+				                             expressionListNeedAComma: expressions
+				                             current: e
+				                             futureIndex: futureIndex
+				                             commentSeries: commentSeries.
+			commentSeries := needCommaAndCommentSeries second ]
 		separatedBy: [
-			(lastRequiredSeparator and: [ futureRequireBeginningSeparator ])
+			needCommaAndCommentSeries first
 				ifFalse: [ stream nextPutAll: ' ' ]
 				ifTrue: [
 					stream nextPutAll: ', '.

--- a/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
+++ b/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
@@ -263,11 +263,19 @@ CSlangPrettyPrinter >> visitExpressionList: anExpressionList [
 	expressions
 		do: [ :e |
 			e acceptVisitor: self.
-			lastRequiredSeparator := e isEmpty not.
+			lastRequiredSeparator := e isEmpty not and: [
+				                         e isComment not or: [
+					                         e comment beginsWith: #end ] ].
 			futureIndex := futureIndex + 1.
 			futureRequireBeginningSeparator := futureIndex <= size and: [
-				                                   (expressions at: futureIndex)
-					                                   isEmpty not ] ]
+				                                   | next |
+				                                   next := expressions at:
+					                                           futureIndex.
+				                                   next isEmpty not and: [
+					                                   next isComment not or: [
+						                                   lastRequiredSeparator and: [
+							                                   next comment beginsWith:
+								                                   #begin ] ] ] ] ]
 		separatedBy: [
 			(lastRequiredSeparator and: [ futureRequireBeginningSeparator ])
 				ifFalse: [ stream nextPutAll: ' ' ]

--- a/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
+++ b/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
@@ -17,6 +17,20 @@ CSlangPrettyPrinter >> contents [
 ]
 
 { #category : 'testing' }
+CSlangPrettyPrinter >> expressionListHasNonCommentStatementAfter: expressions futureIndex: futureIndex [
+	"we found a begin inlining comment in an expressionList, sometimes the last statements of an expression list are serie of comment, we iterate the next element to see if there is an actual statement after otherwise the next part is not an element of the list"
+
+	| index current |
+	index := futureIndex + 1.
+	index to: expressions size do: [ :e |
+		current := expressions at: e.
+		(current isComment not and: [ current isEmpty not ]) ifTrue: [
+			^ true ] ].
+
+	^ false
+]
+
+{ #category : 'testing' }
 CSlangPrettyPrinter >> expressionListNeedAComma: expressions current: e futureIndex: futureIndex commentSeries: commentSeries [
 	"handle space, comma and comment in visitExpressionList, comments only comes from inlining in an expressionList. ensure comments are not considered as element of the list and are linked to theirs respective methods. if the list contains an empty inlined method we can have a potential series of comments  that shouldn't be considered as element, hence the boolean commentSeries. Return if a comma is needed and if the comment series continue/start.
 	"
@@ -42,7 +56,11 @@ CSlangPrettyPrinter >> expressionListNeedAComma: expressions current: e futureIn
 			                               currentIsEndComment ] ].
 	futureRequireBeginningSeparator := next isEmpty not and: [
 		                                   next isComment not or: [
-			                                   nextIsBeginComment ] ].
+			                                   nextIsBeginComment and: [
+				                                   self
+					                                   expressionListHasNonCommentStatementAfter:
+					                                   expressions
+					                                   futureIndex: futureIndex ] ] ].
 
 	^ {
 		  (currentRequiredEndSeparator and: [

--- a/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
+++ b/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
@@ -255,14 +255,21 @@ CSlangPrettyPrinter >> visitEmptyStatement: anEmptyStatement [
 { #category : 'generated' }
 CSlangPrettyPrinter >> visitExpressionList: anExpressionList [
 
-	| lastRequiredSeparator |
+	| lastRequiredSeparator futureRequireBeginningSeparator futureIndex size expressions |
 	stream nextPut: $(.
-	anExpressionList expressions
+	futureIndex := 1.
+	expressions := anExpressionList expressions.
+	size := expressions size.
+	expressions
 		do: [ :e |
 			e acceptVisitor: self.
-			lastRequiredSeparator := e isEmpty not or: [ e comments isNotEmpty  ] ]
+			lastRequiredSeparator := e isEmpty not.
+			futureIndex := futureIndex + 1.
+			futureRequireBeginningSeparator := futureIndex <= size and: [
+				                                   (expressions at: futureIndex)
+					                                   isEmpty not ] ]
 		separatedBy: [
-			lastRequiredSeparator
+			(lastRequiredSeparator and: [ futureRequireBeginningSeparator ])
 				ifFalse: [ stream nextPutAll: ' ' ]
 				ifTrue: [
 					stream nextPutAll: ', '.

--- a/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
+++ b/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
@@ -257,15 +257,16 @@ CSlangPrettyPrinter >> visitExpressionList: anExpressionList [
 
 	| lastRequiredSeparator |
 	stream nextPut: $(.
-	anExpressionList expressions do: [ :e | 
-		e acceptVisitor: self.
-		lastRequiredSeparator := e isEmpty not ]
-	separatedBy: [ 
-		lastRequiredSeparator
-			ifFalse: [ stream nextPutAll: ' ' ]
-			ifTrue: [ 
-				stream nextPutAll: ', '.
-				anExpressionList printOnMultipleLines ifTrue: [ stream cr ] ] ].
+	anExpressionList expressions
+		do: [ :e |
+			e acceptVisitor: self.
+			lastRequiredSeparator := e isEmpty not or: [ e isLabel not ] ]
+		separatedBy: [
+			lastRequiredSeparator
+				ifFalse: [ stream nextPutAll: ' ' ]
+				ifTrue: [
+					stream nextPutAll: ', '.
+					anExpressionList printOnMultipleLines ifTrue: [ stream cr ] ] ].
 	stream nextPut: $)
 ]
 

--- a/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
+++ b/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
@@ -34,7 +34,9 @@ CSlangPrettyPrinter >> expressionListNeedAComma: expressions current: e futureIn
 		 nextIsBeginComment and: [ commentSeries ] ]) ifTrue: [
 		^ { false. true } ].
 
-	continueCommentSeries := commentSeries or: [ nextIsBeginComment ].
+	continueCommentSeries := (commentSeries and: [
+		                          e isComment and: [ next isComment ] ])
+		                         or: [ nextIsBeginComment ].
 	currentRequiredEndSeparator := e isEmpty not and: [
 		                               e isComment not or: [
 			                               currentIsEndComment ] ].

--- a/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
+++ b/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
@@ -265,7 +265,7 @@ CSlangPrettyPrinter >> visitExpressionList: anExpressionList [
 			e acceptVisitor: self.
 			lastRequiredSeparator := e isEmpty not and: [
 				                         e isComment not or: [
-					                         e comment beginsWith: #end ] ].
+					                         e comment beginsWith: #' end' ] ].
 			futureIndex := futureIndex + 1.
 			futureRequireBeginningSeparator := futureIndex <= size and: [
 				                                   | next |
@@ -275,7 +275,7 @@ CSlangPrettyPrinter >> visitExpressionList: anExpressionList [
 					                                   next isComment not or: [
 						                                   lastRequiredSeparator and: [
 							                                   next comment beginsWith:
-								                                   #begin ] ] ] ] ]
+								                                   #' begin' ] ] ] ] ]
 		separatedBy: [
 			(lastRequiredSeparator and: [ futureRequireBeginningSeparator ])
 				ifFalse: [ stream nextPutAll: ' ' ]

--- a/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
+++ b/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
@@ -34,7 +34,7 @@ CSlangPrettyPrinter >> expressionListNeedAComma: expressions current: e futureIn
 		 nextIsBeginComment and: [ commentSeries ] ]) ifTrue: [
 		^ { false. true } ].
 
-	continueCommentSeries := nextIsBeginComment.
+	continueCommentSeries := commentSeries or: [ nextIsBeginComment ].
 	currentRequiredEndSeparator := e isEmpty not and: [
 		                               e isComment not or: [
 			                               currentIsEndComment ] ].

--- a/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
+++ b/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
@@ -17,12 +17,13 @@ CSlangPrettyPrinter >> contents [
 ]
 
 { #category : 'testing' }
-CSlangPrettyPrinter >> expressionListHasNonCommentStatementAfter: expressions futureIndex: futureIndex [
-	"we found a begin inlining comment in an expressionList, sometimes the last statements of an expression list are serie of comment, we iterate the next element to see if there is an actual statement after otherwise the next part is not an element of the list"
+CSlangPrettyPrinter >> expressionListHasNonCommentStatementAfter: expressions futureIndex: startingIndex [
+	"Find a begin inlining comment in an expressionList starting at futureIndex.
+	Sometimes the last statements of an expression list are a sequence of comments.
+	We iterate the next elements to see if there is an actual statement after otherwise the next part is not an element of the list"
 
-	| index current |
-	index := futureIndex + 1.
-	index to: expressions size do: [ :e |
+	startingIndex to: expressions size do: [ :e |
+		| current |
 		current := expressions at: e.
 		(current isComment not and: [ current isEmpty not ]) ifTrue: [
 			^ true ] ].

--- a/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
+++ b/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
@@ -34,7 +34,7 @@ CSlangPrettyPrinter >> expressionListNeedAComma: expressions current: e futureIn
 		 nextIsBeginComment and: [ commentSeries ] ]) ifTrue: [
 		^ { false. true } ].
 
-	continueCommentSeries := e isComment and: [ next isComment ].
+	continueCommentSeries := nextIsBeginComment.
 	currentRequiredEndSeparator := e isEmpty not and: [
 		                               e isComment not or: [
 			                               currentIsEndComment ] ].

--- a/smalltalksrc/Slang/MLStatementListBuider.class.st
+++ b/smalltalksrc/Slang/MLStatementListBuider.class.st
@@ -75,7 +75,7 @@ MLStatementListBuider >> assignLastExpressionOf: aNode toVariable: aTVariableNod
 	[ worklist isEmpty ] whileFalse: [ | current |
 		current := worklist removeLast.
 		current isStatementList ifTrue: [ 
-				worklist add: current last
+				worklist add: current lastNonCommentStatement 
 			] ifFalse: [ | replacement parentBeforeReplacement |
 				self flag: #polymorphism.
 				parentBeforeReplacement := current parent.

--- a/smalltalksrc/Slang/TAssignmentNode.class.st
+++ b/smalltalksrc/Slang/TAssignmentNode.class.st
@@ -93,11 +93,12 @@ TAssignmentNode >> asCASTIn: aBuilder [
 
 { #category : 'C code generation' }
 TAssignmentNode >> asCASTStatementListExpansionAsExpression: aCodeGen [
-	(variable isSameAs: expression statements last) ifTrue:
-		[^ expression asCASTExpressionIn: aCodeGen].
+
+	(variable isSameAs: expression lastNonCommentStatement) ifTrue: [
+		^ expression asCASTExpressionIn: aCodeGen ].
 	^ expression copy
-		assignLastExpressionTo: variable;
-		asCASTExpressionIn: aCodeGen
+		  assignLastExpressionTo: variable;
+		  asCASTExpressionIn: aCodeGen
 ]
 
 { #category : 'C code generation' }
@@ -117,7 +118,7 @@ TAssignmentNode >> asCASTValueExpansionIn: aCodeGen [
 	self assert: (expression isSend and: [ expression isValueExpansion ]).
 
 	stmtList := expression receiver.
-	lastStmt := stmtList statements last.
+	lastStmt := stmtList lastNonCommentStatement.
 
 	"Optimization. If the expression looks like:
 	
@@ -125,11 +126,10 @@ TAssignmentNode >> asCASTValueExpansionIn: aCodeGen [
 	
 	Emit directly the block without the last statement, as the assignment has no impact in the translation.
 	"
-	stmtList statements last = variable ifTrue: [ 
-		^ expression asCASTIn: aCodeGen ].
+	lastStmt = variable ifTrue: [ ^ expression asCASTIn: aCodeGen ].
 	copy := stmtList copy.
 	copy statements
-		at: stmtList statements size
+		at: (stmtList statements indexOf: lastStmt)
 		put:
 		(TAssignmentNode new setVariable: variable expression: lastStmt).
 	^ (TSendNode new

--- a/smalltalksrc/Slang/TLabeledCommentNode.class.st
+++ b/smalltalksrc/Slang/TLabeledCommentNode.class.st
@@ -52,9 +52,11 @@ TLabeledCommentNode >> asCASTIn: aBuilder [
 
 	comment ifNotNil: [
 		| commentNode |
-		commentNode := CEmptyStatementNode new.
-		commentNode comments: { self comment }.
-		commentNode needsSeparator: false.
+		commentNode := CCommentNode new.
+		commentNode comment: (String streamContents: [ :s |
+				 s space.
+				 s nextPutAll: self comment.
+				 s space ]).
 		result add: commentNode.
 		aBuilder previousCommenter: self ].
 

--- a/smalltalksrc/Slang/TLabeledCommentNode.class.st
+++ b/smalltalksrc/Slang/TLabeledCommentNode.class.st
@@ -42,27 +42,27 @@ TLabeledCommentNode >> asCASTIn: aBuilder [
 	result := CCompoundStatementNode new.
 	result needsBrackets: false.
 
-	label ifNotNil: [ 	| labelledNode |
-		labelledNode := CLabeledStatementNode new.		
+	label ifNotNil: [
+		| labelledNode |
+		labelledNode := CLabeledStatementNode new.
 		labelledNode label: (CIdentifierNode name: label).
 		labelledNode statement: CEmptyStatementNode new.
-		result add: labelledNode ].	
+		result add: labelledNode ].
 
 
-	comment ifNotNil: [ | commentNode |
-		(aBuilder previousCommentMarksInlining: (label isNil and: [asmLabel isNil and: [comment beginsWith: 'begin ']]))
-			ifTrue: [ ^ result ].
+	comment ifNotNil: [
+		| commentNode |
 		commentNode := CEmptyStatementNode new.
 		commentNode comments: { self comment }.
 		commentNode needsSeparator: false.
 		result add: commentNode.
-		aBuilder previousCommenter: self].
+		aBuilder previousCommenter: self ].
 
-	(asmLabel notNil "only output labels in the interpret function."
-	 and: [aBuilder currentMethod selector == #interpret]) ifTrue: [ | asmLabelNode |
+	(asmLabel notNil and: [
+		 aBuilder currentMethod selector == #interpret ]) ifTrue: [
+		| asmLabelNode |
 		asmLabelNode := aBuilder asmLabelNodeFor: asmLabel.
-		result add: asmLabelNode
-	].	
+		result add: asmLabelNode ]. "only output labels in the interpret function."
 
 	^ result
 ]

--- a/smalltalksrc/Slang/TMethod.class.st
+++ b/smalltalksrc/Slang/TMethod.class.st
@@ -1713,8 +1713,7 @@ TMethod >> inlineSend: aSendNode directReturn: directReturn exitVar: exitVar in:
 				(TLabeledCommentNode new setLabel: exitLabel comment: 'end ' , sel) ]
 		ifNil: [
 		inlineStmts add: (TLabeledCommentNode new setComment: 'end ' , sel) ].
-	"self haltIf: [ sel = #primitiveFailFor: ]."
-	inlineStmts size = 2 ifTrue: [ "Nuke empty methods; e.g. override of flushAtCache"
+	(inlineStmts size = 2 or: [ sel = #simulationOnly: ]) ifTrue: [ "Nuke empty methods; e.g. override of flushAtCache"
 		self assert: inlineStmts first isComment.
 		self assert: inlineStmts second isComment.
 		inlineStmts removeFirst.

--- a/smalltalksrc/Slang/TMethod.class.st
+++ b/smalltalksrc/Slang/TMethod.class.st
@@ -1637,6 +1637,7 @@ TMethod >> inlineSend: aSendNode directReturn: directReturn exitVar: exitVar in:
 
 	| sel meth methArgs exitLabel inlineStmts label exitType elidedArgs |
 	sel := aSendNode selector.
+	sel = #simulationOnly: ifTrue: [ ^ OrderedCollection new ].
 	meth := aCodeGen methodNamed: sel.
 	methArgs := meth args.
 	"convenient for debugging..."
@@ -1713,7 +1714,7 @@ TMethod >> inlineSend: aSendNode directReturn: directReturn exitVar: exitVar in:
 				(TLabeledCommentNode new setLabel: exitLabel comment: 'end ' , sel) ]
 		ifNil: [
 		inlineStmts add: (TLabeledCommentNode new setComment: 'end ' , sel) ].
-	(inlineStmts size = 2 or: [ sel = #simulationOnly: ]) ifTrue: [ "Nuke empty methods; e.g. override of flushAtCache"
+	inlineStmts size = 2 ifTrue: [ "Nuke empty methods; e.g. override of flushAtCache"
 		self assert: inlineStmts first isComment.
 		self assert: inlineStmts second isComment.
 		inlineStmts removeFirst.

--- a/smalltalksrc/Slang/TMethod.class.st
+++ b/smalltalksrc/Slang/TMethod.class.st
@@ -965,6 +965,7 @@ TMethod >> exitVar: exitVar label: exitLabel [
 	"Replace each return statement in this method with an assignment to the
 	 exit variable followed by either a return or a goto to the given label.
 	 Answer if a goto was generated."
+
 	"Optimization: If exitVar is nil, the return value of the inlined method is not being used, so don't add the assignment statement."
 
 	| labelUsed map elisions eliminateReturnSelfs |
@@ -974,62 +975,70 @@ TMethod >> exitVar: exitVar label: exitLabel [
 	"Conceivably one might ^self from a struct class and mean it.  In most cases though
 	 ^self means `get me outta here, fast'.  So unless this method is from a VMStruct class,
 	 elide any ^self's"
-	eliminateReturnSelfs := ((definingClass inheritsFrom: SlangClass) and: [definingClass isStructClass]) not
-							  and: [returnType = #void or: [returnType = #sqInt]].
-	parseTree nodesDo:
-		[:node | | replacement |
-		node isReturn ifTrue:
-			[self transformReturnSubExpression: node
+	eliminateReturnSelfs := ((definingClass inheritsFrom: SlangClass)
+		                         and: [ definingClass isStructClass ]) not
+		                        and: [
+		                        returnType = #void or: [
+			                        returnType = #sqInt ] ].
+	parseTree nodesDo: [ :node |
+		| replacement |
+		node isReturn ifTrue: [
+			self
+				transformReturnSubExpression: node
 				toAssignmentOf: exitVar
 				andGoto: exitLabel
 				unless: eliminateReturnSelfs
-				into: [:rep :labelWasUsed|
+				into: [ :rep :labelWasUsed |
 					replacement := rep.
-					labelWasUsed ifTrue: [labelUsed := true]].
+					labelWasUsed ifTrue: [ labelUsed := true ] ].
 			"replaceNodesIn: is strictly top-down, so any replacement for ^expr ifTrue: [...^fu...] ifFalse: [...^bar...]
 			 will prevent replacement of either ^fu or ^bar. The corollary is that ^expr ifTrue: [foo] ifFalse: [^bar]
 			 must be transformed into expr ifTrue: [^foo] ifFalse: [^bar]"
-			(node expression isConditionalSend
-			 and: [node expression hasExplicitReturn])
-				ifTrue:
-					[elisions add: node.
-					 (node expression args reject: [:arg| arg endsWithReturn]) do:
-						[:nodeNeedingReturn|
-						 self transformReturnSubExpression: nodeNeedingReturn statements last
-							toAssignmentOf: exitVar
-							andGoto: exitLabel
-							unless: eliminateReturnSelfs
-							into: [:rep :labelWasUsed|
-								replacement := rep.
-								labelWasUsed ifTrue: [labelUsed := true]].
-						 map
-							at: nodeNeedingReturn statements last
-							put: replacement]]
-				ifFalse:
-					[map
-						at: node
-						put: (replacement ifNil:
-								[TLabeledCommentNode new setComment: 'return ', node expression printString])]]].
-	map isEmpty ifTrue:
-		[self deny: labelUsed.
-		 ^false].
+			(node expression isConditionalSend and: [
+				 node expression hasExplicitReturn ])
+				ifTrue: [
+					elisions add: node.
+					(node expression arguments reject: [ :arg | arg endsWithReturn ])
+						do: [ :nodeNeedingReturn |
+							self
+								transformReturnSubExpression:
+								nodeNeedingReturn lastNonCommentStatement
+								toAssignmentOf: exitVar
+								andGoto: exitLabel
+								unless: eliminateReturnSelfs
+								into: [ :rep :labelWasUsed |
+									replacement := rep.
+									labelWasUsed ifTrue: [ labelUsed := true ] ].
+							map
+								at: nodeNeedingReturn lastNonCommentStatement
+								put: replacement ] ]
+				ifFalse: [
+					map at: node put: (replacement ifNil: [
+							 TLabeledCommentNode new setComment:
+								 'return ' , node expression printString ]) ] ] ].
+	map isEmpty ifTrue: [
+		self deny: labelUsed.
+		^ false ].
 	"Now do a top-down replacement for all returns that should be mapped to assignments and gotos"
 	parseTree replaceNodesIn: map.
 	"Now it is safe to eliminate the returning ifs..."
-	elisions isEmpty ifFalse:
-		[| elisionMap |
-		 elisionMap := Dictionary new.
-		 elisions do: [:returnNode| elisionMap at: returnNode put: returnNode expression].
-		 parseTree replaceNodesIn: elisionMap].
+	elisions isEmpty ifFalse: [
+		| elisionMap |
+		elisionMap := Dictionary new.
+		elisions do: [ :returnNode |
+			elisionMap at: returnNode put: returnNode expression ].
+		parseTree replaceNodesIn: elisionMap ].
 	"Now flatten any new statement lists..."
-	parseTree nodesDo:
-		[:node| | list |
-		(node isStatementList
-		 and: [node statements notEmpty
-		 and: [node statements last isStatementList]]) ifTrue:
-			[list := node statements last statements.
-			 node statements removeLast; addAllLast: list]].
-	^labelUsed
+	parseTree nodesDo: [ :node |
+		| list |
+		(node isStatementList and: [
+			 node statements notEmpty and: [
+				 node lastNonCommentStatement isStatementList ] ]) ifTrue: [
+			list := node lastNonCommentStatement statements.
+			node
+				removeLast;
+				addAllLast: list ] ].
+	^ labelUsed
 ]
 
 { #category : 'accessing' }
@@ -1390,22 +1399,38 @@ TMethod >> inlineCodeOrNilForStatement: aNode returningNodes: returningNodes in:
 	"If the given statement node can be inlined, answer the statements that replace it. Otherwise, answer nil."
 
 	| stmts |
-	(aNode isReturn
-	 and: [self inlineableSend: aNode expression in: aCodeGen]) ifTrue:
-		[stmts := self inlineSend: aNode expression
-						directReturn: true exitVar: nil in: aCodeGen.
-		stmts last endsWithReturn ifFalse:
-			[stmts at: stmts size put: stmts last asReturnNode].
-		^stmts].
-	(aNode isAssignment
-	 and: [self inlineableSend: aNode expression in: aCodeGen]) ifTrue:
-		[^self inlineSend: aNode expression
-				directReturn: false exitVar: aNode variable name in: aCodeGen].
-	(aNode isSend
-	 and: [self inlineableSend: aNode in: aCodeGen]) ifTrue:
-		[^self inlineSend: aNode
-				directReturn: (returningNodes includes: aNode) exitVar: nil in: aCodeGen].
-	^nil
+	(aNode isReturn and: [
+		 self inlineableSend: aNode expression in: aCodeGen ]) ifTrue: [
+		| last indexOfLast |
+		stmts := self
+			         inlineSend: aNode expression
+			         directReturn: true
+			         exitVar: nil
+			         in: aCodeGen.
+		"the last statements may be comments"
+		last := stmts last.
+		indexOfLast := stmts size.
+		[ last isComment ] whileTrue: [
+			indexOfLast := indexOfLast - 1.
+			last := stmts at: indexOfLast ].
+		last endsWithReturn ifFalse: [
+			stmts at: indexOfLast put: last asReturnNode ].
+		^ stmts ].
+	(aNode isAssignment and: [
+		 self inlineableSend: aNode expression in: aCodeGen ]) ifTrue: [
+		^ self
+			  inlineSend: aNode expression
+			  directReturn: false
+			  exitVar: aNode variable name
+			  in: aCodeGen ].
+	(aNode isSend and: [ self inlineableSend: aNode in: aCodeGen ])
+		ifTrue: [
+			^ self
+				  inlineSend: aNode
+				  directReturn: (returningNodes includes: aNode)
+				  exitVar: nil
+				  in: aCodeGen ].
+	^ nil
 ]
 
 { #category : 'inlining' }
@@ -1601,7 +1626,6 @@ TMethod >> inlineReturningConditional: aSendNode in: aCodeGen [
 
 { #category : 'inlining' }
 TMethod >> inlineSend: aSendNode directReturn: directReturn exitVar: exitVar in: aCodeGen [
-
 	"Answer a collection of statements to replace the given send.  directReturn indicates
 	 that the send is the expression in a return statement, so returns can be left in the
 	 body of the inlined method. If exitVar is nil, the value returned by the send is not
@@ -1618,49 +1642,51 @@ TMethod >> inlineSend: aSendNode directReturn: directReturn exitVar: exitVar in:
 	"convenient for debugging..."
 	aCodeGen maybeBreakForInlineOf: aSendNode in: self.
 	elidedArgs := #(  ).
-	(methArgs notEmpty and: [ methArgs first beginsWith: 'self_in_' ]) 
+	(methArgs notEmpty and: [ methArgs first beginsWith: 'self_in_' ])
 		ifTrue: [ "If the first arg is not used we can and should elide it."
 			| varNode |
 			varNode := TVariableNode new setName: methArgs first.
-			(meth parseTree noneSatisfy: [ :node | varNode isSameAs: node ]) 
+			(meth parseTree noneSatisfy: [ :node | varNode isSameAs: node ])
 				ifTrue: [ elidedArgs := { methArgs first } ].
 			methArgs := methArgs allButFirst ].
 	methArgs size = aSendNode arguments size ifFalse: [ ^ nil ].
 	meth := meth copy.
 
-	(meth statements size > 1 and: [ 
-		 meth statements first isSend and: [ 
-			 meth statements first selector == #flag: ] ]) ifTrue: [ 
+	(meth statements size > 1 and: [
+		 meth statements first isSend and: [
+			 meth statements first selector == #flag: ] ]) ifTrue: [
 		meth statements removeFirst ].
 
 	"Propagate the return type of an inlined method"
-	(directReturn or: [ exitVar notNil ]) ifTrue: [ 
+	(directReturn or: [ exitVar notNil ]) ifTrue: [
 		exitType := directReturn
 			            ifTrue: [ returnType ]
-			            ifFalse: [ 
+			            ifFalse: [
 			            (self typeFor: exitVar in: aCodeGen) ifNil: [ #sqInt ] ].
-		(exitType = #void or: [ exitType = meth returnType ]) ifFalse: [ 
+		(exitType = #void or: [ exitType = meth returnType ]) ifFalse: [
 			meth propagateReturnIn: aCodeGen ] ].
 
 	"Propagate any unusual argument types to untyped argument variables"
-	methArgs with: aSendNode arguments do: [ :formal :actual | 
-		(meth declarationAt: formal ifAbsent: nil) ifNil: [ | type |
-			(actual isVariable and: [ (type := self typeFor: actual name in: aCodeGen) notNil ])
-			 ifTrue: [
-				type ~= #sqInt ifTrue: [ 
-					meth declarationAt: formal put: (type last = $*
-							 ifTrue: [ type , formal ]
-							 ifFalse: [ type , ' ' , formal ]) ] ] ] ].
+	methArgs with: aSendNode arguments do: [ :formal :actual |
+		(meth declarationAt: formal ifAbsent: nil) ifNil: [
+			| type |
+			(actual isVariable and: [
+				 (type := self typeFor: actual name in: aCodeGen) notNil ])
+				ifTrue: [
+					type ~= #sqInt ifTrue: [
+						meth declarationAt: formal put: (type last = $*
+								 ifTrue: [ type , formal ]
+								 ifFalse: [ type , ' ' , formal ]) ] ] ] ].
 
 	meth renameVarsForInliningInto: self except: elidedArgs in: aCodeGen.
 	meth renameLabelsForInliningInto: self.
 	self addVarsDeclarationsAndLabelsOf: meth except: elidedArgs.
-	meth hasReturn ifTrue: [ 
-		directReturn ifFalse: [ 
+	meth hasReturn ifTrue: [
+		directReturn ifFalse: [
 			exitLabel := self unusedLabelForInliningInto: self.
 			(meth exitVar: exitVar label: exitLabel)
 				ifTrue: [ labels add: exitLabel ]
-				ifFalse: [ exitLabel := nil ] "is label used?" ] ].
+				ifFalse: [ "is label used?" exitLabel := nil ] ] ].
 	(inlineStmts := OrderedCollection new:
 			                meth statements size + meth args size + 2)
 		add: (label := TLabeledCommentNode new setComment: 'begin ' , sel);
@@ -1670,24 +1696,29 @@ TMethod >> inlineSend: aSendNode directReturn: directReturn exitVar: exitVar in:
 				 except: elidedArgs
 				 in: aCodeGen);
 		addAll: meth statements. "method body"
-	directReturn ifTrue: [ 
+	directReturn ifTrue: [
 		meth endsWithReturn
-			ifTrue: [ 
+			ifTrue: [
 				exitVar ifNotNil: [ "don't remove the returns if being invoked in the context of a return"
 					inlineStmts
 						at: inlineStmts size
 						put: inlineStmts last copyWithoutReturn ] ]
-			ifFalse: [ 
+			ifFalse: [
 				inlineStmts add:
 					(TReturnNode new setExpression:
 						 (TVariableNode new setName: 'nil')) ] ].
-	exitLabel ifNotNil: [ 
-		inlineStmts add: (TLabeledCommentNode new
-				 setLabel: exitLabel
-				 comment: 'end ' , meth selector) ].
-	inlineStmts size = 1 ifTrue: [ "Nuke empty methods; e.g. override of flushAtCache"
+	exitLabel
+		ifNotNil: [
+			inlineStmts add:
+				(TLabeledCommentNode new setLabel: exitLabel comment: 'end ' , sel) ]
+		ifNil: [
+		inlineStmts add: (TLabeledCommentNode new setComment: 'end ' , sel) ].
+	"self haltIf: [ sel = #primitiveFailFor: ]."
+	inlineStmts size = 2 ifTrue: [ "Nuke empty methods; e.g. override of flushAtCache"
 		self assert: inlineStmts first isComment.
-		inlineStmts removeFirst ].
+		self assert: inlineStmts second isComment.
+		inlineStmts removeFirst.
+		inlineStmts removeLast ].
 	^ inlineStmts
 ]
 
@@ -1836,9 +1867,9 @@ TMethod >> isFunctionalIn: aCodeGen [
 			or: [(aCodeGen isAssertSelector: parseTree statements first selector)
 				and: [parseTree statements first selector ~~ #asserta:]]]]) ifFalse:
 			[^false]].
-	parseTree statements last isReturn ifFalse:
+	parseTree lastNonCommentStatement isReturn ifFalse:
 		[^false].
-	parseTree statements last expression nodesDo:
+	parseTree lastNonCommentStatement expression nodesDo:
 		[ :n | n isReturn ifTrue: [^false]].
 	^#(int #'unsigned int' #long #'unsigned long' #'long long' #'unsigned long long'
 		sqInt usqInt #'sqIntptr_t' #'usqIntptr_t' sqLong usqLong
@@ -3043,7 +3074,7 @@ TMethod >> transformReturnSubExpression: node toAssignmentOf: exitVar andGoto: e
 								ifNotNil: [TAssignmentNode new
 											setVariable: (TVariableNode new setName: exitVar)
 											expression: expr]].
-	 node == parseTree statements last
+	 node == parseTree lastNonCommentStatement 
 		ifTrue:
 			[aBinaryBlock value: replacement value: false]
 		ifFalse:

--- a/smalltalksrc/Slang/TMethod.class.st
+++ b/smalltalksrc/Slang/TMethod.class.st
@@ -1637,7 +1637,6 @@ TMethod >> inlineSend: aSendNode directReturn: directReturn exitVar: exitVar in:
 
 	| sel meth methArgs exitLabel inlineStmts label exitType elidedArgs |
 	sel := aSendNode selector.
-	sel = #simulationOnly: ifTrue: [ ^ OrderedCollection new ].
 	meth := aCodeGen methodNamed: sel.
 	methArgs := meth args.
 	"convenient for debugging..."

--- a/smalltalksrc/Slang/TMethod.class.st
+++ b/smalltalksrc/Slang/TMethod.class.st
@@ -1035,9 +1035,7 @@ TMethod >> exitVar: exitVar label: exitLabel [
 			 node statements notEmpty and: [
 				 node lastNonCommentStatement isStatementList ] ]) ifTrue: [
 			list := node lastNonCommentStatement statements.
-			node
-				removeLast;
-				addAllLast: list ] ].
+			node replaceChild: node lastNonCommentStatement withList: list ] ].
 	^ labelUsed
 ]
 

--- a/smalltalksrc/Slang/TSendNode.class.st
+++ b/smalltalksrc/Slang/TSendNode.class.st
@@ -276,16 +276,18 @@ TSendNode >> children [
 TSendNode >> constantNumbericValueIfAtAllPossibleOrNilIn: aCCodeGen [
 	"This is a version of constantNumbericValueOrNil for type checking rather than code generation.
 	 It aims to yield a value if at all possible."
-	(#(* // + - << >> bitAnd: bitOr: bitShift:) includes: selector) ifTrue:
-		[(receiver constantNumbericValueIfAtAllPossibleOrNilIn: aCCodeGen) ifNotNil:
-			[:rval|
-			(arguments first constantNumbericValueIfAtAllPossibleOrNilIn: aCCodeGen) ifNotNil:
-				[:aval|
-				^rval perform: selector with: aval]]].
-	^(aCCodeGen anyMethodNamed: selector) ifNotNil:
-		[:m|
-		 m isReturnConstant ifTrue:
-			[m statements last expression constantNumbericValueIfAtAllPossibleOrNilIn: aCCodeGen]]
+
+	(#( #* #'//' #+ #- #'<<' #'>>' bitAnd: bitOr: bitShift: ) includes:
+		 selector) ifTrue: [
+		(receiver constantNumbericValueIfAtAllPossibleOrNilIn: aCCodeGen)
+			ifNotNil: [ :rval |
+				(arguments first constantNumbericValueIfAtAllPossibleOrNilIn:
+					 aCCodeGen) ifNotNil: [ :aval |
+					^ rval perform: selector with: aval ] ] ].
+	^ (aCCodeGen anyMethodNamed: selector) ifNotNil: [ :m |
+		  m isReturnConstant ifTrue: [
+			  m statements last expression
+				  constantNumbericValueIfAtAllPossibleOrNilIn: aCCodeGen ] ]
 ]
 
 { #category : 'accessing' }

--- a/smalltalksrc/Slang/TStatementListNode.class.st
+++ b/smalltalksrc/Slang/TStatementListNode.class.st
@@ -85,40 +85,39 @@ TStatementListNode >> addDeclarations: aCollection [
 
 { #category : 'utilities' }
 TStatementListNode >> addReadBeforeAssignedIn: variables to: readBeforeAssigned assignments: assigned in: aCodeGen [
-
 	"Add any variables in variables that are read before written to readBeforeAssigned.
 	 Add unconditional assignments to assigned.  For convenience answer assigned."
 
 	self
-		nodesWithParentsDo: [ :node :parent | 
-			(node isAssignment and: [ variables includes: node variable name ]) 
+		nodesWithParentsDo: [ :node :parent |
+			(node isAssignment and: [ variables includes: node variable name ])
 				ifTrue: [ assigned add: node variable name ].
-			(node isVariable and: [ 
-				 (variables includes: node name) and: [ 
-					 (assigned includes: node name) not and: [ 
-						 (#( nil pointer ) includes: (node structTargetKindIn: aCodeGen)) 
-							 and: [ 
-								 (parent notNil and: [ 
-									  parent isAssignment and: [ parent variable == node ] ]) not ] ] ] ]) 
-				ifTrue: [ 
+			(node isVariable and: [
+				 (variables includes: node name) and: [
+					 (assigned includes: node name) not and: [
+						 (#( nil pointer ) includes: (node structTargetKindIn: aCodeGen))
+							 and: [
+								 (parent notNil and: [
+									  parent isAssignment and: [ parent variable == node ] ]) not ] ] ] ])
+				ifTrue: [
 					node name = 'theCalloutState' ifTrue: [ self halt ].
 					readBeforeAssigned add: node name ] ]
-		unless: [ :node :parent | 
+		unless: [ :node :parent |
 			| conditionalAssignments mayHaveSideEffects |
 			node isSend
 				ifTrue: [ "First deal with implicit assignments..."
-					node isValueExpansion ifTrue: [ 
+					node isValueExpansion ifTrue: [
 						assigned addAll: node receiver arguments ].
-					(#( #memcpy:_:_: #memmove:_:_: ) includes: node selector) 
-						ifTrue: [ 
+					(#( #memcpy:_:_: #memmove:_:_: ) includes: node selector)
+						ifTrue: [
 							assigned add:
 								(node arguments first detect: [ :subnode | subnode isVariable ])
 									name ].
-					(#( #to:do: #to:by:do: ) includes: node selector) ifTrue: [ 
+					(#( #to:do: #to:by:do: ) includes: node selector) ifTrue: [
 						assigned addAll:
 							(node arguments at: node selector numArgs) arguments.
 						mayHaveSideEffects := node arguments size = 4. "See TMethod>>prepareMethodIn:"
-						mayHaveSideEffects ifTrue: [ 
+						mayHaveSideEffects ifTrue: [
 							assigned add: node arguments last name ] ].
 					"Then deal with read-before-written in the arms of conditionals..."
 					(#( ifTrue: ifFalse: ifNil: ifNotNil: ) intersection:
@@ -133,8 +132,8 @@ TStatementListNode >> addReadBeforeAssignedIn: variables to: readBeforeAssigned 
 								in: aCodeGen.
 							"Now find read-before-written in each arm, and collect the assignments to spot those assigned in both arms"
 							conditionalAssignments := node arguments
-								                          collect: [ :block | 
-									                          block isStatementList ifTrue: [ 
+								                          collect: [ :block |
+									                          block isStatementList ifTrue: [
 										                          block
 											                          addReadBeforeAssignedIn:
 											                          variables
@@ -143,8 +142,8 @@ TStatementListNode >> addReadBeforeAssignedIn: variables to: readBeforeAssigned 
 											                          in: aCodeGen ] ]
 								                          thenSelect: [ :each | each notNil ].
 							"add to assigned those variables written to in both arms"
-							conditionalAssignments size = 2 ifTrue: [ 
-								conditionalAssignments := conditionalAssignments collect: [ 
+							conditionalAssignments size = 2 ifTrue: [
+								conditionalAssignments := conditionalAssignments collect: [
 									                          :set | set difference: assigned ].
 								assigned addAll: (conditionalAssignments first intersection:
 										 conditionalAssignments last) ].
@@ -190,12 +189,21 @@ TStatementListNode >> arguments [
 TStatementListNode >> asCASTExpressionIn: aBuilder [
 
 	| expressionList |
+	"self haltIf: [
+		self tMethod isNotNil and: [
+			self tMethod selector = #genMoveConstant:R: ] ]."
 	expressionList := CExpressionListNode new.
-	statements size == 1 ifTrue: [ 
+	statements size == 1 ifTrue: [
 		^ statements first asCASTExpressionIn: aBuilder ].
-	statements withIndexDo: [ :node :idx | 
-		(node isLeaf and: [ node isLabel not and: [ idx < statements size ] ]) 
-			ifFalse: [ expressionList , (node asCASTExpressionIn: aBuilder) ] ].
+	statements withIndexDo: [ :node :idx |
+		(node isLeaf and: [
+			 node isLabel not and: [ "idx < statements size"
+				 node ~~ self lastNonCommentStatement
+			"		 ifTrue: [
+						 self halt.
+						 true ]
+					 ifFalse: [ false ]" ] ]) ifFalse: [
+			expressionList , (node asCASTExpressionIn: aBuilder) ] ].
 	^ expressionList
 ]
 

--- a/smalltalksrc/Slang/TStatementListNode.class.st
+++ b/smalltalksrc/Slang/TStatementListNode.class.st
@@ -611,8 +611,7 @@ TStatementListNode >> replaceChild: aNode withList: aListOfStatement [
 	statements do: [ :e |
 		aNodeMet
 			ifFalse: [
-				allWithoutANode add: e.
-				aNodeMet := e == aNode ]
+			aNodeMet := e == aNode ifFalse: [ allWithoutANode add: e ] ]
 			ifTrue: [ endWithoutANode add: e ] ].
 	statements := allWithoutANode , aListOfStatement , endWithoutANode
 ]

--- a/smalltalksrc/Slang/TStatementListNode.class.st
+++ b/smalltalksrc/Slang/TStatementListNode.class.st
@@ -189,21 +189,13 @@ TStatementListNode >> arguments [
 TStatementListNode >> asCASTExpressionIn: aBuilder [
 
 	| expressionList |
-	"self haltIf: [
-		self tMethod isNotNil and: [
-			self tMethod selector = #genMoveConstant:R: ] ]."
 	expressionList := CExpressionListNode new.
 	statements size == 1 ifTrue: [
 		^ statements first asCASTExpressionIn: aBuilder ].
 	statements withIndexDo: [ :node :idx |
 		(node isLeaf and: [
-			 node isLabel not and: [ "idx < statements size"
-				 node ~~ self lastNonCommentStatement
-			"		 ifTrue: [
-						 self halt.
-						 true ]
-					 ifFalse: [ false ]" ] ]) ifFalse: [
-			expressionList , (node asCASTExpressionIn: aBuilder) ] ].
+			 node isLabel not and: [ node ~~ self lastNonCommentStatement ] ])
+			ifFalse: [ expressionList , (node asCASTExpressionIn: aBuilder) ] ].
 	^ expressionList
 ]
 

--- a/smalltalksrc/Slang/TStatementListNode.class.st
+++ b/smalltalksrc/Slang/TStatementListNode.class.st
@@ -72,8 +72,18 @@ TStatementListNode >> addAllLast: aListOfStatement [
 	(statements isNotEmpty and: [ statements last isComment ])
 		ifFalse: [ statements addAllLast: aListOfStatement ]
 		ifTrue: [
-			statements := self allButLastNonCommentStatement , aListOfStatement
-			              , { statements last } ]
+			| actualLast actualLastMet allWithoutEndComment endComment |
+			actualLast := self lastNonCommentStatement.
+			allWithoutEndComment := OrderedCollection new.
+			endComment := OrderedCollection new.
+			actualLastMet := false.
+			statements do: [ :e |
+				actualLastMet
+					ifFalse: [
+						allWithoutEndComment add: e.
+						actualLastMet := e == actualLast ]
+					ifTrue: [ endComment add: e ] ].
+			statements := allWithoutEndComment , aListOfStatement , endComment ]
 ]
 
 { #category : 'declarations' }

--- a/smalltalksrc/Slang/TStatementListNode.class.st
+++ b/smalltalksrc/Slang/TStatementListNode.class.st
@@ -602,6 +602,22 @@ TStatementListNode >> replaceChild: aNode with: bNode [
 ]
 
 { #category : 'transformations' }
+TStatementListNode >> replaceChild: aNode withList: aListOfStatement [
+
+	| aNodeMet allWithoutANode endWithoutANode |
+	allWithoutANode := OrderedCollection new.
+	endWithoutANode := OrderedCollection new.
+	aNodeMet := false.
+	statements do: [ :e |
+		aNodeMet
+			ifFalse: [
+				allWithoutANode add: e.
+				aNodeMet := e == aNode ]
+			ifTrue: [ endWithoutANode add: e ] ].
+	statements := allWithoutANode , aListOfStatement , endWithoutANode
+]
+
+{ #category : 'transformations' }
 TStatementListNode >> replaceNodesIn: aDictionary [
 
 	^aDictionary at: self ifAbsent: [

--- a/smalltalksrc/Slang/TStatementListNode.class.st
+++ b/smalltalksrc/Slang/TStatementListNode.class.st
@@ -66,6 +66,16 @@ TStatementListNode >> accept: aVisitor [
 	^ aVisitor visitStatementListNode: self
 ]
 
+{ #category : 'adding' }
+TStatementListNode >> addAllLast: aListOfStatement [
+
+	(statements isNotEmpty and: [ statements last isComment ])
+		ifFalse: [ statements addAllLast: aListOfStatement ]
+		ifTrue: [
+			statements := self allButLastNonCommentStatement , aListOfStatement
+			              , { statements last } ]
+]
+
 { #category : 'declarations' }
 TStatementListNode >> addDeclarations: aCollection [ 
 	
@@ -142,6 +152,16 @@ TStatementListNode >> addReadBeforeAssignedIn: variables to: readBeforeAssigned 
 						ifFalse: [ false ] ]
 				ifFalse: [ false ] ].
 	^ assigned
+]
+
+{ #category : 'accessing' }
+TStatementListNode >> allButLastNonCommentStatement [
+	"the last statement can be a comment if the TStatementList has been through inlining, return the statements without the actual last statement"
+
+	| actualLast |
+	statements last isComment ifFalse: [ ^ statements allButLast ].
+	actualLast := self lastNonCommentStatement.
+	^ statements select: [ :node | node ~~ actualLast ]
 ]
 
 { #category : 'enumerating' }
@@ -237,12 +257,23 @@ TStatementListNode >> asCASTIn: aBuilder prependToEnd: aNodeOrNil [
 
 { #category : 'transformations' }
 TStatementListNode >> asReturnNode [
-	self endsWithReturn ifTrue:
-		[^self].
-	^self class new
-		setArguments: arguments
-			statements: statements allButLast, {statements last asReturnNode};
-		yourself
+	"return a new STatementListNode with the last non-comment statement changed to a return"
+
+	| newStmtsListNode |
+	self endsWithReturn ifTrue: [ ^ self ].
+	newStmtsListNode := self class new setArguments: arguments.
+	statements last isComment
+		ifFalse: [
+			newStmtsListNode statements:
+				statements allButLast , { statements last asReturnNode } ]
+		ifTrue: [
+			| actualLast |
+			newStmtsListNode statements: statements copy.
+			actualLast := newStmtsListNode lastNonCommentStatement.
+			newStmtsListNode
+				replaceChild: actualLast
+				with: actualLast asReturnNode ].
+	^ newStmtsListNode
 ]
 
 { #category : 'transformations' }
@@ -306,13 +337,23 @@ TStatementListNode >> children [
 
 { #category : 'transformations' }
 TStatementListNode >> copyWithoutReturn [
+
+	| newStmtsListNode |
 	self assert: self endsWithReturn.
-	statements size = 1 ifTrue:
-		[^statements last expression].
-	^self class new
-		setArguments: arguments
-			statements: statements allButLast, {statements last copyWithoutReturn};
-		yourself
+	statements size = 1 ifTrue: [ ^ statements last expression ].
+	newStmtsListNode := self class new setArguments: arguments.
+	statements last isComment
+		ifFalse: [
+			newStmtsListNode statements:
+				statements allButLast , { statements last copyWithoutReturn } ]
+		ifTrue: [
+			| actualLast |
+			newStmtsListNode statements: statements copy.
+			actualLast := newStmtsListNode lastNonCommentStatement.
+			newStmtsListNode
+				replaceChild: actualLast
+				with: actualLast copyWithoutReturn ].
+	^ newStmtsListNode
 ]
 
 { #category : 'declarations' }
@@ -344,8 +385,9 @@ TStatementListNode >> displayString [
 TStatementListNode >> endsWithReturn [
 	"Answer true if the last statement of this lock is a return."
 
-	^statements notEmpty
-	  and: [statements last isReturn or: [statements last isReturningIf]]
+	^ statements notEmpty and: [
+		  self lastNonCommentStatement isReturn or: [
+			  self lastNonCommentStatement isReturningIf ] ]
 ]
 
 { #category : 'accessing' }
@@ -402,6 +444,21 @@ TStatementListNode >> isStatementList [
 TStatementListNode >> last [
 	
 	^ self statements last
+]
+
+{ #category : 'accessing' }
+TStatementListNode >> lastNonCommentStatement [
+	"the last statement can be a comment if the TStatementList has been through inlining, return the actual last statement"
+
+	| last indexOfLast |
+	last := statements last.
+	indexOfLast := statements size.
+	[ last isComment ] whileTrue: [
+		indexOfLast := indexOfLast - 1.
+		indexOfLast = 0 ifTrue: [ ^ nil ].
+		last := statements at: indexOfLast ].
+
+	^ last
 ]
 
 { #category : 'accessing' }
@@ -499,6 +556,13 @@ TStatementListNode >> removeAssertions [
 	self setStatements: newStatements asArray
 ]
 
+{ #category : 'transformations' }
+TStatementListNode >> removeLast [
+	"the last statement can be a comment if the TStatementList has been through inlining, remove the actual last statement"
+
+	statements := self allButLastNonCommentStatement
+]
+
 { #category : 'inlining support' }
 TStatementListNode >> renameLabelsForInliningInto: aTMethod [
 	"TMethod already has a method for this; hijack it..."
@@ -535,12 +599,12 @@ TStatementListNode >> returnsExpression [
 
 	statements isEmpty ifTrue:
 		[^false].
-	statements last isReturn ifFalse:
+	self lastNonCommentStatement isReturn ifFalse:
 		[^false].
-	statements last isVariable ifFalse:
+	self lastNonCommentStatement isVariable ifFalse:
 		[^true].
-	^statements last variable ~= 'self'
-	  and: [statements last variable ~= 'nil']
+	^self lastNonCommentStatement variable ~= 'self'
+	  and: [self lastNonCommentStatement variable ~= 'nil']
 ]
 
 { #category : 'accessing' }

--- a/smalltalksrc/Slang/TStatementListNode.class.st
+++ b/smalltalksrc/Slang/TStatementListNode.class.st
@@ -611,7 +611,8 @@ TStatementListNode >> replaceChild: aNode withList: aListOfStatement [
 	statements do: [ :e |
 		aNodeMet
 			ifFalse: [
-			aNodeMet := e == aNode ifFalse: [ allWithoutANode add: e ] ]
+				aNodeMet := e == aNode.
+				aNodeMet ifFalse: [ allWithoutANode add: e ] ]
 			ifTrue: [ endWithoutANode add: e ] ].
 	statements := allWithoutANode , aListOfStatement , endWithoutANode
 ]

--- a/smalltalksrc/Slang/TStatementListNode.class.st
+++ b/smalltalksrc/Slang/TStatementListNode.class.st
@@ -221,36 +221,40 @@ TStatementListNode >> asCASTIn: aBuilder [
 		while: [ self asCASTIn: aBuilder prependToEnd: nil ]
 ]
 
-{ #category : 'tranforming' }
+{ #category : 'C code generation' }
 TStatementListNode >> asCASTIn: aBuilder prependToEnd: aNodeOrNil [
 
-	| cDeclarations collect methodIsVolatile |
+	| cDeclarations collect methodIsVolatile actualLast |
 	cDeclarations := OrderedCollection new.
 	collect := OrderedCollection new.
+	statements isNotEmpty ifTrue: [
+		actualLast := self lastNonCommentStatement ].
 
-	statements doWithIndex: [ :e :index | 
-		(e isLeaf and: [ 
-			 e isLabel not and: [ 
+	statements doWithIndex: [ :e :index |
+		(e isLeaf and: [
+			 e isLabel not and: [
 				 aNodeOrNil isNil or: [ index < statements size ] ] ])
-			ifFalse: [ 
-				(aNodeOrNil notNil and: [ index = statements size ])
-					ifTrue: [ 
+			ifFalse: [
+				(aNodeOrNil notNil and: [ e == actualLast ])
+					ifTrue: [
 					collect add: (e asCASTIn: aBuilder prependToEnd: aNodeOrNil) ]
 					ifFalse: [ collect add: (e asCASTIn: aBuilder) ] ]
 			ifTrue: [ CEmptyStatementNode new ] ].
-	
+
 	"We should collect the variable declarations after generating the body, because the body generation will record used yet non declared variables"
 	methodIsVolatile := aBuilder currentMethod isVolatile.
-	(self parent notNil and: [self parent isTMethod and: [ self parent refersToGlobalStruct ]]) ifTrue: [ 
-		cDeclarations add:
-			(CIdentifierNode name: (methodIsVolatile
-					  ifTrue: [ 'DECL_MAYBE_VOLATILE_SQ_GLOBAL_STRUCT' ]
-					  ifFalse: [ 'DECL_MAYBE_SQ_GLOBAL_STRUCT' ])) ].
+	(self parent notNil and: [
+		 self parent isTMethod and: [ self parent refersToGlobalStruct ] ])
+		ifTrue: [
+			cDeclarations add: (CIdentifierNode name: (methodIsVolatile
+						  ifTrue: [ 'DECL_MAYBE_VOLATILE_SQ_GLOBAL_STRUCT' ]
+						  ifFalse: [ 'DECL_MAYBE_SQ_GLOBAL_STRUCT' ])) ].
 
-	(aBuilder sortStrings: self locals asSet) do: [ :var | | declaration |
+	(aBuilder sortStrings: self locals asSet) do: [ :var |
+		| declaration |
 		declaration := aBuilder
-		  declarationAt: var
-		  ifAbsent: [ aBuilder defaultType, ' ' , var ].
+			               declarationAt: var
+			               ifAbsent: [ aBuilder defaultType , ' ' , var ].
 
 		self flag: #TODO.
 		"Avoid implicit variables.
@@ -258,11 +262,13 @@ TStatementListNode >> asCASTIn: aBuilder prependToEnd: aNodeOrNil [
 		  - tracking used variables during code generation
 		  - generating variables after code"
 		(declaration beginsWith: 'implicit') ifFalse: [
-			methodIsVolatile ifTrue: [ declaration := 'volatile ' , declaration ].
-			cDeclarations add: (CRawCodeNode code: declaration)]
-	].		
+			methodIsVolatile ifTrue: [
+				declaration := 'volatile ' , declaration ].
+			cDeclarations add: (CRawCodeNode code: declaration) ] ].
 
-	^ CCompoundStatementNode declarations: cDeclarations statements: collect
+	^ CCompoundStatementNode
+		  declarations: cDeclarations
+		  statements: collect
 ]
 
 { #category : 'transformations' }


### PR DESCRIPTION
add more comment support to Slang : ensure there is a begin and end comment to every method inlined and restore lost comment. Include small changes in a lot of method executed after inlinining to make it work because of end comment.

change tests related to inlining to include comments in their result.