### PR TITLE
Fix load 32 bits

### DIFF
--- a/smalltalksrc/VMMaker/CogARMCompiler.class.st
+++ b/smalltalksrc/VMMaker/CogARMCompiler.class.st
@@ -307,6 +307,12 @@ CogARMCompiler class >> wordSize [
 	^4
 ]
 
+{ #category : 'abstract instructions' }
+CogARMCompiler >> MoveM32: offset r: baseReg R: destReg [
+
+	^ cogit MoveMw: offset r: baseReg R: destReg
+]
+
 { #category : 'ARM convenience instructions' }
 CogARMCompiler >> add: destReg rn: srcReg imm: immediate ror: rot [
 "Remember the ROR is doubled by the cpu so use 30>>1 etc.

--- a/smalltalksrc/VMMaker/CogARMCompiler.class.st
+++ b/smalltalksrc/VMMaker/CogARMCompiler.class.st
@@ -307,12 +307,6 @@ CogARMCompiler class >> wordSize [
 	^4
 ]
 
-{ #category : 'abstract instructions' }
-CogARMCompiler >> MoveM32: offset r: baseReg R: destReg [
-
-	^ cogit MoveMw: offset r: baseReg R: destReg
-]
-
 { #category : 'ARM convenience instructions' }
 CogARMCompiler >> add: destReg rn: srcReg imm: immediate ror: rot [
 "Remember the ROR is doubled by the cpu so use 30>>1 etc.
@@ -2257,6 +2251,12 @@ CogARMCompiler >> genMarshallNArgs: numArgs arg: regOrConst0 arg: regOrConst1 ar
 	(cogit isTrampolineArgConstant: regOrConst3)
 		ifTrue: [cogit MoveCq: (cogit trampolineArgValue: regOrConst3) R: CArg3Reg]
 		ifFalse: [cogit MoveR: regOrConst3 R: CArg3Reg]
+]
+
+{ #category : 'abstract instructions' }
+CogARMCompiler >> genMoveM32: offset r: baseReg R: destReg [
+
+	^ cogit MoveMw: offset r: baseReg R: destReg
 ]
 
 { #category : 'abstract instructions' }

--- a/smalltalksrc/VMMaker/CogARMv8Compiler.class.st
+++ b/smalltalksrc/VMMaker/CogARMv8Compiler.class.st
@@ -4709,11 +4709,13 @@ CogARMv8Compiler >> ldrSize: is64Bits baseRegister: baseReg unsignedOffset: imme
 	
 	LDR <Xt>, [<Xn|SP>{, #<pimm>}]"
 	
+	self assert: (is64Bits = 0 or: [ is64Bits = 1 ]).
 	self assert: immediate12bitValue >= 0.
 	^ 1 << 31
 		bitOr: ((is64Bits bitAnd: 1) << 30
 		bitOr: (2r11100101 << 22
-		bitOr: ((immediate12bitValue / 8 bitAnd: 2r111111111111) << 10
+		bitOr: ((immediate12bitValue /
+			(is64Bits = 1 ifTrue: [8] ifFalse: [4]) bitAnd: 2r111111111111) << 10
 		bitOr:((baseReg bitAnd: 2r11111) << 5
 		bitOr: (destinationRegister bitAnd: 2r11111)))))
 ]

--- a/smalltalksrc/VMMaker/CogAbstractInstruction.class.st
+++ b/smalltalksrc/VMMaker/CogAbstractInstruction.class.st
@@ -379,16 +379,6 @@ CogAbstractInstruction >> >= anAbstractInstruction [
 	^(opcodesArray identityIndexOf: self) >= (opcodesArray identityIndexOf: anAbstractInstruction)
 ]
 
-{ #category : 'abstract instructions' }
-CogAbstractInstruction >> MoveM32: offset r: baseReg R: destReg [
-
-	^ cogit
-		  gen: MoveM32rR
-		  quickConstant: offset
-		  operand: baseReg
-		  operand: destReg
-]
-
 { #category : 'accessing' }
 CogAbstractInstruction >> addDependent: anInstruction [
 	<var: #anInstruction type: #'AbstractInstruction *'>
@@ -873,6 +863,16 @@ CogAbstractInstruction >> genMarshallNArgs: numArgs floatArg: regOrConst0 floatA
 	 register assignments the original author has grown accustomed to."
 	<inline: true>
 	^self subclassResponsibility
+]
+
+{ #category : 'abstract instructions' }
+CogAbstractInstruction >> genMoveM32: offset r: baseReg R: destReg [
+
+	^ cogit
+		  gen: MoveM32rR
+		  quickConstant: offset
+		  operand: baseReg
+		  operand: destReg
 ]
 
 { #category : 'abstract instructions' }

--- a/smalltalksrc/VMMaker/CogAbstractInstruction.class.st
+++ b/smalltalksrc/VMMaker/CogAbstractInstruction.class.st
@@ -379,6 +379,16 @@ CogAbstractInstruction >> >= anAbstractInstruction [
 	^(opcodesArray identityIndexOf: self) >= (opcodesArray identityIndexOf: anAbstractInstruction)
 ]
 
+{ #category : 'abstract instructions' }
+CogAbstractInstruction >> MoveM32: offset r: baseReg R: destReg [
+
+	^ cogit
+		  gen: MoveM32rR
+		  quickConstant: offset
+		  operand: baseReg
+		  operand: destReg
+]
+
 { #category : 'accessing' }
 CogAbstractInstruction >> addDependent: anInstruction [
 	<var: #anInstruction type: #'AbstractInstruction *'>

--- a/smalltalksrc/VMMaker/Cogit.class.st
+++ b/smalltalksrc/VMMaker/Cogit.class.st
@@ -2299,7 +2299,9 @@ Cogit >> MoveM16: offset r: baseReg R: destReg [
 Cogit >> MoveM32: offset r: baseReg R: destReg [
 	<inline: true>
 	<returnTypeC: #'AbstractInstruction *'>
-	^self gen: MoveM32rR quickConstant: offset operand: baseReg operand: destReg
+	^ backEnd MoveM32: offset r: baseReg R: destReg
+	
+
 ]
 
 { #category : 'abstract instructions' }

--- a/smalltalksrc/VMMaker/Cogit.class.st
+++ b/smalltalksrc/VMMaker/Cogit.class.st
@@ -130,10 +130,13 @@ Class {
 		'printInstructions',
 		'compilationTrace',
 		'clickConfirm',
+		'breakPC',
+		'breakBlock',
 		'singleStep',
 		'guardPageSize',
 		'traceFlags',
 		'traceStores',
+		'breakMethod',
 		'methodObj',
 		'enumeratingCogMethod',
 		'methodHeader',
@@ -2299,7 +2302,7 @@ Cogit >> MoveM16: offset r: baseReg R: destReg [
 Cogit >> MoveM32: offset r: baseReg R: destReg [
 	<inline: true>
 	<returnTypeC: #'AbstractInstruction *'>
-	^ backEnd MoveM32: offset r: baseReg R: destReg
+	^ backEnd genMoveM32: offset r: baseReg R: destReg
 	
 
 ]

--- a/smalltalksrc/VMMakerTests/VMCogitHelpersTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMCogitHelpersTest.class.st
@@ -127,3 +127,49 @@ VMCogitHelpersTest >> testCheckSmallIntegerWithValidSmallIntegers [
 	self assertIsInSmallIntegerRange: 0.
 	self assertIsInSmallIntegerRange: memory maxSmallInteger
 ]
+
+{ #category : 'as yet unclassified' }
+VMCogitHelpersTest >> testLoadHigh32BitsZeroExtends [
+
+	| object stub |
+	object := self newObjectWithSlots: 2.
+	memory storeLong64: 0 ofObject: object withValue: 16r88888888FFFFFFFF.
+	"Some noise in the second slot"
+	memory storeLong64: 1 ofObject: object withValue: 16r7777777777777777.
+
+	self assert: (memory fetchLong32: 0 ofObject: object) equals: 16rFFFFFFFF.
+	self assert: (memory fetchLong32: 1 ofObject: object) equals: 16r88888888.
+	
+	machineSimulator receiverRegisterValue: object.
+	
+	stub := self compile: [ 
+		cogit MoveM32: 8 r: ReceiverResultReg R: ReceiverResultReg.
+		cogit RetN: 0 ].
+	
+	self runUntilReturnFrom: stub.
+
+	self assert: (machineSimulator receiverRegisterValue) equals: 16rFFFFFFFF
+]
+
+{ #category : 'as yet unclassified' }
+VMCogitHelpersTest >> testLoadLow32BitsZeroExtends [
+
+	| object stub |
+	object := self newObjectWithSlots: 2.
+	memory storeLong64: 0 ofObject: object withValue: 16r88888888FFFFFFFF.
+	"Some noise in the second slot"
+	memory storeLong64: 1 ofObject: object withValue: 16r7777777777777777.
+	
+	self assert: (memory fetchLong32: 0 ofObject: object) equals: 16rFFFFFFFF.
+	self assert: (memory fetchLong32: 1 ofObject: object) equals: 16r88888888.
+	
+	machineSimulator receiverRegisterValue: object.
+	
+	stub := self compile: [ 
+		cogit MoveM32: 8 "header" + 4 "slot offset" r: ReceiverResultReg R: ReceiverResultReg.
+		cogit RetN: 0 ].
+	
+	self runUntilReturnFrom: stub.
+
+	self assert: (machineSimulator receiverRegisterValue) equals: 16r88888888
+]

--- a/smalltalksrc/VMMakerTests/VMCogitHelpersTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMCogitHelpersTest.class.st
@@ -128,7 +128,7 @@ VMCogitHelpersTest >> testCheckSmallIntegerWithValidSmallIntegers [
 	self assertIsInSmallIntegerRange: memory maxSmallInteger
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'testing' }
 VMCogitHelpersTest >> testLoadHigh32BitsZeroExtends [
 
 	| object stub |
@@ -151,7 +151,7 @@ VMCogitHelpersTest >> testLoadHigh32BitsZeroExtends [
 	self assert: (machineSimulator receiverRegisterValue) equals: 16rFFFFFFFF
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'testing' }
 VMCogitHelpersTest >> testLoadLow32BitsZeroExtends [
 
 	| object stub |


### PR DESCRIPTION
- Fix generation of Load 32 bits in ARMv8 backend with offsets != 0
- Add support for Armv7 and lower for Load 23 bits
- Add tests to ensure that values are zero extended by default (in 64 bits)