### PR TITLE
Fix some Slang tests

### DIFF
--- a/smalltalksrc/Slang-Tests/SLDeadCodeEliminationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SLDeadCodeEliminationTest.class.st
@@ -422,7 +422,7 @@ methodWithEmptyIfFalseInIfFalseIfTrueAndNoSendInReceiver(SLDeadCodeEliminationTe
 {
 	int i;
 
-	if (1) {
+	{
 		i = 5;
 	}
 	{
@@ -484,7 +484,7 @@ methodWithEmptyIfFalseInIfTrueIfFalseAndNoSendInReceiver(SLDeadCodeEliminationTe
 {
 	int i;
 
-	if (1) {
+	{
 		i = 5;
 	}
 	{
@@ -714,9 +714,7 @@ methodWithEmptyIfTrueInIfFalseIfTrueAndNoSendInReceiver(SLDeadCodeEliminationTes
 {
 	int i;
 
-	if (!1) {
-		i = 5;
-	}
+	;
 	{
 		return;
 	}
@@ -776,9 +774,7 @@ methodWithEmptyIfTrueInIfTrueIfFalseAndNoSendInReceiver(SLDeadCodeEliminationTes
 {
 	int i;
 
-	if (!1) {
-		i = 5;
-	}
+	;
 	{
 		return;
 	}
@@ -838,9 +834,7 @@ methodWithEmptyifNilInIfNilIfNotNilAndNoSendInReceiver(SLDeadCodeEliminationTest
 {
 	int i;
 
-	if (!(null == null)) {
-		i = 5;
-	}
+	;
 	{
 		return;
 	}
@@ -900,9 +894,7 @@ methodWithEmptyifNilInIfNotNilIfNilAndNoSendInReceiver(SLDeadCodeEliminationTest
 {
 	int i;
 
-	if (!(null == null)) {
-		i = 5;
-	}
+	;
 	{
 		return;
 	}
@@ -962,7 +954,7 @@ methodWithEmptyifNotNilInIfNilIfNotNilAndNoSendInReceiver(SLDeadCodeEliminationT
 {
 	int i;
 
-	if (null == null) {
+	{
 		i = 5;
 	}
 	{
@@ -1024,7 +1016,7 @@ methodWithEmptyifNotNilInIfNotNilIfNilAndNoSendInReceiver(SLDeadCodeEliminationT
 {
 	int i;
 
-	if (null == null) {
+	{
 		i = 5;
 	}
 	{

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -1216,6 +1216,7 @@ methodToBeTranslatedWithIfAndShiftRight(void)
 	((usqInt) (((2 < 0)
 		 ? 0
 		 : 2)) ) >> ((2 - 1) * 32);
+	/* end methodWithIfAndShiftRight: */
 	return 0;
 }
 '.
@@ -1247,6 +1248,7 @@ methodUseParametersWithAnnotationstowith(unsigned int *pFrom, unsigned int *pTo,
 		pTo1[i] = (pFrom + anInteger)[i];
 	};
 	return 0;
+	/* end methodFromWithAnnotations:to:len: */
 }'
 ]
 
@@ -1285,6 +1287,7 @@ methodUseParametersWithAnnotationsBuiltIntowith(unsigned int *pFrom, unsigned in
 	for (i = 0; i <= 10; i += 1) {
 		pTo[i] = pFrom1[i];
 	};
+	/* end methodFromWithAnnotations:to: */
 	return 0;
 }'
 ]
@@ -1479,68 +1482,6 @@ SlangBasicTranslationTest >> testInlineNodeWithSharedLabelInCase [
 }'
 ]
 
-{ #category : 'test-inline-comment' }
-SlangBasicTranslationTest >> testInlinedCommentInExpressionMoveReturn [
-	"comments in Slang are related to inlining, they should only be in list of Statement (use as argument or expression but list of statement anyway) at the start or end of a list of statement. Here the return need to be moved to the switch at the location of the actual last statement "
-
-	| translation tMethod |
-	tMethod := self getTMethodFrom: #switchInReturn.
-	tMethod prepareMethodIn: generator.
-	tMethod recordDeclarationsIn: generator.
-	generator doBasicInlining: true.
-	translation := self translate: tMethod.
-	translation := translation trimBoth.
-
-	self
-		assert: translation
-		equals: '/* SlangBasicTranslationTestClass>>#switchInReturn */
-static sqInt
-switchInReturn(void)
-{
-	sqInt switch0;
-
-	switch (1) {
-		case 4:
-		{
-			/* begin methodWithoutInlinePragmaAndEmptyMethodCall */
-			/* begin emptyMethod */
-			/* end emptyMethod */
-			return bodyOfMethodWithoutInlinePragma();
-			/* end methodWithoutInlinePragmaAndEmptyMethodCall */
-		}
-		default:
-		error("Case not found and no otherwise clause");
-		return -1;
-	}
-}'
-]
-
-{ #category : 'test-inline-comment' }
-SlangBasicTranslationTest >> testInlinedMethodCommentInExpression [
-	"comments in Slang are related to inlining, they should only be in list of Statement (use as argument or expression but list of statement anyway) at the start or end of a list of statement. when use as an expression we need to be careful of where to put comma to respect semantics/not produce errors "
-
-	| translation tMethod |
-	tMethod := self getTMethodFrom: #methodCallingMethodExpressionList.
-	tMethod recordDeclarationsIn: generator.
-	generator doBasicInlining: true.
-
-	translation := self translate: tMethod.
-	translation := translation trimBoth.
-
-	self
-		assert: translation
-		equals:
-			'/* SlangBasicTranslationTestClass>>#methodCallingMethodExpressionList */
-static sqInt
-methodCallingMethodExpressionList(void)
-{
-	sqInt i;
-
-	i == ((/* begin emptyMethod */ /* end emptyMethod */, bodyOfMethodWithoutInlinePragma(), /* begin methodWithoutInlinePragmaAndEmptyMethodCall */ /* begin emptyMethod */ /* end emptyMethod */, bodyOfMethodWithoutInlinePragma() /* end methodWithoutInlinePragmaAndEmptyMethodCall */, /* begin methodWithInlinePragma */ bodyOfMethodWithInlinePragma() /* end methodWithInlinePragma */));
-	return 0;
-}'
-]
-
 { #category : 'tests-inlinemethod' }
 SlangBasicTranslationTest >> testInlineWithCoerceAsArgument [
 	"the cast is still in an expression, so inlining does not supress it"
@@ -1639,6 +1580,68 @@ static sqInt
 methodCallingMethodWithCCoerceInReturn(void)
 {
 	method();
+	return 0;
+}'
+]
+
+{ #category : 'test-inline-comment' }
+SlangBasicTranslationTest >> testInlinedCommentInExpressionMoveReturn [
+	"comments in Slang are related to inlining, they should only be in list of Statement (use as argument or expression but list of statement anyway) at the start or end of a list of statement. Here the return need to be moved to the switch at the location of the actual last statement "
+
+	| translation tMethod |
+	tMethod := self getTMethodFrom: #switchInReturn.
+	tMethod prepareMethodIn: generator.
+	tMethod recordDeclarationsIn: generator.
+	generator doBasicInlining: true.
+	translation := self translate: tMethod.
+	translation := translation trimBoth.
+
+	self
+		assert: translation
+		equals: '/* SlangBasicTranslationTestClass>>#switchInReturn */
+static sqInt
+switchInReturn(void)
+{
+	sqInt switch0;
+
+	switch (1) {
+		case 4:
+		{
+			/* begin methodWithoutInlinePragmaAndEmptyMethodCall */
+			/* begin emptyMethod */
+			/* end emptyMethod */
+			return bodyOfMethodWithoutInlinePragma();
+			/* end methodWithoutInlinePragmaAndEmptyMethodCall */
+		}
+		default:
+		error("Case not found and no otherwise clause");
+		return -1;
+	}
+}'
+]
+
+{ #category : 'test-inline-comment' }
+SlangBasicTranslationTest >> testInlinedMethodCommentInExpression [
+	"comments in Slang are related to inlining, they should only be in list of Statement (use as argument or expression but list of statement anyway) at the start or end of a list of statement. when use as an expression we need to be careful of where to put comma to respect semantics/not produce errors "
+
+	| translation tMethod |
+	tMethod := self getTMethodFrom: #methodCallingMethodExpressionList.
+	tMethod recordDeclarationsIn: generator.
+	generator doBasicInlining: true.
+
+	translation := self translate: tMethod.
+	translation := translation trimBoth.
+
+	self
+		assert: translation
+		equals:
+			'/* SlangBasicTranslationTestClass>>#methodCallingMethodExpressionList */
+static sqInt
+methodCallingMethodExpressionList(void)
+{
+	sqInt i;
+
+	i == ((/* begin emptyMethod */ /* end emptyMethod */, bodyOfMethodWithoutInlinePragma(), /* begin methodWithoutInlinePragmaAndEmptyMethodCall */ /* begin emptyMethod */ /* end emptyMethod */, bodyOfMethodWithoutInlinePragma() /* end methodWithoutInlinePragmaAndEmptyMethodCall */, /* begin methodWithInlinePragma */ bodyOfMethodWithInlinePragma() /* end methodWithInlinePragma */));
 	return 0;
 }'
 ]

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTestClass.class.st
@@ -50,17 +50,6 @@ SlangBasicTranslationTestClass >> initializationOptions [
 	^ nil
 ]
 
-{ #category : 'inline-comment' }
-SlangBasicTranslationTestClass >> methodCallingMethodExpressionList [
-
-	| i |
-	i = [
-	self emptyMethod.
-	self bodyOfMethodWithoutInlinePragma.
-	self methodWithoutInlinePragmaAndEmptyMethodCall.
-	self methodWithInlinePragma ]
-]
-
 { #category : 'inline' }
 SlangBasicTranslationTestClass >> methodCallingInAssignemtMethodWithCCoerceInReturn [
 
@@ -78,6 +67,17 @@ SlangBasicTranslationTestClass >> methodCallingInReturnMethodWithCCoerceInReturn
 SlangBasicTranslationTestClass >> methodCallingInSendMethodWithCCoerceInReturn [
 
 	self method: self methodWithCCoerceInReturn
+]
+
+{ #category : 'inline-comment' }
+SlangBasicTranslationTestClass >> methodCallingMethodExpressionList [
+
+	| i |
+	i = [
+	self emptyMethod.
+	self bodyOfMethodWithoutInlinePragma.
+	self methodWithoutInlinePragmaAndEmptyMethodCall.
+	self methodWithInlinePragma ]
 ]
 
 { #category : 'inline' }
@@ -226,16 +226,16 @@ SlangBasicTranslationTestClass >> methodWithAnOptionPragma [
 ]
 
 { #category : 'inline' }
+SlangBasicTranslationTestClass >> methodWithCCoerceInReturn [
+	^ self cCoerce: self method to: #sqInt 
+]
+
+{ #category : 'inline' }
 SlangBasicTranslationTestClass >> methodWithIfAndShiftRight: var [
 
 	^ (var < 0
 		ifTrue:  [ 0 ]
 		ifFalse: [ var ]) >> (var - 1 * 32)
-]
-
-{ #category : 'inline' }
-SlangBasicTranslationTestClass >> methodWithCCoerceInReturn [
-	^ self cCoerce: self method to: #sqInt 
 ]
 
 { #category : 'inline' }


### PR DESCRIPTION
Slang has some tests that where never updated to reflect the codegen changes. This PR fixes some of those:
- Fix tests where we expected `if (1)` or `if (!1)` for `true ifTrue: ... ifFalse: ...` and `false ifTrue: ... ifFalse: ...`
- Fix tests where we expected `if (null == null)` or `if (!(null == null))` for `nil ifNil: ... ifNotNil:` and `nil ifNotNil: ... ifNil: ...`
- Fix tests where we didn't have the "end inlining" comments we are currently inserting.