### PR TITLE
Add a dumb `isNotNil` implementation (the same as `notNil`)

### DIFF
--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -3222,6 +3222,7 @@ CCodeGenerator >> initializeCASTTranslationDictionary [
 	#==			#generateCASTEqual:
 	#~~			#generateCASTNotEqual:
 	#isNil			#generateCASTIsNil:
+	#isNotNil			#generateCASTNotNil:
 	#notNil			#generateCASTNotNil:
 
 	#whileTrue: 	#generateCASTWhileTrue:


### PR DESCRIPTION
If we look at the current source for the pharo project `notNil` is used ~250 times and `isNotNil` ~1200 times. Given that they do exactly the same we should at least support the more "idiomatic" one (maybe even deprecate the other one?).

This change goes in that direction by adding an implementation of `isNotNil` that's just the same handler as for `notNil`.