### PR TITLE
small change in dead code elimination to considers a method with only comments empty

### DIFF
--- a/smalltalksrc/Slang-Tests/SLDeadCodeEliminationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SLDeadCodeEliminationTest.class.st
@@ -27,6 +27,66 @@ SLDeadCodeEliminationTest >> setUp [
 	
 ]
 
+{ #category : 'only-comment' }
+SLDeadCodeEliminationTest >> testConditionalWithOnlyCommentNoSendInReceiver [
+	"currently the only way to get comments in a methods is through inlining, having only comments is equivalent to being empty so it shouldn't change the behavior of the dead code elimination process"
+
+	| translation tMethod |
+	tMethod := ccg methodNamed: #conditionalWithOnlyCommentNoSendInReceiver.
+
+	ccg doBasicInlining: true.
+	ccg currentMethod: tMethod.
+
+	sLDeadCodeEliminationVisitor visit: tMethod parseTree.
+
+	translation := self translate: tMethod.
+	translation := translation trimBoth.
+
+	self
+		assert: translation
+		equals:
+			'/* SLDeadCodeEliminationTestClass>>#conditionalWithOnlyCommentNoSendInReceiver */
+static void
+conditionalWithOnlyCommentNoSendInReceiver(SLDeadCodeEliminationTestClass * self_in_conditionalWithOnlyCommentNoSendInReceiver)
+{
+	{
+		return;
+	}
+}'
+]
+
+{ #category : 'only-comment' }
+SLDeadCodeEliminationTest >> testConditionalWithOnlyCommentSendInReceiver [
+	"currently the only way to get comments in a methods is through inlining, having only comments is equivalent to being empty so it shouldn't change the behavior of the dead code elimination process"
+
+	| translation tMethod |
+	tMethod := ccg methodNamed:
+		           #conditionalWithOnlyCommentSendInReceiver.
+
+	ccg doBasicInlining: true.
+	ccg currentMethod: tMethod.
+
+	sLDeadCodeEliminationVisitor visit: tMethod parseTree.
+
+	translation := self translate: tMethod.
+	translation := translation trimBoth.
+
+	self
+		assert: translation
+		equals:
+			'/* SLDeadCodeEliminationTestClass>>#conditionalWithOnlyCommentSendInReceiver */
+static void
+conditionalWithOnlyCommentSendInReceiver(SLDeadCodeEliminationTestClass * self_in_conditionalWithOnlyCommentSendInReceiver)
+{
+	{
+		method(self_in_conditionalWithOnlyCommentSendInReceiver, method(self_in_conditionalWithOnlyCommentSendInReceiver));
+	}
+	{
+		return;
+	}
+}'
+]
+
 { #category : 'method-in-c-coerce' }
 SLDeadCodeEliminationTest >> testMethodAddingCallInCoerce [
 
@@ -1050,6 +1110,34 @@ static size_t
 methodWithInstanceVariableInReturn(SLDeadCodeEliminationTestClass * self_in_methodWithInstanceVariableInReturn)
 {
 	return (self_in_methodWithInstanceVariableInReturn->instancesVariable);
+}'
+]
+
+{ #category : 'only-comment' }
+SLDeadCodeEliminationTest >> testMethodWithOnlyComment [
+	"currently the only way to get comments in a methods is through inlining, having only comments is equivalent to being empty so it shouldn't change the behavior of the dead code elimination process"
+
+	| translation tMethod |
+	tMethod := ccg methodNamed: #methodWithOnlyComment.
+	ccg doBasicInlining: true.
+	ccg currentMethod: tMethod.
+	sLDeadCodeEliminationVisitor visit: tMethod parseTree.
+
+	translation := self translate: tMethod.
+	translation := translation trimBoth.
+
+	self
+		assert: translation
+		equals:
+			'/* SLDeadCodeEliminationTestClass>>#methodWithOnlyComment */
+static void
+methodWithOnlyComment(SLDeadCodeEliminationTestClass * self_in_methodWithOnlyComment)
+{
+	/* begin method */
+	/* end method */
+	{
+		return;
+	}
 }'
 ]
 
@@ -3702,6 +3790,63 @@ methodWithVariableInReturn(SLDeadCodeEliminationTestClass * self_in_methodWithVa
 	sqInt i;
 
 	return i;
+}'
+]
+
+{ #category : 'only-comment' }
+SLDeadCodeEliminationTest >> testSwitchWithOnlyCommentNoSendInReceiver [
+	"currently the only way to get comments in a methods is through inlining, having only comments is equivalent to being empty so it shouldn't change the behavior of the dead code elimination process"
+
+	| translation tMethod |
+	tMethod := ccg methodNamed: #switchWithOnlyCommentNoSendInReceiver:.
+	tMethod prepareMethodIn: ccg.
+	ccg doBasicInlining: true.
+	ccg currentMethod: tMethod.
+	sLDeadCodeEliminationVisitor visit: tMethod parseTree.
+
+	translation := self translate: tMethod.
+	translation := translation trimBoth.
+
+	self
+		assert: translation
+		equals:
+			'/* SLDeadCodeEliminationTestClass>>#switchWithOnlyCommentNoSendInReceiver: */
+static void
+switchWithOnlyCommentNoSendInReceiver(SLDeadCodeEliminationTestClass * self_in_switchWithOnlyCommentNoSendInReceiver, sqInt anInt)
+{
+	{
+		return;
+	}
+}'
+]
+
+{ #category : 'only-comment' }
+SLDeadCodeEliminationTest >> testSwitchWithOnlyCommentSendInReceiver [
+	"currently the only way to get comments in a methods is through inlining, having only comments is equivalent to being empty so it shouldn't change the behavior of the dead code elimination process"
+
+	| translation tMethod |
+	tMethod := ccg methodNamed: #switchWithOnlyCommentSendInReceiver.
+	tMethod prepareMethodIn: ccg.
+	ccg doBasicInlining: true.
+	ccg currentMethod: tMethod.
+	sLDeadCodeEliminationVisitor visit: tMethod parseTree.
+
+	translation := self translate: tMethod.
+	translation := translation trimBoth.
+
+	self
+		assert: translation
+		equals:
+			'/* SLDeadCodeEliminationTestClass>>#switchWithOnlyCommentSendInReceiver */
+static void
+switchWithOnlyCommentSendInReceiver(SLDeadCodeEliminationTestClass * self_in_switchWithOnlyCommentSendInReceiver)
+{
+	{
+		method(self_in_switchWithOnlyCommentSendInReceiver, method(self_in_switchWithOnlyCommentSendInReceiver));
+	}
+	{
+		return;
+	}
 }'
 ]
 

--- a/smalltalksrc/Slang-Tests/SLDeadCodeEliminationTestClass.class.st
+++ b/smalltalksrc/Slang-Tests/SLDeadCodeEliminationTestClass.class.st
@@ -17,6 +17,24 @@ SLDeadCodeEliminationTestClass class >> instVarNamesAndTypesForTranslationDo: aB
 				 otherwise: [ #sqInt ]) ]
 ]
 
+{ #category : 'only-comment' }
+SLDeadCodeEliminationTestClass >> conditionalWithOnlyCommentNoSendInReceiver [
+
+	<returnTypeC: #void>
+	true
+		ifTrue: [ self method ]
+		ifFalse: [ self method ]
+]
+
+{ #category : 'only-comment' }
+SLDeadCodeEliminationTestClass >> conditionalWithOnlyCommentSendInReceiver [
+
+	<returnTypeC: #void>
+	(self method: self method)
+		ifTrue: [ self method ]
+		ifFalse: [ self method ]
+]
+
 { #category : 'accessing' }
 SLDeadCodeEliminationTestClass >> instancesVariable [
 	^ instancesVariable
@@ -24,6 +42,9 @@ SLDeadCodeEliminationTestClass >> instancesVariable [
 
 { #category : 'helpers' }
 SLDeadCodeEliminationTestClass >> method [
+
+	<inline: true>
+	
 ]
 
 { #category : 'helpers' }
@@ -330,6 +351,13 @@ SLDeadCodeEliminationTestClass >> methodWithInstanceVariableInReturn [
 
 	instancesVariable.
 	^ instancesVariable
+]
+
+{ #category : 'only-comment' }
+SLDeadCodeEliminationTestClass >> methodWithOnlyComment [
+
+	<returnTypeC: #void>
+	self method
 ]
 
 { #category : 'unused-leaf' }
@@ -1122,4 +1150,26 @@ SLDeadCodeEliminationTestClass >> methodWithVariableInReturn [
 	| i |
 	i.
 	^ i
+]
+
+{ #category : 'only-comment' }
+SLDeadCodeEliminationTestClass >> switchWithOnlyCommentNoSendInReceiver: anInt [
+
+	<returnTypeC: #void>
+	anInt
+		caseOf: {
+				([ 5 ] -> [ self method ]).
+				([ 6 ] -> [ self method ]) }
+		otherwise: [ self method ]
+]
+
+{ #category : 'only-comment' }
+SLDeadCodeEliminationTestClass >> switchWithOnlyCommentSendInReceiver [
+
+	<returnTypeC: #void>
+	(self method: self method)
+		caseOf: {
+				([ 5 ] -> [ self method ]).
+				([ 6 ] -> [ self method ]) }
+		otherwise: [ self method ]
 ]

--- a/smalltalksrc/Slang/SlangReturnTypeConflictException.class.st
+++ b/smalltalksrc/Slang/SlangReturnTypeConflictException.class.st
@@ -1,10 +1,11 @@
 Class {
-	#name : #SlangReturnTypeConflictException,
-	#superclass : #SlangTyperException,
-	#category : #Slang
+	#name : 'SlangReturnTypeConflictException',
+	#superclass : 'SlangTyperException',
+	#category : 'Slang',
+	#package : 'Slang'
 }
 
-{ #category : #exceptions }
+{ #category : 'exceptions' }
 SlangReturnTypeConflictException class >> signalConflictIn: aMethod with: aCollectionOfType [
 
 	| message |

--- a/smalltalksrc/Slang/SlangTyperException.class.st
+++ b/smalltalksrc/Slang/SlangTyperException.class.st
@@ -1,5 +1,6 @@
 Class {
-	#name : #SlangTyperException,
-	#superclass : #Error,
-	#category : #Slang
+	#name : 'SlangTyperException',
+	#superclass : 'Error',
+	#category : 'Slang',
+	#package : 'Slang'
 }

--- a/smalltalksrc/Slang/TParseNode.class.st
+++ b/smalltalksrc/Slang/TParseNode.class.st
@@ -202,6 +202,13 @@ TParseNode >> hasExplicitReturn [
 ]
 
 { #category : 'testing' }
+TParseNode >> hasNothingButComments [
+	"an alternative to isEmpty related to inlining"
+
+	^ self children allSatisfy: [ :child | child isComment ]
+]
+
+{ #category : 'testing' }
 TParseNode >> hasSideEffect [
 	"Answer if the parse tree rooted at this node has a side-effect or not.  By default assume it has.  Nodes that don't override."
 	^true
@@ -452,7 +459,7 @@ TParseNode >> removeUnusedNodesInBranch: aChild [
 	"this method should be only called when cleaning an AST tree after an unused expression was found"
 
 	self children remove: aChild.
-	self children isEmpty ifTrue: [
+	(self children isEmpty or: [ self hasNothingButComments ]) ifTrue: [
 		self parent removeUnusedNodesInBranch: self ]
 ]
 

--- a/smalltalksrc/Slang/TSendNode.class.st
+++ b/smalltalksrc/Slang/TSendNode.class.st
@@ -76,6 +76,13 @@ TSendNode >> argumentsForInliningCodeGenerator: aCodeGen [
 		ifFalse: [arguments]
 ]
 
+{ #category : 'testing' }
+TSendNode >> argumentsHasNothingButComments [
+	"related to dead code elimination and inlining, see if the cases has nothing but comment meaning they are empty"
+
+	^ arguments allSatisfy: [ :arg | arg isComment ]
+]
+
 { #category : 'tranforming' }
 TSendNode >> asCASTAsFieldReferenceIn: aCodeGen [
 
@@ -567,7 +574,7 @@ TSendNode >> removeUnusedNodesInBranch: aChild [
 	| branchIndex |
 	branchIndex := arguments indexOf: aChild.
 	arguments := arguments select: [ :e | e ~= aChild ].
-	arguments isEmpty
+	(arguments isEmpty or: [ self argumentsHasNothingButComments ])
 		ifTrue: [
 			self transformReceiverAfterEmptyArguments.
 			self parent removeUnusedNodesInBranch: self ]

--- a/smalltalksrc/Slang/TStatementListNode.class.st
+++ b/smalltalksrc/Slang/TStatementListNode.class.st
@@ -437,9 +437,9 @@ TStatementListNode >> isComment [
 
 { #category : 'testing' }
 TStatementListNode >> isEmptyStmtListNode [
-	"return true if the statement node is empty or has just a nil in it"
+	"return true if the statement node is empty orContains only comments"
 
-	statements isEmpty ifTrue: [ ^ true ].
+	(statements isEmpty or: [ self isComment ]) ifTrue: [ ^ true ].
 	^ false
 ]
 
@@ -586,6 +586,13 @@ TStatementListNode >> removeAssertions [
 	self setStatements: newStatements asArray
 ]
 
+{ #category : 'transformations' }
+TStatementListNode >> removeLast [
+	"the last statement can be a comment if the TStatementList has been through inlining, remove the actual last statement"
+
+	statements := self allButLastNonCommentStatement
+]
+
 { #category : 'dead-code-elimination' }
 TStatementListNode >> removeUnusedNodesInBranch: aChild [
 	"this method should be only called when cleaning an AST tree after an unused expression was found, remove aChild from the list of statements"
@@ -593,13 +600,6 @@ TStatementListNode >> removeUnusedNodesInBranch: aChild [
 	statements := statements select: [ :stmt | stmt ~~ aChild ].
 	(statements isEmpty or: [ self hasNothingButComments ]) ifTrue: [
 		self parent removeUnusedNodesInBranch: self ]
-]
-
-{ #category : 'transformations' }
-TStatementListNode >> removeLast [
-	"the last statement can be a comment if the TStatementList has been through inlining, remove the actual last statement"
-
-	statements := self allButLastNonCommentStatement
 ]
 
 { #category : 'inlining support' }

--- a/smalltalksrc/Slang/TStatementListNode.class.st
+++ b/smalltalksrc/Slang/TStatementListNode.class.st
@@ -373,6 +373,12 @@ TStatementListNode >> initialize [
 ]
 
 { #category : 'testing' }
+TStatementListNode >> isComment [
+
+	^ self hasNothingButComments
+]
+
+{ #category : 'testing' }
 TStatementListNode >> isEmptyStmtListNode [
 	"return true if the statement node is empty or has just a nil in it"
 
@@ -513,7 +519,7 @@ TStatementListNode >> removeUnusedNodesInBranch: aChild [
 	"this method should be only called when cleaning an AST tree after an unused expression was found, remove aChild from the list of statements"
 
 	statements := statements select: [ :stmt | stmt ~~ aChild ].
-	statements isEmpty ifTrue: [
+	(statements isEmpty or: [ self hasNothingButComments ]) ifTrue: [
 		self parent removeUnusedNodesInBranch: self ]
 ]
 

--- a/smalltalksrc/Slang/TSwitchStmtNode.class.st
+++ b/smalltalksrc/Slang/TSwitchStmtNode.class.st
@@ -460,10 +460,10 @@ TSwitchStmtNode >> removeAssertions [
 { #category : 'dead-code-elimination' }
 TSwitchStmtNode >> removeUnusedNodesInBranch: aChild [
 	"when removing a node from a switch, we have to be careful of if it comes from a caseOf: or a caseOf:otherwise:. if it comes from a caseOf:, otherwise is nil and must be kept it will be translated as a no case found error. To indicate that otherwise does nothing Slang use an empty TStatementListNode, hence the following code"
-	
+
 	cases := cases select: [ :each | each second ~~ aChild ].
-	(cases isEmpty or: [ self casesHasNothingButComments ])
-	ifFalse: [ ^ self ].
+	(cases isEmpty or: [ self casesHasNothingButComments ]) ifFalse: [
+		^ self ].
 	"we're from a caseOf: so we keep the node"
 	otherwiseOrNil ifNil: [ ^ self ].
 	"otherwiseOrNil may have been empty from the start or during the cleaning process, either way the node is now completely empty so we can supress it"

--- a/smalltalksrc/Slang/TSwitchStmtNode.class.st
+++ b/smalltalksrc/Slang/TSwitchStmtNode.class.st
@@ -244,6 +244,13 @@ TSwitchStmtNode >> cases: anObject [
 	cases := anObject
 ]
 
+{ #category : 'testing' }
+TSwitchStmtNode >> casesHasNothingButComments [
+	"related to dead code elimination and inlining, see if the cases has nothing but comment meaning they are empty"
+
+	^ cases allSatisfy: [ :case | case second isComment ]
+]
+
 { #category : 'accessing' }
 TSwitchStmtNode >> children [
 	
@@ -455,7 +462,8 @@ TSwitchStmtNode >> removeUnusedNodesInBranch: aChild [
 	"when removing a node from a switch, we have to be careful of if it comes from a caseOf: or a caseOf:otherwise:. if it comes from a caseOf:, otherwise is nil and must be kept it will be translated as a no case found error. To indicate that otherwise does nothing Slang use an empty TStatementListNode, hence the following code"
 	
 	cases := cases select: [ :each | each second ~~ aChild ].
-	self cases isEmpty ifFalse: [ ^ self ].
+	(cases isEmpty or: [ self casesHasNothingButComments ])
+	ifFalse: [ ^ self ].
 	"we're from a caseOf: so we keep the node"
 	otherwiseOrNil ifNil: [ ^ self ].
 	"otherwiseOrNil may have been empty from the start or during the cleaning process, either way the node is now completely empty so we can supress it"


### PR DESCRIPTION
related to https://github.com/pharo-project/pharo-vm/pull/832

comments support was not here when the dead code elimination visitor was done,
fix a bug happening with single statement method getting inlined.
