### PR TITLE
fixing-classTag-tests

### DIFF
--- a/smalltalksrc/VMMaker/CogOutOfLineLiteralsARMCompiler.class.st
+++ b/smalltalksrc/VMMaker/CogOutOfLineLiteralsARMCompiler.class.st
@@ -211,7 +211,8 @@ CogOutOfLineLiteralsARMCompiler >> rewriteInlineCacheAt: callSiteReturnAddress t
 	objectMemory
 		unsignedLongAt: (self instructionAddressBefore: callSiteReturnAddress ) put: call;
 		unsignedLongAt: (self pcRelativeAddressAt: callSiteReturnAddress - 8) put: cacheTag.
-	self assert: (self inlineCacheTagAt: callSiteReturnAddress) = cacheTag.
+	self assert: (self inlineCacheTagAt: callSiteReturnAddress) = (cacheTag signedIntFromLong bitAnd:
+		  1 << objectMemory classIndexFieldWidth - 1).
 	"self cCode: ''
 		inSmalltalk: [cogit disassembleFrom: callSiteReturnAddress - 8 to: (self pcRelativeAddressAt: callSiteReturnAddress - 8)]."
 	^4

--- a/smalltalksrc/VMMaker/CogOutOfLineLiteralsARMv8Compiler.class.st
+++ b/smalltalksrc/VMMaker/CogOutOfLineLiteralsARMv8Compiler.class.st
@@ -379,7 +379,8 @@ CogOutOfLineLiteralsARMv8Compiler >> rewriteInlineCacheAt: callSiteReturnAddress
 	objectMemory
 		uint32AtPointer: (self instructionAddressBefore: callSiteReturnAddress ) put: call;
 		unsignedLong64At: (self pcRelativeAddressAt: callSiteReturnAddress - 8) put: cacheTag signedIntToLong64.
-	self assert: (self inlineCacheTagAt: callSiteReturnAddress) = cacheTag  signedIntToLong64.
+	self assert: (self inlineCacheTagAt: callSiteReturnAddress) = (cacheTag signedIntToLong64 bitAnd:
+		  1 << objectMemory classIndexFieldWidth - 1) .
 	"self cCode: ''
 		inSmalltalk: [cogit disassembleFrom: callSiteReturnAddress - 8 to: (self pcRelativeAddressAt: callSiteReturnAddress - 8)]."
 	^4

--- a/smalltalksrc/VMMakerTests/VMClassTagInlineReadTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMClassTagInlineReadTest.class.st
@@ -21,7 +21,7 @@ VMClassTagInlineReadTest >> testLinkingWithEntryOffset [
 		                jitMethod: (self findMethod: #yourself)
 		                selector: memory trueObject.
 
-	callSiteReturn := sendingMethod address + 16r98.
+	cogit sendSitesIn: sendingMethod do: [ :annotation :pc | callSiteReturn := pc ].
 
 	cogit
 		linkSendAt: callSiteReturn
@@ -41,11 +41,12 @@ VMClassTagInlineReadTest >> testLinkingWithEntryOffsetLargeClassIndex [
 		                 jitMethod: (self findMethod: #methodWithSend)
 		                 selector: memory nilObject.
 
+	cogit sendSitesIn: sendingMethod do: [ :annotation :pc | callSiteReturn := pc ].
+
 	targetMethod := self
 		                jitMethod: (self findMethod: #yourself)
 		                selector: memory trueObject.
 
-	callSiteReturn := sendingMethod address + 16r98.
 
 	obj := self newZeroSizedObject.
 	memory setClassIndexOf: obj to: (1 << memory classIndexFieldWidth - 5).


### PR DESCRIPTION
- Changing the tests to calculate the address and not to use a hardcoded one

- The asserts should bitAnd the class tag to the correct size