### PR TITLE
Void the instructionPointer systematically when creating a base frame

### DIFF
--- a/smalltalksrc/VMMaker/CoInterpreter.class.st
+++ b/smalltalksrc/VMMaker/CoInterpreter.class.st
@@ -1006,9 +1006,6 @@ CoInterpreter >> ceBaseFrameReturn: returnValue [
 					to: contextToReturnTo
 					returnValue: returnValue.
 				^self externalCannotReturn: returnValue from: contextToReturnFrom].
-			 "void the instructionPointer to stop it being incorrectly updated in a code
-			 compaction in makeBaseFrameFor:."
-			 instructionPointer := 0.
 			 thePage := self makeBaseFrameFor: contextToReturnTo.
 			 self setStackPointersFromPage: thePage].
 	self setStackPageAndLimit: thePage.
@@ -4902,9 +4899,6 @@ CoInterpreter >> tearDownAndRebuildFrameForCannotReturnBaseFrameReturnFrom: cont
 	objectMemory
 		storePointer: SenderIndex ofObject: contextToReturnFrom withValue: contextToReturnTo;
 		storePointer: InstructionPointerIndex ofObject: contextToReturnFrom withValue: HasBeenReturnedFromMCPCOop.
-	"void the instructionPointer to stop it being incorrectly updated in a code
-	 compaction in makeBaseFrameFor:."
-	instructionPointer := 0.
 	newPage := self makeBaseFrameFor: contextToReturnFrom.
 	self assert: stackPage = newPage.
 	self setStackPageAndLimit: newPage.

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -14714,18 +14714,12 @@ StackInterpreter >> stackPageByteSize [
 	 Room for 256 slots for frames gives around 40 frames a page which is a
 	 good compromise between overflow rate and latency in divorcing a page."
 	<inline: false>
-	| pageBytes largeSize smallSize |
+	| pageBytes |
 	pageBytes := self stackPageFrameBytes + self stackLimitOffset + self stackPageHeadroom.
 	(pageBytes bitAnd: pageBytes - 1) = 0 ifTrue: "= 0 => a power of two"
 		[^pageBytes].
-	"round up or round down; that is the question.  If rounding down reduces
-	 the size by no more than 1/8th round down, otherwise roundup."
-	largeSize := 1 << pageBytes highBit.
-	smallSize := 1 << (pageBytes highBit - 1).
-	self assert: (largeSize > pageBytes and: [pageBytes > smallSize]).
-	^(pageBytes - smallSize) <= (smallSize / 8)
-		ifTrue: [smallSize]
-		ifFalse: [largeSize]
+	"round up to be a power of 2"
+	^ 1 << pageBytes highBit
 ]
 
 { #category : 'stack pages' }

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -2281,9 +2281,6 @@ StackInterpreter >> baseFrameReturn [
 						  fetchPointer: InstructionPointerIndex
 						  ofObject: contextToReturnTo) ]) ifFalse: [
 				^ self baseFrameCannotReturnTo: contextToReturnTo ].
-			"We must void the instructionPointer to stop it being updated if makeBaseFrameFor:
-			  cogs a method, which may cause a code compaction."
-			instructionPointer := 0.
 			thePage := self makeBaseFrameFor: contextToReturnTo.
 			theFP := thePage headFP ].
 	theSP := thePage headSP.
@@ -8968,9 +8965,17 @@ StackInterpreter >> lookupSelector: selector inClass: class [
 
 { #category : 'frame access' }
 StackInterpreter >> makeBaseFrameFor: aContext [
-	"Marry aContext with the base frame of a new stack page.  Build the base
-	 frame to reflect the context's state.  Answer the new page.
-	Simply hold the caller context in the first word of the stack."
+	"
+	Allocate a new stack page, create a base frame for the argument context.
+	Return the allocated page.
+	
+	This method ignores (and destroys) the instructionPointer variable.
+	Callers must make sure that the instruction pointer is saved/stored in suspended frames.
+	
+	Postconditions:
+	 - The frame and context are married.
+	 - The instruction pointer of the frame is the top of the stack and must be popped by the caller when resuming
+	"
 
 	<returnTypeC: #'StackPage *'>
 	<inline: false>
@@ -8980,6 +8985,12 @@ StackInterpreter >> makeBaseFrameFor: aContext [
 	self assert: (objectMemory isContext: aContext).
 	self assert: (self isSingleContext: aContext).
 	self assert: (objectMemory goodContextSize: aContext).
+
+	"Void the instructionPointer to stop it being updated if we
+	compile a method and cause a code compaction.
+	We are in the state where a new page is on its initialization,
+	so we want to avoid code compaction to touch the stack."
+	instructionPointer := 0.
 
 	page := stackPages newStackPage.
 	"Initialize the stack pointer above the base address.


### PR DESCRIPTION
Void the instructionPointer systematically when creating a base fame.

This stops stack manipulations during potential code compactions since we are creating a base frame,  and the new page is not entirely initialized.

Callers must make sure that the instruction pointer is saved/stored in suspended frames.

This PR fixes a crash happening in an extreme case when:

1. a base frame is created for a context
2. that context was suspended on machine code
3. the machine code method was garbage collected (thus the method needs to be recompiled to resume)
4. there is no more space in the machine code cache, so a code collection happens

See https://ci.inria.fr/pharo-ci-jenkins2/job/pharo-vm/job/pharo-12/64/pipeline-console/?selected-node=897
The stack trace for this case typically shows the following on a crash:

```
libPharoVMCore.so(isSendReturnPC+0x2)[0x7fe6be25dbe2]
libPharoVMCore.so(+0xb9a2c)[0x7fe6be2b9a2c]
libPharoVMCore.so(doReport+0xbc)[0x7fe6be2b9d1c]
libPharoVMCore.so(sigsegv+0x14)[0x7fe6be2b9da4]
libc.so.6(+0x3c050)[0x7fe6be05b050]
libPharoVMCore.so(isSendReturnPC+0x2)[0x7fe6be25dbe2]
libPharoVMCore.so(+0x822fc)[0x7fe6be2822fc]
libPharoVMCore.so(ceSendsupertonumArgs+0x1ba)[0x7fe6be2acf3a]
```