### PR TITLE
Remove the idea that we might have a different bytecode set

### DIFF
--- a/smalltalksrc/VMMaker/CogMethod.class.st
+++ b/smalltalksrc/VMMaker/CogMethod.class.st
@@ -187,9 +187,7 @@ CogMethod >> cbUsesInstVars: anObject [
 CogMethod >> cmIsFullBlock [
 	"Answer the value of cpicHasMNUCaseOrCMIsFullBlock"
 	<inline: true>
-	^SistaV1BytecodeSet
-		ifTrue: [self cpicHasMNUCaseOrCMIsFullBlock]
-		ifFalse: [false]
+	^ self cpicHasMNUCaseOrCMIsFullBlock
 ]
 
 { #category : 'accessing' }
@@ -280,9 +278,7 @@ CogMethod >> cpicHasMNUCase [
 	"Answer if the receiver has an MNU case."
 	<inline: true>
 
-	^SistaV1BytecodeSet
-		ifTrue: [self cpicHasMNUCaseOrCMIsFullBlock and: [self cmType = CMPolymorphicIC]]
-		ifFalse: [cpicHasMNUCaseOrCMIsFullBlock]
+	^ self cpicHasMNUCaseOrCMIsFullBlock and: [self cmType = CMPolymorphicIC]
 ]
 
 { #category : 'accessing' }

--- a/smalltalksrc/VMMaker/CogMethodSurrogate.class.st
+++ b/smalltalksrc/VMMaker/CogMethodSurrogate.class.st
@@ -134,9 +134,7 @@ CogMethodSurrogate >> cPICNumCases: n [
 CogMethodSurrogate >> cmIsFullBlock [
 	"Answer the value of cpicHasMNUCaseOrCMIsFullBlock"
 
-	^SistaV1BytecodeSet
-		ifTrue: [self cpicHasMNUCaseOrCMIsFullBlock]
-		ifFalse: [false]
+	^ self cpicHasMNUCaseOrCMIsFullBlock
 ]
 
 { #category : 'testing' }
@@ -150,9 +148,7 @@ CogMethodSurrogate >> cpicHasMNUCase [
 	"Answer if the receiver has an MNU case."
 	<inline: true>
 
-	^SistaV1BytecodeSet
-		ifTrue: [self cpicHasMNUCaseOrCMIsFullBlock and: [self cmType = CMPolymorphicIC]]
-		ifFalse: [self cpicHasMNUCaseOrCMIsFullBlock]
+	^ self cpicHasMNUCaseOrCMIsFullBlock and: [self cmType = CMPolymorphicIC]
 ]
 
 { #category : 'accessing' }

--- a/smalltalksrc/VMMaker/CogObjectRepresentation.class.st
+++ b/smalltalksrc/VMMaker/CogObjectRepresentation.class.st
@@ -897,7 +897,6 @@ CogObjectRepresentation >> genPrimitiveFormat [
 CogObjectRepresentation >> genPrimitiveFullClosureValue [
 	"Defer to the cogit for this one, to match the split for genPrimitiveClosureValue."
 	<doNotGenerate>
-	<option: #SistaV1BytecodeSet>
 	^cogit genPrimitiveFullClosureValue
 ]
 

--- a/smalltalksrc/VMMaker/CogObjectRepresentationFor64BitSpur.class.st
+++ b/smalltalksrc/VMMaker/CogObjectRepresentationFor64BitSpur.class.st
@@ -62,17 +62,6 @@ CogObjectRepresentationFor64BitSpur >> allocateCounters: nCounters [
 		ifNotNil: [objOop + objectMemory baseHeaderSize]
 ]
 
-{ #category : 'in-line cacheing' }
-CogObjectRepresentationFor64BitSpur >> bitAndByteOffsetOfIsFullBlockBitInto: aBlock [
-
-	"This supplies the bitmask for the isFullBlock bit, and the offset of the byte containing
-	 that bit in a CogMethod header to aBlock.  We don't have named variables holding this
-	 offset.  The following assert tests whether the values are correct by creating a surrogate
-	 on an empty ByteArray, setting the bit, and checking that the expected values are set
-	 in the ByteArray."
-	aBlock value: 16 value: objectMemory baseHeaderSize + 1 "zero-relative"
-]
-
 { #category : 'sista support' }
 CogObjectRepresentationFor64BitSpur >> branch2CasesIf: reg instanceOfBehaviors: arrayObj target: targetFixUp [
 	| classObj tag1 tag2 |
@@ -2283,35 +2272,15 @@ CogObjectRepresentationFor64BitSpur >> maybeGenerateSelectorIndexDereferenceRout
 	 special selectors array and index that.  Otherwise, index the current method.
 	 The routine uses Extra0Reg & Extra1Reg, which are available, since they
 	 are not live at point of send."
-	| jumpNegative jumpNotBlock jumpFullBlock |
+	| jumpNegative |
 	<var: 'jumpNegative' type: #'AbstractInstruction *'>
-	<var: 'jumpNotBlock' type: #'AbstractInstruction *'>
-	<var: 'jumpFullBlock' type: #'AbstractInstruction *'>
 	cogit zeroOpcodeIndex.
 	cogit CmpCq: 0 R: ClassReg.
 	jumpNegative := cogit JumpLess: 0.
 	cogit
 		MoveMw: FoxMethod r: FPReg R: Extra0Reg;
 		AddCq: 2 R: ClassReg; "Change selector index to 1-relative, skipping the method header"
-		TstCq: MFMethodFlagIsBlockFlag R: Extra0Reg.
-	jumpNotBlock := cogit JumpZero: 0.
-	"If in a block, need to find the home method...  If using full blocks, need to test the cpicHasMNUCaseOrCMIsFullBlock bit"
-	cogit AndCq: methodZone zoneAlignment negated R: Extra0Reg.
-	SistaV1BytecodeSet ifTrue:
-		[self bitAndByteOffsetOfIsFullBlockBitInto:
-			[:bitmask :byteOffset|
-			jumpFullBlock := cogit
-				MoveMb: byteOffset r: Extra0Reg R: Extra1Reg;
-				TstCq: bitmask R: Extra1Reg;
-				JumpNonZero: 0]].
-	cogit 
-		MoveM16: 0 r: Extra0Reg R: Extra1Reg;
-		SubR: Extra1Reg R: Extra0Reg.
-	jumpNotBlock jmpTarget: cogit Label.
-	SistaV1BytecodeSet ifTrue:
-		[jumpFullBlock jmpTarget: jumpNotBlock getJmpTarget].
-	cogit "Now fetch the method object and index with the literal index to retrieve the selector"
-		AndCq: methodZone zoneAlignment negated R: Extra0Reg;
+		AndCq: methodZone zoneAlignment negated R: Extra0Reg; "Now fetch the method object and index with the literal index to retrieve the selector"
 		MoveMw: (cogit offset: CogMethod of: #methodObject) r: Extra0Reg R: Extra1Reg;
 		MoveXwr: ClassReg R: Extra1Reg R: ClassReg;
 		RetN: 0.

--- a/smalltalksrc/VMMaker/CogObjectRepresentationForSpur.class.st
+++ b/smalltalksrc/VMMaker/CogObjectRepresentationForSpur.class.st
@@ -61,11 +61,8 @@ CogObjectRepresentationForSpur class >> initializeMiscConstants [
 { #category : 'accessing' }
 CogObjectRepresentationForSpur class >> numTrampolines [
 	^super numTrampolines
-		 + (SistaV1BytecodeSet
-			ifTrue: [9] "(small,large)x(method,block,fullBlock) context creation,
+		 + 9 "(small,large)x(method,block,fullBlock) context creation,
 						 ceNewHashTrampoline, ceStoreCheckContextReceiverTrampoline and ceScheduleScavengeTrampoline"
-			ifFalse: [7] "(small,large)x(method,block) context creation, 
-						 ceNewHashTrampoline, ceStoreCheckContextReceiverTrampoline and ceScheduleScavengeTrampoline")
 		 + NumStoreTrampolines
 		 + (SistaVM
 			ifTrue: [1] "inline newHash"
@@ -2977,11 +2974,9 @@ CogObjectRepresentationForSpur >> generateObjectRepresentationTrampolines [
 											called: 'ceScheduleScavengeTrampoline'
 											regsToSave: CallerSavedRegisterMask.
 	ceSmallActiveContextInMethodTrampoline := self genActiveContextTrampolineLarge: false inBlock: 0 called: 'ceSmallMethodContext'.
-	SistaV1BytecodeSet ifTrue:
-		[ceSmallActiveContextInFullBlockTrampoline := self genActiveContextTrampolineLarge: false inBlock: InFullBlock called: 'ceSmallFullBlockContext'].
+	ceSmallActiveContextInFullBlockTrampoline := self genActiveContextTrampolineLarge: false inBlock: InFullBlock called: 'ceSmallFullBlockContext'.
 	ceLargeActiveContextInMethodTrampoline := self genActiveContextTrampolineLarge: true inBlock: 0 called: 'ceLargeMethodContext'.
-	SistaV1BytecodeSet ifTrue:
-		[ceLargeActiveContextInFullBlockTrampoline := self genActiveContextTrampolineLarge: true inBlock: InFullBlock called: 'ceLargeFullBlockContext'].
+	ceLargeActiveContextInFullBlockTrampoline := self genActiveContextTrampolineLarge: true inBlock: InFullBlock called: 'ceLargeFullBlockContext'.
 ]
 
 { #category : 'bytecode generator support' }

--- a/smalltalksrc/VMMaker/Cogit.class.st
+++ b/smalltalksrc/VMMaker/Cogit.class.st
@@ -130,13 +130,10 @@ Class {
 		'printInstructions',
 		'compilationTrace',
 		'clickConfirm',
-		'breakPC',
-		'breakBlock',
 		'singleStep',
 		'guardPageSize',
 		'traceFlags',
 		'traceStores',
-		'breakMethod',
 		'methodObj',
 		'enumeratingCogMethod',
 		'methodHeader',
@@ -4637,7 +4634,6 @@ Cogit >> cogFullBlockMethod: aMethodObj numCopied: numCopied [
 	 depend on the zone remaining constant across method generation."
 
 	<api>
-	<option: #SistaV1BytecodeSet>
 	<returnTypeC: #'CogMethod *'>
 	<var: #startTime type: #usqLong>
 	<var: #cogMethod type: #'CogMethod *'>
@@ -5196,7 +5192,6 @@ Cogit >> compileCallFor: aRoutine numArgs: numArgs arg: regOrConst0 arg: regOrCo
 { #category : 'compile abstract instructions' }
 Cogit >> compileCogFullBlockMethod: numCopied [
 	<returnTypeC: #'CogMethod *'>
-	<option: #SistaV1BytecodeSet>
 	| numBytecodes successScan result |
 	hasYoungReferent := (objectMemory getMemoryMap isYoungObject: methodObj).
 	methodOrBlockNumArgs := coInterpreter argumentCountOf: methodObj.
@@ -5267,7 +5262,6 @@ Cogit >> compileCogMethod: selector [
 { #category : 'compile abstract instructions' }
 Cogit >> compileEntireFullBlockMethod: numCopied [
 	"Compile the abstract instructions for the entire full block method."
-	<option: #SistaV1BytecodeSet>
 	| result |
 	self preenMethodLabel.
 	self compileFullBlockEntry.
@@ -5317,7 +5311,6 @@ Cogit >> compileFrameBuild [
 
 { #category : 'compile abstract instructions' }
 Cogit >> compileFullBlockEntry [
-	<option: #SistaV1BytecodeSet>
 	"Compile the abstract instructions for the entire method, including blocks."
 	| jumpNoContextSwitch |
 
@@ -5585,14 +5578,14 @@ Cogit >> computeFullBlockEntryOffsets [
 	 need cmNoCheckEntryOffset up front to be able to generate the map starting from cmNoCheckEntryOffset"
 	"stack allocate the various collections so that they
 	 are effectively garbage collected on return."
-	SistaV1BytecodeSet ifTrue:
-		[self allocateOpcodes: 24 bytecodes: 0.
-		 methodOrBlockNumArgs := 0.
-		 self compileFullBlockEntry.
-		 self computeMaximumSizes.
-		 self enableCodeZoneWriteDuring: [self generateInstructionsAt: methodZoneBase + (self sizeof: CogMethod)].
-		 cbEntryOffset := fullBlockEntry address - methodZoneBase.
-		 cbNoSwitchEntryOffset := fullBlockNoContextSwitchEntry address - methodZoneBase]
+	self allocateOpcodes: 24 bytecodes: 0.
+	methodOrBlockNumArgs := 0.
+	self compileFullBlockEntry.
+	self computeMaximumSizes.
+	self enableCodeZoneWriteDuring: [
+		self generateInstructionsAt: methodZoneBase + (self sizeof: CogMethod)].
+	cbEntryOffset := fullBlockEntry address - methodZoneBase.
+	cbNoSwitchEntryOffset := fullBlockNoContextSwitchEntry address - methodZoneBase
 ]
 
 { #category : 'generate machine code' }
@@ -7506,7 +7499,6 @@ Cogit >> generateCogFullBlock [
 	 that fixes up jumps.  When fixing up a jump the jump is not allowed to
 	 choose a smaller offset but must stick to the size set in the second pass."
 	<returnTypeC: #'CogMethod *'>
-	<option: #SistaV1BytecodeSet>
 	| codeSize headerSize mapSize totalSize startAddress result method |
 	<var: #method type: #'CogMethod *'>
 	headerSize := self sizeof: CogMethod.

--- a/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
@@ -1685,7 +1685,6 @@ InterpreterPrimitives >> primitiveFractionalPart [
 
 { #category : 'control primitives' }
 InterpreterPrimitives >> primitiveFullClosureValue [
-	<option: #SistaV1BytecodeSet>
 	| blockClosure numArgs closureMethod |
 	blockClosure := self stackValue: argumentCount.
 	numArgs := self argumentCountOfClosure: blockClosure.
@@ -1705,7 +1704,6 @@ InterpreterPrimitives >> primitiveFullClosureValueNoContextSwitch [
 	 check for interrupts on stack overflow.  It may invoke the garbage collector
 	 but will not switch processes.  See checkForInterruptsMayContextSwitch:"
 	<api>
-	<option: #SistaV1BytecodeSet>
 	| blockClosure numArgs closureMethod |
 	blockClosure := self stackValue: argumentCount.
 	numArgs := self argumentCountOfClosure: blockClosure.
@@ -1721,7 +1719,6 @@ InterpreterPrimitives >> primitiveFullClosureValueNoContextSwitch [
 
 { #category : 'control primitives' }
 InterpreterPrimitives >> primitiveFullClosureValueWithArgs [
-	<option: #SistaV1BytecodeSet>
 	| argumentArray arraySize blockClosure numArgs closureMethod index |
 	argumentArray := self stackTop.
 	(objectMemory isArray: argumentArray) ifFalse:

--- a/smalltalksrc/VMMaker/SimpleStackBasedCogit.class.st
+++ b/smalltalksrc/VMMaker/SimpleStackBasedCogit.class.st
@@ -1870,7 +1870,6 @@ SimpleStackBasedCogit >> genPrimitiveFullClosureValue [
 	 block entry or the no-context-switch entry, as appropriate, and we're done.  If not,
 	 invoke the interpreter primitive."
 
-	<option: #SistaV1BytecodeSet>
 	<var: #jumpFailImmediateMethod type: #'AbstractInstruction *'>
 	<var: #jumpFail4 type: #'AbstractInstruction *'>
 	<var: #jumpFailNArgs type: #'AbstractInstruction *'>

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -644,8 +644,6 @@ StackInterpreter class >> initializeBytecodeTableForSistaV1 [
 	"StackInterpreter initializeBytecodeTableForSistaV1"
 	"Note: This table will be used to generate a C switch statement."
 
-	InitializationOptions at: #SistaV1BytecodeSet put: (SistaV1BytecodeSet := true).
-
 	BytecodeTable := Array new: 256.
 	BytecodeEncoderClassName := #EncoderForSistaV1.
 	BytecodeSetHasDirectedSuperSend := true.

--- a/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
+++ b/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
@@ -957,7 +957,6 @@ StackToRegisterMappingCogit >> compileAbstractInstructionsFrom: start through: e
 
 { #category : 'compile abstract instructions' }
 StackToRegisterMappingCogit >> compileCogFullBlockMethod: numCopied [
-	<option: #SistaV1BytecodeSet>
 	methodOrBlockNumTemps := coInterpreter tempCountOf: methodObj.
 	self cCode: '' inSmalltalk:
 		[debugStackPointers := coInterpreter debugStackPointersFor: methodObj].
@@ -1008,7 +1007,6 @@ StackToRegisterMappingCogit >> compileFullBlockFramelessEntry: numCopied [
 
 { #category : 'compile abstract instructions' }
 StackToRegisterMappingCogit >> compileFullBlockMethodFrameBuild: numCopied [
-	<option: #SistaV1BytecodeSet>
 	useTwoPaths ifTrue: 
 		[ "method with only inst var store, we compile only slow path for now" 
 		 useTwoPaths := false.
@@ -2116,7 +2114,6 @@ StackToRegisterMappingCogit >> genPrimReturn [
 { #category : 'primitive generators' }
 StackToRegisterMappingCogit >> genPrimitiveFullClosureValue [
 	"Override to push the register args first."
-	<option: #SistaV1BytecodeSet>
 	self genPushRegisterArgs.
 	^super genPrimitiveFullClosureValue
 ]

--- a/smalltalksrc/VMMaker/VMBytecodeConstants.class.st
+++ b/smalltalksrc/VMMaker/VMBytecodeConstants.class.st
@@ -12,7 +12,6 @@ Class {
 		'CtxtTempFrameStart',
 		'LargeContextBit',
 		'LargeContextSlots',
-		'SistaV1BytecodeSet',
 		'SmallContextSlots'
 	],
 	#pools : [
@@ -25,7 +24,7 @@ Class {
 
 { #category : 'simulator initialization' }
 VMBytecodeConstants class >> falsifyBytecodeSetFlags: initializationOptions [
-	SistaV1BytecodeSet.
+
 	classPool keys do:
 		[:k|
 		(k endsWith: 'BytecodeSet') ifTrue:


### PR DESCRIPTION
This PR remove the `SistaV1BytecodeSet` option. We are currently using only one bytecode set.

More than that, the routine for loading selectors on inline cache misses is reduced ~4 instructions because we are not using the old representation. Every block is a "full block" on our current VM, testing for that is just wasting time and energy.

If I'm mistaken by my understanding of our current status (or future ambitions) feel free to ask me to change this PR.