### PR TITLE
Add windows support for non ASCII filenames in basicImageFileExists

### DIFF
--- a/src/imageAccess.c
+++ b/src/imageAccess.c
@@ -171,8 +171,23 @@ size_t basicImageFileWrite(void* initialPtr, size_t sz, size_t count, sqImageFil
 
 int basicImageFileExists(const char* aPath){
 	struct stat st;
-
+#ifndef _WIN32
 	return stat(aPath, &st) == 0;
+#else
+	/*
+	 * In Win32, the filename if using fopen only works with ANSI characters.
+	 * We need to use the wide version.
+	 */
+
+	WCHAR * wideFileName = vm_string_convert_utf8_to_utf16(aPath);
+
+	int result = _wstat(wideFileName, &st) == 0;
+
+	free(wideFileName);
+
+	return result;
+
+#endif
 }
 
 void basicImageReportProgress(size_t totalSize, size_t currentSize){


### PR DESCRIPTION
This allows us to open files with non-ASCII names.
Previously we failed to open a file whose path was something like: `C:\User\Iñaki\Pharo\images\myImage.image`.