### PR TITLE
Fix linking of UnixOSProcessPlugin - Remove dead code

### DIFF
--- a/extracted/plugins/UnixOSProcessPlugin/src/common/UnixOSProcessPlugin.c
+++ b/extracted/plugins/UnixOSProcessPlugin/src/common/UnixOSProcessPlugin.c
@@ -68,7 +68,6 @@ EXPORT(char**) getProcessArgumentVector();
 EXPORT(char**) getProcessEnvironmentVector();
 
 /*** Function Prototypes ***/
-static sqInt argumentAtAsType(sqInt classIdentifier);
 static void * callocWrappersize(sqInt count, sqInt objectSize);
 static sqInt copyBytesFromtolength(void *charArray1, void *charArray2, sqInt len);
 static sqInt createPipeForReaderwriter(FILEHANDLETYPE *readerIOStreamPtr, FILEHANDLETYPE *writerIOStreamPtr);
@@ -352,43 +351,6 @@ static pthread_t vmThread;
 
 /*** Macros ***/
 #define sessionIdentifierFromSqFile(sqFile) (((SQFile *)(sqFile))->sessionID)
-
-
-
-/*	Answer a string containing the OS process argument at index (an Integer)
-	in the
-	argument list.
- */
-
-	/* UnixOSProcessPlugin>>#argumentAtAsType: */
-static sqInt
-argumentAtAsType(sqInt classIdentifier)
-{
-    extern char **argVec;
-    sqInt index;
-    sqInt len;
-    sqInt newString;
-    sqInt s;
-    char *sPtr;
-
-    int argCnt = getProcessArgumentCount();
-
-	index = stackIntegerValue(0);
-	if ((index > argCnt) || (index < 1)) {
-		popthenPush(2, nilObject());
-	}
-	else {
-		sPtr = argVec[index - 1];
-		/* begin cString:asCollection: */
-		len = strlen(sPtr);
-		newString = instantiateClassindexableSize(classIdentifier, len);
-		strncpy(arrayValueOf(newString), sPtr, len);
-		s = newString;
-		popthenPush(2, s);
-	}
-	return 0;
-}
-
 
 /*	Using malloc() and calloc() is something I would like to avoid, since it
 	is likely to cause problems some time in the future if somebody redesigns


### PR DESCRIPTION
In newer nixes (e.g., Debian 12) the linker does not allow loading UnixOSProcessPlugin because of the undefined `argVec` symbol defined as `extern`.

The only reference to this was in a dead function: remove it.