### PR TITLE
add a comment explaining why declareCVarsIn: is empty in some subclasses

### DIFF
--- a/smalltalksrc/VMMaker/ComposedImageReader.class.st
+++ b/smalltalksrc/VMMaker/ComposedImageReader.class.st
@@ -10,6 +10,7 @@ Class {
 
 { #category : 'translation' }
 ComposedImageReader class >> declareCVarsIn: aCCodeGenerator [
+	"currently Slang lacks some support for subclasses: prevent <sys/stat.h> to be include a second time during C code generation as the superclass already includes it but declareCVarsIn: is called for each concrete class logging the warning inside addHeaderFile: method"
 ]
 
 { #category : 'reading' }

--- a/smalltalksrc/VMMaker/ComposedImageWriter.class.st
+++ b/smalltalksrc/VMMaker/ComposedImageWriter.class.st
@@ -10,6 +10,7 @@ Class {
 
 { #category : 'translation' }
 ComposedImageWriter class >> declareCVarsIn: aCCodeGenerator [
+	"currently Slang lacks some support for subclasses: prevent <sys/stat.h> to be include a second time during C code generation as the superclass already includes it but declareCVarsIn: is called for each concrete class logging the warning inside addHeaderFile: method"
 ]
 
 { #category : 'writing' }


### PR DESCRIPTION
related to https://github.com/pharo-project/pharo-vm/pull/840