### PR TITLE
Improving Implementation of CompositeImageFormat and PermanentSpace

### DIFF
--- a/smalltalksrc/Melchor/CCodeGeneratorGlobalStructure.class.st
+++ b/smalltalksrc/Melchor/CCodeGeneratorGlobalStructure.class.st
@@ -190,17 +190,26 @@ CCodeGeneratorGlobalStructure >> emitGlobalStructFlagOn: aStream [
 { #category : 'CAST translation' }
 CCodeGeneratorGlobalStructure >> generateCASTSetFieldTo: aTSendNode [
 
-	| structType fieldName fieldVale setFieldStatements |
+	| structType fieldName fieldVale setFieldStatements structClass |
 	self assert: aTSendNode arguments size = 2.
 
 	fieldName := aTSendNode arguments first.
 	fieldVale := aTSendNode arguments second.
 
 	structType := self structTypeFor: aTSendNode receiver.
+	structClass := structType asClassInEnvironment: self class environment.
 
+	"If the field name is known at compile time, we can just use the accessor, we don't need to compare by the name"
+	fieldName isConstant 
+		ifTrue: [ 
+			self assert: (structClass hasSlotNamed: fieldName value).
+			
+			^ (TSendNode
+                        receiver: aTSendNode receiver
+                        selector: fieldName value , ':'
+                        arguments: { fieldVale }) asCASTIn: self ].
 
-	setFieldStatements := (structType asClassInEnvironment:
-		                       self class environment) allSlots collect: [
+	setFieldStatements := structClass allSlots collect: [
 		                      :slot |
 		                      | comparison |
 		                      comparison := TSendNode
@@ -237,7 +246,7 @@ CCodeGeneratorGlobalStructure >> generateCASTWithFieldsDoSeparatedBy: aTSendNode
 	self assert: aTSendNode arguments second arguments size = 0.
 
 	fieldBlock := aTSendNode arguments first.
-	blockSeparatorStatements := aTSendNode arguments second statements.
+	blockSeparatorStatements := aTSendNode arguments second statements reject: [ :e | e isConstant and: [ e value isNil ] ].
 
 	structType := self structTypeFor: aTSendNode receiver.
 
@@ -257,8 +266,7 @@ CCodeGeneratorGlobalStructure >> generateCASTWithFieldsDoSeparatedBy: aTSendNode
 		do: [ :fieldArgs |
 			allRewrittenStatements addAll:
 				(self bindBlock: fieldBlock withArgs: fieldArgs) ]
-		separatedBy: [
-		allRewrittenStatements addAll: blockSeparatorStatements ].
+		separatedBy: [ allRewrittenStatements addAll: blockSeparatorStatements ].
 
 	^ CCompoundStatementNode statements:
 		  (allRewrittenStatements collect: [ :e | e asCASTIn: self ])

--- a/smalltalksrc/Slang/SlangStructType.class.st
+++ b/smalltalksrc/Slang/SlangStructType.class.st
@@ -222,6 +222,16 @@ SlangStructType >> setField: fieldName to: fieldValue [
 ]
 
 { #category : 'macros' }
+SlangStructType >> withFieldsDo: forEachBlock [
+
+	<inline: #always>
+
+	self class allSlots 
+		do: [ :aSlot | forEachBlock value: aSlot name value: (aSlot read: self) ] 
+		separatedBy: [  ]
+]
+
+{ #category : 'macros' }
 SlangStructType >> withFieldsDo: forEachBlock separatedBy: separatorBlock [ 
 
 	self class allSlots 

--- a/smalltalksrc/Slang/SlangStructType.class.st
+++ b/smalltalksrc/Slang/SlangStructType.class.st
@@ -216,9 +216,9 @@ SlangStructType class >> voidStructTypeCache [
 { #category : 'macros' }
 SlangStructType >> setField: fieldName to: fieldValue [
 
-	| slot |
-	slot := self class slotNamed: fieldName.
-	slot write: fieldValue to: self
+	self class
+		slotNamed: fieldName
+		ifFound: [ :slot | slot write: fieldValue to: self ]
 ]
 
 { #category : 'macros' }

--- a/smalltalksrc/Slang/TStatementListNode.class.st
+++ b/smalltalksrc/Slang/TStatementListNode.class.st
@@ -371,7 +371,8 @@ TStatementListNode >> copyWithoutReturn [
 			newStmtsListNode
 				replaceChild: actualLast
 				with: actualLast copyWithoutReturn ].
-	^ newStmtsListNode]
+	^ newStmtsListNode
+]
 
 { #category : 'declarations' }
 TStatementListNode >> declarationAt: aString ifPresent: aFullBlockClosure [ 

--- a/smalltalksrc/VMMaker/AbstractComposedImageAccess.class.st
+++ b/smalltalksrc/VMMaker/AbstractComposedImageAccess.class.st
@@ -264,13 +264,14 @@ AbstractComposedImageAccess >> sscanf: line _: format _: varHolder1 _: varHolder
 
 	<doNotGenerate>
 
-	^ (format = self fieldFormat)
+	(format = self fieldFormat)
 		  ifTrue: [ 
 			  | dataArray |
 			  dataArray := line substrings: '#:, '.
-			  dataArray first = '}' ifTrue: [ ^ false ].
+			  dataArray first = '}' ifTrue: [ ^ self ].
 			  varHolder1 contents: dataArray second.
-			  varHolder2 contents: dataArray third asInteger ].
+			  varHolder2 contents: dataArray third asInteger.
+			  ^ self ].
 
 	self error
 ]

--- a/smalltalksrc/VMMaker/AbstractComposedImageAccess.class.st
+++ b/smalltalksrc/VMMaker/AbstractComposedImageAccess.class.st
@@ -168,6 +168,44 @@ AbstractComposedImageAccess >> permSpaceMetadataFileNameInImage: imageFileName [
 	^ self permSpaceFileName: 'permSpace.ston' inImage: imageFileName into: buffer bufferSize: 255
 ]
 
+{ #category : 'file primitives' }
+AbstractComposedImageAccess >> readLineFrom: file into: lineBuffer ofSize: bufferSize [
+
+	<var: #lineBuffer type: 'char*'>
+	<var: #file type: #sqImageFile>
+
+	self 
+		cCode: [ 
+			| idx aCharacter |
+			
+			idx := 0.
+			
+			aCharacter := self fgetc: file.
+			
+			[ aCharacter = -1 ] 
+				whileFalse: [
+					aCharacter = 10 
+						ifTrue: [ aCharacter := -1 ]
+						ifFalse: [ 
+							aCharacter = 13 
+								ifTrue: [ 
+									aCharacter := self fgetc: file.
+									aCharacter ~= 13 ifTrue: [ self ungetc: aCharacter _: file  ].
+									aCharacter := -1 ]
+								ifFalse: [ 
+									lineBuffer at: idx put: aCharacter.
+									idx := idx + 1.
+									bufferSize = (idx + 1) 
+										ifTrue: [ aCharacter := -1 ]
+										ifFalse: [ aCharacter := self fgetc: file].
+								]
+							 ]].
+			
+				lineBuffer at: idx put: 0.
+			 ]
+		inSmalltalk: [ lineBuffer contents: file nextLine].
+]
+
 { #category : 'segments' }
 AbstractComposedImageAccess >> segmentDataFile: segmentIndex inImage: imageFileName [
 
@@ -208,4 +246,31 @@ AbstractComposedImageAccess >> segmentMetadataFile: segmentIndex inImage: imageF
 
 	^ self segmentFileName: segmentIndex withExtension: '.ston' inImage: imageFileName into: buffer bufferSize: 255. 
 
+]
+
+{ #category : 'file primitives' }
+AbstractComposedImageAccess >> sscanf: aString _: format _: varHolder [
+
+	<doNotGenerate>
+	(format = self headFormat)
+		  ifTrue: [ 
+			  ^ varHolder contents: (aString substrings: ' ') first ].
+
+	self error.
+]
+
+{ #category : 'file primitives' }
+AbstractComposedImageAccess >> sscanf: line _: format _: varHolder1 _: varHolder2 [
+
+	<doNotGenerate>
+
+	^ (format = self fieldFormat)
+		  ifTrue: [ 
+			  | dataArray |
+			  dataArray := line substrings: '#:, '.
+			  dataArray first = '}' ifTrue: [ ^ false ].
+			  varHolder1 contents: dataArray second.
+			  varHolder2 contents: dataArray third asInteger ].
+
+	self error
 ]

--- a/smalltalksrc/VMMaker/ComposedImageReader.class.st
+++ b/smalltalksrc/VMMaker/ComposedImageReader.class.st
@@ -123,6 +123,10 @@ ComposedImageReader >> readHeaderFromImage: imageFileName [
 	
 	headerPtr := self addressOf: header.
 	self readSTONFrom: file into: headerPtr.
+	
+	"If the field is missing, as it was added later"
+	header hdrOldSpaceSize = 0 
+		ifTrue: [ header hdrOldSpaceSize: header dataSize ].
 
 	self extractImageVersionFrom: (header imageFormat) into: headerPtr.
 	

--- a/smalltalksrc/VMMaker/ComposedImageReader.class.st
+++ b/smalltalksrc/VMMaker/ComposedImageReader.class.st
@@ -15,14 +15,15 @@ ComposedImageReader class >> declareCVarsIn: aCCodeGenerator [
 
 { #category : 'reading' }
 ComposedImageReader >> endOfSTON: file [
-	
-	"This method consume 2 chars from file and return they are equivalent to '\n}'"
-		
-	| charLeft charRight |
-	charLeft := self fgetc: file.
-	charRight := self fgetc: file.
 
-	^ (self isEndOfLine: charLeft) and: [ charRight = $} ]
+	^ self 
+		cCode: [ | aCharacter |
+			aCharacter := self fgetc: file.
+			self ungetc: aCharacter  _:file.
+			aCharacter = -1 or: [ aCharacter = $} ]] 
+		inSmalltalk: [ file peek = $} ].
+	
+	
 ]
 
 { #category : 'reading' }
@@ -55,10 +56,13 @@ ComposedImageReader >> readFieldsSTONFrom: file into: aStruct [
 	<inline: true>
 	<var: #fieldName declareC: 'char fieldName[255]'>
 	<var: #fieldValue type: #'long long'>
-	| fieldName fieldValue |
+	<var: #lineBuffer declareC: 'char lineBuffer[1024]'>
+	
+	| fieldName fieldValue lineBuffer |
 	self simulationOnly: [ 
 		fieldName := ValueHolder new.
-		fieldValue := ValueHolder new ].
+		fieldValue := ValueHolder new.
+		lineBuffer := ValueHolder new ].
 
 	"Initialize the Struct with zeros"
 	
@@ -67,9 +71,14 @@ ComposedImageReader >> readFieldsSTONFrom: file into: aStruct [
 		separatedBy: [ ].
 
 	"This solution does NOT WORK with STON file without fields (empty STON)"
-	[ 
+	[ 	
+		self 
+			readLineFrom: file 
+			into: lineBuffer 
+			ofSize: 1024.
+			
 		self
-			fscanf: file
+			sscanf: (self contentsOf: lineBuffer)
 			_: self fieldFormat
 			_: fieldName
 			_: (self cCoerce: (self addressOf: fieldValue) to: #'sqInt*').
@@ -85,10 +94,20 @@ ComposedImageReader >> readHeadSTONFrom: file into: aStruct [
 
 	<inline: true>
 	<var: #structName declareC: 'char structName[255]'>
-	| structName |
-	self simulationOnly: [ structName := ValueHolder new ].
+	<var: #lineBuffer declareC: 'char lineBuffer[1024]'>
 
-	self fscanf: file _: self headFormat _: structName.
+	| structName lineBuffer |
+
+	self simulationOnly: [ 
+		lineBuffer := ValueHolder new.
+		structName := ValueHolder new ].
+
+	self 
+		readLineFrom: file 
+		into: lineBuffer 
+		ofSize: 1024.
+
+	self sscanf: (self contentsOf: lineBuffer) _: self headFormat _: structName.
 
 	self simulationOnly: [ 
 		aStruct withStructNameDo: [ :name | 

--- a/smalltalksrc/VMMaker/Spur32BitMMLESimulator.class.st
+++ b/smalltalksrc/VMMaker/Spur32BitMMLESimulator.class.st
@@ -85,14 +85,6 @@ Spur32BitMMLESimulator >> fetchFloatAt: floatBitsAddress into: aFloat [
 	aFloat at: 1 put: (self uint32AtPointer: floatBitsAddress+4)
 ]
 
-{ #category : 'as yet unclassified' }
-Spur32BitMMLESimulator >> fetchPointer: fieldIndex ofObject: objOop [
-	self assert: (self isForwarded: objOop) not.
-	self assert: (fieldIndex >= 0 and: [fieldIndex < (self numSlotsOfAny: objOop)
-				or: [fieldIndex = 0 "forwarders"]]).
-	^super fetchPointer: fieldIndex ofObject: objOop
-]
-
 { #category : 'spur bootstrap' }
 Spur32BitMMLESimulator >> freeLists [
 	^freeLists

--- a/smalltalksrc/VMMaker/Spur64BitMMLESimulator.class.st
+++ b/smalltalksrc/VMMaker/Spur64BitMMLESimulator.class.st
@@ -85,14 +85,6 @@ Spur64BitMMLESimulator >> fetchFloatAt: floatBitsAddress into: aFloat [
 	aFloat at: 1 put: (self uint32AtPointer: floatBitsAddress+4)
 ]
 
-{ #category : 'as yet unclassified' }
-Spur64BitMMLESimulator >> fetchPointer: fieldIndex ofObject: objOop [
-	self assert: (self isForwarded: objOop) not.
-	self assert: (fieldIndex >= 0 and: [fieldIndex < (self numSlotsOfAny: objOop)
-				or: [fieldIndex = 0 "forwarders"]]).
-	^super fetchPointer: fieldIndex ofObject: objOop
-]
-
 { #category : 'spur bootstrap' }
 Spur64BitMMLESimulator >> freeLists [
 	^freeLists

--- a/smalltalksrc/VMMaker/SpurImageHeaderStruct.class.st
+++ b/smalltalksrc/VMMaker/SpurImageHeaderStruct.class.st
@@ -3,6 +3,7 @@ Class {
 	#superclass : 'VMStructType',
 	#instVars : [
 		'dataSize',
+		'hdrOldSpaceSize',
 		'oldBaseAddr',
 		'initialSpecialObjectsOop',
 		'headerFlags',
@@ -157,6 +158,18 @@ SpurImageHeaderStruct >> hdrNumStackPages [
 SpurImageHeaderStruct >> hdrNumStackPages: anObject [
 
 	hdrNumStackPages := anObject
+]
+
+{ #category : 'accessing' }
+SpurImageHeaderStruct >> hdrOldSpaceSize [
+
+	^ hdrOldSpaceSize
+]
+
+{ #category : 'accessing' }
+SpurImageHeaderStruct >> hdrOldSpaceSize: anObject [
+
+	hdrOldSpaceSize := anObject
 ]
 
 { #category : 'accessing' }

--- a/smalltalksrc/VMMaker/SpurImageReader.class.st
+++ b/smalltalksrc/VMMaker/SpurImageReader.class.st
@@ -81,6 +81,9 @@ SpurImageReader >> readHeaderFrom: f startingAt: headerStart [
 
 	header imageHeaderSize: (self getWord32FromFile: f swap: header swapBytes).
 	header dataSize: (self getLongFromFile: f swap: header swapBytes).
+	"In SpurFormat the dataSize is just the oldSpace size"
+	header hdrOldSpaceSize: header dataSize.
+
 	header oldBaseAddr: (self getLongFromFile: f swap: header swapBytes).
 	header initialSpecialObjectsOop:
 		(self getLongFromFile: f swap: header swapBytes).

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -10166,6 +10166,12 @@ SpurMemoryManager >> oldSpaceSize [
 	^segmentManager totalBytesInSegments
 ]
 
+{ #category : 'snapshot' }
+SpurMemoryManager >> oldSpaceSizeToWrite [
+	<returnTypeC: #'size_t'> 
+	^segmentManager totalBytesInNonEmptySegments
+]
+
 { #category : 'become implementation' }
 SpurMemoryManager >> outOfPlaceBecome: obj1 and: obj2 copyHashFlag: copyHashFlag [
 	<inline: #never> "in an effort to fix a compiler bug with two-way become post r3427"

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -914,7 +914,8 @@ SpurMemoryManager class >> initializeSpurObjectRepresentationConstants [
 	BecamePointerObjectFlag := 1.
 	BecameCompiledMethodFlag := 2.
 	OldBecameNewFlag := 4.
-	BecameActiveClassFlag := 8 "For flushing method caches"
+	BecameActiveClassFlag := 8 "For flushing method caches".
+	BecamePermanentObject := 16.
 ]
 
 { #category : 'class initialization' }
@@ -1814,6 +1815,13 @@ SpurMemoryManager >> allPastSpaceObjectsDo: aBlock [
 		[:objOop|
 		 self assert: (self isEnumerableObjectNoAssert: objOop).
 		 aBlock value: objOop]
+]
+
+{ #category : 'perm - space' }
+SpurMemoryManager >> allPermSpaceNonForwardedObjectsDo: aBlockClosure [
+
+	self allPermSpaceObjectsDo: [ :anObj |
+		(self isForwarded: anObj) ifFalse: [ aBlockClosure value: anObj ] ]
 ]
 
 { #category : 'perm - space' }
@@ -3960,15 +3968,20 @@ SpurMemoryManager >> clone: objOop [
 	| numSlots fmt newObj |
 	numSlots := self numSlotsOf: objOop.
 	fmt := self formatOf: objOop.
-	numSlots > self maxSlotsForNewSpaceAlloc
-		ifTrue:
-			[newObj := self allocateSlotsInOldSpace: numSlots
-							format: fmt
-							classIndex: (self classIndexOf: objOop)]
-		ifFalse:
-			[newObj := self allocateSlots: numSlots
-							format: fmt
-							classIndex: (self classIndexOf: objOop)].
+	
+	(memoryMap isPermanentObject: objOop)
+		ifTrue: [ newObj := self allocateSlotsInPermSpace: numSlots format: fmt classIndex: (self classIndexOf: objOop)]
+		ifFalse: [  
+				numSlots > self maxSlotsForNewSpaceAlloc
+					ifTrue:
+						[newObj := self allocateSlotsInOldSpace: numSlots
+										format: fmt
+										classIndex: (self classIndexOf: objOop)]
+					ifFalse:
+						[newObj := self allocateSlots: numSlots
+										format: fmt
+										classIndex: (self classIndexOf: objOop)]].
+
 	newObj ifNil:
 		[^0].
 	(self isPointersFormat: fmt)
@@ -4366,6 +4379,9 @@ SpurMemoryManager >> doBecome: obj1 and: obj2 copyHash: copyHashFlag [
 	(o2ClassIndex ~= 0 and: [(self classAtIndex: o2ClassIndex) ~= obj2]) ifTrue:
 		[o2ClassIndex := 0].
 
+	((self isPermanent: obj1) or: [ self isPermanent: obj2 ])
+		ifTrue: [ becomeEffectsFlags := becomeEffectsFlags bitOr: BecamePermanentObject ].
+
 	"Refuse to do an in-place become on classes since their being
 	 forwarded is used in the flush method cache implementations."
 	((self numSlotsOf: obj1) = (self numSlotsOf: obj2)
@@ -4410,12 +4426,20 @@ SpurMemoryManager >> doBecome: obj1 to: obj2 copyHash: copyHashFlag [
 	 then the entry at obj1's hash is valid, otherwise the the existing one at obj2's
 	 hash.  When all the instances with the old hash have been collected, the GC will
 	 discover this and expunge obj2 at the unused index (see markAndTraceClassOf:)."
+
 	self forward: obj1 to: obj2.
-	copyHashFlag ifTrue: [self setHashBitsOf: obj2 to: (self rawHashBitsOf: obj1)].
-	((memoryMap isOldObject: obj1)
-	 and: [self isYoung: obj2]) ifTrue:
-		[becomeEffectsFlags := becomeEffectsFlags bitOr: OldBecameNewFlag].
-	self deny: (self isOopForwarded: obj2)
+	copyHashFlag ifTrue: [
+		self setHashBitsOf: obj2 to: (self rawHashBitsOf: obj1) ].
+
+	self deny: (self isOopForwarded: obj2).
+
+	(memoryMap isPermanentObject: obj1) 
+		ifTrue: [ becomeEffectsFlags := 
+			becomeEffectsFlags bitOr: BecamePermanentObject ].
+
+	((memoryMap isOldObject: obj1) and: [ self isYoung: obj2 ])
+		ifTrue: [
+				becomeEffectsFlags := becomeEffectsFlags bitOr: OldBecameNewFlag ] 
 ]
 
 { #category : 'private - perm space' }
@@ -6350,8 +6374,6 @@ SpurMemoryManager >> ifOopInvalidForBecome: oop errorCodeInto: aBlock [
 	(self isPinned: oop) ifTrue:
 		[^aBlock value: PrimErrObjectIsPinned].
 	(self isObjImmutable: oop) ifTrue:
-		[^aBlock value: PrimErrNoModification].
-	(memoryMap isPermanentObject: oop) ifTrue:
 		[^aBlock value: PrimErrNoModification]
 ]
 
@@ -7768,7 +7790,7 @@ SpurMemoryManager >> isPermSpaceRememberedSetSane [
 
 	isValid := true.
 
-	self allPermSpaceObjectsDo: [ :objOop |
+	self allPermSpaceNonForwardedObjectsDo: [ :objOop |
 		
 		refersNewSpace := self hasYoungReferents: objOop.	
 		refersOldSpace := self hasOldReferents: objOop.
@@ -8925,13 +8947,14 @@ SpurMemoryManager >> markLoopFrom: objOop [
 			[ index > 0 ] whileTrue: [
 				index := index - 1.
 				field := self fetchPointer: index ofObject: objToScan.
-				((self isNonImmediate: field) and: [(self isPermanent: field) not]) ifTrue: [ 
+				(self isNonImmediate: field) ifTrue: [ 
 					(self isForwarded: field) ifTrue: [ "fixFollowedField: is /not/ inlined"
 						field := self
 							         fixFollowedField: index
 							         ofObject: objToScan
 							         withInitialValue: field ].
-					(self markAndShouldScan: field) ifTrue: [
+					((self isPermanent: field) not and: [self markAndShouldScan: field]) 
+					ifTrue: [
 						self push: field onObjStack: markStack.
 						((self rawNumSlotsOf: field) > self traceImmediatelySlotLimit
 							 and: [
@@ -9295,7 +9318,7 @@ SpurMemoryManager >> moveToPermSpaceAllOldObjects [
 			(self isValidToMoveToPermSpace: objOop) 
 				ifTrue: [ self doMoveToPermSpace: objOop addToRememberedSet: true ]]].
 
-	self allPermSpaceObjectsDo: [ :permObj |
+	self allPermSpaceNonForwardedObjectsDo: [ :permObj |
 		self followForwardedObjectFields: permObj toDepth: 0 ].
 
 	self recreateFromPermSpaceRememberedSet.
@@ -11323,7 +11346,7 @@ SpurMemoryManager >> recreateFromPermSpaceRememberedSet [
 	self getFromPermToOldSpaceRememberedSet emptyRememberedSet.
 	self getFromPermToNewSpaceRememberedSet emptyRememberedSet.
 
-	self allPermSpaceObjectsDo: [ :aPermSpaceObject | 
+	self allPermSpaceNonForwardedObjectsDo: [ :aPermSpaceObject | 
 			| slotIndex referenced numPointerSlots refersNewSpace refersOldSpace |
 	
 		"We clear the bit of all remembered objects, it will be recalculated"

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -1327,12 +1327,9 @@ SpurMemoryManager >> adjustAllOopsBy: bytesToShift [
 					[self swizzleFieldsOfFreeChunk: obj]].
 		 obj := self objectAfter: obj limit: memoryMap oldSpaceEnd].
 	
+	"We need to iterate all the permSpace, as still we don't have the fromPermToOldSpaceRememberedSet. If we move the initialization of the remembered set before we can use it here or just after the initialization"
 	
-	"As we know all the permanent space objects that are pointing to the old space, and as the permanent space is always in the same place.
-	We need only to iterate the remembered set to swizzle the fields of permanent objects"
-	
-	self getFromPermToOldSpaceRememberedSet 
-		rememberedSetWithIndexDo: [ :oop :i | self swizzleFieldsOfObject: oop ].
+	self allPermSpaceObjectsDo: [ :oop | self swizzleFieldsOfObject: oop ].
 
 ]
 
@@ -3965,12 +3962,23 @@ SpurMemoryManager >> cleverSwapHeaders: obj1 and: obj2 copyHashFlag: copyHashFla
 
 { #category : 'allocation' }
 SpurMemoryManager >> clone: objOop [
+
+	^ self clone: objOop shouldAllocateInPermSpace: false
+]
+
+{ #category : 'allocation' }
+SpurMemoryManager >> clone: objOop shouldAllocateInPermSpace: shouldAllocateInPermSpace [
+
+	"Attention: the shouldAllocateInPermSpace is only used by the become, as it handles adding or not the new perm object to the remembered sets"
+
 	| numSlots fmt newObj |
 	numSlots := self numSlotsOf: objOop.
 	fmt := self formatOf: objOop.
 	
-	(memoryMap isPermanentObject: objOop)
-		ifTrue: [ newObj := self allocateSlotsInPermSpace: numSlots format: fmt classIndex: (self classIndexOf: objOop)]
+	(shouldAllocateInPermSpace)
+		ifTrue: [ newObj := self allocateSlotsInPermSpace: numSlots 
+										format: fmt 
+										classIndex: (self classIndexOf: objOop)]
 		ifFalse: [  
 				numSlots > self maxSlotsForNewSpaceAlloc
 					ifTrue:
@@ -4014,6 +4022,7 @@ SpurMemoryManager >> clone: objOop [
 				 ((memoryMap isOldObject: newObj)
 				  and: [(memoryMap isYoungObject: objOop) or: [self isRemembered: objOop]]) ifTrue:
 					[self getFromOldSpaceRememberedSet remember: newObj]]].
+		
 	^newObj
 ]
 
@@ -10212,13 +10221,13 @@ SpurMemoryManager >> outOfPlaceBecome: obj1 and: obj2 copyHashFlag: copyHashFlag
 	| clone1 clone2 |
 	clone1 := (self isContextNonImm: obj1)
 				ifTrue: [coInterpreter cloneContext: obj1]
-				ifFalse: [self clone: obj1].
+				ifFalse: [self clone: obj1 shouldAllocateInPermSpace: (memoryMap isPermanentObject: obj1)].
 	
 	clone1 ifNil: [ self error: 'Not enough space to copy the objects in two-way become. This should have been detected before'. ^ self].	
 			
 	clone2 := (self isContextNonImm: obj2)
 				ifTrue: [coInterpreter cloneContext: obj2]
-				ifFalse: [self clone: obj2].	
+				ifFalse: [self clone: obj2 shouldAllocateInPermSpace: (memoryMap isPermanentObject: obj2)].	
 
 	clone2 ifNil: [ self error: 'Not enough space to copy the objects in two-way become. This should have been detected before'.^ self ].	
 			

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -1815,6 +1815,15 @@ SpurMemoryManager >> allPastSpaceObjectsDo: aBlock [
 ]
 
 { #category : 'perm - space' }
+SpurMemoryManager >> allPermSpaceForwarded: aForwardedBlockClosure ObjectsDo: aBlockClosure [
+
+	self allPermSpaceObjectsDo: [ :anObj |
+		(self isForwarded: anObj) 
+			ifTrue: [ aForwardedBlockClosure value: anObj ]
+			ifFalse: [ aBlockClosure value: anObj ] ]
+]
+
+{ #category : 'perm - space' }
 SpurMemoryManager >> allPermSpaceNonForwardedObjectsDo: aBlockClosure [
 
 	self allPermSpaceObjectsDo: [ :anObj |
@@ -4541,6 +4550,40 @@ SpurMemoryManager >> doScavenge: tenuringCriterion [
 	self resetAllocationAccountingAfterGC
 ]
 
+{ #category : 'validations' }
+SpurMemoryManager >> doValidateObjectMemory [
+
+	| returnCode |
+	
+	returnCode := true.
+
+	self allObjectsDo: [ :anOop |
+		(self isForwarded: anOop)
+			ifTrue: [ |referent |
+					referent := self fetchPointer: 0 ofMaybeForwardedObject: anOop.
+					(self addressCouldBeObj: referent)
+						ifFalse: [ 
+							self 
+								logError: 'Error found in object at %p' 
+								_: (self cCoerce: anOop to: 'void*').
+							returnCode := false. ]
+					]
+			ifFalse: [
+				0 to: (self numPointerSlotsOf: anOop) - 1 do: [ :idx |
+					| aReference |
+					aReference := self fetchPointer: idx ofObject: anOop.
+					((self isImmediate: aReference) or: [
+						 (self addressCouldBeObj: aReference) 
+							or: [ memoryMap isInCodeZone: aReference ] ]) 
+						ifFalse: [ 
+							self 
+								logError: 'Error found in object at %p' 
+								_: (self cCoerce: anOop to: 'void*').
+							returnCode := false ] ] ] ].
+
+	^ returnCode
+]
+
 { #category : 'accessing' }
 SpurMemoryManager >> edenBytes [
 	<doNotGenerate>
@@ -6075,6 +6118,8 @@ SpurMemoryManager >> globalGarbageCollect [
 	self assert: (self isEmptyObjStack: markStack).
 	self assert: (self isEmptyObjStack: weaklingStack).
 
+	"self validateObjectMemory."
+	
 	"Mark objects /before/ scavenging, to empty the rememberedTable of unmarked roots."
 	self markObjects: true.
 	gcMarkEndUsecs := coInterpreter ioUTCMicrosecondsNow.
@@ -6098,7 +6143,9 @@ SpurMemoryManager >> globalGarbageCollect [
 	self assert: (self isEmptyObjStack: markStack).
 	self assert: (self isEmptyObjStack: weaklingStack).
 	self assert: self allObjectsUnmarked.
-	self runLeakCheckerFor: GCModeFull
+	self runLeakCheckerFor: GCModeFull.
+	
+	"self validateObjectMemory"
 ]
 
 { #category : 'object testing' }
@@ -7794,48 +7841,74 @@ SpurMemoryManager >> isPermSpaceRememberedSetSane [
 
 	<inline: false>
 	<api>
-		
-	| refersNewSpace refersOldSpace isInPermToNewRememberedSet isInPermToOldRememberedSet isValid|
+	| refersNewSpace refersOldSpace isValid |
 
 	isValid := true.
 
-	self allPermSpaceNonForwardedObjectsDo: [ :objOop |
-		
-		refersNewSpace := self hasYoungReferents: objOop.	
-		refersOldSpace := self hasOldReferents: objOop.
+	self
+		allPermSpaceForwarded: [ :aForwardedPermSpaceObject |
+			| referenced |
+			referenced := self
+				              fetchPointer: 0
+				              ofMaybeForwardedObject: aForwardedPermSpaceObject.
+
+			refersOldSpace := self getMemoryMap isYoungObject: referenced.
+			refersNewSpace := self getMemoryMap isOldObject: referenced.
+
+			(self
+				 isPermSpaceRememberedSetSaneMember: aForwardedPermSpaceObject
+				 withNewSpaceRefs: refersNewSpace
+				 withOldSpaceRefs: refersOldSpace)
+				ifFalse: [ isValid := false ] ]
+		ObjectsDo: [ :objOop |
+			refersNewSpace := self hasYoungReferents: objOop.
+			refersOldSpace := self hasOldReferents: objOop.
+
+			(self
+				 isPermSpaceRememberedSetSaneMember: objOop
+				 withNewSpaceRefs: refersNewSpace
+				 withOldSpaceRefs: refersOldSpace) 
+				ifFalse: [ isValid := false ] ].
+
+	^ isValid
+]
+
+{ #category : 'debug printing' }
+SpurMemoryManager >> isPermSpaceRememberedSetSaneMember: objOop withNewSpaceRefs: refersNewSpace withOldSpaceRefs: refersOldSpace [
+
+	| isInPermToNewRememberedSet isInPermToOldRememberedSet| 
+
+	isInPermToNewRememberedSet := self getFromPermToNewSpaceRememberedSet
+		                              isInRememberedSet: objOop.
+	isInPermToOldRememberedSet := self getFromPermToOldSpaceRememberedSet
+		                              isInRememberedSet: objOop.
+
+	(isInPermToNewRememberedSet and: [ refersNewSpace or: refersOldSpace ])
+		ifTrue: [
+			(self isRemembered: objOop) ifFalse: [
+				self logError: 'Offending Object: %p' _: objOop.
+				self error: 'Object should be marked as remembered'.
+				^ false ] ].
+
+	(refersNewSpace and: [ isInPermToNewRememberedSet not ]) ifTrue: [
+		self logError: 'Offending Object: %p' _: objOop.
+		self error: 'Object should be in remembered set (Perm to New)'.
+		^ false ].
+
+	(isInPermToNewRememberedSet and: [
+		 refersNewSpace not and: [ refersOldSpace not ] ]) ifTrue: [
+		self logError: 'Offending Object: %p' _: objOop.
+		self error: 'Object should not be in remembered set (Perm to New)'.
+		^ false ].
+
+	(refersOldSpace and: [
+		 isInPermToNewRememberedSet not and: [
+			 isInPermToOldRememberedSet not ] ]) ifTrue: [
+		self logError: 'Offending Object: %p' _: objOop.
+		self error: 'Object should not be in remembered set (Perm to Old)'.
+		^ false ].
 	
-		isInPermToNewRememberedSet := self getFromPermToNewSpaceRememberedSet isInRememberedSet: objOop.
-		isInPermToOldRememberedSet := self getFromPermToOldSpaceRememberedSet isInRememberedSet: objOop.
-
-		(isInPermToNewRememberedSet and: [ refersNewSpace or: refersOldSpace ])
-			ifTrue: [ 
-				(self isRemembered: objOop) 
-					ifFalse: [ 
-						isValid := false.
-						self logError: 'Offending Object: %p' _: objOop.						
-						self error: 'Object should be marked as remembered' ]].
-
-		(refersNewSpace and: [ isInPermToNewRememberedSet not ])
-			ifTrue: [ 
-						isValid := false.
-						self logError: 'Offending Object: %p' _: objOop.
-						self error: 'Object should be in remembered set (Perm to New)' ].
-
-		(isInPermToNewRememberedSet and: [refersNewSpace not and: [ refersOldSpace not ]])
-			ifTrue: [ 
-						isValid := false.
-						self logError: 'Offending Object: %p' _: objOop.
-						self error: 'Object should not be in remembered set (Perm to New)'. ].
-
-		(refersOldSpace and: [ isInPermToNewRememberedSet not and: [isInPermToOldRememberedSet not] ])
-			ifTrue: [ 
-						isValid := false.
-						self logError: 'Offending Object: %p' _: objOop.
-						self error: 'Object should not be in remembered set (Perm to Old)'. ].
-
-		].
-	
-	^ isValid.
+	^ true.
 ]
 
 { #category : 'object testing' }
@@ -11355,7 +11428,25 @@ SpurMemoryManager >> recreateFromPermSpaceRememberedSet [
 	self getFromPermToOldSpaceRememberedSet emptyRememberedSet.
 	self getFromPermToNewSpaceRememberedSet emptyRememberedSet.
 
-	self allPermSpaceNonForwardedObjectsDo: [ :aPermSpaceObject | 
+	self 
+		allPermSpaceForwarded: [ :aForwardedPermSpaceObject | 
+			| referenced |
+			referenced := self 
+								fetchPointer: 0 
+								ofMaybeForwardedObject: aForwardedPermSpaceObject.
+			
+			(self isForwarded: referenced)	
+				ifTrue: [
+					referenced := self followForwarded: referenced.
+					self storePointerUnchecked: 0 ofMaybeForwardedObject: aForwardedPermSpaceObject withValue: referenced ].
+			
+			(self getMemoryMap isYoungObject: referenced)
+				ifTrue: [ self getFromPermToNewSpaceRememberedSet remember: aForwardedPermSpaceObject ]
+				ifFalse: [ (self getMemoryMap isOldObject: referenced) 
+					ifTrue: [ self getFromPermToOldSpaceRememberedSet rememberWithoutMarkingAsRemembered: aForwardedPermSpaceObject ] ]
+			
+		]	
+		ObjectsDo: [ :aPermSpaceObject | 
 			| slotIndex referenced numPointerSlots refersNewSpace refersOldSpace |
 	
 		"We clear the bit of all remembered objects, it will be recalculated"
@@ -11367,7 +11458,6 @@ SpurMemoryManager >> recreateFromPermSpaceRememberedSet [
 	
 		slotIndex := 0.
 
-		"If the object already refers to new space, we don't check anymore"
 		[ refersNewSpace not and: [slotIndex < numPointerSlots]  ]
 			whileTrue: [ 
 				referenced := self fetchPointer: slotIndex ofObject: aPermSpaceObject.
@@ -13469,6 +13559,16 @@ SpurMemoryManager >> validObjStacks [
 	^(markStack = nilObj or: [self isValidObjStack: markStack])
 	  and: [(weaklingStack = nilObj or: [self isValidObjStack: weaklingStack])
 	  and: [mournQueue = nilObj or: [self isValidObjStack: mournQueue]]]
+]
+
+{ #category : 'validations' }
+SpurMemoryManager >> validateObjectMemory [
+
+	<api>
+	<inline: false>
+	
+	self doValidateObjectMemory
+		ifFalse: [ self logError: 'Error in validating object memory' ].
 ]
 
 { #category : 'gc - scavenge/compact' }

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -1312,18 +1312,27 @@ SpurMemoryManager >> adjustAllOopsBy: bytesToShift [
 	| obj classIndex |
 	self assert: self newSpaceIsEmpty.
 	self countNumClassPagesPreSwizzle: bytesToShift.
-	(bytesToShift ~= 0
-	 or: [segmentManager numSegments > 1]) ifTrue:
-		[obj := self objectStartingAt: memoryMap oldSpaceStart.
-		 [self oop: obj isLessThan: freeOldSpaceStart] whileTrue:
-			[classIndex := self classIndexOf: obj.
-			 classIndex >= self isForwardedObjectClassIndexPun
-				ifTrue:
-					[self swizzleFieldsOfObject: obj]
-				ifFalse:
-					[classIndex = self isFreeObjectClassIndexPun ifTrue:
-						[self swizzleFieldsOfFreeChunk: obj]].
-			 obj := self objectAfter: obj limit: memoryMap oldSpaceEnd]]
+
+	(bytesToShift = 0 and: [segmentManager numSegments = 1]) ifTrue:[ ^ self ].
+	
+	obj := self objectStartingAt: memoryMap oldSpaceStart.
+	 [self oop: obj isLessThan: freeOldSpaceStart] whileTrue:
+		[classIndex := self classIndexOf: obj.
+		 classIndex >= self isForwardedObjectClassIndexPun
+			ifTrue:
+				[self swizzleFieldsOfObject: obj]
+			ifFalse:
+				[classIndex = self isFreeObjectClassIndexPun ifTrue:
+					[self swizzleFieldsOfFreeChunk: obj]].
+		 obj := self objectAfter: obj limit: memoryMap oldSpaceEnd].
+	
+	
+	"As we know all the permanent space objects that are pointing to the old space, and as the permanent space is always in the same place.
+	We need only to iterate the remembered set to swizzle the fields of permanent objects"
+	
+	self getFromPermToOldSpaceRememberedSet 
+		rememberedSetWithIndexDo: [ :oop :i | self swizzleFieldsOfObject: oop ].
+
 ]
 
 { #category : 'object enumeration' }

--- a/smalltalksrc/VMMaker/SpurSegmentManager.class.st
+++ b/smalltalksrc/VMMaker/SpurSegmentManager.class.st
@@ -661,6 +661,11 @@ SpurSegmentManager >> someSegmentContainsPinned [
 SpurSegmentManager >> swizzleObj: objOop [
 	<inline: false>
 	self assert: canSwizzle.
+
+	"The permanent space is always loaded in the same place"	
+	(manager getMemoryMap isPermanentObject: objOop)
+		ifTrue: [ ^ objOop ].
+	
 	numSegments - 1 to: 1 by: -1 do:
 		[:i|
 		objOop >= (segments at: i) segStart ifTrue:

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -2067,7 +2067,7 @@ StackInterpreter >> allocateMemoryForImageHeader: header [
 
 	objectMemory getMemoryMap 
 		allocationReserve: self interpreterAllocationReserveBytes;
-		initialOldSpaceSize: header dataSize;
+		initialOldSpaceSize: header hdrOldSpaceSize;
 		initialNewSpaceSize: objectMemory newSpaceBytes;
 		initialHeadroom: (objectMemory initialHeadroom: extraVMMemory givenFreeOldSpaceInImage: header freeOldSpaceInImage);
 		allocateHeap.
@@ -10341,6 +10341,7 @@ StackInterpreter >> newHeader [
 	
 	sizeToWrite := objectMemory imageSizeToWrite.
 	header dataSize: sizeToWrite.
+	header hdrOldSpaceSize: objectMemory oldSpaceSizeToWrite.
 
 	header oldBaseAddr: objectMemory getMemoryMap oldSpaceStart.
 	header initialSpecialObjectsOop: objectMemory specialObjectsOop.

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -12280,6 +12280,25 @@ StackInterpreter >> printPageHeadFrame [
 ]
 
 { #category : 'debug printing' }
+StackInterpreter >> printPointersTo: anAddress [
+
+	<api>
+	
+	| referent |
+	
+	objectMemory allObjectsDo: [ :anOop |
+		(objectMemory isForwarded: anOop)
+			ifTrue: [ 
+					referent := objectMemory fetchPointer: 0 ofMaybeForwardedObject: anOop.
+					referent = anAddress ifTrue: [ self shortPrintOop: anOop ]]
+			ifFalse: [
+				0 to: (objectMemory numPointerSlotsOf: anOop) - 1 do: [ :idx |
+					referent := objectMemory fetchPointer: idx ofObject: anOop.
+					referent = anAddress ifTrue: [ self shortPrintOop: anOop ] ]]].
+
+]
+
+{ #category : 'debug printing' }
 StackInterpreter >> printProcessStack: aProcess [
 	<api>
 	<inline: false>

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -6454,6 +6454,15 @@ StackInterpreter >> followForwardedMethodsInMethodZone [
 ]
 
 { #category : 'object memory support' }
+StackInterpreter >> followForwardingPointersInPermSpace [
+
+	objectMemory allPermSpaceNonForwardedObjectsDo: [ :permObj |
+			objectMemory followForwardedObjectFields: permObj toDepth: 0 ].
+
+	objectMemory recreateFromPermSpaceRememberedSet
+]
+
+{ #category : 'object memory support' }
 StackInterpreter >> followForwardingPointersInProfileState [
 	(objectMemory isForwarded: profileProcess) ifTrue:
 		[profileProcess := objectMemory followForwarded: profileProcess].
@@ -10813,7 +10822,10 @@ StackInterpreter >> postBecomeAction: theBecomeEffectsFlags [
 			self followForwardingPointersInSpecialObjectsArray ].
 		(theBecomeEffectsFlags anyMask:
 			 BecamePointerObjectFlag + BecameCompiledMethodFlag) ifTrue: [ 
-			self followForwardingPointersInProfileState ] ].
+			self followForwardingPointersInProfileState ].
+		(theBecomeEffectsFlags anyMask: BecamePermanentObject) ifTrue: [  
+			self followForwardingPointersInPermSpace] 
+		].
 	self followForwardingPointersInStackZone: theBecomeEffectsFlags
 ]
 

--- a/smalltalksrc/VMMaker/VMMemoryMap.class.st
+++ b/smalltalksrc/VMMaker/VMMemoryMap.class.st
@@ -494,6 +494,14 @@ VMMemoryMap >> insufficientMemoryAvailableError [
 ]
 
 { #category : 'testing objects' }
+VMMemoryMap >> isInCodeZone: anOop [ 
+
+	<api>
+
+	^ anOop >= codeZoneStart  and: [ anOop < codeZoneEnd ]
+]
+
+{ #category : 'testing objects' }
 VMMemoryMap >> isOldObject: anOop [ 
 
 	<api>

--- a/smalltalksrc/VMMaker/VMSpurObjectRepresentationConstants.class.st
+++ b/smalltalksrc/VMMaker/VMSpurObjectRepresentationConstants.class.st
@@ -4,6 +4,7 @@ Class {
 	#classVars : [
 		'BecameActiveClassFlag',
 		'BecameCompiledMethodFlag',
+		'BecamePermanentObject',
 		'BecamePointerObjectFlag',
 		'OldBecameNewFlag'
 	],

--- a/smalltalksrc/VMMakerTests/VMPermanentSpaceMemoryTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPermanentSpaceMemoryTest.class.st
@@ -27,31 +27,631 @@ VMPermanentSpaceMemoryTest >> testAllInstancesReturnsObjectsInPermSpace [
 	self assert: (memory fetchPointer: 0 ofObject: allInstances) equals: permanentObject.
 ]
 
-{ #category : 'tests - allocation' }
-VMPermanentSpaceMemoryTest >> testBecomingOfPermanentObjectFails [
+{ #category : 'tests - become' }
+VMPermanentSpaceMemoryTest >> testBecomingOneWayOfPermanentObjectWithOldObject [
 
-	| permanentObject oldObject youngReplacement arrFrom arrTo ec |
+	| permanentObject oldReplacement arrFrom arrTo ec youngObjectReferencingPermanent oldObjectReferencingPermanent permanentObjectReferencingPermanent |
 	
-	permanentObject := self newPermanentObjectWithSlots:  1.
-	oldObject := self newOldSpaceObjectWithSlots: 0.
-	memory storePointer: 0 ofObject: permanentObject withValue: oldObject.
+	permanentObject := self newPermanentObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: permanentObject withValue: (self newOldSpaceObjectWithSlots: 0).
+
+	youngObjectReferencingPermanent := self newObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: youngObjectReferencingPermanent withValue: permanentObject.
+	self keepObjectInVMVariable1: youngObjectReferencingPermanent.
+	
+	oldObjectReferencingPermanent := self newOldSpaceObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: oldObjectReferencingPermanent withValue: permanentObject.
+	self keepObjectInVMVariable2: oldObjectReferencingPermanent.
+
+	permanentObjectReferencingPermanent := self newPermanentObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: permanentObjectReferencingPermanent withValue: permanentObject.
 	
 	memory fullGC.
-	self assert: (memory getFromPermToOldSpaceRememberedSet isInRememberedSet: permanentObject).
-	
-	youngReplacement := self newObjectWithSlots: 2.
-	memory storePointer: 0 ofObject: youngReplacement withValue: oldObject.
 
-	self keepObjectInVMVariable1: youngReplacement.
+	youngObjectReferencingPermanent := self keptObjectInVMVariable1.
+	oldObjectReferencingPermanent := self keptObjectInVMVariable2.
+
+	self assert: (memory getFromPermToOldSpaceRememberedSet isInRememberedSet: permanentObject).
+	self assert: (memory fetchPointer: 0 ofObject: oldObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: permanentObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: youngObjectReferencingPermanent) equals: permanentObject.
+	
+	oldReplacement := self newOldSpaceObjectWithSlots: 0.
+	self keepObjectInVMVariable3: oldReplacement.
+	
+	arrFrom := self newArrayWithSlots: 1.
+	arrTo := self newArrayWithSlots: 1.
+
+	memory storePointer: 0 ofObject: arrFrom withValue: permanentObject.
+	memory storePointer: 0 ofObject: arrTo withValue: oldReplacement.
+	ec := memory become: arrFrom with: arrTo twoWay: false copyHash: false.
+
+	self assert: ec equals: PrimNoErr.
+	
+	"The initial permanent object is now forwarded"	
+	self assert: (memory isForwarded: permanentObject).
+	"Old and New objects still points to it"
+	self assert: (memory fetchPointer: 0 ofObject: oldObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: youngObjectReferencingPermanent) equals: permanentObject.
+
+	"Perm objects still points to the result"
+	self assert: (memory fetchPointer: 0 ofObject: permanentObjectReferencingPermanent) equals: oldReplacement.
+	
+	"The forwarded object is not in any remembered set"
+	self deny: (memory getFromPermToOldSpaceRememberedSet isInRememberedSet: permanentObject).
+	self deny: (memory getFromPermToNewSpaceRememberedSet isInRememberedSet: permanentObject).
+	
+	self assert: (memory getFromPermToOldSpaceRememberedSet isInRememberedSet: permanentObjectReferencingPermanent).
+	self deny: (memory getFromPermToNewSpaceRememberedSet isInRememberedSet: permanentObjectReferencingPermanent).
+	
+	memory fullGC.
+	
+	youngObjectReferencingPermanent := self keptObjectInVMVariable1.
+	oldObjectReferencingPermanent := self keptObjectInVMVariable2.
+	oldReplacement := self keptObjectInVMVariable3.
+	
+	"After GC nobody points to the forwarded object"
+	self assert: (memory fetchPointer: 0 ofObject: oldObjectReferencingPermanent) equals: oldReplacement.
+	self assert: (memory fetchPointer: 0 ofObject: youngObjectReferencingPermanent) equals: oldReplacement.
+	self assert: (memory fetchPointer: 0 ofObject: permanentObjectReferencingPermanent) equals: oldReplacement.
+]
+
+{ #category : 'tests - become' }
+VMPermanentSpaceMemoryTest >> testBecomingOneWayOfPermanentObjectWithPermanentObject [
+
+	| permanentObject permanentReplacement arrFrom arrTo ec youngObjectReferencingPermanent oldObjectReferencingPermanent permanentObjectReferencingPermanent |
+	
+	permanentObject := self newPermanentObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: permanentObject withValue: (self newOldSpaceObjectWithSlots: 0).
+
+	youngObjectReferencingPermanent := self newObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: youngObjectReferencingPermanent withValue: permanentObject.
+	self keepObjectInVMVariable1: youngObjectReferencingPermanent.
+	
+	oldObjectReferencingPermanent := self newOldSpaceObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: oldObjectReferencingPermanent withValue: permanentObject.
+	self keepObjectInVMVariable2: oldObjectReferencingPermanent.
+
+	permanentObjectReferencingPermanent := self newPermanentObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: permanentObjectReferencingPermanent withValue: permanentObject.
+	
+	memory fullGC.
+
+	youngObjectReferencingPermanent := self keptObjectInVMVariable1.
+	oldObjectReferencingPermanent := self keptObjectInVMVariable2.
+
+	self assert: (memory getFromPermToOldSpaceRememberedSet isInRememberedSet: permanentObject).
+	self assert: (memory fetchPointer: 0 ofObject: oldObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: permanentObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: youngObjectReferencingPermanent) equals: permanentObject.
+	
+	permanentReplacement := self newPermanentObjectWithSlots: 0.
+	
+	arrFrom := self newArrayWithSlots: 1.
+	arrTo := self newArrayWithSlots: 1.
+
+	memory storePointer: 0 ofObject: arrFrom withValue: permanentObject.
+	memory storePointer: 0 ofObject: arrTo withValue: permanentReplacement.
+	ec := memory become: arrFrom with: arrTo twoWay: false copyHash: false.
+
+	self assert: ec equals: PrimNoErr.
+	
+	"The initial permanent object is now forwarded"	
+	self assert: (memory isForwarded: permanentObject).
+	"Old and New objects still points to it"
+	self assert: (memory fetchPointer: 0 ofObject: oldObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: youngObjectReferencingPermanent) equals: permanentObject.
+
+	"Perm objects still points to the result"
+	self assert: (memory fetchPointer: 0 ofObject: permanentObjectReferencingPermanent) equals: permanentReplacement.
+	
+	"The forwarded object is not in any remembered set"
+	self deny: (memory getFromPermToOldSpaceRememberedSet isInRememberedSet: permanentObject).
+	self deny: (memory getFromPermToNewSpaceRememberedSet isInRememberedSet: permanentObject).
+	
+	memory fullGC.
+	
+	youngObjectReferencingPermanent := self keptObjectInVMVariable1.
+	oldObjectReferencingPermanent := self keptObjectInVMVariable2.
+	
+	
+	"After GC nobody points to the forwarded object"
+	self assert: (memory fetchPointer: 0 ofObject: oldObjectReferencingPermanent) equals: permanentReplacement.
+	self assert: (memory fetchPointer: 0 ofObject: youngObjectReferencingPermanent) equals: permanentReplacement.
+	self assert: (memory fetchPointer: 0 ofObject: permanentObjectReferencingPermanent) equals: permanentReplacement.
+]
+
+{ #category : 'tests - become' }
+VMPermanentSpaceMemoryTest >> testBecomingOneWayOfPermanentObjectWithYoungObject [
+
+	| permanentObject oldReplacement arrFrom arrTo ec youngObjectReferencingPermanent oldObjectReferencingPermanent permanentObjectReferencingPermanent |
+	
+	permanentObject := self newPermanentObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: permanentObject withValue: (self newOldSpaceObjectWithSlots: 0).
+
+	youngObjectReferencingPermanent := self newObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: youngObjectReferencingPermanent withValue: permanentObject.
+	self keepObjectInVMVariable1: youngObjectReferencingPermanent.
+	
+	oldObjectReferencingPermanent := self newOldSpaceObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: oldObjectReferencingPermanent withValue: permanentObject.
+	self keepObjectInVMVariable2: oldObjectReferencingPermanent.
+
+	permanentObjectReferencingPermanent := self newPermanentObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: permanentObjectReferencingPermanent withValue: permanentObject.
+	
+	memory fullGC.
+
+	youngObjectReferencingPermanent := self keptObjectInVMVariable1.
+	oldObjectReferencingPermanent := self keptObjectInVMVariable2.
+
+	self assert: (memory getFromPermToOldSpaceRememberedSet isInRememberedSet: permanentObject).
+	self assert: (memory fetchPointer: 0 ofObject: oldObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: permanentObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: youngObjectReferencingPermanent) equals: permanentObject.
+	
+	oldReplacement := self newObjectWithSlots: 0.
+	self keepObjectInVMVariable3: oldReplacement.
+	
+	arrFrom := self newArrayWithSlots: 1.
+	arrTo := self newArrayWithSlots: 1.
+
+	memory storePointer: 0 ofObject: arrFrom withValue: permanentObject.
+	memory storePointer: 0 ofObject: arrTo withValue: oldReplacement.
+	ec := memory become: arrFrom with: arrTo twoWay: false copyHash: false.
+
+	self assert: ec equals: PrimNoErr.
+	
+	"The initial permanent object is now forwarded"	
+	self assert: (memory isForwarded: permanentObject).
+	"Old and New objects still points to it"
+	self assert: (memory fetchPointer: 0 ofObject: oldObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: youngObjectReferencingPermanent) equals: permanentObject.
+
+	"Perm objects still points to the result"
+	self assert: (memory fetchPointer: 0 ofObject: permanentObjectReferencingPermanent) equals: oldReplacement.
+	
+	"The forwarded object is not in any remembered set"
+	self deny: (memory getFromPermToOldSpaceRememberedSet isInRememberedSet: permanentObject).
+	self deny: (memory getFromPermToNewSpaceRememberedSet isInRememberedSet: permanentObject).
+	
+	self deny: (memory getFromPermToOldSpaceRememberedSet isInRememberedSet: permanentObjectReferencingPermanent).
+	self assert: (memory getFromPermToNewSpaceRememberedSet isInRememberedSet: permanentObjectReferencingPermanent).
+	
+	memory fullGC.
+	
+	youngObjectReferencingPermanent := self keptObjectInVMVariable1.
+	oldObjectReferencingPermanent := self keptObjectInVMVariable2.
+	oldReplacement := self keptObjectInVMVariable3.
+	
+	"After GC nobody points to the forwarded object"
+	self assert: (memory fetchPointer: 0 ofObject: oldObjectReferencingPermanent) equals: oldReplacement.
+	self assert: (memory fetchPointer: 0 ofObject: youngObjectReferencingPermanent) equals: oldReplacement.
+	self assert: (memory fetchPointer: 0 ofObject: permanentObjectReferencingPermanent) equals: oldReplacement.
+]
+
+{ #category : 'tests - become' }
+VMPermanentSpaceMemoryTest >> testBecomingTwoWayOfPermanentObjectWithOldObjectLeavingForwarded [
+
+	| permanentObject oldReplacement arrFrom arrTo ec youngObjectReferencingPermanent oldObjectReferencingPermanent permanentObjectReferencingPermanent |
+	
+	permanentObject := self newPermanentObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: permanentObject withValue: (self newOldSpaceObjectWithSlots: 0).
+
+	youngObjectReferencingPermanent := self newObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: youngObjectReferencingPermanent withValue: permanentObject.
+	self keepObjectInVMVariable1: youngObjectReferencingPermanent.
+	
+	oldObjectReferencingPermanent := self newOldSpaceObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: oldObjectReferencingPermanent withValue: permanentObject.
+	self keepObjectInVMVariable2: oldObjectReferencingPermanent.
+
+	permanentObjectReferencingPermanent := self newPermanentObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: permanentObjectReferencingPermanent withValue: permanentObject.
+	
+	memory fullGC.
+
+	youngObjectReferencingPermanent := self keptObjectInVMVariable1.
+	oldObjectReferencingPermanent := self keptObjectInVMVariable2.
+
+	self assert: (memory getFromPermToOldSpaceRememberedSet isInRememberedSet: permanentObject).
+	self assert: (memory fetchPointer: 0 ofObject: oldObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: permanentObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: youngObjectReferencingPermanent) equals: permanentObject.
+	
+	oldReplacement := self newOldSpaceObjectWithSlots: 0.
+	
+	arrFrom := self newArrayWithSlots: 1.
+	arrTo := self newArrayWithSlots: 1.
+
+	memory storePointer: 0 ofObject: arrFrom withValue: permanentObject.
+	memory storePointer: 0 ofObject: arrTo withValue: oldReplacement.
+	ec := memory become: arrFrom with: arrTo twoWay: true copyHash: false.
+
+	self assert: ec equals: PrimNoErr.
+	
+	self keepObjectInVMVariable3: (memory followForwarded: permanentObject).
+	self assert: (memory isPermanent: (memory followForwarded: oldReplacement)).
+	
+	"The initial permanent object is now forwarded"	
+	self assert: (memory isForwarded: permanentObject).
+	"Old and New objects still points to it"
+	self assert: (memory fetchPointer: 0 ofObject: oldObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: youngObjectReferencingPermanent) equals: permanentObject.
+
+	"Perm objects still points to the result"
+	self assert: (memory fetchPointer: 0 ofObject: permanentObjectReferencingPermanent) equals: self keptObjectInVMVariable3.
+	
+	"The forwarded object is not in any remembered set"
+	self deny: (memory getFromPermToOldSpaceRememberedSet isInRememberedSet: permanentObject).
+	self deny: (memory getFromPermToNewSpaceRememberedSet isInRememberedSet: permanentObject).
+	
+	memory fullGC.
+	
+	youngObjectReferencingPermanent := self keptObjectInVMVariable1.
+	oldObjectReferencingPermanent := self keptObjectInVMVariable2.
+	
+	
+	"After GC nobody points to the forwarded object"
+	self assert: (memory fetchPointer: 0 ofObject: oldObjectReferencingPermanent) equals: self keptObjectInVMVariable3.
+	self assert: (memory fetchPointer: 0 ofObject: youngObjectReferencingPermanent) equals: self keptObjectInVMVariable3.
+	self assert: (memory fetchPointer: 0 ofObject: permanentObjectReferencingPermanent) equals: self keptObjectInVMVariable3.
+	
+	self assert: memory isPermSpaceRememberedSetSane.
+]
+
+{ #category : 'tests - become' }
+VMPermanentSpaceMemoryTest >> testBecomingTwoWayOfPermanentObjectWithOldObjectNotLeavingForwarded [
+
+	| permanentObject oldReplacement arrFrom arrTo ec youngObjectReferencingPermanent oldObjectReferencingPermanent permanentObjectReferencingPermanent oldValue newValue |
+	
+	permanentObject := self newPermanentObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: permanentObject withValue: (oldValue := self newOldSpaceObjectWithSlots: 0).
+
+	youngObjectReferencingPermanent := self newObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: youngObjectReferencingPermanent withValue: permanentObject.
+	self keepObjectInVMVariable1: youngObjectReferencingPermanent.
+	
+	oldObjectReferencingPermanent := self newOldSpaceObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: oldObjectReferencingPermanent withValue: permanentObject.
+	self keepObjectInVMVariable2: oldObjectReferencingPermanent.
+
+	permanentObjectReferencingPermanent := self newPermanentObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: permanentObjectReferencingPermanent withValue: permanentObject.
+	
+	memory fullGC.
+
+	youngObjectReferencingPermanent := self keptObjectInVMVariable1.
+	oldObjectReferencingPermanent := self keptObjectInVMVariable2.
+
+	self assert: (memory getFromPermToOldSpaceRememberedSet isInRememberedSet: permanentObject).
+	self assert: (memory fetchPointer: 0 ofObject: oldObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: permanentObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: youngObjectReferencingPermanent) equals: permanentObject.
+	
+	oldReplacement := self newOldSpaceObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: oldReplacement withValue: (newValue := self newObjectWithSlots: 0).
+
+	self keepObjectInVMVariable3: oldReplacement.
+	
+	arrFrom := self newArrayWithSlots: 1.
+	arrTo := self newArrayWithSlots: 1.
+
+	memory storePointer: 0 ofObject: arrFrom withValue: permanentObject.
+	memory storePointer: 0 ofObject: arrTo withValue: oldReplacement.
+	ec := memory become: arrFrom with: arrTo twoWay: true copyHash: false.
+
+	self assert: ec equals: PrimNoErr.
+		
+	"The initial permanent object is in place changed, so it is the same address"	
+	self deny: (memory isForwarded: permanentObject).
+	"Old and New objects still points to it"
+	self assert: (memory fetchPointer: 0 ofObject: oldObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: youngObjectReferencingPermanent) equals: permanentObject.
+
+	"Perm objects still points to the result"
+	self assert: (memory fetchPointer: 0 ofObject: permanentObjectReferencingPermanent) equals: permanentObject.
+	
+	"The forwarded object is not in any remembered set"
+	self deny: (memory getFromPermToOldSpaceRememberedSet isInRememberedSet: permanentObject).
+	self assert: (memory getFromPermToNewSpaceRememberedSet isInRememberedSet: permanentObject).
+
+	self assert: (memory fetchPointer: 0 ofObject: permanentObject) equals: newValue.
+	
+	memory fullGC.
+	
+	youngObjectReferencingPermanent := self keptObjectInVMVariable1.
+	oldObjectReferencingPermanent := self keptObjectInVMVariable2.	
+	
+	"After GC nobody points to the forwarded object"
+	self assert: (memory fetchPointer: 0 ofObject: oldObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: youngObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: permanentObjectReferencingPermanent) equals: permanentObject.
+	
+	self assert: memory isPermSpaceRememberedSetSane.
+]
+
+{ #category : 'tests - become' }
+VMPermanentSpaceMemoryTest >> testBecomingTwoWayOfPermanentObjectWithPermanentObjectLeavingForwarded [
+
+	| permanentObject permanentReplacement arrFrom arrTo ec youngObjectReferencingPermanent oldObjectReferencingPermanent permanentObjectReferencingPermanent |
+	
+	permanentObject := self newPermanentObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: permanentObject withValue: (self newOldSpaceObjectWithSlots: 0).
+
+	youngObjectReferencingPermanent := self newObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: youngObjectReferencingPermanent withValue: permanentObject.
+	self keepObjectInVMVariable1: youngObjectReferencingPermanent.
+	
+	oldObjectReferencingPermanent := self newOldSpaceObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: oldObjectReferencingPermanent withValue: permanentObject.
+	self keepObjectInVMVariable2: oldObjectReferencingPermanent.
+
+	permanentObjectReferencingPermanent := self newPermanentObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: permanentObjectReferencingPermanent withValue: permanentObject.
+	
+	memory fullGC.
+
+	youngObjectReferencingPermanent := self keptObjectInVMVariable1.
+	oldObjectReferencingPermanent := self keptObjectInVMVariable2.
+
+	self assert: (memory getFromPermToOldSpaceRememberedSet isInRememberedSet: permanentObject).
+	self assert: (memory fetchPointer: 0 ofObject: oldObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: permanentObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: youngObjectReferencingPermanent) equals: permanentObject.
+	
+	permanentReplacement := self newPermanentObjectWithSlots: 0.
+	
+	arrFrom := self newArrayWithSlots: 1.
+	arrTo := self newArrayWithSlots: 1.
+
+	memory storePointer: 0 ofObject: arrFrom withValue: permanentObject.
+	memory storePointer: 0 ofObject: arrTo withValue: permanentReplacement.
+	ec := memory become: arrFrom with: arrTo twoWay: true copyHash: false.
+
+	self assert: ec equals: PrimNoErr.
+	
+	self keepObjectInVMVariable3: (memory followForwarded: permanentObject).
+	
+	self assert: (memory isPermanent: (memory followForwarded: permanentReplacement)).
+	
+	"The initial permanent object is now forwarded"	
+	self assert: (memory isForwarded: permanentObject).
+	"Old and New objects still points to it"
+	self assert: (memory fetchPointer: 0 ofObject: oldObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: youngObjectReferencingPermanent) equals: permanentObject.
+
+	"Perm objects still points to the result"
+	self assert: (memory fetchPointer: 0 ofObject: permanentObjectReferencingPermanent) equals: self keptObjectInVMVariable3.
+	
+	"The forwarded object is not in any remembered set"
+	self deny: (memory getFromPermToOldSpaceRememberedSet isInRememberedSet: permanentObject).
+	self deny: (memory getFromPermToNewSpaceRememberedSet isInRememberedSet: permanentObject).
+	
+	memory fullGC.
+	
+	youngObjectReferencingPermanent := self keptObjectInVMVariable1.
+	oldObjectReferencingPermanent := self keptObjectInVMVariable2.
+	
+	
+	"After GC nobody points to the forwarded object"
+	self assert: (memory fetchPointer: 0 ofObject: oldObjectReferencingPermanent) equals: self keptObjectInVMVariable3.
+	self assert: (memory fetchPointer: 0 ofObject: youngObjectReferencingPermanent) equals: self keptObjectInVMVariable3.
+	self assert: (memory fetchPointer: 0 ofObject: permanentObjectReferencingPermanent) equals: self keptObjectInVMVariable3.
+	
+	self assert: memory isPermSpaceRememberedSetSane.
+]
+
+{ #category : 'tests - become' }
+VMPermanentSpaceMemoryTest >> testBecomingTwoWayOfPermanentObjectWithPermanentObjectNotLeavingForwarded [
+
+	| permanentObject oldReplacement arrFrom arrTo ec youngObjectReferencingPermanent oldObjectReferencingPermanent permanentObjectReferencingPermanent oldValue newValue |
+	
+	permanentObject := self newPermanentObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: permanentObject withValue: (oldValue := self newOldSpaceObjectWithSlots: 0).
+
+	youngObjectReferencingPermanent := self newObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: youngObjectReferencingPermanent withValue: permanentObject.
+	self keepObjectInVMVariable1: youngObjectReferencingPermanent.
+	
+	oldObjectReferencingPermanent := self newOldSpaceObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: oldObjectReferencingPermanent withValue: permanentObject.
+	self keepObjectInVMVariable2: oldObjectReferencingPermanent.
+
+	permanentObjectReferencingPermanent := self newPermanentObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: permanentObjectReferencingPermanent withValue: permanentObject.
+	
+	memory fullGC.
+
+	youngObjectReferencingPermanent := self keptObjectInVMVariable1.
+	oldObjectReferencingPermanent := self keptObjectInVMVariable2.
+
+	self assert: (memory getFromPermToOldSpaceRememberedSet isInRememberedSet: permanentObject).
+	self assert: (memory fetchPointer: 0 ofObject: oldObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: permanentObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: youngObjectReferencingPermanent) equals: permanentObject.
+	
+	oldReplacement := self newPermanentObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: oldReplacement withValue: (newValue := self newObjectWithSlots: 0).
+
+	self keepObjectInVMVariable3: oldReplacement.
+	
+	arrFrom := self newArrayWithSlots: 1.
+	arrTo := self newArrayWithSlots: 1.
+
+	memory storePointer: 0 ofObject: arrFrom withValue: permanentObject.
+	memory storePointer: 0 ofObject: arrTo withValue: oldReplacement.
+	ec := memory become: arrFrom with: arrTo twoWay: true copyHash: false.
+
+	self assert: ec equals: PrimNoErr.
+		
+	"The initial permanent object is in place changed, so it is the same address"	
+	self deny: (memory isForwarded: permanentObject).
+	"Old and New objects still points to it"
+	self assert: (memory fetchPointer: 0 ofObject: oldObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: youngObjectReferencingPermanent) equals: permanentObject.
+
+	"Perm objects still points to the result"
+	self assert: (memory fetchPointer: 0 ofObject: permanentObjectReferencingPermanent) equals: permanentObject.
+	
+	"The forwarded object is not in any remembered set"
+	self deny: (memory getFromPermToOldSpaceRememberedSet isInRememberedSet: permanentObject).
+	self assert: (memory getFromPermToNewSpaceRememberedSet isInRememberedSet: permanentObject).
+
+	self assert: (memory fetchPointer: 0 ofObject: permanentObject) equals: newValue.
+	
+	memory fullGC.
+	
+	youngObjectReferencingPermanent := self keptObjectInVMVariable1.
+	oldObjectReferencingPermanent := self keptObjectInVMVariable2.	
+	
+	"After GC nobody points to the forwarded object"
+	self assert: (memory fetchPointer: 0 ofObject: oldObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: youngObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: permanentObjectReferencingPermanent) equals: permanentObject.
+	
+	self assert: memory isPermSpaceRememberedSetSane.
+]
+
+{ #category : 'tests - become' }
+VMPermanentSpaceMemoryTest >> testBecomingTwoWayOfPermanentObjectWithYoungObjectLeavingForwarded [
+
+	| permanentObject youngReplacement arrFrom arrTo ec youngObjectReferencingPermanent oldObjectReferencingPermanent permanentObjectReferencingPermanent |
+	
+	permanentObject := self newPermanentObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: permanentObject withValue: (self newOldSpaceObjectWithSlots: 0).
+
+	youngObjectReferencingPermanent := self newObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: youngObjectReferencingPermanent withValue: permanentObject.
+	self keepObjectInVMVariable1: youngObjectReferencingPermanent.
+	
+	oldObjectReferencingPermanent := self newOldSpaceObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: oldObjectReferencingPermanent withValue: permanentObject.
+	self keepObjectInVMVariable2: oldObjectReferencingPermanent.
+
+	permanentObjectReferencingPermanent := self newPermanentObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: permanentObjectReferencingPermanent withValue: permanentObject.
+	
+	memory fullGC.
+
+	youngObjectReferencingPermanent := self keptObjectInVMVariable1.
+	oldObjectReferencingPermanent := self keptObjectInVMVariable2.
+
+	self assert: (memory getFromPermToOldSpaceRememberedSet isInRememberedSet: permanentObject).
+	self assert: (memory fetchPointer: 0 ofObject: oldObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: permanentObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: youngObjectReferencingPermanent) equals: permanentObject.
+	
+	youngReplacement := self newObjectWithSlots: 0.
 	
 	arrFrom := self newArrayWithSlots: 1.
 	arrTo := self newArrayWithSlots: 1.
 
 	memory storePointer: 0 ofObject: arrFrom withValue: permanentObject.
 	memory storePointer: 0 ofObject: arrTo withValue: youngReplacement.
-	ec := memory become: arrFrom with: arrTo twoWay: false copyHash: false.
+	ec := memory become: arrFrom with: arrTo twoWay: true copyHash: false.
 
-	self deny: ec equals: PrimNoErr
+	self assert: ec equals: PrimNoErr.
+	
+	self keepObjectInVMVariable3: (memory followForwarded: permanentObject).
+	self assert: (memory isPermanent: (memory followForwarded: youngReplacement)).
+	
+	"The initial permanent object is now forwarded"	
+	self assert: (memory isForwarded: permanentObject).
+	"Old and New objects still points to it"
+	self assert: (memory fetchPointer: 0 ofObject: oldObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: youngObjectReferencingPermanent) equals: permanentObject.
+
+	"Perm objects still points to the result"
+	self assert: (memory fetchPointer: 0 ofObject: permanentObjectReferencingPermanent) equals: self keptObjectInVMVariable3.
+	
+	"The forwarded object is not in any remembered set"
+	self deny: (memory getFromPermToOldSpaceRememberedSet isInRememberedSet: permanentObject).
+	self deny: (memory getFromPermToNewSpaceRememberedSet isInRememberedSet: permanentObject).
+	
+	memory fullGC.
+	
+	youngObjectReferencingPermanent := self keptObjectInVMVariable1.
+	oldObjectReferencingPermanent := self keptObjectInVMVariable2.
+	
+	
+	"After GC nobody points to the forwarded object"
+	self assert: (memory fetchPointer: 0 ofObject: oldObjectReferencingPermanent) equals: self keptObjectInVMVariable3.
+	self assert: (memory fetchPointer: 0 ofObject: youngObjectReferencingPermanent) equals: self keptObjectInVMVariable3.
+	self assert: (memory fetchPointer: 0 ofObject: permanentObjectReferencingPermanent) equals: self keptObjectInVMVariable3.
+	
+	self assert: memory isPermSpaceRememberedSetSane.
+]
+
+{ #category : 'tests - become' }
+VMPermanentSpaceMemoryTest >> testBecomingTwoWayOfPermanentObjectWithYoungObjectNotLeavingForwarded [
+
+	| permanentObject youngReplacement arrFrom arrTo ec youngObjectReferencingPermanent oldObjectReferencingPermanent permanentObjectReferencingPermanent oldValue newValue |
+	
+	permanentObject := self newPermanentObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: permanentObject withValue: (oldValue := self newOldSpaceObjectWithSlots: 0).
+
+	youngObjectReferencingPermanent := self newObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: youngObjectReferencingPermanent withValue: permanentObject.
+	self keepObjectInVMVariable1: youngObjectReferencingPermanent.
+	
+	oldObjectReferencingPermanent := self newOldSpaceObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: oldObjectReferencingPermanent withValue: permanentObject.
+	self keepObjectInVMVariable2: oldObjectReferencingPermanent.
+
+	permanentObjectReferencingPermanent := self newPermanentObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: permanentObjectReferencingPermanent withValue: permanentObject.
+	
+	memory fullGC.
+
+	youngObjectReferencingPermanent := self keptObjectInVMVariable1.
+	oldObjectReferencingPermanent := self keptObjectInVMVariable2.
+
+	self assert: (memory getFromPermToOldSpaceRememberedSet isInRememberedSet: permanentObject).
+	self assert: (memory fetchPointer: 0 ofObject: oldObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: permanentObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: youngObjectReferencingPermanent) equals: permanentObject.
+	
+	youngReplacement := self newObjectWithSlots: 1.
+	memory storePointer: 0 ofObject: youngReplacement withValue: (newValue := self newObjectWithSlots: 0).
+
+	self keepObjectInVMVariable3: youngReplacement.
+	
+	arrFrom := self newArrayWithSlots: 1.
+	arrTo := self newArrayWithSlots: 1.
+
+	memory storePointer: 0 ofObject: arrFrom withValue: permanentObject.
+	memory storePointer: 0 ofObject: arrTo withValue: youngReplacement.
+	ec := memory become: arrFrom with: arrTo twoWay: true copyHash: false.
+
+	self assert: ec equals: PrimNoErr.
+		
+	"The initial permanent object is in place changed, so it is the same address"	
+	self deny: (memory isForwarded: permanentObject).
+	"Old and New objects still points to it"
+	self assert: (memory fetchPointer: 0 ofObject: oldObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: youngObjectReferencingPermanent) equals: permanentObject.
+
+	"Perm objects still points to the result"
+	self assert: (memory fetchPointer: 0 ofObject: permanentObjectReferencingPermanent) equals: permanentObject.
+	
+	"The forwarded object is not in any remembered set"
+	self deny: (memory getFromPermToOldSpaceRememberedSet isInRememberedSet: permanentObject).
+	self assert: (memory getFromPermToNewSpaceRememberedSet isInRememberedSet: permanentObject).
+
+	self assert: (memory fetchPointer: 0 ofObject: permanentObject) equals: newValue.
+	
+	memory fullGC.
+	
+	youngObjectReferencingPermanent := self keptObjectInVMVariable1.
+	oldObjectReferencingPermanent := self keptObjectInVMVariable2.	
+	
+	"After GC nobody points to the forwarded object"
+	self assert: (memory fetchPointer: 0 ofObject: oldObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: youngObjectReferencingPermanent) equals: permanentObject.
+	self assert: (memory fetchPointer: 0 ofObject: permanentObjectReferencingPermanent) equals: permanentObject.
+	
+	self assert: memory isPermSpaceRememberedSetSane.
 ]
 
 { #category : 'test - moving' }

--- a/src/parameters/parameters.c
+++ b/src/parameters/parameters.c
@@ -76,6 +76,7 @@ static VMErrorCode processMaxCodeSpaceSizeOption(const char *argument, VMParamet
 static VMErrorCode processEdenSizeOption(const char *argument, VMParameters * params);
 static VMErrorCode processWorkerOption(const char *argument, VMParameters * params);
 static VMErrorCode processMinPermSpaceSizeOption(const char *argument, VMParameters * params);
+static VMErrorCode processWorkingDirectory(const char *argument, VMParameters * params);
 static VMErrorCode processAvoidSearchingSegmentsWithPinnedObjects(const char *argument, VMParameters * params);
 
 static const VMParameterSpec vm_parameters_spec[] =
@@ -95,6 +96,8 @@ static const VMParameterSpec vm_parameters_spec[] =
   {.name = "codeSize", .hasArgument = true, .function = processMaxCodeSpaceSizeOption},
   {.name = "edenSize", .hasArgument = true, .function = processEdenSizeOption},
   {.name = "minPermSpaceSize", .hasArgument = true, .function = processMinPermSpaceSizeOption},
+
+  {.name = "workingDirectory", .hasArgument = true, .function = processWorkingDirectory},
 
   {.name = "avoidSearchingSegmentsWithPinnedObjects", .hasArgument = false, .function = processAvoidSearchingSegmentsWithPinnedObjects},
 #ifdef __APPLE__
@@ -439,6 +442,7 @@ vm_printUsageTo(FILE *out)
 "                                       It is possible to use k(kB), M(MB) and G(GB).\n"
 "  --minPermSpaceSize=<size>[mk]        Sets the size of eden\n"
 "                                       It is possible to use k(kB), M(MB) and G(GB).\n"
+"  --workingDirectory=<dir>				It sets the working directory for the running image.\n"
 "\n"
 "  --avoidSearchingSegmentsWithPinnedObjects\n"
 "                                       When pinning young objects, the objects are clonned into the old space.\n"
@@ -537,6 +541,18 @@ processMinPermSpaceSizeOption(const char* originalArgument, VMParameters * param
 	}
 
 	params->minPermSpaceSize = intValue;
+
+	return VM_SUCCESS;
+}
+
+static VMErrorCode
+processWorkingDirectory(const char* originalArgument, VMParameters * params)
+{
+
+	logDebug("Changing working directory to: %s", originalArgument);
+	if(chdir(originalArgument)== -1){
+		logErrorFromErrno("Error changing directory");
+	}
 
 	return VM_SUCCESS;
 }


### PR DESCRIPTION

- When there was perm space it was allocating more memory on starting for the old space as it was using the total size of the image to allocate, this space was not used but the space was required to the OS: 
  - Adding a new field to the header to hold only the old space size. 
  - Making it optional to support older images  
  - In Spur format images the value is set as the whole image size, as there is not perm space.

- Fixing the generation of reflective accessing to structures
- Improving the reading of STON files so we can handle the lf / crlf differences
- Swizzling should be aware that permanent space always is in the same place
- Adjusting the objects that are in the permanent space