### PR TITLE
Simplify signal handler space calculation: use SIGSTKSZ, posix defined

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -495,8 +495,14 @@ static int stackPageHeadroom;
 int
 osCogStackPageHeadroom()
 {
-	if (!stackPageHeadroom)
+	if (!stackPageHeadroom){
+		#if defined(SIGSTKSZ) /* posix */
 		stackPageHeadroom = SIGSTKSZ + 1024;
+		#else // Non-posix, possibly mingw using exception, use 4k as stack size
+		stackPageHeadroom = 4096 + 1024;
+		#endif
+	}
+		
 	return stackPageHeadroom;
 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -479,50 +479,9 @@ isCFramePointerInUse()
 }
 #endif // COGVM
 
-/* Answer an approximation of the size of the redzone (if any).  Do so by
- * sending a signal to the process and computing the difference between the
- * stack pointer in the signal handler and that in the caller. Assumes stacks
- * descend.
- */
-
-static char * volatile redZoneTestEndPointer = 0;
-
-
-#ifdef SIGPROF
-static void redZoneTestSigHandler(int sig, siginfo_t *info, void *uap)
-{
-	redZoneTestEndPointer = (char *)&sig;
-}
-#else
-static void redZoneTestSigHandler(int sig)
-{
-	redZoneTestEndPointer = (char *)&sig;
-}
-#endif
-
 #ifndef _WIN32
 static long int min(long int x, long int y) { return (x < y) ? x : y; }
 #endif
-
-static int getRedZoneSize()
-{
-#if defined(SIGPROF) /* cygwin */
-	struct sigaction handler_action, old;
-	handler_action.sa_sigaction = redZoneTestSigHandler;
-	handler_action.sa_flags = SA_NODEFER | SA_SIGINFO;
-	sigemptyset(&handler_action.sa_mask);
-	(void)sigaction(SIGPROF, &handler_action, &old);
-
-	do kill(getpid(),SIGPROF); while (!redZoneTestEndPointer);
-	(void)sigaction(SIGPROF, &old, 0);
-	return (int)min((usqInt)&old,(usqInt)&handler_action) - sizeof(struct sigaction) - (usqInt)redZoneTestEndPointer;
-#else /* cygwin */
-	void (*old)(int) = signal(SIGBREAK, redZoneTestSigHandler);
-
-	do raise(SIGBREAK); while (!redZoneTestEndPointer);
-	return (int) ((char *)&old - redZoneTestEndPointer);
-#endif /* cygwin */
-}
 
 sqInt reportStackHeadroom;
 static int stackPageHeadroom;
@@ -537,7 +496,7 @@ int
 osCogStackPageHeadroom()
 {
 	if (!stackPageHeadroom)
-		stackPageHeadroom = getRedZoneSize() + 1024;
+		stackPageHeadroom = SIGSTKSZ + 1024;
 	return stackPageHeadroom;
 }
 


### PR DESCRIPTION
Use SIGSTKSZ that defines the recommended stack size to handle signals, instead of trying to guess it.
The code guessing it uses a signal handler defined in the same executable, which will not account for the worst case scenario.

Moreover, this allows a seamless usage of [`rr`](https://rr-project.org/) to debug the VM, since it defines a separate stack for signals and messes up this calculation that does *many* assumptions that do not hold.

Not to say that this simplifies the code substantially also.