### PR TITLE
fix warnings related to multiple include of the same header file

### DIFF
--- a/smalltalksrc/VMMaker/ComposedImageReader.class.st
+++ b/smalltalksrc/VMMaker/ComposedImageReader.class.st
@@ -8,6 +8,10 @@ Class {
 	#tag : 'ImageFormat'
 }
 
+{ #category : 'translation' }
+ComposedImageReader class >> declareCVarsIn: aCCodeGenerator [
+]
+
 { #category : 'reading' }
 ComposedImageReader >> endOfSTON: file [
 	

--- a/smalltalksrc/VMMaker/ComposedImageWriter.class.st
+++ b/smalltalksrc/VMMaker/ComposedImageWriter.class.st
@@ -8,6 +8,10 @@ Class {
 	#tag : 'ImageFormat'
 }
 
+{ #category : 'translation' }
+ComposedImageWriter class >> declareCVarsIn: aCCodeGenerator [
+]
+
 { #category : 'writing' }
 ComposedImageWriter >> ensureDeleteSegments: imageFileName [ 
 	


### PR DESCRIPTION
small change to fix the 'warning, attempt to include <sys/stat.h> /* for e.g. mkdir */ a second time' happening in Slang during C code generation.

the class AbstractImageAccess include sys/stat.h and the subclasses don't override declareCVarsIn: so we get the warning for each of them each time a CCodeGenerator is created.