### PR TITLE
Fix broken GC tests

### DIFF
--- a/smalltalksrc/VMMakerTests/VMSpurOldSpaceGarbageCollectorTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurOldSpaceGarbageCollectorTest.class.st
@@ -60,6 +60,10 @@ VMSpurOldSpaceGarbageCollectorTest >> setUp [
 
 	objectStackLimit :=  10.
 	super setUp.
+	"[HACK]
+	 When the GC checks for stack integrity we should have *something* resembling a stack.
+	 For now adding a dummy frame works well enough :)"
+	stackBuilder addNewFrame; buildStack.
 ]
 
 { #category : 'tests-OldSpaceSize' }

--- a/smalltalksrc/VMMakerTests/VMSpurScavengeEphemeronTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSpurScavengeEphemeronTest.class.st
@@ -26,6 +26,10 @@ VMSpurScavengeEphemeronTest >> pushRoot: anObject [
 VMSpurScavengeEphemeronTest >> setUp [
 
 	super setUp.
+	"[HACK]
+	 When the GC checks for stack integrity we should have *something* resembling a stack.
+	 For now adding a dummy frame works well enough :)"
+	stackBuilder addNewFrame; buildStack.
 	memory initializeMournQueue.
 	self createEphemeronClass
 ]


### PR DESCRIPTION
Some assertions we added at the end of december require now to have something that looks like a stack in order to run the GC. **This is an ugly hack good enough for the tests to pass.**

Maybe we need to rethink simulator initialization? idk