### PR TITLE
Build on old linux server

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -479,7 +479,11 @@ try{
 		def platform = platf
 		
 		builders[platform] = {
-			node(platform){
+            def nodeName = platform
+            if (nodeName == 'Linux-x86_64'){
+                nodeName = 'old-linux-vm-build'
+            }
+			node(nodeName){
 				timeout(40){
 					runBuild(platform, "CoInterpreter")
 				}


### PR DESCRIPTION
Re enable builds on the old server for now, to enable compatibility with older glibc versions.
We will move back the build to the new servers (on debian 12) after ubuntu LTS version moves to ubuntu 22 in april