### PR TITLE
small change to fix locals having the same name as methods causing conflicts during inlining

### DIFF
--- a/smalltalksrc/VMMaker/CoInterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/CoInterpreterPrimitives.class.st
@@ -51,89 +51,110 @@ CoInterpreterPrimitives >> mcprimHashMultiply: receiverArg [
 ]
 
 { #category : 'object access primitives' }
-CoInterpreterPrimitives >> pathTo: goal using: stack followWeak: followWeak [
-	"Trace objects and frames from the root, marking visited objects, pushing the current path on stack, until goal is found.
-	 If found, unmark, leaving path in stack, and answer 0.  Otherwise answer an error:
-		PrimErrBadArgument if stack is not an Array
-		PrimErrBadIndex if search overflows stack
+CoInterpreterPrimitives >> pathTo: goal using: _stack followWeak: followWeak [
+	"Trace objects and frames from the root, marking visited objects, pushing the current path on _stack, until goal is found.
+	 If found, unmark, leaving path in _stack, and answer 0.  Otherwise answer an error:
+		PrimErrBadArgument if _stack is not an Array
+		PrimErrBadIndex if search overflows _stack
 		PrimErrNotFound if goal cannot be found"
+
+	<var: #index type: #sqInt>
 	| current index next stackSize stackp freeStartAtStart |
-	<var: #index type: #sqInt> "Force the sign because typeInference does not seem to work"
-	(objectMemory isArray: stack) ifFalse:
-		[^PrimErrBadArgument].
+	(objectMemory isArray: _stack) ifFalse: [ ^ PrimErrBadArgument ]. "Force the sign because typeInference does not seem to work"
 	self assert: objectMemory allObjectsUnmarked.
 	freeStartAtStart := objectMemory freeStart. "check no allocations during search"
-	objectMemory beRootIfOld: stack. "so no store checks are necessary on stack"
-	stackSize := objectMemory lengthOf: stack.
-	objectMemory mark: stack.
+	objectMemory beRootIfOld: _stack. "so no store checks are necessary on _stack"
+	stackSize := objectMemory lengthOf: _stack.
+	objectMemory mark: _stack.
 	"no need. the current context is not reachable from the active process (suspendedContext is nil)"
 	"objectMemory mark: self activeProcess."
 	current := objectMemory specialObjectsOop.
 	objectMemory mark: current.
 	index := objectMemory lengthOf: current.
 	stackp := 0.
-	[[(index := index - 1) >= -1] whileTrue:
-		[(stackPages couldBeFramePointer: current)
-			ifTrue:
-				[next := index >= 0
-							ifTrue: [self field: index ofFrame: (self cCoerceSimple: current to: #'char *')]
-							ifFalse: [objectMemory nilObject]]
-			ifFalse:
-				[index >= 0
-					ifTrue:
-						[next := (objectMemory isContextNonImm: current)
-									ifTrue: [self fieldOrSenderFP: index ofContext: current]
-									ifFalse: [objectMemory fetchPointer: index ofObject: current]]
-					ifFalse:
-						[next := objectMemory fetchClassOfNonImm: current]].
-		 (stackPages couldBeFramePointer: next)
-			ifTrue: [self assert: (self isFrame: (self cCoerceSimple: next to: #'char *')
-										onPage: (stackPages stackPageFor: (self cCoerceSimple: next to: #'char *')))]
-			ifFalse:
-				[next >= objectMemory getMemoryMap startOfObjectMemory ifTrue: "exclude Cog methods"
-					[self assert: (self checkOkayOop: next)]].
-		 next = goal ifTrue:
-			[self assert: freeStartAtStart = objectMemory freeStart.
-			 self unmarkAfterPathTo.
-			 objectMemory storePointer: stackp ofObject: stack withValue: current.
-			 self pruneStack: stack stackp: stackp.
-			 ^0].
-		 ((objectMemory isNonIntegerObject: next)
-		  and: [(stackPages couldBeFramePointer: next)
-				ifTrue: [(self frameIsMarked: next) not]
-				ifFalse:
-					[next >= objectMemory getMemoryMap startOfObjectMemory "exclude Cog methods"
-					  and: [(objectMemory isMarked: next) not
-					  and: [((objectMemory isPointers: next) or: [objectMemory isCompiledMethod: next])
-					  and: [followWeak or: [(objectMemory isWeakNonImm: next) not]]]]]])
-			ifTrue:
-				[stackp + 2 > stackSize ifTrue:
-					[self assert: freeStartAtStart = objectMemory freeStart.
-					 self unmarkAfterPathTo.
-					 objectMemory nilFieldsOf: stack.
-					 ^PrimErrBadIndex]. "PrimErrNoMemory ?"
-				 objectMemory
-					storePointerUnchecked: stackp ofObject: stack withValue: current;
-					storePointerUnchecked: stackp + 1 ofObject: stack withValue: (objectMemory integerObjectOf: index).
-				 stackp := stackp + 2.
-				 (stackPages couldBeFramePointer: (self cCoerceSimple: next to: #'char *'))
-					ifTrue:
-						[self markFrame: next.
-						index := self fieldsInFrame: (self cCoerceSimple: next to: #'char *')]
-					ifFalse:
-						[objectMemory mark: next.
-						 (objectMemory isCompiledMethod: next)
-							ifTrue: [index := (objectMemory literalCountOf: next) + LiteralStart]
-							ifFalse: [index := objectMemory lengthOf: next]].
-				 current := next]].
-		 current = objectMemory specialObjectsOop ifTrue:
-			[self assert: freeStartAtStart = objectMemory freeStart.
-			 self unmarkAfterPathTo.
-			 objectMemory nilFieldsOf: stack.
-			^PrimErrNotFound].
-		 index := objectMemory integerValueOf: (objectMemory fetchPointer: stackp - 1 ofObject: stack).
-		 current := objectMemory fetchPointer: stackp - 2 ofObject: stack.
-		 stackp := stackp - 2] repeat
+	[
+	[ (index := index - 1) >= -1 ] whileTrue: [
+		(stackPages couldBeFramePointer: current)
+			ifTrue: [
+				next := index >= 0
+					        ifTrue: [
+						        self
+							        field: index
+							        ofFrame: (self cCoerceSimple: current to: #'char *') ]
+					        ifFalse: [ objectMemory nilObject ] ]
+			ifFalse: [
+				index >= 0
+					ifTrue: [
+						next := (objectMemory isContextNonImm: current)
+							        ifTrue: [
+							        self fieldOrSenderFP: index ofContext: current ]
+							        ifFalse: [
+							        objectMemory fetchPointer: index ofObject: current ] ]
+					ifFalse: [ next := objectMemory fetchClassOfNonImm: current ] ].
+		(stackPages couldBeFramePointer: next)
+			ifTrue: [
+				self assert: (self
+						 isFrame: (self cCoerceSimple: next to: #'char *')
+						 onPage:
+						 (stackPages stackPageFor:
+							  (self cCoerceSimple: next to: #'char *'))) ]
+			ifFalse: [
+				next >= objectMemory getMemoryMap startOfObjectMemory ifTrue: [ "exclude Cog methods"
+					self assert: (self checkOkayOop: next) ] ].
+		next = goal ifTrue: [
+			self assert: freeStartAtStart = objectMemory freeStart.
+			self unmarkAfterPathTo.
+			objectMemory
+				storePointer: stackp
+				ofObject: _stack
+				withValue: current.
+			self pruneStack: _stack stackp: stackp.
+			^ 0 ].
+		((objectMemory isNonIntegerObject: next) and: [
+			 (stackPages couldBeFramePointer: next)
+				 ifTrue: [ (self frameIsMarked: next) not ]
+				 ifFalse: [
+					 next >= objectMemory getMemoryMap startOfObjectMemory and: [
+						 (objectMemory isMarked: next) not and: [
+							 ((objectMemory isPointers: next) or: [
+								  objectMemory isCompiledMethod: next ]) and: [
+								 followWeak or: [ (objectMemory isWeakNonImm: next) not ] ] ] ] "exclude Cog methods" ] ])
+			ifTrue: [
+				stackp + 2 > stackSize ifTrue: [
+					self assert: freeStartAtStart = objectMemory freeStart.
+					self unmarkAfterPathTo.
+					objectMemory nilFieldsOf: _stack.
+					^ PrimErrBadIndex ]. "PrimErrNoMemory ?"
+				objectMemory
+					storePointerUnchecked: stackp
+					ofObject: _stack
+					withValue: current;
+					storePointerUnchecked: stackp + 1
+					ofObject: _stack
+					withValue: (objectMemory integerObjectOf: index).
+				stackp := stackp + 2.
+				(stackPages couldBeFramePointer:
+					 (self cCoerceSimple: next to: #'char *'))
+					ifTrue: [
+						self markFrame: next.
+						index := self fieldsInFrame:
+							         (self cCoerceSimple: next to: #'char *') ]
+					ifFalse: [
+						objectMemory mark: next.
+						(objectMemory isCompiledMethod: next)
+							ifTrue: [
+							index := (objectMemory literalCountOf: next) + LiteralStart ]
+							ifFalse: [ index := objectMemory lengthOf: next ] ].
+				current := next ] ].
+	current = objectMemory specialObjectsOop ifTrue: [
+		self assert: freeStartAtStart = objectMemory freeStart.
+		self unmarkAfterPathTo.
+		objectMemory nilFieldsOf: _stack.
+		^ PrimErrNotFound ].
+	index := objectMemory integerValueOf:
+		         (objectMemory fetchPointer: stackp - 1 ofObject: _stack).
+	current := objectMemory fetchPointer: stackp - 2 ofObject: _stack.
+	stackp := stackp - 2 ] repeat
 ]
 
 { #category : 'method introspection support' }

--- a/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
@@ -1758,10 +1758,10 @@ InterpreterPrimitives >> primitiveFlushExternalPrimitives [
 { #category : 'object access primitives' }
 InterpreterPrimitives >> primitiveFormat [
 
-	| receiver header format |
-	receiver := self stackTop.
-	(objectMemory isImmediate: receiver) ifTrue: [ ^ self primitiveFail ].
-	header := objectMemory baseHeader: receiver.
+	| _receiver header format |
+	_receiver := self stackTop.
+	(objectMemory isImmediate: _receiver) ifTrue: [ ^ self primitiveFail ].
+	header := objectMemory baseHeader: _receiver.
 	format := objectMemory formatOfHeader: header.
 	self
 		pop: argumentCount + 1

--- a/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
+++ b/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
@@ -3947,67 +3947,74 @@ StackToRegisterMappingCogit >> printSimStack: aSimStack toDepth: limit spillBase
 
 { #category : 'method introspection' }
 StackToRegisterMappingCogit >> profilingDataFor: descriptor Annotation: isBackwardBranchAndAnnotation Mcpc: mcpc Bcpc: bcpc Method: cogMethodArg [
+
 	<var: #descriptor type: #'BytecodeDescriptor *'>
 	<var: #mcpc type: #'char *'>
 	<var: #cogMethodArg type: #'void *'>
-	<var: #methodClassIfSuper type: #'sqInt'>
+	<var: #methodClassIfSuper type: #sqInt>
+	<var: #counter type: #'unsigned int'>
 	| annotation entryPoint tuple counter |
 	"N.B. Counters are always 32-bits, having two 16-bit halves for the reached and taken counts."
-	<var: #counter type: #'unsigned int'>
+	descriptor ifNil: [ ^ 0 ].
+	descriptor isBranch ifTrue: [ "it's a branch; conditional?"
+		(descriptor isBranchTrue or: [ descriptor isBranchFalse ]) ifTrue: [
+			| _counters |
+			_counters := self
+				             cCoerce:
+				             (self cCoerceSimple: cogMethodArg to: #'CogMethod *')
+					             counters
+				             to: #'usqInt *'.
+			"If no _counters are available, do not record _counters"
+			_counters = 0 ifTrue: [ ^ 0 ].
 
-	descriptor ifNil:
-		[^0].
-	descriptor isBranch ifTrue:
-		["it's a branch; conditional?"
-		 (descriptor isBranchTrue or: [descriptor isBranchFalse]) ifTrue: [ | counters | 
-			counters := self
-							cCoerce: ((self
-											cCoerceSimple: cogMethodArg
-											to: #'CogMethod *') counters)
-							to: #'usqInt *'.
-			"If no counters are available, do not record counters"
-			counters = 0 ifTrue: [ ^ 0 ].
-			
-			counter := counters at: counterIndex.
+			counter := _counters at: counterIndex.
 			tuple := self profilingDataForCounter: counter at: bcpc + 1.
-			tuple = 0 ifTrue: [^PrimErrNoMemory].
+			tuple = 0 ifTrue: [ ^ PrimErrNoMemory ].
 			objectMemory
 				storePointer: introspectionDataIndex
 				ofObject: introspectionData
 				withValue: tuple.
 			introspectionDataIndex := introspectionDataIndex + 1.
-			counterIndex := counterIndex + 1].
-		 ^0].
+			counterIndex := counterIndex + 1 ].
+		^ 0 ].
 
 	annotation := isBackwardBranchAndAnnotation >> 1.
-	((self isPureSendAnnotation: annotation)
-	 and: [entryPoint := backEnd callTargetFromReturnAddress: mcpc asUnsignedInteger.
-		 entryPoint > methodZoneBase]) ifFalse: "send is not linked, or is not a send"
-		[^0].
+	((self isPureSendAnnotation: annotation) and: [
+		 entryPoint := backEnd callTargetFromReturnAddress:
+			               mcpc asUnsignedInteger.
+		 entryPoint > methodZoneBase ]) ifFalse: [ "send is not linked, or is not a send"
+		^ 0 ].
 
 	"It's a linked send; find which kind."
-	self targetMethodAndSendTableFor: entryPoint
+	self
+		targetMethodAndSendTableFor: entryPoint
 		annotation: annotation
-		into: [:targetCogCode :sendTable| | methodClassIfSuper association |
+		into: [ :targetCogCode :sendTable |
+			| methodClassIfSuper association |
 			methodClassIfSuper := nil.
 			sendTable = superSendTrampolines ifTrue: [
-				methodClassIfSuper := coInterpreter methodClassOf: (self cCoerceSimple: cogMethodArg to: #'CogMethod *') methodObject.
-			].
+				methodClassIfSuper := coInterpreter methodClassOf:
+					                      (self
+						                       cCoerceSimple: cogMethodArg
+						                       to: #'CogMethod *') methodObject ].
 			sendTable = directedSuperSendTrampolines ifTrue: [
-				association := backEnd literalBeforeInlineCacheTagAt: mcpc asUnsignedInteger.
-				methodClassIfSuper := objectRepresentation valueOfAssociation: association ].
-			tuple := self profilingDataForSendTo: targetCogCode
-						methodClassIfSuper: methodClassIfSuper
-						at: mcpc
-						bcpc: bcpc + 1].
+				association := backEnd literalBeforeInlineCacheTagAt:
+					               mcpc asUnsignedInteger.
+				methodClassIfSuper := objectRepresentation valueOfAssociation:
+					                      association ].
+			tuple := self
+				         profilingDataForSendTo: targetCogCode
+				         methodClassIfSuper: methodClassIfSuper
+				         at: mcpc
+				         bcpc: bcpc + 1 ].
 
-	tuple = 0 ifTrue: [^PrimErrNoMemory].
+	tuple = 0 ifTrue: [ ^ PrimErrNoMemory ].
 	objectMemory
 		storePointer: introspectionDataIndex
 		ofObject: introspectionData
 		withValue: tuple.
 	introspectionDataIndex := introspectionDataIndex + 1.
-	^0
+	^ 0
 ]
 
 { #category : 'method introspection' }


### PR DESCRIPTION
fix all current Slang warning in the form of 'Local variable name 'variable' in selector may mask method when inlining'

add an '_' to the concerned variables. 