### PR TITLE
fix unused-local-typedef

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,7 +308,6 @@ add_compile_options(
     -Wno-deprecated-declarations
     -Wno-pointer-to-int-cast
     -Wno-compare-distinct-pointer-types
-    -Wno-unused-local-typedef
     -Wno-unknown-warning-option
 )
 

--- a/extracted/plugins/FilePlugin/src/common/sqFilePluginBasicPrims.c
+++ b/extracted/plugins/FilePlugin/src/common/sqFilePluginBasicPrims.c
@@ -841,7 +841,6 @@ waitForDataonSemaphoreIndex(SQFile *file, sqInt semaphoreIndex){
 		return interpreterProxy->success(false);
 
 	aioEnable(fileno(getFile(file)), (void*) semaphoreIndex, AIO_EXT);
-	typedef void (*aioHandler)(int fd, void *clientData, int flag);
 	aioHandle(fileno(getFile(file)), signalOnDataArrival, AIO_R);
 
 	return interpreterProxy->success(true);


### PR DESCRIPTION
If the VM is compiled without the Wno-unused-local-typedef, we get one warning from the C file sqFilePluginBasicPrims.c which redifine the typedef  void (*aioHandler)(int fd, void *clientData, int flag) (already present in sqaio.h) and doesn't use it.

Simply suppress it from the file
