### PR TITLE
DojoVM 2025-01-07

### DIFF
--- a/smalltalksrc/CAST/CCommentNode.class.st
+++ b/smalltalksrc/CAST/CCommentNode.class.st
@@ -40,15 +40,3 @@ CCommentNode >> isComment [
 
 	^ true
 ]
-
-{ #category : 'testing' }
-CCommentNode >> needsSeparator [
-
-	^ false
-]
-
-{ #category : 'testing' }
-CCommentNode >> needsTrailingSemicolon [
-
-	^ false
-]

--- a/smalltalksrc/CAST/CCompoundStatementNode.class.st
+++ b/smalltalksrc/CAST/CCompoundStatementNode.class.st
@@ -47,7 +47,8 @@ CCompoundStatementNode >> acceptVisitor: anAbstractVisitor [
 { #category : 'adding' }
 CCompoundStatementNode >> add: aStatement [
 
-	statements add: aStatement
+	statements add: aStatement.
+	aStatement parent: self
 ]
 
 { #category : 'adding' }
@@ -87,8 +88,19 @@ CCompoundStatementNode >> initialize [
 	super initialize.
 	statements := OrderedCollection new: 2.
 	declarations := OrderedCollection new: 2.
-	needsBrackets := true.
-	needsSeparator := false
+	needsBrackets := true
+]
+
+{ #category : 'testing' }
+CCompoundStatementNode >> isAtEndOfStatement [
+	"Signals whether the end of this block (think of the closing brace) is at the
+	 end of a statement. This is only false when the block is followed by a
+	 `while(..);` or an `else`."
+	parent ifNil: [ ^ true ].
+	parent isDoWhile ifTrue: [ ^ false ].
+	parent isIf ifTrue: [
+		^ parent else = self or: [ parent else isNil ] ].
+	^ true
 ]
 
 { #category : 'testing' }
@@ -138,12 +150,6 @@ CCompoundStatementNode >> needsBrackets [
 CCompoundStatementNode >> needsBrackets: anObject [
 
 	needsBrackets := anObject
-]
-
-{ #category : 'testing' }
-CCompoundStatementNode >> needsTrailingSemicolon [
-
-	^ false
 ]
 
 { #category : 'generated' }

--- a/smalltalksrc/CAST/CFunctionDefinitionNode.class.st
+++ b/smalltalksrc/CAST/CFunctionDefinitionNode.class.st
@@ -124,18 +124,6 @@ CFunctionDefinitionNode >> initialize [
 	arguments := OrderedCollection new: 2.
 ]
 
-{ #category : 'testing' }
-CFunctionDefinitionNode >> needsSeparator [
-
-	^ false
-]
-
-{ #category : 'testing' }
-CFunctionDefinitionNode >> needsTrailingSemicolon [
-
-	^ false
-]
-
 { #category : 'generated' }
 CFunctionDefinitionNode >> specifiers [
 	^ specifiers

--- a/smalltalksrc/CAST/CGLRAbstractNode.class.st
+++ b/smalltalksrc/CAST/CGLRAbstractNode.class.st
@@ -1,9 +1,6 @@
 Class {
 	#name : 'CGLRAbstractNode',
 	#superclass : 'SmaCCParseNode',
-	#instVars : [
-		'needsSeparator'
-	],
 	#category : 'CAST',
 	#package : 'CAST'
 }
@@ -44,13 +41,6 @@ CGLRAbstractNode >> comments [
 ]
 
 { #category : 'testing' }
-CGLRAbstractNode >> initialize [
-
-	super initialize.
-	needsSeparator := true
-]
-
-{ #category : 'testing' }
 CGLRAbstractNode >> isBinaryOperation [
 	
 	^ false
@@ -76,6 +66,11 @@ CGLRAbstractNode >> isCompoundStatement [
 { #category : 'testing' }
 CGLRAbstractNode >> isConstant [
 	
+	^ false
+]
+
+{ #category : 'testing' }
+CGLRAbstractNode >> isDoWhile [
 	^ false
 ]
 
@@ -116,6 +111,11 @@ CGLRAbstractNode >> isIdentifier [
 ]
 
 { #category : 'testing' }
+CGLRAbstractNode >> isIf [
+	^ false
+]
+
+{ #category : 'testing' }
 CGLRAbstractNode >> isLeaf [
 	
 	^ false
@@ -144,22 +144,4 @@ CGLRAbstractNode >> last: aReplacement [
 	
 	"I replace myself by the node as argument"
 	^ aReplacement
-]
-
-{ #category : 'accessing' }
-CGLRAbstractNode >> needsSeparator [
-
-	^ needsSeparator
-]
-
-{ #category : 'accessing' }
-CGLRAbstractNode >> needsSeparator: aBoolean [
-
-	needsSeparator := aBoolean
-]
-
-{ #category : 'testing' }
-CGLRAbstractNode >> needsTrailingSemicolon [ 
-	
-	^ true
 ]

--- a/smalltalksrc/CAST/CIfStatementNode.class.st
+++ b/smalltalksrc/CAST/CIfStatementNode.class.st
@@ -71,18 +71,6 @@ CIfStatementNode >> isIf [
 	^ true
 ]
 
-{ #category : 'testing' }
-CIfStatementNode >> needsSeparator [
-
-	^ false
-]
-
-{ #category : 'testing' }
-CIfStatementNode >> needsTrailingSemicolon [
-
-	^ false
-]
-
 { #category : 'generated' }
 CIfStatementNode >> then [
 	^ then

--- a/smalltalksrc/CAST/CLabeledStatementNode.class.st
+++ b/smalltalksrc/CAST/CLabeledStatementNode.class.st
@@ -61,15 +61,6 @@ CLabeledStatementNode >> label: aCGLRIdentifierNode [
 		ifTrue: [ self label parent: self ]
 ]
 
-{ #category : 'testing' }
-CLabeledStatementNode >> needsSeparator [
-
-	"The labeled statement node is a case:.
-	The case itself should not have a statement separator.
-	Its child statement will have its own separator"
-	^ false
-]
-
 { #category : 'generated' }
 CLabeledStatementNode >> statement [
 	^ statement

--- a/smalltalksrc/CAST/CPreprocessorIfNode.class.st
+++ b/smalltalksrc/CAST/CPreprocessorIfNode.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : 'CPreprocessorIfNode',
-	#superclass : 'CExpressionNode',
+	#superclass : 'CGLRAbstractNode',
 	#instVars : [
 		'then',
 		'else',
@@ -89,10 +89,10 @@ CPreprocessorIfNode >> isArgument: aBoolean [
 	isArgument := aBoolean
 ]
 
-{ #category : 'accessing' }
-CPreprocessorIfNode >> needsSeparator [
+{ #category : 'testing' }
+CPreprocessorIfNode >> isExpression [
 
-	^ false
+	^ then isExpression
 ]
 
 { #category : 'accessing' }

--- a/smalltalksrc/CAST/CSwitchStatementNode.class.st
+++ b/smalltalksrc/CAST/CSwitchStatementNode.class.st
@@ -46,12 +46,6 @@ CSwitchStatementNode >> isSwitch [
 	^ true
 ]
 
-{ #category : 'testing' }
-CSwitchStatementNode >> needsSeparator [
-
-	^ false
-]
-
 { #category : 'generated' }
 CSwitchStatementNode >> statement [
 	^ statement

--- a/smalltalksrc/Slang-Tests/CSlangPrettyPrinterTest.class.st
+++ b/smalltalksrc/Slang-Tests/CSlangPrettyPrinterTest.class.st
@@ -94,7 +94,7 @@ CSlangPrettyPrinterTest >> testVisitBreakStatement [
 	| print |
 	print := self prettyPrint: (CBreakStatementNode new).
 
-	self assert: print trimBoth equals: 'break'
+	self assert: print trimBoth equals: 'break;'
 ]
 
 { #category : 'tests-visitor' }
@@ -207,7 +207,8 @@ CSlangPrettyPrinterTest >> testVisitDeclaration [
 	9, 10, 12
 }, tutu[] = {
 	5, 2
-}'
+};
+'
 
 
 ]
@@ -246,9 +247,9 @@ CSlangPrettyPrinterTest >> testVisitDoStatement [
 					           right: (CIdentifierNode name: 'b'))
 			          statement: compound).
 
-	self assert: print trimBoth equals: 'do{
+	self assert: print trimBoth equals: 'do {
 	15;
-}while(a && b)'
+} while (a && b);'
 ]
 
 { #category : 'tests-visitor' }
@@ -347,7 +348,8 @@ CSlangPrettyPrinterTest >> testVisitGotoStatement [
 	| print |
 	print := self prettyPrint: (CGotoStatementNode identifier: 'toto').
 	
-	self assert: print equals: 'goto toto'
+	self assert: print equals: 'goto toto;
+'
 
 
 ]
@@ -575,7 +577,8 @@ CSlangPrettyPrinterTest >> testVisitReturnStatement [
 	| print |
 	print := self prettyPrint: (CReturnStatementNode expression: (CIdentifierNode name: 'x')).
 	
-	self assert: print equals: 'return x'
+	self assert: print equals: 'return x;
+'
 
 
 ]

--- a/smalltalksrc/Slang-Tests/SLDeadCodeEliminationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SLDeadCodeEliminationTest.class.st
@@ -714,7 +714,6 @@ methodWithEmptyIfTrueInIfFalseIfTrueAndNoSendInReceiver(SLDeadCodeEliminationTes
 {
 	int i;
 
-	;
 	{
 		return;
 	}
@@ -774,7 +773,6 @@ methodWithEmptyIfTrueInIfTrueIfFalseAndNoSendInReceiver(SLDeadCodeEliminationTes
 {
 	int i;
 
-	;
 	{
 		return;
 	}
@@ -834,7 +832,6 @@ methodWithEmptyifNilInIfNilIfNotNilAndNoSendInReceiver(SLDeadCodeEliminationTest
 {
 	int i;
 
-	;
 	{
 		return;
 	}
@@ -894,7 +891,6 @@ methodWithEmptyifNilInIfNotNilIfNilAndNoSendInReceiver(SLDeadCodeEliminationTest
 {
 	int i;
 
-	;
 	{
 		return;
 	}
@@ -3846,7 +3842,5 @@ switchWithOnlyCommentSendInReceiver(SLDeadCodeEliminationTestClass * self_in_swi
 SLDeadCodeEliminationTest >> translate: tast [
 
 	^ String streamContents: [ :str | 
-		self
-			perform: (#astTranslate , #':inStream:') asSymbol
-			withArguments: { tast . str } ]
+		self astTranslate: tast inStream: str ]
 ]

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -942,7 +942,8 @@ SlangBasicTranslationTest >> testCaseStatementIsTranslatedAsSwitch [
 		someBytecode();
 	}
 	break;
-}'
+}
+'
 ]
 
 { #category : 'tests-case' }
@@ -966,7 +967,8 @@ SlangBasicTranslationTest >> testCaseStatementWithDifferentBodyAreDifferentCases
 		someBytecode2();
 	}
 	break;
-}'
+}
+'
 ]
 
 { #category : 'tests-case' }
@@ -986,7 +988,8 @@ SlangBasicTranslationTest >> testCaseStatementWithSameBodyAreSameCase [
 		someBytecode();
 	}
 	break;
-}'
+}
+'
 ]
 
 { #category : 'tests-constants' }
@@ -1189,7 +1192,8 @@ SlangBasicTranslationTest >> testGoto [
 	
 	translation := self translate: (TGoToNode label: 'lab').
 
-	self assert: translation equals: 'goto lab'
+	self assert: translation equals: 'goto lab;
+'
 ]
 
 { #category : 'tests-inlinemethod' }
@@ -1245,7 +1249,7 @@ methodUseParametersWithAnnotationstowith(unsigned int *pFrom, unsigned int *pTo,
 	pTo1 = ((unsigned int *) (yourself(pTo)) );
 	for (i = 0; i < 5; i += 1) {
 		pTo1[i] = (pFrom + anInteger)[i];
-	};
+	}
 	return 0;
 	/* end methodFromWithAnnotations:to:len: */
 }'
@@ -1284,7 +1288,7 @@ methodUseParametersWithAnnotationsBuiltIntowith(unsigned int *pFrom, unsigned in
 	pFrom1 = ((sqInt) (pFrom + anInteger) );
 	for (i = 0; i <= 10; i += 1) {
 		pTo[i] = pFrom1[i];
-	};
+	}
 	/* end methodFromWithAnnotations:to: */
 	return 0;
 }'
@@ -1306,7 +1310,8 @@ SlangBasicTranslationTest >> testInlineNodeDoesNotInitializeReadBeforeWrittenArr
 
 		bar = foo;
 	}
-}'
+}
+'
 ]
 
 { #category : 'tests-inlinenode' }
@@ -1325,7 +1330,8 @@ SlangBasicTranslationTest >> testInlineNodeDoesNotInitializeReadBeforeWrittenExt
 
 		bar = foo;
 	}
-}'
+}
+'
 ]
 
 { #category : 'tests-inlinenode' }
@@ -1345,7 +1351,8 @@ SlangBasicTranslationTest >> testInlineNodeDoesNotInitializeReadBeforeWrittenIni
 		foo = 0;
 		bar = foo;
 	}
-}'
+}
+'
 ]
 
 { #category : 'tests-inlinenode' }
@@ -1364,7 +1371,8 @@ SlangBasicTranslationTest >> testInlineNodeDoesNotInitializeReadBeforeWrittenSta
 
 		bar = foo;
 	}
-}'
+}
+'
 ]
 
 { #category : 'tests-inlinenode' }
@@ -1380,9 +1388,9 @@ SlangBasicTranslationTest >> testInlineNodeDoesNotRemoveExternalTemp [
 	{
 		extern int foo;
 
-
 	}
-}'
+}
+'
 ]
 
 { #category : 'tests-inlinenode' }
@@ -1398,9 +1406,9 @@ SlangBasicTranslationTest >> testInlineNodeDoesNotRemoveStaticTemp [
 	{
 		static int foo;
 
-
 	}
-}'
+}
+'
 ]
 
 { #category : 'tests-inlinenode' }
@@ -1417,7 +1425,8 @@ SlangBasicTranslationTest >> testInlineNodeRemovesUnusedTemps [
 	VM_LABEL(methodDefiningSingleVariable);
 	{
 	}
-}'
+}
+'
 ]
 
 { #category : 'tests-inlinenode' }
@@ -1443,7 +1452,8 @@ SlangBasicTranslationTest >> testInlineNodeSortsLocalTemps [
 		bar = aaa;
 		ddd = zzz + foo;
 	}
-}'
+}
+'
 ]
 
 { #category : 'tests-inlinenode' }
@@ -1460,7 +1470,8 @@ SlangBasicTranslationTest >> testInlineNodeWithSharedCase [
 	VM_LABEL(methodWithSharedCase);
 	{
 	}
-}'
+}
+'
 ]
 
 { #category : 'tests-inlinenode' }
@@ -1477,7 +1488,8 @@ SlangBasicTranslationTest >> testInlineNodeWithSharedLabelInCase [
 	VM_LABEL(methodWithSharedLabelInCase);
 	{
 	}
-}'
+}
+'
 ]
 
 { #category : 'tests-inlinemethod' }
@@ -1652,7 +1664,7 @@ SlangBasicTranslationTest >> testLabel [
 	translation := self translate: label.
 
 	self assert: translation equals: 'aLabel:
-;'
+'
 ]
 
 { #category : 'tests-labels' }
@@ -1676,7 +1688,7 @@ SlangBasicTranslationTest >> testLabelWithASMLabelWithinInterpret [
 	label := TLabeledCommentNode new asmLabel: 'vm_label'.
 	translation := self translate: label.
 
-	self assert: translation equals: 'VM_LABEL(vm_label);'
+	self assert: translation equals: 'VM_LABEL(vm_label)'
 ]
 
 { #category : 'tests-labels' }
@@ -1752,7 +1764,6 @@ methodWithAnOptionPragma(void)
 {
 	return 0;
 }
-
 #endif /* OPTION */'
 ]
 
@@ -1773,7 +1784,6 @@ methodWithOptionPragma(void)
 {
 	return 0;
 }
-
 #endif /* OPTION1 && OPTION3 */'
 ]
 
@@ -2118,7 +2128,8 @@ SlangBasicTranslationTest >> testNonContiguousCaseStatementWithSameBodyAreCollap
 		someBytecode2();
 	}
 	break;
-}'
+}
+'
 ]
 
 { #category : 'tests-blocks' }
@@ -2173,7 +2184,8 @@ SlangBasicTranslationTest >> testReturnCaseStatementDoesNotReplaceGotoByReturn [
 	default:
 	error("Case not found");
 	return -1;
-}'
+}
+'
 ]
 
 { #category : 'tests-case' }
@@ -2194,7 +2206,8 @@ SlangBasicTranslationTest >> testReturnCaseStatementMovesReturnIntoSwitch [
 	default:
 	error("Case not found");
 	return -1;
-}'
+}
+'
 ]
 
 { #category : 'tests-return' }
@@ -2214,7 +2227,8 @@ SlangBasicTranslationTest >> testReturnIfTrue [
 		
 	self assert: translation equals: 'return ((aBoolean)
 	 ? 1
-	 : 2)'
+	 : 2);
+'
 ]
 
 { #category : 'tests-return' }
@@ -2228,7 +2242,8 @@ SlangBasicTranslationTest >> testReturnLeafInVoidMethod [
 		setExpression: (TVariableNode new setName: 'var');
 		yourself).
 		
-	self assert: translation equals: 'return;'
+	self assert: translation equals: 'return;
+'
 ]
 
 { #category : 'tests-return' }
@@ -2245,7 +2260,8 @@ SlangBasicTranslationTest >> testReturnNonLeafExpressionInVoidMethod [
 		yourself).
 		
 	self assert: translation equals: 'var = 7;
-return;'
+return;
+'
 ]
 
 { #category : 'tests-switch' }
@@ -2323,7 +2339,8 @@ SlangBasicTranslationTest >> testReturnVariable [
 		setExpression: (TVariableNode new setName: 'var');
 		yourself).
 		
-	self assert: translation equals: 'return var'
+	self assert: translation equals: 'return var;
+'
 ]
 
 { #category : 'tests-builtins' }
@@ -3182,7 +3199,8 @@ SlangBasicTranslationTest >> testSendCppIfIfTrueWithSingleExpressionDoesNotAddsS
 	self assert: translation trimBoth equals: 'return 
 #  if FEATURE
 		(a = 0)
-#  endif /* FEATURE */'
+#  endif /* FEATURE */
+		;'
 ]
 
 { #category : 'tests-builtins' }
@@ -6107,9 +6125,9 @@ SlangBasicTranslationTest >> testSendWhileFalseWithoutArguments [
 		        arguments: {  }.
 	translation := self translate: send.
 
-	self assert: translation trimBoth equals: 'do{
+	self assert: translation trimBoth equals: 'do {
 	var -= 7;
-}while(!(var >= 21))'
+} while (!(var >= 21));'
 ]
 
 { #category : 'tests-builtins' }
@@ -6174,9 +6192,9 @@ SlangBasicTranslationTest >> testSendWhileTrueWithNilAsArgument [
 				         { (TVariableNode new setName: 'nil') }) }.
 	translation := self translate: send.
 
-	self assert: translation trimBoth equals: 'do{
+	self assert: translation trimBoth equals: 'do {
 	var -= 7;
-}while(a < b)'
+} while (a < b);'
 ]
 
 { #category : 'tests-builtins' }
@@ -6235,9 +6253,9 @@ SlangBasicTranslationTest >> testSendWhileTrueWithTemporary [
 		        arguments: {  }.
 	translation := self translate: send.
 
-	self assert: translation trimBoth equals: 'do{
+	self assert: translation trimBoth equals: 'do {
 	var -= 7;
-}while(var >= 21)'
+} while (var >= 21);'
 ]
 
 { #category : 'tests-builtins' }
@@ -6267,11 +6285,11 @@ SlangBasicTranslationTest >> testSendWhileTrueWithTemporaryDeclaration [
 		        arguments: {  }.
 	translation := self translate: send.
 
-	self assert: translation trimBoth equals: 'do{
+	self assert: translation trimBoth equals: 'do {
 	int temp;
 
 	var -= 7;
-}while(var >= 21)'
+} while (var >= 21);'
 ]
 
 { #category : 'tests-builtins' }
@@ -6299,9 +6317,9 @@ SlangBasicTranslationTest >> testSendWhileTrueWithoutArguments [
 		        arguments: {  }.
 	translation := self translate: send.
 
-	self assert: translation trimBoth equals: 'do{
+	self assert: translation trimBoth equals: 'do {
 	var -= 7;
-}while(var >= 21)'
+} while (var >= 21);'
 ]
 
 { #category : 'tests-assignment' }
@@ -6355,7 +6373,8 @@ switch (currentBytecode) {
 		someBytecode();
 	}
 	break;
-}'
+}
+'
 ]
 
 { #category : 'tests-switch' }

--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -1239,7 +1239,6 @@ static sqInt
 methodUseParametersWithAnnotationstowith(unsigned int *pFrom, unsigned int *pTo, sqInt anInteger)
 {
 	sqInt i;
-	sqInt pFrom1;
 	unsigned int *pTo1;
 
 	/* begin methodFromWithAnnotations:to:len: */
@@ -1280,7 +1279,6 @@ methodUseParametersWithAnnotationsBuiltIntowith(unsigned int *pFrom, unsigned in
 {
 	sqInt i;
 	sqInt pFrom1;
-	sqInt pTo1;
 
 	/* begin methodFromWithAnnotations:to: */
 	pFrom1 = ((sqInt) (pFrom + anInteger) );

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -2770,7 +2770,6 @@ CCodeGenerator >> generateCASTTimesRepeat: tast [
 	| repeat |
 	repeat := CCompoundStatementNode statements: OrderedCollection new.
 	repeat needsBrackets: false.
-	repeat needsSeparator: false.
 
 	tast receiver value timesRepeat: [
 		repeat add: (tast arguments first asCASTIn: self) ].

--- a/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
+++ b/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
@@ -164,7 +164,7 @@ CSlangPrettyPrinter >> visitBinary: aBinary [
 { #category : 'generated' }
 CSlangPrettyPrinter >> visitBreakStatement: aBreakStatement [
 
-	stream nextPutAll: 'break'
+	stream nextPutAll: 'break;'; cr
 ]
 
 { #category : 'generated' }
@@ -203,7 +203,9 @@ CSlangPrettyPrinter >> visitComment: aComment [
 
 	stream nextPutAll: '/*'.
 	stream nextPutAll: aComment comment.
-	stream nextPutAll: '*/'
+	stream nextPutAll: '*/'.
+	(aComment parent isNotNil and: [ aComment parent isExpression not ])
+		ifTrue: [ stream cr ]
 ]
 
 { #category : 'generated' }
@@ -220,32 +222,39 @@ CSlangPrettyPrinter >> visitCompoundStatement: aCompoundStatement [
 
 	aCompoundStatement declarations do: [ :e |
 		first
-			ifTrue: [ first := false. ]
-			ifFalse: [ stream tab: level ].
-			e acceptVisitor: self.
-			e needsSeparator ifTrue: [ stream nextPut: $; ].
-			stream cr. ].
+			ifTrue: [ first := false ]
+			ifFalse: [
+				e isEmptyStatement
+					ifFalse: [ stream tab: level  ] ].
+		e acceptVisitor: self.
+		e isExpression
+			ifTrue: [
+				stream nextPut: $;.
+				stream cr ] ].
 	
 	"Put at least one empty line to separate declarations and statements.
 	This is required for the current GNUisation to work, which searches for empty lines"
-	aCompoundStatement declarations ifNotEmpty: [
-		stream cr.
-	].
+	aCompoundStatement declarations ifNotEmpty: [ stream cr ].
 
 	aCompoundStatement statements do: [ :e |
 		first
-			ifTrue: [ first := false. ]
-			ifFalse: [ stream tab: level ].
-			e acceptVisitor: self.
-			e needsSeparator ifTrue: [ stream nextPut: $; ]]
-		separatedBy: [ stream cr ].
+			ifTrue: [ first := false ]
+			ifFalse: [
+				e isEmptyStatement
+					ifFalse: [ stream tab: level  ] ].
+		e acceptVisitor: self.
+		e isExpression
+			ifTrue: [
+				stream nextPut: $;.
+				stream cr ] ].
 
 	aCompoundStatement needsBrackets ifTrue: [ 
 		level := level - 1.
-		(aCompoundStatement statements, aCompoundStatement declarations)
-			ifNotEmpty: [ stream cr ].
 		stream tab: level.
-		stream nextPut: $} ]
+		stream nextPut: $}.
+
+		aCompoundStatement isAtEndOfStatement ifTrue: [
+			stream cr ] ].
 ]
 
 { #category : 'generated' }
@@ -265,7 +274,8 @@ CSlangPrettyPrinter >> visitDeclaration: aDeclaration [
 		aDeclaration declarators
 			do: [ :e | e acceptVisitor: self ]
 			separatedBy: [ stream nextPutAll: ', ' ] ].
-	aDeclaration isFunctionPrototype ifTrue: [ stream nextPut: $; ]
+	stream nextPut: $;.
+	stream cr.
 ]
 
 { #category : 'generated' }
@@ -292,11 +302,12 @@ CSlangPrettyPrinter >> visitDecrement: anDecrementNode [
 { #category : 'generated' }
 CSlangPrettyPrinter >> visitDoStatement: aDoStatement [
 
-	stream nextPutAll: 'do'.
+	stream nextPutAll: 'do '.
 	aDoStatement statement acceptVisitor: self.
-	stream nextPutAll: 'while('.
+	stream nextPutAll: ' while ('.
 	aDoStatement while acceptVisitor: self.
-	stream nextPut: $)
+	stream nextPutAll: ');'.
+	stream cr
 ]
 
 { #category : 'generated' }
@@ -371,14 +382,15 @@ CSlangPrettyPrinter >> visitFunctionDefinition: aFunction [
 		aFunction declarator acceptVisitor: self ].
 	stream cr.
 	aFunction body acceptVisitor: self.
-	stream cr.
 ]
 
 { #category : 'generated' }
 CSlangPrettyPrinter >> visitGotoStatement: aGoToStatement [
 
 	stream nextPutAll: 'goto ';
-			 nextPutAll: aGoToStatement label name
+			 nextPutAll: aGoToStatement label name;
+			 nextPut: $;;
+			 cr.
 	
 ]
 
@@ -396,13 +408,13 @@ CSlangPrettyPrinter >> visitIfStatement: anIf [
 	stream nextPutAll: ') '.
 	anIf then isCompoundStatement ifFalse: [ stream crtab: level + 1 ].
 	anIf then acceptVisitor: self.
-	anIf then needsTrailingSemicolon ifTrue: [ stream nextPut: $; ].
+	anIf then isExpression ifTrue: [ stream nextPut: $; ].
 	anIf else ifNotNil: [ :e | 
 		anIf then isCompoundStatement ifFalse: [ stream crtab: level ].
 		stream nextPutAll: ' else '.
 		anIf else isCompoundStatement ifFalse: [ stream crtab: level + 1 ].
 		e acceptVisitor: self.
-		anIf else needsTrailingSemicolon ifTrue: [ stream nextPut: $; ]]
+		anIf else isExpression ifTrue: [ stream nextPut: $; ]]
 ]
 
 { #category : 'generated' }
@@ -459,11 +471,21 @@ CSlangPrettyPrinter >> visitLabeledStatement: aLabeledStatement [
 	stream crtab: level.
 
 	aLabeledStatement statement acceptVisitor: self.
-
-	"Close the statement here to keep compatibility with slang"
-	((aLabeledStatement case notNil or: [ aLabeledStatement label notNil ]) 
-		 and: [ aLabeledStatement statement needsSeparator ]) ifTrue: [ 
-		stream nextPutAll: ';' ]
+	"If this statement labels an expression OR we are at the end of a compound
+	 statement labeling an empty statement then we need to add the closing
+	 semicolon"
+	(aLabeledStatement statement isExpression
+		or: [ aLabeledStatement statement isEmpty
+				and: [ aLabeledStatement case isNil
+				and: [ aLabeledStatement parent isNotNil
+				and: [ aLabeledStatement parent isCompoundStatement
+				and: [ | statements lastNonCommentIdx |
+					statements := aLabeledStatement parent statements.
+					lastNonCommentIdx := statements findLast: [ :e | e isComment not ].
+					(statements at: lastNonCommentIdx) = aLabeledStatement ] ] ] ] ])
+		ifTrue: [
+			stream nextPutAll: ';'.
+			stream cr ]
 ]
 
 { #category : 'generated' }
@@ -520,10 +542,11 @@ CSlangPrettyPrinter >> visitPreprocessorIf: anIf [
 	anIf if acceptVisitor: self.
 	stream crtab: level.
 	anIf then acceptVisitor: self.
+	anIf then isExpression
+		ifTrue: [ stream cr. ].
 	
 	anIf else ifNotNil: [ :e | 
 		stream
-			cr;
 			nextPut: $#;
 			next: tabbing * 2 put: Character space;
 			nextPutAll: 'else /* '.
@@ -531,16 +554,19 @@ CSlangPrettyPrinter >> visitPreprocessorIf: anIf [
 		stream
 			nextPutAll: ' */';
 			crtab: level.
-		e acceptVisitor: self ].
+		e acceptVisitor: self.
+		e isExpression
+			ifTrue: [ stream cr. ] ].
 	stream
-		cr;
 		nextPut: $#;
 		next: tabbing * 2 put: Character space;
 		nextPutAll: 'endif /* '.
 	anIf if acceptVisitor: self.
 	stream
 		nextPutAll: ' */'.
-	anIf isArgument ifTrue: [ stream crtab: level ].
+	anIf isArgument
+		ifTrue: [ stream crtab: level ]
+		ifFalse: [ stream cr ].
 	level := previousLevel.
 ]
 
@@ -556,7 +582,9 @@ CSlangPrettyPrinter >> visitReturnStatement: aReturn [
 	stream nextPutAll: 'return'.
 	aReturn expression ifNotNil: [ :exp |
 		stream space.
-		exp acceptVisitor: self ]
+		exp acceptVisitor: self ].
+	stream nextPut: $;.
+	stream cr
 ]
 
 { #category : 'generated' }

--- a/smalltalksrc/Slang/TLabeledCommentNode.class.st
+++ b/smalltalksrc/Slang/TLabeledCommentNode.class.st
@@ -38,16 +38,15 @@ TLabeledCommentNode >> accept: aVisitor [
 { #category : 'tranforming' }
 TLabeledCommentNode >> asCASTIn: aBuilder [
 
-	| result |
-	result := CCompoundStatementNode new.
-	result needsBrackets: false.
+	| statements |
+	statements := OrderedCollection new.
 
 	label ifNotNil: [
 		| labelledNode |
 		labelledNode := CLabeledStatementNode new.
 		labelledNode label: (CIdentifierNode name: label).
 		labelledNode statement: CEmptyStatementNode new.
-		result add: labelledNode ].
+		statements add: labelledNode ].
 
 
 	comment ifNotNil: [
@@ -57,16 +56,22 @@ TLabeledCommentNode >> asCASTIn: aBuilder [
 				 s space.
 				 s nextPutAll: self comment.
 				 s space ]).
-		result add: commentNode.
+		statements add: commentNode.
 		aBuilder previousCommenter: self ].
 
 	(asmLabel notNil and: [
 		 aBuilder currentMethod selector == #interpret ]) ifTrue: [
 		| asmLabelNode |
 		asmLabelNode := aBuilder asmLabelNodeFor: asmLabel.
-		result add: asmLabelNode ]. "only output labels in the interpret function."
+		statements add: asmLabelNode ]. "only output labels in the interpret function."
 
-	^ result
+	statements size = 1
+		ifTrue: [ ^ statements first ].
+
+	^ CCompoundStatementNode new
+		statements: statements;
+		needsBrackets: false;
+		yourself.
 ]
 
 { #category : 'accessing' }

--- a/smalltalksrc/Slang/TMethod.class.st
+++ b/smalltalksrc/Slang/TMethod.class.st
@@ -358,7 +358,7 @@ TMethod >> asCASTFunctionPrototypeIn: aCodeGen isPrototype: isPrototype [
 { #category : 'CAST translation' }
 TMethod >> asCASTIn: aCodeGen [
 
-	| compoundStatement functionDefinition body|
+	| compoundStatement functionDefinition body |
 	aCodeGen currentMethod: self.
 	compoundStatement := CCompoundStatementNode new
 		                     needsBrackets: false;

--- a/smalltalksrc/Slang/TMethod.class.st
+++ b/smalltalksrc/Slang/TMethod.class.st
@@ -118,7 +118,7 @@ TMethod >> addVarsDeclarationsAndLabelsOf: methodToBeInlined except: doNotRename
 
     | newLocals |
 
-   newLocals := methodToBeInlined args , methodToBeInlined allLocals asOrderedCollection .
+   newLocals := methodToBeInlined allLocals copyWithAll: methodToBeInlined args.
 
 	self addLocals: (newLocals copyWithoutAll: doNotRename).
 
@@ -1635,27 +1635,27 @@ TMethod >> inlineSend: aSendNode directReturn: directReturn exitVar: exitVar in:
 	 otherwise the assignee variable type must match the return type of the inlinee.  Return
 	 types are not propagated."
 
-	| sel meth methArgs exitLabel inlineStmts label exitType elidedArgs |
+	| sel callee calleeParameters exitLabel inlineStmts label exitType omittedParameters |
 	sel := aSendNode selector.
-	meth := aCodeGen methodNamed: sel.
-	methArgs := meth args.
+	callee := aCodeGen methodNamed: sel.
+	calleeParameters := callee args.
 	"convenient for debugging..."
 	aCodeGen maybeBreakForInlineOf: aSendNode in: self.
-	elidedArgs := #(  ).
-	(methArgs notEmpty and: [ methArgs first beginsWith: 'self_in_' ])
+	omittedParameters := #(  ).
+	(calleeParameters notEmpty and: [ calleeParameters first beginsWith: 'self_in_' ])
 		ifTrue: [ "If the first arg is not used we can and should elide it."
 			| varNode |
-			varNode := TVariableNode new setName: methArgs first.
-			(meth parseTree noneSatisfy: [ :node | varNode isSameAs: node ])
-				ifTrue: [ elidedArgs := { methArgs first } ].
-			methArgs := methArgs allButFirst ].
-	methArgs size = aSendNode arguments size ifFalse: [ ^ nil ].
-	meth := meth copy.
+			varNode := TVariableNode new setName: calleeParameters first.
+			(callee parseTree noneSatisfy: [ :node | varNode isSameAs: node ])
+				ifTrue: [ omittedParameters := { calleeParameters first } ].
+			calleeParameters := calleeParameters allButFirst ].
+	calleeParameters size = aSendNode arguments size ifFalse: [ ^ nil ].
+	callee := callee copy.
 
-	(meth statements size > 1 and: [
-		 meth statements first isSend and: [
-			 meth statements first selector == #flag: ] ]) ifTrue: [
-		meth statements removeFirst ].
+	(callee statements size > 1 and: [
+		 callee statements first isSend and: [
+			 callee statements first selector == #flag: ] ]) ifTrue: [
+		callee statements removeFirst ].
 
 	"Propagate the return type of an inlined method"
 	(directReturn or: [ exitVar notNil ]) ifTrue: [
@@ -1663,42 +1663,42 @@ TMethod >> inlineSend: aSendNode directReturn: directReturn exitVar: exitVar in:
 			            ifTrue: [ returnType ]
 			            ifFalse: [
 			            (self typeFor: exitVar in: aCodeGen) ifNil: [ #sqInt ] ].
-		(exitType = #void or: [ exitType = meth returnType ]) ifFalse: [
-			meth propagateReturnIn: aCodeGen ] ].
+		(exitType = #void or: [ exitType = callee returnType ]) ifFalse: [
+			callee propagateReturnIn: aCodeGen ] ].
 
 	"Propagate any unusual argument types to untyped argument variables"
-	methArgs with: aSendNode arguments do: [ :formal :actual |
-		(meth declarationAt: formal ifAbsent: nil) ifNil: [
+	calleeParameters with: aSendNode arguments do: [ :formal :actual |
+		(callee declarationAt: formal ifAbsent: nil) ifNil: [
 			| type |
 			(actual isVariable and: [
 				 (type := self typeFor: actual name in: aCodeGen) notNil ])
 				ifTrue: [
 					type ~= #sqInt ifTrue: [
-						meth declarationAt: formal put: (type last = $*
+						callee declarationAt: formal put: (type last = $*
 								 ifTrue: [ type , formal ]
 								 ifFalse: [ type , ' ' , formal ]) ] ] ] ].
 
-	meth renameVarsForInliningInto: self except: elidedArgs in: aCodeGen.
-	meth renameLabelsForInliningInto: self.
-	self addVarsDeclarationsAndLabelsOf: meth except: elidedArgs.
-	meth hasReturn ifTrue: [
+	callee renameVarsForInliningInto: self except: omittedParameters in: aCodeGen.
+	callee renameLabelsForInliningInto: self.
+	self addVarsDeclarationsAndLabelsOf: callee except: omittedParameters.
+	callee hasReturn ifTrue: [
 		directReturn ifFalse: [
 			exitLabel := self unusedLabelForInliningInto: self.
-			(meth exitVar: exitVar label: exitLabel)
+			(callee exitVar: exitVar label: exitLabel)
 				ifTrue: [ labels add: exitLabel ]
 				ifFalse: [ "is label used?" exitLabel := nil ] ] ].
 	(inlineStmts := OrderedCollection new:
-			                meth statements size + meth args size + 2)
+			                callee statements size + callee args size + 2)
 		add: (label := TLabeledCommentNode new setComment: 'begin ' , sel);
 		addAll: (self
-				 argAssignmentsFor: meth
+				 argAssignmentsFor: callee
 				 send: aSendNode
-				 except: elidedArgs
+				 except: omittedParameters
 				 in: aCodeGen);
-		addAll: meth statements. "method body"
+		addAll: callee statements. "method body"
 	directReturn ifTrue: [
-		meth parseTree parent: aSendNode parent.
-		meth endsWithReturn
+		callee parseTree parent: aSendNode parent.
+		callee endsWithReturn
 			ifTrue: [
 				exitVar ifNotNil: [ "don't remove the returns if being invoked in the context of a return"
 					inlineStmts
@@ -2590,7 +2590,8 @@ TMethod >> removeLocal: local [
 TMethod >> removeLocal: local ifAbsent: aBlock [
 
 	cachedLocals := nil.
-	self locals remove: local ifAbsent: aBlock
+	self locals remove: local ifAbsent: aBlock.
+	self declarations removeKey: local ifAbsent: [ ] "We assume local-declarations are a subset of locals"
 ]
 
 { #category : 'dead-code-elimination' }

--- a/smalltalksrc/Slang/TStatementListNode.class.st
+++ b/smalltalksrc/Slang/TStatementListNode.class.st
@@ -205,7 +205,11 @@ TStatementListNode >> asCASTExpressionIn: aBuilder [
 	statements withIndexDo: [ :node :idx |
 		(node isLeaf and: [
 			 node isLabel not and: [ node ~~ self lastNonCommentStatement ] ])
-			ifFalse: [ expressionList , (node asCASTExpressionIn: aBuilder) ] ].
+			ifFalse: [
+				| expr |
+				expr := node asCASTExpressionIn: aBuilder.
+				expr parent: expressionList.
+				expressionList , expr ] ].
 	^ expressionList
 ]
 


### PR DESCRIPTION
This fixes the remaining Slang test failures and weird semicolons. See #892 for more info.

The change has some codegen impact because it reverses who's responsible for ending lines (now that happens when visiting a statement instead of on the statement parent).

The changes compile and run our VM but we should probably do a small manual inspection of the generated code to see if any weirdnesses are still present.