### PR TITLE
When patching JITed code after become of a class, the class index can look like a negative number

### DIFF
--- a/smalltalksrc/VMMaker/CogAbstractInstruction.class.st
+++ b/smalltalksrc/VMMaker/CogAbstractInstruction.class.st
@@ -1057,7 +1057,7 @@ CogAbstractInstruction >> getOperandsWithFormat: format [
 						ifTrue: [ (operand > 16 and: [ opcode ~= Label ]) 
 							ifTrue: [ 
 								(operand allMask: 16r80000000) 
-									ifTrue: [ strOperands add: operand, '/', operand signedIntFromLong ].
+									ifTrue: [ strOperands add: operand printString, '/', operand signedIntFromLong printString ].
 									strOperands add: operand asString, '/', (operand hex)]
 							ifFalse: [ 
 								strOperands add: operand.

--- a/smalltalksrc/VMMaker/CogIA32Compiler.class.st
+++ b/smalltalksrc/VMMaker/CogIA32Compiler.class.st
@@ -3646,7 +3646,11 @@ CogIA32Compiler >> hasThreeAddressArithmetic [
 { #category : 'inline cacheing' }
 CogIA32Compiler >> inlineCacheTagAt: callSiteReturnAddress [
 	"Answer the inline cache tag for the return address of a send."
-	^self literalBeforeFollowingAddress: callSiteReturnAddress - 5
+
+	<returnTypeC: #usqInt>
+
+	^ (self literalBeforeFollowingAddress: callSiteReturnAddress - 5)
+		  bitAnd: 1 << objectMemory classIndexFieldWidth - 1
 ]
 
 { #category : 'disassembly' }

--- a/smalltalksrc/VMMaker/CogInLineLiteralsARMCompiler.class.st
+++ b/smalltalksrc/VMMaker/CogInLineLiteralsARMCompiler.class.st
@@ -50,8 +50,15 @@ CogInLineLiteralsARMCompiler >> getDefaultCogCodeSize [
 { #category : 'inline cacheing' }
 CogInLineLiteralsARMCompiler >> inlineCacheTagAt: callSiteReturnAddress [
 	"Answer the inline cache tag for the return address of a send."
-	self assert: (self instructionIsBL: (self instructionBeforeAddress: callSiteReturnAddress)).
-	^self extract32BitOperandFrom4InstructionsPreceding: callSiteReturnAddress - 4
+
+	<returnTypeC: #usqInt>
+
+	self assert: (self instructionIsBL:
+			 (self instructionBeforeAddress: callSiteReturnAddress)).
+
+	^ (self extract32BitOperandFrom4InstructionsPreceding:
+		   callSiteReturnAddress - 4) bitAnd:
+		  1 << objectMemory classIndexFieldWidth - 1
 ]
 
 { #category : 'testing' }

--- a/smalltalksrc/VMMaker/CogInLineLiteralsX64Compiler.class.st
+++ b/smalltalksrc/VMMaker/CogInLineLiteralsX64Compiler.class.st
@@ -164,7 +164,11 @@ CogInLineLiteralsX64Compiler >> getDefaultCogCodeSize [
 { #category : 'inline cacheing' }
 CogInLineLiteralsX64Compiler >> inlineCacheTagAt: callSiteReturnAddress [
 	"Answer the inline cache tag for the return address of a send."
-	^self literal32BeforeFollowingAddress: callSiteReturnAddress - 5
+
+	<returnTypeC: #usqInt>
+
+	^ (self literal32BeforeFollowingAddress: callSiteReturnAddress - 5)
+		  bitAnd: 1 << objectMemory classIndexFieldWidth - 1
 ]
 
 { #category : 'testing' }

--- a/smalltalksrc/VMMaker/CogMIPSELCompiler.class.st
+++ b/smalltalksrc/VMMaker/CogMIPSELCompiler.class.st
@@ -1908,6 +1908,8 @@ CogMIPSELCompiler >> inlineCacheTagAt: callSiteReturnAddress [
 	 ...  <-- callSiteReturnAddress"
 	
 	<var: #callSiteReturnAddress type: #usqInt>
+	<returnTypeC: #usqInt>
+	
 	self assert: (self opcodeAtAddress: callSiteReturnAddress - 24) = LUI.
 	self assert: (self opcodeAtAddress: callSiteReturnAddress - 20) = ORI.
 	self assert: (self opcodeAtAddress: callSiteReturnAddress - 16) = LUI.
@@ -1916,7 +1918,8 @@ CogMIPSELCompiler >> inlineCacheTagAt: callSiteReturnAddress [
 	self assert: (self functionAtAddress: callSiteReturnAddress - 8) = JALR.
 	self assert: (objectMemory longAt: callSiteReturnAddress - 4) = self nop.
 
-	^self literalAtAddress: callSiteReturnAddress - 20
+	^(self literalAtAddress: callSiteReturnAddress - 20) bitAnd:
+		  1 << objectMemory classIndexFieldWidth - 1
 ]
 
 { #category : 'disassembly' }

--- a/smalltalksrc/VMMaker/CogOutOfLineLiteralsARMCompiler.class.st
+++ b/smalltalksrc/VMMaker/CogOutOfLineLiteralsARMCompiler.class.st
@@ -51,8 +51,11 @@ CogOutOfLineLiteralsARMCompiler >> getDefaultCogCodeSize [
 
 { #category : 'inline cacheing' }
 CogOutOfLineLiteralsARMCompiler >> inlineCacheTagAt: callSiteReturnAddress [
-	<inline: true>
-	^objectMemory uint32AtPointer: (self pcRelativeAddressAt: (callSiteReturnAddress - 8) asUnsignedInteger)
+
+	<returnTypeC: #usqInt>
+
+	^(objectMemory uint32AtPointer: (self pcRelativeAddressAt: (callSiteReturnAddress - 8) asUnsignedInteger)) bitAnd:
+		  1 << objectMemory classIndexFieldWidth - 1
 ]
 
 { #category : 'testing' }

--- a/smalltalksrc/VMMaker/CogOutOfLineLiteralsARMv8Compiler.class.st
+++ b/smalltalksrc/VMMaker/CogOutOfLineLiteralsARMv8Compiler.class.st
@@ -207,8 +207,12 @@ CogOutOfLineLiteralsARMv8Compiler >> getDefaultCogCodeSize [
 
 { #category : 'inline cacheing' }
 CogOutOfLineLiteralsARMv8Compiler >> inlineCacheTagAt: callSiteReturnAddress [
-	<inline: true>
-	^objectMemory unsignedLongAt: (self pcRelativeAddressAt: (callSiteReturnAddress - 8) asUnsignedInteger)
+
+	<returnTypeC: #usqInt>
+
+	^ (objectMemory unsignedLongAt: (self pcRelativeAddressAt:
+			    (callSiteReturnAddress - 8) asUnsignedInteger)) bitAnd:
+		  1 << objectMemory classIndexFieldWidth - 1
 ]
 
 { #category : 'testing' }

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -8163,14 +8163,9 @@ SpurMemoryManager >> isValidClassIndex: classIndex [
 ]
 
 { #category : 'class table' }
-SpurMemoryManager >> isValidClassTag: classIndexToMask [
+SpurMemoryManager >> isValidClassTag: classIndex [
 	<api>
-	| classOrNil classIndex |
-
-	<var: 'classIndexToMask' type: #usqInt>
-	<var: 'classIndex' type: #usqInt>
-	
-	classIndex := classIndexToMask bitAnd: 1 << self classIndexFieldWidth - 1.
+	| classOrNil |
 
 	self assert: (classIndex between: 0 and: 1 << self classIndexFieldWidth - 1).
 	classOrNil := self classOrNilAtIndex: classIndex.

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -8163,9 +8163,15 @@ SpurMemoryManager >> isValidClassIndex: classIndex [
 ]
 
 { #category : 'class table' }
-SpurMemoryManager >> isValidClassTag: classIndex [
+SpurMemoryManager >> isValidClassTag: classIndexToMask [
 	<api>
-	| classOrNil |
+	| classOrNil classIndex |
+
+	<var: 'classIndexToMask' type: #usqInt>
+	<var: 'classIndex' type: #usqInt>
+	
+	classIndex := classIndexToMask bitAnd: 1 << self classIndexFieldWidth - 1.
+
 	self assert: (classIndex between: 0 and: 1 << self classIndexFieldWidth - 1).
 	classOrNil := self classOrNilAtIndex: classIndex.
 	^classOrNil ~= nilObj

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -3697,6 +3697,7 @@ SpurMemoryManager >> classFormatFromInstFormat: instFormat [
 
 { #category : 'header format' }
 SpurMemoryManager >> classIndexFieldWidth [
+	<api>
 	"22-bit class mask => ~ 4M classes"
 	^22
 ]

--- a/smalltalksrc/VMMakerTests/VMClassTagInlineReadTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMClassTagInlineReadTest.class.st
@@ -1,0 +1,62 @@
+Class {
+	#name : 'VMClassTagInlineReadTest',
+	#superclass : 'VMPrimitiveCallAbstractTest',
+	#pools : [
+		'CogRTLOpcodes'
+	],
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
+}
+
+{ #category : 'tests' }
+VMClassTagInlineReadTest >> testLinkingWithEntryOffset [
+
+	| sendingMethod targetMethod callSiteReturn |
+	sendingMethod := self
+		                 jitMethod: (self findMethod: #methodWithSend)
+		                 selector: memory nilObject.
+
+	targetMethod := self
+		                jitMethod: (self findMethod: #yourself)
+		                selector: memory trueObject.
+
+	callSiteReturn := sendingMethod address + 16r98.
+
+	cogit
+		linkSendAt: callSiteReturn
+		in: sendingMethod
+		to: targetMethod
+		offset: cogit entryOffset
+		receiver: memory falseObject.
+		
+	self assert: (cogit backend inlineCacheTagAt: callSiteReturn) equals:(memory classIndexOf: memory falseObject)
+]
+
+{ #category : 'tests' }
+VMClassTagInlineReadTest >> testLinkingWithEntryOffsetLargeClassIndex [
+
+	| sendingMethod targetMethod callSiteReturn |
+	sendingMethod := self
+		                 jitMethod: (self findMethod: #methodWithSend)
+		                 selector: memory nilObject.
+
+	targetMethod := self
+		                jitMethod: (self findMethod: #yourself)
+		                selector: memory trueObject.
+
+	callSiteReturn := sendingMethod address + 16r98.
+
+	obj := self newZeroSizedObject.
+	memory setClassIndexOf: obj to: (1 << memory classIndexFieldWidth - 5).
+
+	cogit
+		linkSendAt: callSiteReturn
+		in: sendingMethod
+		to: targetMethod
+		offset: cogit entryOffset
+		receiver: obj.
+	
+
+	self assert: (cogit backend inlineCacheTagAt: callSiteReturn) equals: (1 << memory classIndexFieldWidth - 5)
+]


### PR DESCRIPTION
The classIndex that we read from the JITed code might be sign extended when encoding, so we need to guarantee that we bit mask it before using it and the correct types of the variables