### PR TITLE
remove a few unused variables

### DIFF
--- a/plugins/BitBltPlugin/src/common/BitBltPlugin.c
+++ b/plugins/BitBltPlugin/src/common/BitBltPlugin.c
@@ -1679,6 +1679,9 @@ copyBitsRule41Test(void)
 void
 copyBitsFallback(operation_t *op, unsigned int flags)
 {
+
+#  if ENABLE_FAST_BLT
+
 	sqInt done;
 	sqInt dxLowBits;
 	sqInt endBits;
@@ -1689,9 +1692,6 @@ copyBitsFallback(operation_t *op, unsigned int flags)
 	sqInt startBits1;
 	sqInt sxLowBits;
 	sqInt t;
-
-	
-#  if ENABLE_FAST_BLT
 
 	/* recover values from the operation struct used by the fast ARM code */
 	
@@ -5018,7 +5018,6 @@ primitiveCompareColors(void)
 	sqInt rcvr;
 	sqInt testID;
 	sqInt val;
-	sqInt _return_value;
 
 	val = 0;
 	if (!((isPositiveMachineIntegerObject(stackValue(2)))
@@ -5040,6 +5039,9 @@ primitiveCompareColors(void)
 	}
 	
 #  if ENABLE_FAST_BLT
+
+	sqInt _return_value;
+
 	if (!(loadBitBltFromwarping(rcvr, 0))) {
 		primitiveFail();
 		return null;

--- a/plugins/FileAttributesPlugin/src/common/FileAttributesPlugin.c
+++ b/plugins/FileAttributesPlugin/src/common/FileAttributesPlugin.c
@@ -706,10 +706,11 @@ primitiveFileMasks(void)
 EXPORT(sqInt)
 primitiveLogicalDrives(void)
 {
-    unsigned int mask;
-
 	
 #  if defined(_WIN32)
+
+	unsigned int mask;
+
 	mask = GetLogicalDrives();
 	if (mask != 0) {
 		popthenPush(1, positive32BitIntegerFor(mask));

--- a/plugins/FilePlugin/src/unix/sqUnixCharConv.c
+++ b/plugins/FilePlugin/src/unix/sqUnixCharConv.c
@@ -103,9 +103,8 @@ void freeEncoding(void *encoding) { }
 void setEncoding(void **encoding, char *rawName)
 {
   char *name= strdup(rawName);
-  int   len= strlen(name);
+  int   len = strlen(name);
   int   i;
-  int   utf8= 0;
   alias *ap= encodings;
   for (i= 0;  i < len;  ++i)
     name[i]= toupper(name[i]);

--- a/plugins/JPEGReaderPlugin/src/common/JPEGReaderPlugin.c
+++ b/plugins/JPEGReaderPlugin/src/common/JPEGReaderPlugin.c
@@ -95,10 +95,8 @@ static int *acTable;
 static sqInt acTableSize;
 static int *cbBlocks[128];
 static int cbComponent[11];
-static sqInt cbSampleStream;
 static int *crBlocks[128];
 static int crComponent[11];
-static sqInt crSampleStream;
 static int *dcTable;
 static sqInt dcTableSize;
 static sqInt ditherMask;
@@ -165,8 +163,6 @@ static const char *moduleName =
 static int *residuals;
 static int *yBlocks[128];
 static int yComponent[11];
-static sqInt ySampleStream;
-
 
 	/* JPEGReaderPlugin>>#cbColorComponentFrom: */
 static sqInt

--- a/plugins/SocketPlugin/src/common/SocketPluginImpl.c
+++ b/plugins/SocketPlugin/src/common/SocketPluginImpl.c
@@ -191,9 +191,7 @@ The Socket plugin uses this value as a limit for the FQDN (Fully Qualified Domai
 #define LINGER_SECS		 1
 
 volatile static int thisNetSession = 0;
-static int one= 1;
-
-static char   localHostName[MAXHOSTNAMELEN];
+static int one = 1;
 
 /*
  * The ERROR constants are different in Windows and in Unix.

--- a/smalltalksrc/BaselineOfVMMaker/BaselineOfVMMaker.class.st
+++ b/smalltalksrc/BaselineOfVMMaker/BaselineOfVMMaker.class.st
@@ -17,11 +17,11 @@ BaselineOfVMMaker >> baseline: spec [
 				package: 'CAST' with: [ spec requires: #('SmaCC-GLR' ) ];
 				package: 'CAST-Tests' with: [ spec requires: #('CAST') ];
 				package: 'Slang' with: [ spec requires: #('CAST') ];
-				package: 'Slang-Tests' with: [ spec requires: #('Slang') ].
+				package: 'Slang-Tests' with: [ spec requires: #('Slang' 'Melchor') ].
 			
 			"Melchor is a VM-oriented Slang"
 			spec package: 'Melchor' with: [
-				spec requires: #('Slang' 'Slang-Tests') ].
+				spec requires: #('Slang') ].
 			
 			"External Dependencies"
 			spec baseline: 'SmaCC-GLR' with: [ 

--- a/smalltalksrc/Melchor/CCodeGeneratorGlobalStructure.class.st
+++ b/smalltalksrc/Melchor/CCodeGeneratorGlobalStructure.class.st
@@ -333,7 +333,7 @@ CCodeGeneratorGlobalStructure >> localizeGlobalVariables [
 			globalsToDelete add: assoc key ] ].
 
 	variables do: [ :var |
-		(globalVariableUsage includes: var) ifFalse: [
+		(globalVariableUsage keys includes: var) ifFalse: [
 			globalsToDelete add: var ] ].
 
 	globalsToDelete do: [ :var |

--- a/smalltalksrc/Melchor/CCodeGeneratorGlobalStructure.class.st
+++ b/smalltalksrc/Melchor/CCodeGeneratorGlobalStructure.class.st
@@ -317,12 +317,18 @@ CCodeGeneratorGlobalStructure >> isGlobalStructureBuild [
 
 { #category : 'utilities' }
 CCodeGeneratorGlobalStructure >> localizeGlobalVariables [
-"TPR - remove all the global vars destined for the structure that are only used once - not worth the space,
+	"TPR - remove all the global vars destined for the structure that are only used once - not worth the space,
 actually what will happen is the folding code will fold these variables into the method"
 
+	| globalsToDelete globalVariableUsageKeys |
 	super localizeGlobalVariables.
-	globalVariableUsage := globalVariableUsage select: [:e | e size > 1].
-
+	globalVariableUsage := globalVariableUsage select: [ :e | e size > 1 ].
+	globalVariableUsageKeys := globalVariableUsage keys.
+	globalsToDelete := variables reject: [ :var |
+		                   (globalVariableUsageKeys includes: var) or: [
+			                   ((variableDeclarations at: var ifAbsent: [ '' ])
+				                    beginsWith: 'extern') or: [ var = #sendTrace ] ] ].
+	globalsToDelete do: [ :var | self removeVariable: var ]
 ]
 
 { #category : 'C code generator' }

--- a/smalltalksrc/Melchor/CCodeGeneratorGlobalStructure.class.st
+++ b/smalltalksrc/Melchor/CCodeGeneratorGlobalStructure.class.st
@@ -315,30 +315,6 @@ CCodeGeneratorGlobalStructure >> isGlobalStructureBuild [
 	^true
 ]
 
-{ #category : 'utilities' }
-CCodeGeneratorGlobalStructure >> localizeGlobalVariables [
-	"TPR - remove all the global vars destined for the structure that are only used once, also supress global variables which have 0 usage"
-
-	| globalsToDelete |
-	super localizeGlobalVariables.
-	globalsToDelete := Set new.
-
-	globalVariableUsage associationsDo: [ :assoc |
-		| var |
-		var := assoc key.
-		(assoc value size = 1 and: [
-			 (self mustBeGlobal: var) not and: [
-				 ((variableDeclarations at: var ifAbsent: [ '' ]) beginsWith:
-					  'extern') not ] ]) ifTrue: [ globalsToDelete add: assoc key ] ].
-	variables do: [ :var |
-		((globalVariableUsage keys includes: var) or: [
-			 self mustBeGlobal: var ]) ifFalse: [ globalsToDelete add: var ] ].
-
-	globalsToDelete do: [ :var |
-		self removeVariable: var.
-		globalVariableUsage removeKey: var ifAbsent: [  ] ]
-]
-
 { #category : 'C code generator' }
 CCodeGeneratorGlobalStructure >> placeInStructure: var [
 	"See if we should put this array into a structure.

--- a/smalltalksrc/Melchor/CCodeGeneratorGlobalStructure.class.st
+++ b/smalltalksrc/Melchor/CCodeGeneratorGlobalStructure.class.st
@@ -317,12 +317,12 @@ CCodeGeneratorGlobalStructure >> isGlobalStructureBuild [
 
 { #category : 'utilities' }
 CCodeGeneratorGlobalStructure >> localizeGlobalVariables [
-	"TPR - remove all the global vars destined for the structure that are only used once - not worth the space,
-actually what will happen is the folding code will fold these variables into the method"
+	"TPR - remove all the global vars destined for the structure that are only used once, also supress variables which have 0 global usage"
 
 	| globalsToDelete |
 	super localizeGlobalVariables.
 	globalsToDelete := Set new.
+
 	globalVariableUsage associationsDo: [ :assoc |
 		| var |
 		var := assoc key.
@@ -331,9 +331,14 @@ actually what will happen is the folding code will fold these variables into the
 				 ((variableDeclarations at: var ifAbsent: [ '' ]) beginsWith:
 					  'extern') not and: [ var ~= #sendTrace ] ] ]) ifTrue: [
 			globalsToDelete add: assoc key ] ].
+
+	variables do: [ :var |
+		(globalVariableUsage includes: var) ifFalse: [
+			globalsToDelete add: var ] ].
+
 	globalsToDelete do: [ :var |
 		self removeVariable: var.
-		globalVariableUsage removeKey: var ]
+		globalVariableUsage removeKey: var ifAbsent: [  ] ]
 ]
 
 { #category : 'C code generator' }

--- a/smalltalksrc/Melchor/CCodeGeneratorGlobalStructure.class.st
+++ b/smalltalksrc/Melchor/CCodeGeneratorGlobalStructure.class.st
@@ -329,12 +329,10 @@ CCodeGeneratorGlobalStructure >> localizeGlobalVariables [
 		(assoc value size = 1 and: [
 			 (self mustBeGlobal: var) not and: [
 				 ((variableDeclarations at: var ifAbsent: [ '' ]) beginsWith:
-					  'extern') not and: [ var ~= #sendTrace ] ] ]) ifTrue: [
-			globalsToDelete add: assoc key ] ].
-
+					  'extern') not ] ]) ifTrue: [ globalsToDelete add: assoc key ] ].
 	variables do: [ :var |
-		(globalVariableUsage keys includes: var) ifFalse: [
-			globalsToDelete add: var ] ].
+		((globalVariableUsage keys includes: var) or: [ var = #sendTrace ])
+			ifFalse: [ globalsToDelete add: var ] ].
 
 	globalsToDelete do: [ :var |
 		self removeVariable: var.

--- a/smalltalksrc/Melchor/CCodeGeneratorGlobalStructure.class.st
+++ b/smalltalksrc/Melchor/CCodeGeneratorGlobalStructure.class.st
@@ -127,7 +127,7 @@ CCodeGeneratorGlobalStructure >> emitCVariablesOn: aStream [
 										[self preDeclareInterpreterProxyOn: target]
 									ifFalse: [target nextPutAll: 'static ']]
 							ifFalse:
-								[(self vmClass mustBeGlobal: varString) ifFalse:
+								[(self vmClass mustBeGlobalAndExport: varString) ifFalse:
 									[target nextPutAll: (inStruct ifTrue: ['_iss '] ifFalse: ['static '])]].
 						target nextPutAll: decl; nextPut: $;; cr]
 			]
@@ -328,7 +328,7 @@ CCodeGeneratorGlobalStructure >> placeInStructure: var [
 	(check includesSubstring: 'static') ifTrue: [^false].
 	(check includesSubstring: 'volatile') ifTrue: [^false].
 
-	^(self vmClass mustBeGlobal: var) not
+	^(self vmClass mustBeGlobalAndExport: var) not
 ]
 
 { #category : 'C code generator' }

--- a/smalltalksrc/Melchor/CCodeGeneratorGlobalStructure.class.st
+++ b/smalltalksrc/Melchor/CCodeGeneratorGlobalStructure.class.st
@@ -320,16 +320,20 @@ CCodeGeneratorGlobalStructure >> localizeGlobalVariables [
 	"TPR - remove all the global vars destined for the structure that are only used once - not worth the space,
 actually what will happen is the folding code will fold these variables into the method"
 
-	| globalsToDelete globalVariableUsageKeys |
+	| globalsToDelete |
 	super localizeGlobalVariables.
-	globalVariableUsage := globalVariableUsage select: [ :e |
-		                       e size > 1 or: [ self mustBeGlobal: e ] ].
-	globalVariableUsageKeys := globalVariableUsage keys.
-	globalsToDelete := variables reject: [ :var |
-		                   (globalVariableUsageKeys includes: var) or: [
-			                   ((variableDeclarations at: var ifAbsent: [ '' ])
-				                    beginsWith: 'extern') or: [ var = #sendTrace ] ] ].
-	globalsToDelete do: [ :var | self removeVariable: var ]
+	globalsToDelete := Set new.
+	globalVariableUsage associationsDo: [ :assoc |
+		| var |
+		var := assoc key.
+		(assoc value size = 1 and: [
+			 (self mustBeGlobal: var) not and: [
+				 ((variableDeclarations at: var ifAbsent: [ '' ]) beginsWith:
+					  'extern') not and: [ var ~= #sendTrace ] ] ]) ifTrue: [
+			globalsToDelete add: assoc key ] ].
+	globalsToDelete do: [ :var |
+		self removeVariable: var.
+		globalVariableUsage removeKey: var ]
 ]
 
 { #category : 'C code generator' }

--- a/smalltalksrc/Melchor/CCodeGeneratorGlobalStructure.class.st
+++ b/smalltalksrc/Melchor/CCodeGeneratorGlobalStructure.class.st
@@ -317,7 +317,7 @@ CCodeGeneratorGlobalStructure >> isGlobalStructureBuild [
 
 { #category : 'utilities' }
 CCodeGeneratorGlobalStructure >> localizeGlobalVariables [
-	"TPR - remove all the global vars destined for the structure that are only used once, also supress variables which have 0 global usage"
+	"TPR - remove all the global vars destined for the structure that are only used once, also supress global variables which have 0 usage"
 
 	| globalsToDelete |
 	super localizeGlobalVariables.
@@ -331,8 +331,8 @@ CCodeGeneratorGlobalStructure >> localizeGlobalVariables [
 				 ((variableDeclarations at: var ifAbsent: [ '' ]) beginsWith:
 					  'extern') not ] ]) ifTrue: [ globalsToDelete add: assoc key ] ].
 	variables do: [ :var |
-		((globalVariableUsage keys includes: var) or: [ var = #sendTrace ])
-			ifFalse: [ globalsToDelete add: var ] ].
+		((globalVariableUsage keys includes: var) or: [
+			 self mustBeGlobal: var ]) ifFalse: [ globalsToDelete add: var ] ].
 
 	globalsToDelete do: [ :var |
 		self removeVariable: var.

--- a/smalltalksrc/Melchor/CCodeGeneratorGlobalStructure.class.st
+++ b/smalltalksrc/Melchor/CCodeGeneratorGlobalStructure.class.st
@@ -322,7 +322,8 @@ actually what will happen is the folding code will fold these variables into the
 
 	| globalsToDelete globalVariableUsageKeys |
 	super localizeGlobalVariables.
-	globalVariableUsage := globalVariableUsage select: [ :e | e size > 1 ].
+	globalVariableUsage := globalVariableUsage select: [ :e |
+		                       e size > 1 or: [ self mustBeGlobal: e ] ].
 	globalVariableUsageKeys := globalVariableUsage keys.
 	globalsToDelete := variables reject: [ :var |
 		                   (globalVariableUsageKeys includes: var) or: [

--- a/smalltalksrc/Melchor/MLVMCCodeGenerator.class.st
+++ b/smalltalksrc/Melchor/MLVMCCodeGenerator.class.st
@@ -380,7 +380,7 @@ MLVMCCodeGenerator >> localizeGlobalVariables [
 	| globalsToDelete |
 	super localizeGlobalVariables.
 	globalsToDelete := Set new.
-	"	self haltIf: [ variables includes: #aMethodLabel ]."
+
 	globalVariableUsage associationsDo: [ :assoc |
 		| var |
 		var := assoc key.

--- a/smalltalksrc/Melchor/MLVMCCodeGenerator.class.st
+++ b/smalltalksrc/Melchor/MLVMCCodeGenerator.class.st
@@ -200,6 +200,7 @@ MLVMCCodeGenerator >> emitCHeaderOn: aStream [
 { #category : 'C code generator' }
 MLVMCCodeGenerator >> emitCVariableDeclarationFor: aDeclaration andVarString: varString on: aStream [
 	| declaration |
+	self haltIf: [varString = #memoryManager].
 	declaration := aDeclaration.
 	self isGeneratingPluginCode
 		ifTrue: [ 
@@ -371,6 +372,28 @@ MLVMCCodeGenerator >> isNonArgumentImplicitReceiverVariableName: aString [
 MLVMCCodeGenerator >> kernelReturnTypes [
 	
 	^ kernelReturnTypes ifNil: [ kernelReturnTypes := self computeKernelReturnTypes ]
+]
+
+{ #category : 'utilities' }
+MLVMCCodeGenerator >> localizeGlobalVariables [
+	"TPR - remove all the global vars destined for the structure that are only used once, also supress global variables which have 0 usage"
+
+	| globalsToDelete |
+	super localizeGlobalVariables.
+	globalsToDelete := Set new.
+
+	globalVariableUsage associationsDo: [ :assoc |
+		| var |
+		var := assoc key.
+		(assoc value size = 1 and: [
+			 (self mustBeGlobal: var) not and: [
+				 ((variableDeclarations at: var ifAbsent: [ '' ]) beginsWith:
+					  'extern') not ] ]) ifTrue: [ globalsToDelete add: assoc key ] ].
+	variables do: [ :var |
+		((globalVariableUsage keys includes: var) or: [
+			 self mustBeGlobal: var ]) ifFalse: [ globalsToDelete add: var ] ].
+
+	globalsToDelete do: [ :var | self removeVariable: var ]
 ]
 
 { #category : 'C translation support' }

--- a/smalltalksrc/Melchor/MLVMCCodeGenerator.class.st
+++ b/smalltalksrc/Melchor/MLVMCCodeGenerator.class.st
@@ -210,7 +210,7 @@ MLVMCCodeGenerator >> emitCVariableDeclarationFor: aDeclaration andVarString: va
 					(declaration beginsWith: 'static') ifFalse: [ 
 						aStream nextPutAll: 'static ' ] ] ]
 		ifFalse: [ 
-			(self vmClass mustBeGlobal: varString)
+			(self vmClass mustBeGlobalAndExport: varString)
 				ifTrue: [ 
 					(declaration beginsWith: 'static ') ifTrue: [ 
 						declaration := declaration allButFirst: 7 ] ]
@@ -274,7 +274,7 @@ MLVMCCodeGenerator >> emitGlobalCVariablesOn: aStream [
 
 	aStream newLine; nextPutAll: '/*** Global Variables ***/'; newLine.
 	
-	(self sortStrings: (variables select: [:v| self vmClass mustBeGlobal: v])) do:
+	(self sortStrings: (variables select: [:v| self vmClass mustBeGlobalAndExport: v])) do:
 		[:var | | varString decl |
 		varString := var asString.
 		decl := variableDeclarations at: varString ifAbsent: ['sqInt ' , varString].
@@ -380,7 +380,7 @@ MLVMCCodeGenerator >> localizeGlobalVariables [
 	| globalsToDelete |
 	super localizeGlobalVariables.
 	globalsToDelete := Set new.
-"	self haltIf: [ variables includes: #aMethodLabel ]."
+	"	self haltIf: [ variables includes: #aMethodLabel ]."
 	globalVariableUsage associationsDo: [ :assoc |
 		| var |
 		var := assoc key.
@@ -420,7 +420,20 @@ MLVMCCodeGenerator >> mostBasicConstantSelectors [
 
 { #category : 'inlining' }
 MLVMCCodeGenerator >> mustBeGlobal: aName [
-	^ self vmClass mustBeGlobal: aName
+
+	^ (self mustBeGlobalAndExport: aName) or: [
+		  self mustBeGlobalInFile: aName ]
+]
+
+{ #category : 'inlining' }
+MLVMCCodeGenerator >> mustBeGlobalAndExport: aName [
+	^ self vmClass mustBeGlobalAndExport: aName
+]
+
+{ #category : 'inlining' }
+MLVMCCodeGenerator >> mustBeGlobalInFile: aName [
+
+	^ self vmClass mustBeGlobalInFile: aName
 ]
 
 { #category : 'C code generator' }

--- a/smalltalksrc/Melchor/MLVMCCodeGenerator.class.st
+++ b/smalltalksrc/Melchor/MLVMCCodeGenerator.class.st
@@ -200,7 +200,6 @@ MLVMCCodeGenerator >> emitCHeaderOn: aStream [
 { #category : 'C code generator' }
 MLVMCCodeGenerator >> emitCVariableDeclarationFor: aDeclaration andVarString: varString on: aStream [
 	| declaration |
-	self haltIf: [varString = #memoryManager].
 	declaration := aDeclaration.
 	self isGeneratingPluginCode
 		ifTrue: [ 
@@ -381,7 +380,7 @@ MLVMCCodeGenerator >> localizeGlobalVariables [
 	| globalsToDelete |
 	super localizeGlobalVariables.
 	globalsToDelete := Set new.
-
+"	self haltIf: [ variables includes: #aMethodLabel ]."
 	globalVariableUsage associationsDo: [ :assoc |
 		| var |
 		var := assoc key.

--- a/smalltalksrc/Melchor/VMBasicConstants.class.st
+++ b/smalltalksrc/Melchor/VMBasicConstants.class.st
@@ -34,7 +34,6 @@ Class {
 		'HashMultiplyMask',
 		'IMMUTABILITY',
 		'PRIdSQINT',
-		'PharoVM',
 		'PrimErrBadArgument',
 		'PrimErrBadIndex',
 		'PrimErrBadMethod',

--- a/smalltalksrc/Melchor/VMClass.class.st
+++ b/smalltalksrc/Melchor/VMClass.class.st
@@ -111,11 +111,14 @@ VMClass class >> declareCAsUSqLong: arrayOfVariableNames in: aCCodeGenerator [
 ]
 
 { #category : 'translation' }
-VMClass class >> declareCVarsIn: aCCodeGenerator [ 
+VMClass class >> declareCVarsIn: aCCodeGenerator [
 	"Declare any additional variables and/or add type declarations for existing variables."
+
 	aCCodeGenerator
 		var: #expensiveAsserts
-		declareC: 'char expensiveAsserts = 0'
+		declareC: 'char expensiveAsserts = 0'.
+
+	aCCodeGenerator declareVar: 'memoryManager' type: #implicit
 ]
 
 { #category : 'translation' }

--- a/smalltalksrc/Melchor/VMClass.class.st
+++ b/smalltalksrc/Melchor/VMClass.class.st
@@ -265,10 +265,15 @@ VMClass class >> monticelloDescription [
 ]
 
 { #category : 'translation' }
-VMClass class >> mustBeGlobal: var [
+VMClass class >> mustBeGlobalAndExport: var [
 	"Answer if a variable must be global and exported.  Used for inst vars that are accessed from VM support code."
 
 	^var = #expensiveAsserts
+]
+
+{ #category : 'translation' }
+VMClass class >> mustBeGlobalInFile: var [ 
+	^ false
 ]
 
 { #category : 'translation' }

--- a/smalltalksrc/Slang-Tests/MLVMCCodeGeneratorLocalizationMock.class.st
+++ b/smalltalksrc/Slang-Tests/MLVMCCodeGeneratorLocalizationMock.class.st
@@ -1,0 +1,14 @@
+Class {
+	#name : 'MLVMCCodeGeneratorLocalizationMock',
+	#superclass : 'MLVMCCodeGenerator',
+	#category : 'Slang-Tests',
+	#package : 'Slang-Tests'
+}
+
+{ #category : 'utilities' }
+MLVMCCodeGeneratorLocalizationMock >> mustBeGlobal: aName [
+
+	^ (super mustBeGlobal: aName) or: [
+		  #( #instanceVariableMustBeGlobal #globalMustBeGlobal ) includes:
+			  aName ]
+]

--- a/smalltalksrc/Slang-Tests/SLASTTransformationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SLASTTransformationTest.class.st
@@ -1,0 +1,180 @@
+Class {
+	#name : 'SLASTTransformationTest',
+	#superclass : 'SLAbstractTranslationTestCase',
+	#category : 'Slang-Tests',
+	#package : 'Slang-Tests'
+}
+
+{ #category : 'running' }
+SLASTTransformationTest >> setUp [
+
+	super setUp.
+	ccg addClass: SLASTTransformationTestClass.
+	"necessary to get the type of sqInt"
+	SpurMemoryManager initBytesPerWord: 8.
+	ccg inferTypes
+]
+
+{ #category : 'send-transformation' }
+SLASTTransformationTest >> testMethodWithBlockValue [
+
+	| translation tMethod |
+	tMethod := ccg methodNamed: #methodWithBlockValue.
+
+	tMethod expandAST.
+
+	translation := self translate: tMethod.
+	translation := translation trimBoth.
+
+	self
+		assert: translation
+		equals: '/* SLASTTransformationTestClass>>#methodWithBlockValue */
+static sqInt
+methodWithBlockValue(void)
+{
+	sqInt arg;
+
+	{
+		2 + 1;
+	}
+	return 0;
+}'
+]
+
+{ #category : 'send-transformation' }
+SLASTTransformationTest >> testMethodWithBlockValueValue [
+
+	| translation tMethod |
+	tMethod := ccg methodNamed: #methodWithBlockValueValue.
+
+	tMethod expandAST.
+
+	translation := self translate: tMethod.
+	translation := translation trimBoth.
+
+	self
+		assert: translation
+		equals:
+			'/* SLASTTransformationTestClass>>#methodWithBlockValueValue */
+static sqInt
+methodWithBlockValueValue(void)
+{
+	sqInt arg1;
+	sqInt arg2;
+
+	{
+		2 + 3;
+	}
+	return 0;
+}'
+]
+
+{ #category : 'assignment-transformation' }
+SLASTTransformationTest >> testMethodWithBockInAssignment [
+
+	| translation tMethod |
+	tMethod := ccg methodNamed: #methodWithBockInAssignment.
+
+	tMethod expandAST.
+
+	translation := self translate: tMethod.
+	translation := translation trimBoth.
+
+	self
+		assert: translation
+		equals:
+			'/* SLASTTransformationTestClass>>#methodWithBockInAssignment */
+static sqInt
+methodWithBockInAssignment(void)
+{
+	int var;
+
+	{
+		emptyMethod();
+		var = 5;
+	}
+	return 0;
+}'
+]
+
+{ #category : 'assignment-transformation' }
+SLASTTransformationTest >> testMethodWithBockValueInAssignment [
+
+	| translation tMethod |
+	tMethod := ccg methodNamed: #methodWithBockValueInAssignment.
+
+	tMethod expandAST.
+
+	translation := self translate: tMethod.
+	translation := translation trimBoth.
+
+	self
+		assert: translation
+		equals:
+			'/* SLASTTransformationTestClass>>#methodWithBockValueInAssignment */
+static sqInt
+methodWithBockValueInAssignment(void)
+{
+	sqInt arg;
+	sqInt var;
+
+	{
+		emptyMethod(1);
+		var = 5;
+	}
+	return 0;
+}'
+]
+
+{ #category : 'assignment-transformation' }
+SLASTTransformationTest >> testMethodWithBockValueValueInAssignment [
+
+	| translation tMethod |
+	tMethod := ccg methodNamed: #methodWithBockValueValueInAssignment.
+
+	tMethod expandAST.
+
+	translation := self translate: tMethod.
+	translation := translation trimBoth.
+
+	self
+		assert: translation
+		equals:
+			'/* SLASTTransformationTestClass>>#methodWithBockValueValueInAssignment */
+static sqInt
+methodWithBockValueValueInAssignment(void)
+{
+	sqInt arg1;
+	sqInt arg2;
+	sqInt var;
+
+	{
+		emptyMethod(1);
+		emptyMethod(2);
+		var = 5;
+	}
+	return 0;
+}'
+]
+
+{ #category : 'send-transformation' }
+SLASTTransformationTest >> testMethodWithFPrintF [
+
+	| translation tMethod |
+	tMethod := ccg methodNamed: #methodWithFPrintF.
+
+	tMethod expandAST.
+
+	translation := self translate: tMethod.
+	translation := translation trimBoth.
+
+	self
+		assert: translation
+		equals: '/* SLASTTransformationTestClass>>#methodWithFPrintF */
+static sqInt
+methodWithFPrintF(void)
+{
+	fprintf(something, "%d %d %d %d %d %d", 1, 2, 3, 4, 5, 6);
+	return 0;
+}'
+]

--- a/smalltalksrc/Slang-Tests/SLASTTransformationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SLASTTransformationTest.class.st
@@ -1,6 +1,9 @@
 Class {
 	#name : 'SLASTTransformationTest',
 	#superclass : 'SLAbstractTranslationTestCase',
+	#instVars : [
+		'sLExpandASTVisitor'
+	],
 	#category : 'Slang-Tests',
 	#package : 'Slang-Tests'
 }
@@ -12,7 +15,8 @@ SLASTTransformationTest >> setUp [
 	ccg addClass: SLASTTransformationTestClass.
 	"necessary to get the type of sqInt"
 	SpurMemoryManager initBytesPerWord: 8.
-	ccg inferTypes
+	ccg inferTypes.
+	sLExpandASTVisitor := SLExpandASTVisitor new
 ]
 
 { #category : 'send-transformation' }
@@ -21,7 +25,8 @@ SLASTTransformationTest >> testMethodWithBlockValue [
 	| translation tMethod |
 	tMethod := ccg methodNamed: #methodWithBlockValue.
 
-	tMethod expandAST.
+	sLExpandASTVisitor currentMethod: tMethod .
+	sLExpandASTVisitor expandASTInCurrentMethod.
 
 	translation := self translate: tMethod.
 	translation := translation trimBoth.
@@ -47,7 +52,8 @@ SLASTTransformationTest >> testMethodWithBlockValueValue [
 	| translation tMethod |
 	tMethod := ccg methodNamed: #methodWithBlockValueValue.
 
-	tMethod expandAST.
+	sLExpandASTVisitor currentMethod: tMethod.
+	sLExpandASTVisitor expandASTInCurrentMethod.
 
 	translation := self translate: tMethod.
 	translation := translation trimBoth.
@@ -75,7 +81,8 @@ SLASTTransformationTest >> testMethodWithBockInAssignment [
 	| translation tMethod |
 	tMethod := ccg methodNamed: #methodWithBockInAssignment.
 
-	tMethod expandAST.
+	sLExpandASTVisitor currentMethod: tMethod.
+	sLExpandASTVisitor expandASTInCurrentMethod.
 
 	translation := self translate: tMethod.
 	translation := translation trimBoth.
@@ -103,7 +110,8 @@ SLASTTransformationTest >> testMethodWithBockValueInAssignment [
 	| translation tMethod |
 	tMethod := ccg methodNamed: #methodWithBockValueInAssignment.
 
-	tMethod expandAST.
+	sLExpandASTVisitor currentMethod: tMethod.
+	sLExpandASTVisitor expandASTInCurrentMethod.
 
 	translation := self translate: tMethod.
 	translation := translation trimBoth.
@@ -132,7 +140,8 @@ SLASTTransformationTest >> testMethodWithBockValueValueInAssignment [
 	| translation tMethod |
 	tMethod := ccg methodNamed: #methodWithBockValueValueInAssignment.
 
-	tMethod expandAST.
+	sLExpandASTVisitor currentMethod: tMethod.
+	sLExpandASTVisitor expandASTInCurrentMethod.
 
 	translation := self translate: tMethod.
 	translation := translation trimBoth.
@@ -163,7 +172,8 @@ SLASTTransformationTest >> testMethodWithFPrintF [
 	| translation tMethod |
 	tMethod := ccg methodNamed: #methodWithFPrintF.
 
-	tMethod expandAST.
+	sLExpandASTVisitor currentMethod: tMethod.
+	sLExpandASTVisitor expandASTInCurrentMethod.
 
 	translation := self translate: tMethod.
 	translation := translation trimBoth.

--- a/smalltalksrc/Slang-Tests/SLASTTransformationTestClass.class.st
+++ b/smalltalksrc/Slang-Tests/SLASTTransformationTestClass.class.st
@@ -1,0 +1,69 @@
+Class {
+	#name : 'SLASTTransformationTestClass',
+	#superclass : 'SlangClass',
+	#instVars : [
+		'something'
+	],
+	#category : 'Slang-Tests',
+	#package : 'Slang-Tests'
+}
+
+{ #category : 'helpers' }
+SLASTTransformationTestClass >> emptyMethod [
+]
+
+{ #category : 'helpers' }
+SLASTTransformationTestClass >> emptyMethod: arg [ 
+]
+
+{ #category : 'helpers' }
+SLASTTransformationTestClass >> f: string printf: args [
+
+	
+]
+
+{ #category : 'send-transformation' }
+SLASTTransformationTestClass >> methodWithBlockValue [
+
+	[ :arg | arg + 1 ] value: 2
+]
+
+{ #category : 'send-transformation' }
+SLASTTransformationTestClass >> methodWithBlockValueValue [
+
+	[ :arg1 :arg2 | arg1 + arg2 ] value: 2 value: 3
+]
+
+{ #category : 'assignment-transformation' }
+SLASTTransformationTestClass >> methodWithBockInAssignment [
+
+	| var |
+	var := [
+	       self emptyMethod.
+	       5 ]
+]
+
+{ #category : 'assignment-transformation' }
+SLASTTransformationTestClass >> methodWithBockValueInAssignment [
+
+	| var |
+	var := [ :arg |
+	       self emptyMethod: arg.
+	       5 ] value: 1
+]
+
+{ #category : 'assignment-transformation' }
+SLASTTransformationTestClass >> methodWithBockValueValueInAssignment [
+
+	| var |
+	var := [ :arg1 :arg2 |
+	       self emptyMethod: arg1.
+	       self emptyMethod: arg2.
+	       5 ] value: 1 value: 2
+]
+
+{ #category : 'send-transformation' }
+SLASTTransformationTestClass >> methodWithFPrintF [ 
+	something f: '%d %d %d %d %d %d'
+		printf:{	1. 2. 3. 4. 5. 6 }.
+]

--- a/smalltalksrc/Slang-Tests/SLAbstractTranslationTestCase.class.st
+++ b/smalltalksrc/Slang-Tests/SLAbstractTranslationTestCase.class.st
@@ -1,0 +1,23 @@
+Class {
+	#name : 'SLAbstractTranslationTestCase',
+	#superclass : 'SlangAbstractTestCase',
+	#category : 'Slang-Tests',
+	#package : 'Slang-Tests'
+}
+
+{ #category : 'helpers' }
+SLAbstractTranslationTestCase >> astTranslate: tast inStream: aWriteStream [ 
+	
+	| cAST prettyPrinter |
+	cAST := tast asCASTIn: ccg.
+	prettyPrinter := CSlangPrettyPrinter new.
+	prettyPrinter writeStream: aWriteStream.
+	cAST acceptVisitor: prettyPrinter.
+]
+
+{ #category : 'helpers' }
+SLAbstractTranslationTestCase >> translate: tast [
+
+	^ String streamContents: [ :str |
+		  self astTranslate: tast inStream: str ]
+]

--- a/smalltalksrc/Slang-Tests/SLDeadCodeEliminationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SLDeadCodeEliminationTest.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : 'SLDeadCodeEliminationTest',
-	#superclass : 'SlangAbstractTestCase',
+	#superclass : 'SLAbstractTranslationTestCase',
 	#instVars : [
 		'sLDeadCodeEliminationVisitor',
 		'sLDeadCodeElimination'
@@ -8,16 +8,6 @@ Class {
 	#category : 'Slang-Tests',
 	#package : 'Slang-Tests'
 }
-
-{ #category : 'helpers' }
-SLDeadCodeEliminationTest >> astTranslate: tast inStream: aWriteStream [ 
-	
-	| cAST prettyPrinter |
-	cAST := tast asCASTIn: ccg.
-	prettyPrinter := CSlangPrettyPrinter new.
-	prettyPrinter writeStream: aWriteStream.
-	cAST acceptVisitor: prettyPrinter.
-]
 
 { #category : 'running' }
 SLDeadCodeEliminationTest >> setUp [
@@ -42,7 +32,6 @@ SLDeadCodeEliminationTest >> testConditionalWithOnlyCommentNoSendInReceiver [
 	ccg doBasicInlining: true.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -72,7 +61,6 @@ SLDeadCodeEliminationTest >> testConditionalWithOnlyCommentSendInReceiver [
 	ccg doBasicInlining: true.
 	
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -101,7 +89,6 @@ SLDeadCodeEliminationTest >> testMethodAddingCallInCoerce [
 	tMethod := ccg methodNamed: #methodAddingCallInCoerce.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -129,7 +116,6 @@ SLDeadCodeEliminationTest >> testMethodWithBlockValueAssignmentIntoSameVariableI
 		           #methodWithBlockValueAssignmentIntoSameVariableInArguments.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
@@ -162,7 +148,6 @@ SLDeadCodeEliminationTest >> testMethodWithBlockValueAssignmentNotIntoSameVariab
 		           #methodWithBlockValueAssignmentNotIntoSameVariableInArguments.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
@@ -198,7 +183,6 @@ SLDeadCodeEliminationTest >> testMethodWithBlockValueValueAssignmentIntoSameVari
 		           #methodWithBlockValueValueAssignmentIntoSameVariableInArguments.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 
@@ -235,7 +219,6 @@ SLDeadCodeEliminationTest >> testMethodWithBlockValueValueAssignmentNotIntoSameV
 		           #methodWithBlockValueValueAssignmentNotIntoSameVariableInArguments.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 
@@ -275,7 +258,6 @@ SLDeadCodeEliminationTest >> testMethodWithCallInCoerce [
 	tMethod := ccg methodNamed: #methodWithCallInCoerce.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 
@@ -303,7 +285,6 @@ SLDeadCodeEliminationTest >> testMethodWithConstantInAssignment [
 	tMethod := ccg methodNamed: #methodWithConstantInAssignment.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 
@@ -331,7 +312,6 @@ SLDeadCodeEliminationTest >> testMethodWithConstantInReturn [
 	tMethod := ccg methodNamed: #methodWithConstantInReturn.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 
@@ -356,7 +336,6 @@ SLDeadCodeEliminationTest >> testMethodWithDeadCodeInRepeat [
 	tMethod := ccg methodNamed: #methodWithDeadCodeInRepeat.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -385,7 +364,6 @@ SLDeadCodeEliminationTest >> testMethodWithDeadCodeInTimesRepeat [
 	tMethod := ccg methodNamed: #methodWithDeadCodeInTimesRepeat.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
@@ -423,7 +401,6 @@ SLDeadCodeEliminationTest >> testMethodWithDeadCodeInToByDo [
 	tMethod := ccg methodNamed: #methodWithDeadCodeInToByDo.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -452,7 +429,6 @@ SLDeadCodeEliminationTest >> testMethodWithDeadCodeInToDo [
 	tMethod := ccg methodNamed: #methodWithDeadCodeInToDo.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -482,7 +458,6 @@ SLDeadCodeEliminationTest >> testMethodWithDeadCodeInWhileFalse [
 		           #methodWithDeadCodeInWhileFalseLastExpressionIsLeaf.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -512,7 +487,6 @@ SLDeadCodeEliminationTest >> testMethodWithDeadCodeInWhileFalseBinaryNoSendInRec
 		           #methodWithDeadCodeInWhileFalseBinaryNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
@@ -547,7 +521,6 @@ SLDeadCodeEliminationTest >> testMethodWithDeadCodeInWhileFalseBinarySendInRecei
 		           #methodWithDeadCodeInWhileFalseBinarySendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -577,7 +550,6 @@ SLDeadCodeEliminationTest >> testMethodWithDeadCodeInWhileTrue [
 		           #methodWithDeadCodeInWhileTrueLastExpressionIsLeaf.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -607,7 +579,6 @@ SLDeadCodeEliminationTest >> testMethodWithDeadCodeInWhileTrueBinaryNoSendInRece
 		           #methodWithDeadCodeInWhileTrueBinaryNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
@@ -642,7 +613,6 @@ SLDeadCodeEliminationTest >> testMethodWithDeadCodeInWhileTrueBinarySendInReceiv
 		           #methodWithDeadCodeInWhileTrueBinarySendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -673,7 +643,6 @@ SLDeadCodeEliminationTest >> testMethodWithEmptyCaseOfNoSendInReceiver [
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -711,7 +680,6 @@ SLDeadCodeEliminationTest >> testMethodWithEmptyCaseOfOtherwiseNoSendInReceiver 
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -740,7 +708,6 @@ SLDeadCodeEliminationTest >> testMethodWithEmptyCaseOfOtherwiseSendInReceiver [
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -771,7 +738,6 @@ SLDeadCodeEliminationTest >> testMethodWithEmptyCaseOfSendInReceiver [
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 
@@ -809,7 +775,6 @@ SLDeadCodeEliminationTest >> testMethodWithEmptyIfFalseIfTrueAndNoSendInReceiver
 		           #methodWithEmptyIfFalseIfTrueAndNoSendInReceiver.
 		
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -837,7 +802,6 @@ SLDeadCodeEliminationTest >> testMethodWithEmptyIfFalseIfTrueAndSendInReceiver [
 		           #methodWithEmptyIfFalseIfTrueAndSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -871,7 +835,6 @@ SLDeadCodeEliminationTest >> testMethodWithEmptyIfFalseInIfFalseIfTrueAndNoSendI
 		           #methodWithEmptyIfFalseInIfFalseIfTrueAndNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
 
@@ -904,7 +867,6 @@ SLDeadCodeEliminationTest >> testMethodWithEmptyIfFalseInIfFalseIfTrueAndSendInR
 		           #methodWithEmptyIfFalseInIfFalseIfTrueAndSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -935,7 +897,6 @@ SLDeadCodeEliminationTest >> testMethodWithEmptyIfFalseInIfTrueIfFalseAndNoSendI
 		           #methodWithEmptyIfFalseInIfTrueIfFalseAndNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
 
@@ -968,7 +929,6 @@ SLDeadCodeEliminationTest >> testMethodWithEmptyIfFalseInIfTrueIfFalseAndSendInR
 		           #methodWithEmptyIfFalseInIfTrueIfFalseAndSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -999,7 +959,6 @@ SLDeadCodeEliminationTest >> testMethodWithEmptyIfNilIfNotNilAndNoSendInReceiver
 		           #methodWithEmptyIfNilIfNotNilAndNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -1027,7 +986,6 @@ SLDeadCodeEliminationTest >> testMethodWithEmptyIfNilIfNotNilAndSendInReceiver [
 		           #methodWithEmptyIfNilIfNotNilAndSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -1058,7 +1016,6 @@ SLDeadCodeEliminationTest >> testMethodWithEmptyIfNotNilIfNilAndNoSendInReceiver
 		           #methodWithEmptyIfNotNilIfNilAndNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -1086,7 +1043,6 @@ SLDeadCodeEliminationTest >> testMethodWithEmptyIfNotNilIfNilAndSendInReceiver [
 		           #methodWithEmptyIfNotNilIfNilAndSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -1117,7 +1073,6 @@ SLDeadCodeEliminationTest >> testMethodWithEmptyIfTrueIfFalseAndNoSendInReceiver
 		           #methodWithEmptyIfTrueIfFalseAndNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -1145,7 +1100,6 @@ SLDeadCodeEliminationTest >> testMethodWithEmptyIfTrueIfFalseAndSendInReceiver [
 		           #methodWithEmptyIfTrueIfFalseAndSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -1179,7 +1133,6 @@ SLDeadCodeEliminationTest >> testMethodWithEmptyIfTrueInIfFalseIfTrueAndNoSendIn
 		           #methodWithEmptyIfTrueInIfFalseIfTrueAndNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
 
@@ -1212,7 +1165,6 @@ SLDeadCodeEliminationTest >> testMethodWithEmptyIfTrueInIfFalseIfTrueAndSendInRe
 		           #methodWithEmptyIfTrueInIfFalseIfTrueAndSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -1243,7 +1195,6 @@ SLDeadCodeEliminationTest >> testMethodWithEmptyIfTrueInIfTrueIfFalseAndNoSendIn
 		           #methodWithEmptyIfTrueInIfTrueIfFalseAndNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
 
@@ -1276,7 +1227,6 @@ SLDeadCodeEliminationTest >> testMethodWithEmptyIfTrueInIfTrueIfFalseAndSendInRe
 		           #methodWithEmptyIfTrueInIfTrueIfFalseAndSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -1306,7 +1256,6 @@ SLDeadCodeEliminationTest >> testMethodWithEmptyWhileFalseNoSendInCondition [
 		           #methodWithEmptyWhileFalseNoSendInCondition.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -1332,7 +1281,6 @@ SLDeadCodeEliminationTest >> testMethodWithEmptyWhileFalseSendInCondition [
 	tMethod := ccg methodNamed: #methodWithEmptyWhileFalseSendInCondition.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -1362,7 +1310,6 @@ SLDeadCodeEliminationTest >> testMethodWithEmptyWhileTrueNoSendInCondition [
 		           #methodWithEmptyWhileTrueNoSendInCondition.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	
 	translation := self translate: tMethod.
@@ -1388,7 +1335,6 @@ SLDeadCodeEliminationTest >> testMethodWithEmptyWhileTrueSendInCondition [
 	tMethod := ccg methodNamed: #methodWithEmptyWhileTrueSendInCondition.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -1419,7 +1365,6 @@ SLDeadCodeEliminationTest >> testMethodWithEmptyifNilInIfNilIfNotNilAndNoSendInR
 		           #methodWithEmptyifNilInIfNilIfNotNilAndNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
 
@@ -1452,7 +1397,6 @@ SLDeadCodeEliminationTest >> testMethodWithEmptyifNilInIfNilIfNotNilAndSendInRec
 		           #methodWithEmptyifNilInIfNilIfNotNilAndSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
 
@@ -1485,7 +1429,6 @@ SLDeadCodeEliminationTest >> testMethodWithEmptyifNilInIfNotNilIfNilAndNoSendInR
 		           #methodWithEmptyifNilInIfNotNilIfNilAndNoSendInReceiver.
 	
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
 
@@ -1518,7 +1461,6 @@ SLDeadCodeEliminationTest >> testMethodWithEmptyifNilInIfNotNilIfNilAndSendInRec
 		           #methodWithEmptyifNilInIfNotNilIfNilAndSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
 
@@ -1551,7 +1493,6 @@ SLDeadCodeEliminationTest >> testMethodWithEmptyifNotNilInIfNilIfNotNilAndNoSend
 		           #methodWithEmptyifNotNilInIfNilIfNotNilAndNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
 
@@ -1584,7 +1525,6 @@ SLDeadCodeEliminationTest >> testMethodWithEmptyifNotNilInIfNilIfNotNilAndSendIn
 		           #methodWithEmptyifNotNilInIfNilIfNotNilAndSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
 
@@ -1617,7 +1557,6 @@ SLDeadCodeEliminationTest >> testMethodWithEmptyifNotNilInIfNotNilIfNilAndNoSend
 		           #methodWithEmptyifNotNilInIfNotNilIfNilAndNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
 
@@ -1650,7 +1589,6 @@ SLDeadCodeEliminationTest >> testMethodWithEmptyifNotNilInIfNotNilIfNilAndSendIn
 		           #methodWithEmptyifNotNilInIfNotNilIfNilAndSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
 
@@ -1681,7 +1619,6 @@ SLDeadCodeEliminationTest >> testMethodWithInstanceVariableInAssignment [
 	tMethod := ccg methodNamed: #methodWithInstanceVariableInAssignment.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -1708,7 +1645,6 @@ SLDeadCodeEliminationTest >> testMethodWithInstanceVariableInReturn [
 	tMethod := ccg methodNamed: #methodWithInstanceVariableInReturn.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -1733,7 +1669,6 @@ SLDeadCodeEliminationTest >> testMethodWithNeverUsedLocals [
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 
@@ -1764,7 +1699,6 @@ SLDeadCodeEliminationTest >> testMethodWithNeverUsedLocalsFromBlock [
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 
@@ -1797,7 +1731,6 @@ SLDeadCodeEliminationTest >> testMethodWithNeverUsedLocalsFromBlockStatement [
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
 
@@ -1832,7 +1765,6 @@ SLDeadCodeEliminationTest >> testMethodWithNeverUsedLocalsFromBlockWithExpressio
 
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 
@@ -1867,7 +1799,6 @@ SLDeadCodeEliminationTest >> testMethodWithNeverUsedLocalsFromBlockasArguments [
 	ccg doBasicInlining: true.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 
@@ -1893,7 +1824,6 @@ SLDeadCodeEliminationTest >> testMethodWithNoRedundantLocalDefinition [
 	tMethod := ccg methodNamed: #methodWithNoRedundantLocalDefinition.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -1933,7 +1863,6 @@ SLDeadCodeEliminationTest >> testMethodWithOnlyBlockValueAssignmentIntoSameVaria
 		           #methodWithOnlyBlockValueAssignmentIntoSameVariableInArguments.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -1960,7 +1889,6 @@ SLDeadCodeEliminationTest >> testMethodWithOnlyBlockValueAssignmentNotIntoSameVa
 		           #methodWithOnlyBlockValueAssignmentNotIntoSameVariableInArguments.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
 
@@ -1994,7 +1922,6 @@ SLDeadCodeEliminationTest >> testMethodWithOnlyComment [
 
 	ccg doBasicInlining: true.
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -2022,7 +1949,6 @@ SLDeadCodeEliminationTest >> testMethodWithOnlyDeadCodeInRepeat [
 	tMethod := ccg methodNamed: #methodWithOnlyDeadCodeInRepeat.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
 
@@ -2050,7 +1976,6 @@ SLDeadCodeEliminationTest >> testMethodWithOnlyDeadCodeInWhileFalse [
 	tMethod := ccg methodNamed: #methodWithOnlyDeadCodeInWhileFalse.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
 
@@ -2079,7 +2004,6 @@ SLDeadCodeEliminationTest >> testMethodWithOnlyDeadCodeInWhileFalseBinaryNoSendI
 		           #methodWithOnlyDeadCodeInWhileFalseBinaryNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	tMethod removeUnusedNodesInBranch: ccg.
 
@@ -2107,7 +2031,6 @@ SLDeadCodeEliminationTest >> testMethodWithOnlyDeadCodeInWhileFalseBinarySendInR
 		           #methodWithOnlyDeadCodeInWhileFalseBinarySendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
 
@@ -2138,7 +2061,6 @@ SLDeadCodeEliminationTest >> testMethodWithOnlyDeadCodeInWhileTrue [
 	tMethod := ccg methodNamed: #methodWithOnlyDeadCodeInWhileTrue.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
 
@@ -2167,7 +2089,6 @@ SLDeadCodeEliminationTest >> testMethodWithOnlyDeadCodeInWhileTrueBinaryNoSendIn
 		           #methodWithOnlyDeadCodeInWhileTrueBinaryNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
 
@@ -2196,7 +2117,6 @@ SLDeadCodeEliminationTest >> testMethodWithOnlyDeadCodeInWhileTrueBinarySendInRe
 		           #methodWithOnlyDeadCodeInWhileTrueBinarySendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
 
@@ -2228,7 +2148,6 @@ SLDeadCodeEliminationTest >> testMethodWithOnlyNeverUsedLocals [
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
 
@@ -2255,7 +2174,6 @@ SLDeadCodeEliminationTest >> testMethodWithOnlyUselessAssignment [
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
 
@@ -2283,7 +2201,6 @@ SLDeadCodeEliminationTest >> testMethodWithRedundantLocalDefinition [
 	tMethod := ccg methodNamed: #methodWithRedundantLocalDefinition.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -2320,7 +2237,6 @@ SLDeadCodeEliminationTest >> testMethodWithSelfAssign [
 	tMethod := ccg methodNamed: #methodWithSelfAssign.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
 
@@ -2348,7 +2264,6 @@ SLDeadCodeEliminationTest >> testMethodWithSendWithNoSideEffectInCoerce [
 	tMethod := ccg methodNamed: #methodWithSendWithNoSideEffectInCoerce.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	
 	translation := self translate: tMethod.
@@ -2374,7 +2289,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedConstant [
 	tMethod := ccg methodNamed: #methodWithUnusedConstant.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -2403,7 +2317,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedConstantAndReturnInCaseOfNoSend
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 
@@ -2448,7 +2361,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedConstantAndReturnInCaseOfSendIn
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 
@@ -2488,7 +2400,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedConstantInCaseOfAndReturnInOthe
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
 
@@ -2531,7 +2442,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedConstantInCaseOfAndReturnInOthe
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 
@@ -2573,7 +2483,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedConstantInCaseOfAndUnusedConsta
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 
@@ -2601,7 +2510,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedConstantInCaseOfAndUnusedConsta
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 
@@ -2632,7 +2540,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedConstantInCaseOfNoSendInExpress
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -2667,7 +2574,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedConstantInCaseOfSendInExpressio
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -2699,7 +2605,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedConstantInCoerce [
 	tMethod := ccg methodNamed: #methodWithUnusedConstantInCoerce.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -2724,7 +2629,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedConstantInIfFalseIfTrueNoSendIn
 		           #methodWithUnusedConstantInIfFalseIfTrueNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -2749,7 +2653,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedConstantInIfFalseIfTrueSendInRe
 		           #methodWithUnusedConstantInIfFalseIfTrueSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -2781,7 +2684,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedConstantInIfFalseNoSendInReceiv
 		           #methodWithUnusedConstantInIfFalseNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -2808,7 +2710,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedConstantInIfFalseSendInReceiver
 		           #methodWithUnusedConstantInIfFalseSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -2840,7 +2741,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedConstantInIfNilIfNotNilNoSendIn
 		           #methodWithUnusedConstantInIfNilIfNotNilNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -2867,7 +2767,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedConstantInIfNilIfNotNillSendInR
 		           #methodWithUnusedConstantInIfNilIfNotNilSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -2897,7 +2796,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedConstantInIfNilNoSendInReceiver
 		           #methodWithUnusedConstantInIfNilNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	
 	translation := self translate: tMethod.
@@ -2924,7 +2822,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedConstantInIfNilSendInReceiver [
 		           #methodWithUnusedConstantInIfNilSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -2954,7 +2851,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedConstantInIfNotNilIfNilNoSendIn
 		           #methodWithUnusedConstantInIfNotNilIfNilNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -2981,7 +2877,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedConstantInIfNotNilIfNilSendInRe
 		           #methodWithUnusedConstantInIfNotNilIfNilSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -3011,7 +2906,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedConstantInIfNotNilNoSendInRecei
 		           #methodWithUnusedConstantInIfNotNilNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -3038,7 +2932,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedConstantInIfNotNilSendInReceive
 		           #methodWithUnusedConstantInIfNotNilSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -3068,7 +2961,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedConstantInIfTrueIfFalseNoSendIn
 		           #methodWithUnusedConstantInIfTrueIfFalseNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -3095,7 +2987,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedConstantInIfTrueIfFalseSendInRe
 		           #methodWithUnusedConstantInIfTrueIfFalseSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -3127,7 +3018,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedConstantInIfTrueNoSendInReceive
 		           #methodWithUnusedConstantInIfTrueNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -3154,7 +3044,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedConstantInIfTrueSendInReceiver 
 		           #methodWithUnusedConstantInIfTrueSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -3188,7 +3077,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedConstantReturnInCaseOfAndUnused
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 
@@ -3229,7 +3117,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedConstantReturnInCaseOfAndUnused
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -3266,7 +3153,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedInstanceVariable [
 	tMethod := ccg methodNamed: #methodWithUnusedInstanceVariable.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -3295,7 +3181,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedInstanceVariableAndReturnInCase
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -3334,7 +3219,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedInstanceVariableAndReturnInCase
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -3373,7 +3257,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedInstanceVariableInCaseOfAndRetu
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -3411,7 +3294,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedInstanceVariableInCaseOfAndRetu
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -3449,7 +3331,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedInstanceVariableInCaseOfAndUnus
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -3476,7 +3357,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedInstanceVariableInCaseOfAndUnus
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -3506,7 +3386,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedInstanceVariableInCaseOfNoSendI
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -3543,7 +3422,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedInstanceVariableInCaseOfSendInE
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 
@@ -3578,7 +3456,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedInstanceVariableInCoerce [
 	tMethod := ccg methodNamed: #methodWithUnusedInstanceVariableInCoerce.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -3605,7 +3482,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedInstanceVariableInIfFalseIfTrue
 		           #methodWithUnusedInstanceVariableInIfFalseIfTrueNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -3632,7 +3508,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedInstanceVariableInIfFalseIfTrue
 		           #methodWithUnusedInstanceVariableInIfFalseIfTrueSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -3664,7 +3539,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedInstanceVariableInIfFalseNoSend
 		           #methodWithUnusedInstanceVariableInIfFalseNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -3691,7 +3565,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedInstanceVariableInIfFalseSendIn
 		           #methodWithUnusedInstanceVariableInIfFalseSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -3723,7 +3596,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedInstanceVariableInIfNilIfNotNil
 		           #methodWithUnusedInstanceVariableInIfNilIfNotNilNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -3750,7 +3622,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedInstanceVariableInIfNilIfNotNil
 		           #methodWithUnusedInstanceVariableInIfNilIfNotNilSendInReceiver.
 	
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	
 	translation := self translate: tMethod.
@@ -3780,7 +3651,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedInstanceVariableInIfNilNoSendIn
 		           #methodWithUnusedInstanceVariableInIfNilNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -3807,7 +3677,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedInstanceVariableInIfNilSendInRe
 		           #methodWithUnusedInstanceVariableInIfNilSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -3837,7 +3706,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedInstanceVariableInIfNotNilIfNil
 		           #methodWithUnusedInstanceVariableInIfNotNilIfNilNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -3864,7 +3732,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedInstanceVariableInIfNotNilIfNil
 		           #methodWithUnusedInstanceVariableInIfNotNilIfNilSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -3894,7 +3761,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedInstanceVariableInIfNotNilNoSen
 		           #methodWithUnusedInstanceVariableInIfNotNilNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -3921,7 +3787,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedInstanceVariableInIfNotNilSendI
 		           #methodWithUnusedInstanceVariableInIfNotNilSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	translation := self translate: tMethod.
 	translation := translation trimBoth.
@@ -3950,7 +3815,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedInstanceVariableInIfTrueIfFalse
 		           #methodWithUnusedInstanceVariableInIfTrueIfFalseNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -3977,7 +3841,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedInstanceVariableInIfTrueIfFalse
 		           #methodWithUnusedInstanceVariableInIfTrueIfFalseSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -4009,7 +3872,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedInstanceVariableInIfTrueNoSendI
 		           #methodWithUnusedInstanceVariableInIfTrueNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -4036,7 +3898,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedInstanceVariableInIfTrueSendInR
 		           #methodWithUnusedInstanceVariableInIfTrueSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -4070,7 +3931,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedInstanceVariableReturnInCaseOfA
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -4115,7 +3975,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedInstanceVariableReturnInCaseOfA
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -4157,7 +4016,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedVariable [
 	tMethod := ccg methodNamed: #methodWithUnusedVariable.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 
@@ -4187,7 +4045,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedVariableAndReturnInCaseOfNoSend
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 
@@ -4230,7 +4087,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedVariableAndReturnInCaseOfSendIn
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -4272,7 +4128,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedVariableInCaseOfAndReturnInOthe
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -4313,7 +4168,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedVariableInCaseOfAndReturnInOthe
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -4354,7 +4208,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedVariableInCaseOfAndUnusedVariab
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -4383,7 +4236,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedVariableInCaseOfAndUnusedVariab
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -4415,7 +4267,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedVariableInCaseOfNoSendInExpress
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 
@@ -4453,7 +4304,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedVariableInCaseOfSendInExpressio
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -4487,7 +4337,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedVariableInCoerce [
 	tMethod := ccg methodNamed: #methodWithUnusedVariableInCoerce.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	
 	translation := self translate: tMethod.
@@ -4514,7 +4363,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedVariableInIfFalseIfTrueNoSendIn
 		           #methodWithUnusedVariableInIfFalseIfTrueNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -4541,7 +4389,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedVariableInIfFalseIfTrueSendInRe
 		           #methodWithUnusedVariableInIfFalseIfTrueSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -4573,7 +4420,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedVariableInIfFalseNoSendInReceiv
 		           #methodWithUnusedVariableInIfFalseNoSendInReceiver.
 		
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -4600,7 +4446,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedVariableInIfFalseSendInReceiver
 		           #methodWithUnusedVariableInIfFalseSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -4633,8 +4478,8 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedVariableInIfNilIfNotNilNoSendIn
 		           #methodWithUnusedVariableInIfNilIfNotNilNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
+	
 	translation := self translate: tMethod.
 	translation := translation trimBoth.
 
@@ -4659,7 +4504,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedVariableInIfNilIfNotNilSendInRe
 		           #methodWithUnusedVariableInIfNilIfNotNilSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -4688,9 +4532,7 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedVariableInIfNilNoSendInReceiver
 	tMethod := ccg methodNamed:
 		           #methodWithUnusedVariableInIfNilNoSendInReceiver.
 
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -4717,7 +4559,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedVariableInIfNilSendInReceiver [
 		           #methodWithUnusedVariableInIfNilSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -4747,7 +4588,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedVariableInIfNotNilIfNilNoSendIn
 		           #methodWithUnusedVariableInIfNotNilIfNilNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -4774,7 +4614,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedVariableInIfNotNilIfNilSendInRe
 		           #methodWithUnusedVariableInIfNotNilIfNilSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -4804,7 +4643,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedVariableInIfNotNilNoSendInRecei
 		           #methodWithUnusedVariableInIfNotNilNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -4831,7 +4669,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedVariableInIfNotNilSendInReceive
 		           #methodWithUnusedVariableInIfNotNilSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -4861,7 +4698,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedVariableInIfTrueIfFalseNoSendIn
 		           #methodWithUnusedVariableInIfTrueIfFalseNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -4888,7 +4724,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedVariableInIfTrueIfFalseSendInRe
 		           #methodWithUnusedVariableInIfTrueIfFalseSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -4920,7 +4755,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedVariableInIfTrueNoSendInReceive
 		           #methodWithUnusedVariableInIfTrueNoSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -4947,7 +4781,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedVariableInIfTrueSendInReceiver 
 		           #methodWithUnusedVariableInIfTrueSendInReceiver.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -4980,7 +4813,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedVariableReturnInCaseOfAndUnused
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -5021,7 +4853,6 @@ SLDeadCodeEliminationTest >> testMethodWithUnusedVariableReturnInCaseOfAndUnused
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -5062,7 +4893,6 @@ SLDeadCodeEliminationTest >> testMethodWithUselessAssignment [
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
 
@@ -5094,7 +4924,6 @@ SLDeadCodeEliminationTest >> testMethodWithUselessCodeInBinaryIterativeNoSendInL
 	tMethod prepareMethodIn: ccg.
 	
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
 
@@ -5129,7 +4958,6 @@ SLDeadCodeEliminationTest >> testMethodWithUselessCodeInBinaryIterativeSendWithN
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
 
@@ -5162,7 +4990,6 @@ SLDeadCodeEliminationTest >> testMethodWithUselessCodeInBinaryIterativeSendWithS
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
 
@@ -5197,8 +5024,6 @@ SLDeadCodeEliminationTest >> testMethodWithUselessLocalsDefinitionsWithSameNameI
 	tMethod prepareMethodIn: ccg.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
-
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 	tMethod removeUnusedTempsAndNilIfRequiredIn: ccg.
 
@@ -5400,7 +5225,6 @@ SLDeadCodeEliminationTest >> testSwitchWithOnlyCommentSendInReceiver [
 	ccg doBasicInlining: true.
 
 	sLDeadCodeElimination currentMethod: tMethod.
-	ccg currentMethod: tMethod.
 	sLDeadCodeElimination removeDeadCodeInCurrentMethod.
 
 	translation := self translate: tMethod.
@@ -5420,11 +5244,4 @@ switchWithOnlyCommentSendInReceiver(SLDeadCodeEliminationTestClass * self_in_swi
 		return;
 	}
 }'
-]
-
-{ #category : 'helpers' }
-SLDeadCodeEliminationTest >> translate: tast [
-
-	^ String streamContents: [ :str | 
-		self astTranslate: tast inStream: str ]
 ]

--- a/smalltalksrc/Slang-Tests/SLLocalizationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SLLocalizationTest.class.st
@@ -26,6 +26,48 @@ SLLocalizationTest >> testGlobalLocalized [
 ]
 
 { #category : 'instance-variables' }
+SLLocalizationTest >> testGlobalMustBeGlobaWithMultipleUsage [
+
+	| tMethod1 tMethod2 |
+	tMethod1 := ccg methodNamed: #methodWithInstanceVariableMustBeGlobal.
+	tMethod2 := ccg methodNamed:
+		            #methodWithInstanceVariableMustBeGlobalBis.
+
+	ccg
+		checkForGlobalUsage: (tMethod1 allReferencedVariablesUsing: ccg)
+		in: tMethod1.
+	ccg
+		checkForGlobalUsage: (tMethod2 allReferencedVariablesUsing: ccg)
+		in: tMethod2.
+
+	ccg localizeGlobalVariables.
+
+	self assert: ccg globalsAsSet size equals: 3.
+	self assert: (ccg globalsAsSet includes: #globalMustBeGlobal).
+	self assert:
+		(ccg globalsAsSet includes: #instanceVariableMustBeGlobal).
+	self assert: (ccg globalsAsSet includes: #instanceVariableWithUsage)
+]
+
+{ #category : 'instance-variables' }
+SLLocalizationTest >> testGlobalMustBeGlobalEvenIfOnlyOneUsage [
+
+	| tMethod |
+	tMethod := ccg methodNamed: #methodWithInstanceVariableMustBeGlobal.
+
+	ccg
+		checkForGlobalUsage: (tMethod allReferencedVariablesUsing: ccg)
+		in: tMethod.
+
+	ccg localizeGlobalVariables.
+
+	self assert: ccg globalsAsSet size equals: 2.
+	self assert: (ccg globalsAsSet includes: #globalMustBeGlobal).
+	self assert:
+		(ccg globalsAsSet includes: #instanceVariableMustBeGlobal)
+]
+
+{ #category : 'instance-variables' }
 SLLocalizationTest >> testGlobalMustBeGlobalEvenWithNoUsage [
 
 	ccg localizeGlobalVariables.

--- a/smalltalksrc/Slang-Tests/SLLocalizationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SLLocalizationTest.class.st
@@ -24,3 +24,14 @@ SLLocalizationTest >> testGlobalLocalized [
 		(ccg globalsAsSet includes: #instanceVariableToLocalize) not.
 	self assert: (tMethod locals includes: #instanceVariableToLocalize)
 ]
+
+{ #category : 'instance-variables' }
+SLLocalizationTest >> testGlobalMustBeGlobalEvenWithNoUsage [
+
+	ccg localizeGlobalVariables.
+
+	self assert: ccg globalsAsSet size equals: 2.
+	self assert: (ccg globalsAsSet includes: #globalMustBeGlobal).
+	self assert:
+		(ccg globalsAsSet includes: #instanceVariableMustBeGlobal)
+]

--- a/smalltalksrc/Slang-Tests/SLLocalizationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SLLocalizationTest.class.st
@@ -4,3 +4,23 @@ Class {
 	#category : 'Slang-Tests',
 	#package : 'Slang-Tests'
 }
+
+{ #category : 'instance-variables' }
+SLLocalizationTest >> testGlobalLocalized [
+
+	| tMethod |
+	tMethod := ccg methodNamed: #methodWithInstanceVariableToLocalize.
+
+	self assert: (ccg globalsAsSet includes: #instanceVariableToLocalize).
+	self assert:
+		(tMethod locals includes: #instanceVariableToLocalize) not.
+
+	ccg
+		checkForGlobalUsage: (tMethod allReferencedVariablesUsing: ccg)
+		in: tMethod.
+	ccg localizeGlobalVariables.
+
+	self assert:
+		(ccg globalsAsSet includes: #instanceVariableToLocalize) not.
+	self assert: (tMethod locals includes: #instanceVariableToLocalize)
+]

--- a/smalltalksrc/Slang-Tests/SLLocalizationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SLLocalizationTest.class.st
@@ -1,0 +1,6 @@
+Class {
+	#name : 'SLLocalizationTest',
+	#superclass : 'SlangAbstractTestCase',
+	#category : 'Slang-Tests',
+	#package : 'Slang-Tests'
+}

--- a/smalltalksrc/Slang-Tests/SLLocalizationTestClass.class.st
+++ b/smalltalksrc/Slang-Tests/SLLocalizationTestClass.class.st
@@ -1,6 +1,12 @@
 Class {
 	#name : 'SLLocalizationTestClass',
 	#superclass : 'SlangClass',
+	#instVars : [
+		'instanceVariableWithNoUsage',
+		'instanceVariableWithUsage',
+		'instanceVariableToLocalize',
+		'instanceVariableMustBeGlobal'
+	],
 	#category : 'Slang-Tests',
 	#package : 'Slang-Tests'
 }

--- a/smalltalksrc/Slang-Tests/SLLocalizationTestClass.class.st
+++ b/smalltalksrc/Slang-Tests/SLLocalizationTestClass.class.st
@@ -13,8 +13,9 @@ Class {
 
 { #category : 'instance-variables' }
 SLLocalizationTestClass >> methodWithInstanceVariableMustBeGlobal [
-	"even if the variable can be localized or have no sender in Slang, it should remain a global.
-	See the 'sendTrace' case or 'generatorTable' cases (only use in macros)"
+	"Even if the variable can be localized or have no sender in Slang, it should remain a global.
+	Happens because some cases are undetected by Slang.
+	See the 'sendTrace' case and 'generatorTable' cases (only use in macros) or 'aMethodLabel' (only use to set up other globals)"
 
 	instanceVariableMustBeGlobal.
 	instanceVariableWithUsage
@@ -22,8 +23,9 @@ SLLocalizationTestClass >> methodWithInstanceVariableMustBeGlobal [
 
 { #category : 'instance-variables' }
 SLLocalizationTestClass >> methodWithInstanceVariableMustBeGlobalBis [
-	"even if the variable can be localized or have no sender in Slang, it should remain a global.
-	See the 'sendTrace' case or 'generatorTable' cases (only use in macros)"
+	"Even if the variable can be localized or have no sender in Slang, it should remain a global.
+	Happens because some cases are undetected by Slang.
+	See the 'sendTrace' case and 'generatorTable' cases (only use in macros) or 'aMethodLabel' (only use to set up other globals)"
 
 	instanceVariableMustBeGlobal.
 	instanceVariableWithUsage

--- a/smalltalksrc/Slang-Tests/SLLocalizationTestClass.class.st
+++ b/smalltalksrc/Slang-Tests/SLLocalizationTestClass.class.st
@@ -10,3 +10,29 @@ Class {
 	#category : 'Slang-Tests',
 	#package : 'Slang-Tests'
 }
+
+{ #category : 'instance-variables' }
+SLLocalizationTestClass >> methodWithInstanceVariableMustBeGlobal [
+	"even if the variable can be localized or have no sender in Slang, it should remain a global.
+	See the 'sendTrace' case or 'generatorTable' cases (only use in macros)"
+
+	instanceVariableMustBeGlobal.
+	instanceVariableWithUsage
+]
+
+{ #category : 'instance-variables' }
+SLLocalizationTestClass >> methodWithInstanceVariableMustBeGlobalBis [
+	"even if the variable can be localized or have no sender in Slang, it should remain a global.
+	See the 'sendTrace' case or 'generatorTable' cases (only use in macros)"
+
+	instanceVariableMustBeGlobal.
+	instanceVariableWithUsage
+]
+
+{ #category : 'instance-variables' }
+SLLocalizationTestClass >> methodWithInstanceVariableToLocalize [
+	"Only user of instanceVariableToLocalize the definition should be localize to this method"
+
+	instanceVariableToLocalize.
+	instanceVariableWithUsage
+]

--- a/smalltalksrc/Slang-Tests/SLLocalizationTestClass.class.st
+++ b/smalltalksrc/Slang-Tests/SLLocalizationTestClass.class.st
@@ -1,0 +1,6 @@
+Class {
+	#name : 'SLLocalizationTestClass',
+	#superclass : 'SlangClass',
+	#category : 'Slang-Tests',
+	#package : 'Slang-Tests'
+}

--- a/smalltalksrc/Slang-Tests/SlangMethodPrototypeTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangMethodPrototypeTranslationTest.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : 'SlangMethodPrototypeTranslationTest',
-	#superclass : 'TestCase',
+	#superclass : 'SLAbstractTranslationTestCase',
 	#instVars : [
 		'generator'
 	],
@@ -26,11 +26,4 @@ SlangMethodPrototypeTranslationTest >> testMethodPrototype [
 	tMethod := generator methodNamed: #first:second:.
 	translation := self translate: tMethod.
 	self assert: translation trimBoth equals: 'static sqInt firstsecond(sqInt param1, sqInt param2);'
-]
-
-{ #category : 'helpers' }
-SlangMethodPrototypeTranslationTest >> translate: tast [
-
-	^ String streamContents: [ :str | 
-		self astTranslate: tast inStream: str ]
 ]

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -3722,7 +3722,7 @@ CCodeGenerator >> localizeGlobalVariables [
 	"find all globals used in only one method"
 	candidates := globalVariableUsage select: [ :e | e size = 1 ].
 	"Don't localize globals"
-	(candidates keys select: [ :k | self mustBeGlobalAndExport: k ]) do: [ :k |
+	(candidates keys select: [ :k | self mustBeGlobal: k ]) do: [ :k |
 		candidates removeKey: k ].
 	elected := Set new.
 	localized := Dictionary new. "for an ordered report"

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -3758,9 +3758,7 @@ CCodeGenerator >> localizeGlobalVariables [
 					show: var , ' localised to ' , name;
 					cr ] ] ].
 
-	elected do: [ :var |
-		self removeVariable: var.
-		globalVariableUsage removeKey: var ]
+	elected do: [ :var | self removeVariable: var ]
 ]
 
 { #category : 'inlining' }
@@ -4518,8 +4516,10 @@ CCodeGenerator >> removeVariable: aName [
 { #category : 'utilities' }
 CCodeGenerator >> removeVariable: aName ifAbsent: ifAbsentBlock [
 	"Remove the given (instance) variable from the code base."
-	variableDeclarations removeKey: aName ifAbsent: [].
-	^variables remove: aName ifAbsent: ifAbsentBlock
+
+	variableDeclarations removeKey: aName ifAbsent: [  ].
+	globalVariableUsage removeKey: aName ifAbsent: [  ].
+	^ variables remove: aName ifAbsent: ifAbsentBlock
 ]
 
 { #category : 'renaming' }

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -769,18 +769,27 @@ CCodeGenerator >> checkClassForNameConflicts: aClass [
 ]
 
 { #category : 'utilities' }
-CCodeGenerator >> checkForGlobalUsage: vars in: aTMethod [ 
-	vars do:
-		[:var |
-		(variables includes: var) ifTrue: "find the set of method names using this global var"
-			[(globalVariableUsage at: var ifAbsentPut: [Set new])
-				add: aTMethod selector]].
+CCodeGenerator >> checkForGlobalUsage: vars in: aTMethod [
+
+	vars do: [ :var |
+		(variables includes: var) ifTrue: [
+			((variableDeclarations at: var ifAbsent: [ '' ]) beginsWith:
+				 #implicit) ifFalse: [ "find the set of method names using this global var"
+				(globalVariableUsage at: var ifAbsentPut: [ Set new ]) add:
+					aTMethod selector ] ] ].
 	aTMethod clearReferencesToGlobalStruct.
-	(aTMethod allLocals select: [:l| self reservedWords includes: l]) do:
-		[:l| | em |
-		em := aTMethod definingClass name, '>>', aTMethod smalltalkSelector, ' has variable that is a C reserved word: ', l.
-		self error: em.
-		self logger cr; nextPutAll: em; cr; flush]
+	(aTMethod allLocals select: [ :l | self reservedWords includes: l ])
+		do: [ :l |
+			| em |
+			em := aTMethod definingClass name , '>>'
+			      , aTMethod smalltalkSelector
+			      , ' has variable that is a C reserved word: ' , l.
+			self error: em.
+			self logger
+				cr;
+				nextPutAll: em;
+				cr;
+				flush ]
 ]
 
 { #category : 'error notification' }

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -986,6 +986,7 @@ CCodeGenerator >> declareModuleName: nameString [
 { #category : 'public' }
 CCodeGenerator >> declareVar: varName type: type [
 	"This both creates a varable and provides its type"
+
 	self var: (variables add: varName asString) type: type
 ]
 
@@ -3758,15 +3759,14 @@ CCodeGenerator >> localizeVariables: varsList inMethod: m [
 
 	self validateLocalizationOfGlobals: varsList exceptMethod: m selector.
 	m localizeVariables: varsList.
-	varsList do: [ :v | 
+	varsList do: [ :v |
 		| varString |
 		varString := v asString.
-		variables remove: varString ifAbsent: [  ].
-		(variableDeclarations includesKey: varString) ifTrue: [ 
+		(variableDeclarations includesKey: varString) ifTrue: [
 			m
 				declarationAt: v asString
-				put: (variableDeclarations at: varString).
-			variableDeclarations removeKey: varString ] ]
+				put: (variableDeclarations at: varString) ].
+		self removeVariable: varString ]
 ]
 
 { #category : 'utilities' }

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -3748,7 +3748,9 @@ CCodeGenerator >> localizeGlobalVariables [
 					show: var , ' localised to ' , name;
 					cr ] ] ].
 
-	elected do: [ :var | self removeVariable: var ]
+	elected do: [ :var |
+		self removeVariable: var.
+		globalVariableUsage removeKey: var ]
 ]
 
 { #category : 'inlining' }

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -3722,7 +3722,7 @@ CCodeGenerator >> localizeGlobalVariables [
 	"find all globals used in only one method"
 	candidates := globalVariableUsage select: [ :e | e size = 1 ].
 	"Don't localize globals"
-	(candidates keys select: [ :k | self mustBeGlobal: k ]) do: [ :k |
+	(candidates keys select: [ :k | self mustBeGlobalAndExport: k ]) do: [ :k |
 		candidates removeKey: k ].
 	elected := Set new.
 	localized := Dictionary new. "for an ordered report"
@@ -3921,7 +3921,7 @@ CCodeGenerator >> mostBasicConstantSelectors [
 ]
 
 { #category : 'utilities' }
-CCodeGenerator >> mustBeGlobal: aName [
+CCodeGenerator >> mustBeGlobalAndExport: aName [
 	^ false
 ]
 

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -3738,8 +3738,7 @@ CCodeGenerator >> localizeGlobalVariables [
 												[:s|
 												 s nextPutAll: newDeclaration; nextPutAll: ' = '.
 												(initializerNode asCASTIn: self) prettyPrintOn: s ]].
-					procedure declarationAt: key put: newDeclaration.
-					variableDeclarations removeKey: key ifAbsent: []]]]].
+					procedure declarationAt: key put: newDeclaration ]]]].
 	logger ifNotNil:
 		[localized keys asSortedCollection do:
 			[:name|
@@ -3747,7 +3746,7 @@ CCodeGenerator >> localizeGlobalVariables [
 				[:var|
 				logger newLine; show: var, ' localised to ', name; cr]]].
 
-	variables removeAllFoundIn: elected
+	elected do: [ :var | self removeVariable: var ]
 ]
 
 { #category : 'inlining' }

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -3707,44 +3707,46 @@ CCodeGenerator >> isVoidPointer: aCType [ "<String>"
 
 { #category : 'utilities' }
 CCodeGenerator >> localizeGlobalVariables [
-	| candidates elected localized |
 
+	| candidates elected localized |
 	"find all globals used in only one method"
-	candidates := globalVariableUsage select: [:e | e size = 1].
-	"Don't localize globals; nor those that are only assigned to; they're for debugging..."
-	(candidates keys select: [:k| (self mustBeGlobal: k)
-								or: [(self methodNamed: (globalVariableUsage at: k) anyOne)
-										ifNil: [false]
-										ifNotNil: [:m| (m readsVariable: k) not]]]) do:
-		[:k| candidates removeKey: k].
-	
+	candidates := globalVariableUsage select: [ :e | e size = 1 ].
+	"Don't localize globals"
+	(candidates keys select: [ :k | self mustBeGlobal: k ]) do: [ :k |
+		candidates removeKey: k ].
 	elected := Set new.
 	localized := Dictionary new. "for an ordered report"
 	"move any suitable global to be local to the single method using it"
-	candidates keysAndValuesDo:
-		[:key :targets |
-		targets do:
-			[:name |
-			(methods at: name ifAbsent: []) ifNotNil:
-				[:procedure | | newDeclaration |
-				(procedure isRealMethod
-				 and: [self shouldGenerateMethod: procedure]) ifTrue:
-					[(localized at: name ifAbsentPut: [SortedCollection new]) add: key.
+	candidates keysAndValuesDo: [ :key :targets |
+		targets do: [ :name |
+			(methods at: name ifAbsent: [  ]) ifNotNil: [ :procedure |
+				| newDeclaration |
+				(procedure isRealMethod and: [
+					 self shouldGenerateMethod: procedure ]) ifTrue: [
+					(localized at: name ifAbsentPut: [ SortedCollection new ]) add:
+						key.
 					elected add: (procedure addLocal: key).
-					newDeclaration := variableDeclarations at: key ifAbsent: ['sqInt ', key].
-					(self initializerForInstVar: key inStartClass: procedure definingClass) ifNotNil:
-						[:initializerNode|
-						newDeclaration := String streamContents:
-												[:s|
-												 s nextPutAll: newDeclaration; nextPutAll: ' = '.
-												(initializerNode asCASTIn: self) prettyPrintOn: s ]].
-					procedure declarationAt: key put: newDeclaration ]]]].
-	logger ifNotNil:
-		[localized keys asSortedCollection do:
-			[:name|
-			(localized at: name) do:
-				[:var|
-				logger newLine; show: var, ' localised to ', name; cr]]].
+					newDeclaration := variableDeclarations
+						                  at: key
+						                  ifAbsent: [ 'sqInt ' , key ].
+					(self
+						 initializerForInstVar: key
+						 inStartClass: procedure definingClass) ifNotNil: [
+						:initializerNode |
+						newDeclaration := String streamContents: [ :s |
+							                  s
+								                  nextPutAll: newDeclaration;
+								                  nextPutAll: ' = '.
+							                  (initializerNode asCASTIn: self)
+								                  prettyPrintOn: s ] ].
+					procedure declarationAt: key put: newDeclaration ] ] ] ].
+	logger ifNotNil: [
+		localized keys asSortedCollection do: [ :name |
+			(localized at: name) do: [ :var |
+				logger
+					newLine;
+					show: var , ' localised to ' , name;
+					cr ] ] ].
 
 	elected do: [ :var | self removeVariable: var ]
 ]

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -3921,6 +3921,12 @@ CCodeGenerator >> mostBasicConstantSelectors [
 ]
 
 { #category : 'utilities' }
+CCodeGenerator >> mustBeGlobal: aName [
+
+	^ false
+]
+
+{ #category : 'utilities' }
 CCodeGenerator >> mustBeGlobalAndExport: aName [
 	^ false
 ]

--- a/smalltalksrc/Slang/SLDeadCodeElimination.class.st
+++ b/smalltalksrc/Slang/SLDeadCodeElimination.class.st
@@ -2,6 +2,7 @@ Class {
 	#name : 'SLDeadCodeElimination',
 	#superclass : 'Object',
 	#instVars : [
+		'sLExpandASTVisitor',
 		'codeGenerator',
 		'workList',
 		'markedElements',
@@ -145,7 +146,9 @@ SLDeadCodeElimination >> currentMethod [
 { #category : 'accessing' }
 SLDeadCodeElimination >> currentMethod: aTMethod [
 
-	currentMethod := aTMethod
+	currentMethod := aTMethod.
+	sLExpandASTVisitor currentMethod: aTMethod.
+	codeGenerator currentMethod: aTMethod
 ]
 
 { #category : 'cleaning' }
@@ -271,7 +274,8 @@ SLDeadCodeElimination >> initialize [
 	variableOccurences := Dictionary new: 100.
 	variableDefinitions := Dictionary new: 100.
 	variableDefiningStmtList := Dictionary new: 100.
-	localVariableScope := Stack new
+	localVariableScope := Stack new.
+	sLExpandASTVisitor := SLExpandASTVisitor new
 ]
 
 { #category : 'testing' }
@@ -372,8 +376,7 @@ SLDeadCodeElimination >> removeDeadCodeUsing: aCodeGen [
 		during: [ :bar |
 			codeGenerator methods doWithIndex: [ :m :i |
 				bar value: i.
-				currentMethod := m.
-				codeGenerator currentMethod: m.
+				self currentMethod: m.
 				self removeDeadCodeInCurrentMethod ] ]
 ]
 
@@ -448,10 +451,9 @@ SLDeadCodeElimination >> visitSendNode: aSendNode [
 	self markAsStatementAndAddToWorkList: aSendNode.
 	self markAsExpressionAndAddToWorkList: aSendNode receiver.
 
-	(#( #cCall:withArguments: f:printf: ) includes: aSendNode selector)
-		ifTrue: [
-			(aSendNode arguments at: 2) statements do: [ :stmt |
-				self markAsExpressionAndAddToWorkList: stmt ] ].
+	(#( #cCall:withArguments: ) includes: aSendNode selector) ifTrue: [
+		(aSendNode arguments at: 2) statements do: [ :stmt |
+			self markAsExpressionAndAddToWorkList: stmt ] ].
 
 
 

--- a/smalltalksrc/Slang/SLDeadCodeElimination.class.st
+++ b/smalltalksrc/Slang/SLDeadCodeElimination.class.st
@@ -356,7 +356,7 @@ SLDeadCodeElimination >> propagateMarkedElement: node [
 SLDeadCodeElimination >> removeDeadCodeInCurrentMethod [
 
 	| i |
-	currentMethod expandAST.
+	sLExpandASTVisitor expandASTInCurrentMethod.
 	self initMarkAndWorkList.
 	[ workList isEmpty ] whileFalse: [
 		i := workList removeFirst.

--- a/smalltalksrc/Slang/SLExpandASTVisitor.class.st
+++ b/smalltalksrc/Slang/SLExpandASTVisitor.class.st
@@ -29,7 +29,6 @@ SLExpandASTVisitor >> initTranslationDictionary [
 	pairs := #( 
 		f:printf: #expandPrintfIn:
 		
-		#value	 #expandASTIn:
 		#value: #expandASTIn:
 		#value:value: #expandASTIn:
 		#value:value:value: #expandASTIn:

--- a/smalltalksrc/Slang/SLExpandASTVisitor.class.st
+++ b/smalltalksrc/Slang/SLExpandASTVisitor.class.st
@@ -1,0 +1,117 @@
+Class {
+	#name : 'SLExpandASTVisitor',
+	#superclass : 'Object',
+	#instVars : [
+		'translationDictionary',
+		'currentTMethod'
+	],
+	#category : 'Slang',
+	#package : 'Slang'
+}
+
+{ #category : 'acccessing' }
+SLExpandASTVisitor >> currentMethod: aTMethod [
+
+	currentTMethod := aTMethod
+]
+
+{ #category : 'initialization' }
+SLExpandASTVisitor >> initTranslationDictionary [
+	
+	| pairs |
+	translationDictionary  := Dictionary new.
+	pairs := #( 
+		f:printf: #expandPrintfIn:
+		
+		#value	 #expandASTIn:
+		#value: #expandASTIn:
+		#value:value: #expandASTIn:
+		#value:value:value: #expandASTIn:
+		#value:value:value:value: #expandASTIn:
+		#value:value:value:value:value: #expandASTIn:
+		#value:value:value:value:value:value: #expandASTIn:
+	).
+	
+	1 to: pairs size by: 2 do: [:i |
+		translationDictionary at: (pairs at: i) put: (pairs at: i + 1)].
+]
+
+{ #category : 'initialization' }
+SLExpandASTVisitor >> initialize [ 
+	super initialize .
+	self initTranslationDictionary
+]
+
+{ #category : 'visiting' }
+SLExpandASTVisitor >> visit: aNode [
+	aNode accept: self
+]
+
+{ #category : 'visiting' }
+SLExpandASTVisitor >> visitAssignmentNode: anAssignmentNode [
+
+	anAssignmentNode expandASTIn: currentTMethod.
+
+	self visit: anAssignmentNode expression.
+	self visit: anAssignmentNode variable
+]
+
+{ #category : 'visiting' }
+SLExpandASTVisitor >> visitCaseStatementNode: aCaseStatementNode [
+
+	self visit: aCaseStatementNode expression.
+	aCaseStatementNode cases do: [ :case | self visit: case ]
+]
+
+{ #category : 'visiting' }
+SLExpandASTVisitor >> visitConstantNode: aConstantNode [
+]
+
+{ #category : 'visiting' }
+SLExpandASTVisitor >> visitGoToNode: aGotoNde [
+]
+
+{ #category : 'visiting' }
+SLExpandASTVisitor >> visitInlineNode: anInlineNode [
+
+	self visit: anInlineNode method parseTree
+]
+
+{ #category : 'visiting' }
+SLExpandASTVisitor >> visitLabeledCommentNode: aLabeledCommentNode [
+]
+
+{ #category : 'visiting' }
+SLExpandASTVisitor >> visitReturnNode: aReturnNode [
+
+	self visit: aReturnNode expression
+]
+
+{ #category : 'visiting' }
+SLExpandASTVisitor >> visitSendNode: aSendNode [
+
+	| action |
+	action := translationDictionary
+		          at: aSendNode selector
+		          ifAbsent: [ ^ self ].
+	^ aSendNode perform: action with: currentTMethod
+]
+
+{ #category : 'visiting' }
+SLExpandASTVisitor >> visitStatementListNode: aStatementListNode [
+
+	aStatementListNode statements do: [ :stmt | self visit: stmt ]
+]
+
+{ #category : 'visiting' }
+SLExpandASTVisitor >> visitSwitchStatementNode: aSwitchStatmentNode [
+
+	self visit: aSwitchStatmentNode expression.
+	aSwitchStatmentNode cases: [ :cases | self visit: cases second ]
+]
+
+{ #category : 'visiting' }
+SLExpandASTVisitor >> visitVariableNode: aVariableNode [
+
+	
+]

--- a/smalltalksrc/Slang/SLExpandASTVisitor.class.st
+++ b/smalltalksrc/Slang/SLExpandASTVisitor.class.st
@@ -99,7 +99,10 @@ SLExpandASTVisitor >> visitSendNode: aSendNode [
 	action := translationDictionary
 		          at: aSendNode selector
 		          ifAbsent: [ nil ].
+
+	self visit: aSendNode receiver.
 	aSendNode arguments do: [ :arg | self visit: arg ].
+
 	action ifNotNil: [ aSendNode perform: action with: currentTMethod ]
 ]
 

--- a/smalltalksrc/Slang/SLExpandASTVisitor.class.st
+++ b/smalltalksrc/Slang/SLExpandASTVisitor.class.st
@@ -15,6 +15,12 @@ SLExpandASTVisitor >> currentMethod: aTMethod [
 	currentTMethod := aTMethod
 ]
 
+{ #category : 'transformation' }
+SLExpandASTVisitor >> expandASTInCurrentMethod [
+
+	self visit: currentTMethod parseTree
+]
+
 { #category : 'initialization' }
 SLExpandASTVisitor >> initTranslationDictionary [
 	
@@ -93,8 +99,9 @@ SLExpandASTVisitor >> visitSendNode: aSendNode [
 	| action |
 	action := translationDictionary
 		          at: aSendNode selector
-		          ifAbsent: [ ^ self ].
-	^ aSendNode perform: action with: currentTMethod
+		          ifAbsent: [ nil ].
+	aSendNode arguments do: [ :arg | self visit: arg ].
+	action ifNotNil: [ aSendNode perform: action with: currentTMethod ]
 ]
 
 { #category : 'visiting' }
@@ -107,7 +114,7 @@ SLExpandASTVisitor >> visitStatementListNode: aStatementListNode [
 SLExpandASTVisitor >> visitSwitchStatementNode: aSwitchStatmentNode [
 
 	self visit: aSwitchStatmentNode expression.
-	aSwitchStatmentNode cases: [ :cases | self visit: cases second ]
+	aSwitchStatmentNode cases do: [ :cases | self visit: cases second ]
 ]
 
 { #category : 'visiting' }

--- a/smalltalksrc/Slang/TMethod.class.st
+++ b/smalltalksrc/Slang/TMethod.class.st
@@ -1020,16 +1020,6 @@ TMethod >> exitVar: exitVar label: exitLabel [
 	^ labelUsed
 ]
 
-{ #category : 'transformations' }
-TMethod >> expandAST [
-	"the order is important, expanding assignment can/will modify the value selector"
-
-	parseTree nodesDo: [ :node |
-		node isAssignment ifTrue: [ node expandASTIn: self ].
-		(node isSend and: [ node isValueExpansion ]) ifTrue: [
-			node expandASTIn: self ] ]
-]
-
 { #category : 'accessing' }
 TMethod >> export [
 

--- a/smalltalksrc/Slang/TMethod.class.st
+++ b/smalltalksrc/Slang/TMethod.class.st
@@ -92,7 +92,8 @@ TMethod >> addLabelsTo: aTMethod [
 TMethod >> addLocal: aString [
 
 	cachedLocals := nil.
-	self locals add: aString
+	self locals add: aString.
+	^ aString
 ]
 
 { #category : 'adding' }

--- a/smalltalksrc/Slang/TSendNode.class.st
+++ b/smalltalksrc/Slang/TSendNode.class.st
@@ -377,6 +377,18 @@ TSendNode >> expandASTIn: aTMethod [
 	parent replaceChild: self with: substitution
 ]
 
+{ #category : 'transformations' }
+TSendNode >> expandPrintfIn: aTMethod [
+
+	| flatArgs |
+	selector = #f:printf: ifFalse: [ ^ self ].
+	flatArgs := OrderedCollection new
+		            add: (arguments at: 1);
+		            yourself.
+	(arguments at: 2) statements do: [ :stmt | flatArgs add: stmt ].
+	self arguments: flatArgs
+]
+
 { #category : 'testing' }
 TSendNode >> hasSideEffect [
 	"Answer if the parse tree rooted at this node has a side-effect or not."

--- a/smalltalksrc/VMMaker/CoInterpreter.class.st
+++ b/smalltalksrc/VMMaker/CoInterpreter.class.st
@@ -370,10 +370,10 @@ CoInterpreter class >> isNonArgumentImplicitReceiverVariableName: aString [
 ]
 
 { #category : 'translation' }
-CoInterpreter class >> mustBeGlobal: var [
+CoInterpreter class >> mustBeGlobalAndExport: var [
 	"Answer if a variable must be global and exported.  Used for inst vars that are accessed from VM support code."
 
-	^(super mustBeGlobal: var)
+	^(super mustBeGlobalAndExport: var)
 	   or: [#('desiredCogCodeSize' 'heapBase'
 			'maxLiteralCountForCompile' 'minBackwardJumpCountForCompile') includes: var]
 ]

--- a/smalltalksrc/VMMaker/CoInterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/CoInterpreterPrimitives.class.st
@@ -6,12 +6,6 @@ Class {
 	#tag : 'JIT'
 }
 
-{ #category : 'translation' }
-CoInterpreterPrimitives class >> mustBeGlobalInFile: var [
-
-	^ #( #composedImageWriter #spurImageWriter ) includes: var
-]
-
 { #category : 'arithmetic primitives' }
 CoInterpreterPrimitives >> mcprimHashMultiply: receiverArg [
 	"Machine code primitive for hash multiply. c.f. primitiveHashMultiply.

--- a/smalltalksrc/VMMaker/CoInterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/CoInterpreterPrimitives.class.st
@@ -6,6 +6,12 @@ Class {
 	#tag : 'JIT'
 }
 
+{ #category : 'translation' }
+CoInterpreterPrimitives class >> mustBeGlobalInFile: var [
+
+	^ #( #composedImageWriter #spurImageWriter ) includes: var
+]
+
 { #category : 'arithmetic primitives' }
 CoInterpreterPrimitives >> mcprimHashMultiply: receiverArg [
 	"Machine code primitive for hash multiply. c.f. primitiveHashMultiply.

--- a/smalltalksrc/VMMaker/Cogit.class.st
+++ b/smalltalksrc/VMMaker/Cogit.class.st
@@ -1187,7 +1187,7 @@ Cogit class >> methodZoneClass [
 ]
 
 { #category : 'translation' }
-Cogit class >> mustBeGlobal: var [
+Cogit class >> mustBeGlobalAndExport: var [
 	"Answer if a variable must be global and exported.  Used for inst vars that are accessed from VM
 	 support code.  include cePositive32BitIntegerTrampoline as a hack to prevent it being inlined (it is
 	 only used outside of Cogit by the object representation).  Include CFramePointer CStackPointer as

--- a/smalltalksrc/VMMaker/FilePlugin.class.st
+++ b/smalltalksrc/VMMaker/FilePlugin.class.st
@@ -191,7 +191,6 @@ FilePlugin >> makeDirEntryName: entryName size: entryNameSize
 FilePlugin >> makeDirEntryName: entryName size: entryNameSize createDate: createDate modDate: modifiedDate isDir: dirFlag fileSize: fileSize posixPermissions: posixPermissions isSymlink: symlinkFlag [
 	<var: 'entryName' type: #'char *'>
 	<var: 'fileSize' type: #squeakFileOffsetType>
-	<option: #PharoVM>
 	| modDateOop createDateOop nameString results stringPtr posixPermissionsOop fileSizeOop |
 	<var: 'stringPtr' type: #'char *'>
 
@@ -441,66 +440,63 @@ FilePlugin >> primitiveDirectoryGetMacTypeAndCreator [
 { #category : 'directory primitives' }
 FilePlugin >> primitiveDirectoryLookup [
 
-	| index pathName pathNameIndex pathNameSize status entryName entryNameSize createDate modifiedDate dirFlag symlinkFlag posixPermissions fileSize |
-	
 	<var: 'entryName' declareC: 'char entryName[256]'>
 	<var: 'pathNameIndex' type: 'char *'>
 	<var: 'fileSize' type: 'squeakFileOffsetType'>
 	<export: true>
-
+	| index pathName pathNameIndex pathNameSize status entryName entryNameSize createDate modifiedDate dirFlag symlinkFlag posixPermissions fileSize |
 	index := interpreterProxy stackIntegerValue: 0.
 	pathName := interpreterProxy stackValue: 1.
-	(interpreterProxy isBytes: pathName)
-		ifFalse: [^interpreterProxy primitiveFail].
+	(interpreterProxy isBytes: pathName) ifFalse: [
+		^ interpreterProxy primitiveFail ].
 	pathNameIndex := interpreterProxy firstIndexableField: pathName.
 	pathNameSize := interpreterProxy byteSizeOf: pathName.
-	self cCode: '' inSmalltalk:
-		[entryName := ByteString new: 256.
-		 entryNameSize := createDate := modifiedDate := dirFlag := fileSize := posixPermissions := symlinkFlag := nil].
+	self cCode: '' inSmalltalk: [
+		entryName := ByteString new: 256.
+		entryNameSize := createDate := modifiedDate := dirFlag := fileSize := posixPermissions := symlinkFlag := nil ].
 	"If the security plugin can be loaded, use it to check for permission. 
 	If not, assume it's ok"
-	status := self dir_Lookup: pathNameIndex _: pathNameSize
-					_: index
-					_: entryName _: (self addressOf: entryNameSize put: [:v| entryNameSize := v])
-					_: (self addressOf: createDate put: [:v| createDate := v])
-					_: (self addressOf: modifiedDate put: [:v| modifiedDate := v])
-					_: (self addressOf: dirFlag put: [:v| dirFlag := v])
-					_: (self addressOf: fileSize put: [:v| fileSize := v])
-					_: (self addressOf: posixPermissions put: [:v| posixPermissions := v])
-					_: (self addressOf: symlinkFlag put: [:v| symlinkFlag := v]).
-					
-	interpreterProxy failed ifTrue:
-		[^nil].
-	status = DirNoMoreEntries ifTrue: "no more entries; return nil"
-		[interpreterProxy "pop pathName, index, rcvr"
-			pop: 3 thenPush: interpreterProxy nilObject.
-		^nil].
-	status = DirBadPath ifTrue:
-		[^interpreterProxy primitiveFail]."bad path"
+	status := self
+		          dir_Lookup: pathNameIndex
+		          _: pathNameSize
+		          _: index
+		          _: entryName
+		          _:
+		          (self
+			           addressOf: entryNameSize
+			           put: [ :v | entryNameSize := v ])
+		          _:
+		          (self addressOf: createDate put: [ :v | createDate := v ])
+		          _:
+		          (self
+			           addressOf: modifiedDate
+			           put: [ :v | modifiedDate := v ])
+		          _: (self addressOf: dirFlag put: [ :v | dirFlag := v ])
+		          _: (self addressOf: fileSize put: [ :v | fileSize := v ])
+		          _:
+		          (self
+			           addressOf: posixPermissions
+			           put: [ :v | posixPermissions := v ])
+		          _:
+		          (self
+			           addressOf: symlinkFlag
+			           put: [ :v | symlinkFlag := v ]).
 
-	interpreterProxy 
-		pop: 3	"pop pathName, index, rcvr" 
-		thenPush:
-			(self 
-				cppIf: PharoVM 
-				ifTrue:
-					[self
-						makeDirEntryName: entryName
-						size: entryNameSize
-						createDate: createDate
-						modDate: modifiedDate
-						isDir: dirFlag
-						fileSize: fileSize
-						posixPermissions: posixPermissions
-						isSymlink: symlinkFlag]
-				ifFalse:
-					[self
-						makeDirEntryName: entryName
-						size: entryNameSize
-						createDate: createDate
-						modDate: modifiedDate
-						isDir: dirFlag
-						fileSize: fileSize])
+	interpreterProxy failed ifTrue: [ ^ nil ].
+	status = DirNoMoreEntries ifTrue: [ "no more entries; return nil"
+		interpreterProxy pop: 3 thenPush: interpreterProxy nilObject. "pop pathName, index, rcvr"
+		^ nil ].
+	status = DirBadPath ifTrue: [ ^ interpreterProxy primitiveFail ]. "bad path"
+
+	interpreterProxy pop: 3 thenPush: (self
+			 makeDirEntryName: entryName
+			 size: entryNameSize
+			 createDate: createDate
+			 modDate: modifiedDate
+			 isDir: dirFlag
+			 fileSize: fileSize
+			 posixPermissions: posixPermissions
+			 isSymlink: symlinkFlag) "pop pathName, index, rcvr"
 ]
 
 { #category : 'directory primitives' }

--- a/smalltalksrc/VMMaker/SLLocalizationTest.extension.st
+++ b/smalltalksrc/VMMaker/SLLocalizationTest.extension.st
@@ -7,9 +7,6 @@ SLLocalizationTest >> setUp [
 	ccg vmClass: VMClass.
 	ccg vmMaker: VMMaker new.
 	ccg vmMaker vmmakerConfiguration: VMMakerConfiguration.
-	ccg declareVar: #globalWithNoUsage type: #int.
-	ccg declareVar: #globalWithUsage type: #int.
-	ccg declareVar: #globalToLocalize type: #int.
 	ccg declareVar: #globalMustBeGlobal type: #int.
 	ccg addClass: SLLocalizationTestClass
 ]

--- a/smalltalksrc/VMMaker/SLLocalizationTest.extension.st
+++ b/smalltalksrc/VMMaker/SLLocalizationTest.extension.st
@@ -7,5 +7,6 @@ SLLocalizationTest >> setUp [
 	ccg declareVar: #globalWithNoUsage type: #int.
 	ccg declareVar: #globalWithUsage type: #int.
 	ccg declareVar: #globalToLocalize type: #int.
-	ccg declareVar: #globalMustBeGlobal type: #int
+	ccg declareVar: #globalMustBeGlobal type: #int.
+	ccg addClass: SLLocalizationTestClass
 ]

--- a/smalltalksrc/VMMaker/SLLocalizationTest.extension.st
+++ b/smalltalksrc/VMMaker/SLLocalizationTest.extension.st
@@ -3,7 +3,10 @@ Extension { #name : 'SLLocalizationTest' }
 { #category : '*VMMaker' }
 SLLocalizationTest >> setUp [
 
-	super setUp.
+	ccg := MLVMCCodeGeneratorLocalizationMock new.
+	ccg vmClass: VMClass.
+	ccg vmMaker: VMMaker new.
+	ccg vmMaker vmmakerConfiguration: VMMakerConfiguration.
 	ccg declareVar: #globalWithNoUsage type: #int.
 	ccg declareVar: #globalWithUsage type: #int.
 	ccg declareVar: #globalToLocalize type: #int.

--- a/smalltalksrc/VMMaker/SLLocalizationTest.extension.st
+++ b/smalltalksrc/VMMaker/SLLocalizationTest.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : 'SLLocalizationTest' }
+
+{ #category : '*VMMaker' }
+SLLocalizationTest >> setUp [
+
+	super setUp.
+	ccg declareVar: #globalWithNoUsage type: #int.
+	ccg declareVar: #globalWithUsage type: #int.
+	ccg declareVar: #globalToLocalize type: #int.
+	ccg declareVar: #globalMustBeGlobal type: #int
+]

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -960,7 +960,7 @@ SpurMemoryManager class >> memoryManagerVersion [
 ]
 
 { #category : 'translation' }
-SpurMemoryManager class >> mustBeGlobal: var [
+SpurMemoryManager class >> mustBeGlobalAndExport: var [
 	"Answer if a variable must be global and exported.  Used for inst vars that are accessed from VM support code."
 
 	^#('checkForLeaks' 'maxOldSpaceSize') includes: var

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -1477,11 +1477,11 @@ StackInterpreter class >> isStackAccessor: selector [
 ]
 
 { #category : 'translation' }
-StackInterpreter class >> mustBeGlobal: var [
+StackInterpreter class >> mustBeGlobalAndExport: var [
 	"Answer if a variable must be global and exported.  Used for inst vars that are accessed from VM support code."
 
-	^ (super mustBeGlobal: var) or: [
-		  (self objectMemoryClass mustBeGlobal: var) or: [
+	^ (super mustBeGlobalAndExport: var) or: [
+		  (self objectMemoryClass mustBeGlobalAndExport: var) or: [
 			  #( 'interpreterProxy' 'interpreterVersion' 'extraVMMemory'
 			     'desiredNumStackPages' 'desiredEdenBytes' 'sendTrace'
 			     'checkAllocFiller' 'checkedPluginName' 'reenterInterpreter'

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -577,10 +577,6 @@ If ffi is put as a separate header, slang will sort the header and put it outsid
 		declareC:
 			'void (*externalPrimitiveTable[MaxExternalPrimitiveTableSize + 1 /* '
 			, (MaxExternalPrimitiveTableSize + 1) printString , ' */])(void)';
-		var: #interruptCheckChain
-		declareC: 'void (*interruptCheckChain)(void) = 0';
-		var: #showSurfaceFn
-		declareC: 'int (*showSurfaceFn)(sqIntptr_t, int, int, int, int)';
 		var: #jmpBuf
 		declareC:
 			'jmp_buf jmpBuf[MaxJumpBuf + 1 /* ' , (MaxJumpBuf + 1) printString
@@ -605,8 +601,6 @@ If ffi is put as a separate header, slang will sort the header and put it outsid
 	aCCodeGenerator
 		var: #reenterInterpreter
 		declareC: 'jmp_buf reenterInterpreter; /* private export */'.
-
-	aCCodeGenerator var: #messageCount type: #usqInt.
 
 	aCCodeGenerator removeVariable: #libFFI.
 	LibFFIConstants classVariables do: [ :e |
@@ -1484,20 +1478,14 @@ StackInterpreter class >> isStackAccessor: selector [
 
 { #category : 'translation' }
 StackInterpreter class >> mustBeGlobal: var [
-
 	"Answer if a variable must be global and exported.  Used for inst vars that are accessed from VM support code."
 
-	^ (super mustBeGlobal: var) or: [ 
-		  (self objectMemoryClass mustBeGlobal: var) or: [ 
-			  #( 'interpreterProxy' 'interpreterVersion' 'inIOProcessEvents'
-			     'sendWheelEvents' 'deferDisplayUpdates' 'extraVMMemory'
-			     'showSurfaceFn' 'displayBits' 'displayWidth' 'displayHeight'
-			     'displayDepth' 'desiredNumStackPages' 'desiredEdenBytes'
-			     'breakLookupClassTag' 'breakSelector' 'breakSelectorLength'
-			     'sendTrace' 'checkAllocFiller' 'checkedPluginName'
-			     'reenterInterpreter' 'suppressHeartbeatFlag'
-			     'ffiExceptionResponse' 'debugCallbackInvokes'
-			     'debugCallbackPath' 'debugCallbackReturns' ) includes: var ] ]
+	^ (super mustBeGlobal: var) or: [
+		  (self objectMemoryClass mustBeGlobal: var) or: [
+			  #( 'interpreterProxy' 'interpreterVersion' 'extraVMMemory'
+			     'desiredNumStackPages' 'desiredEdenBytes' 'sendTrace'
+			     'checkAllocFiller' 'checkedPluginName' 'reenterInterpreter'
+			     'suppressHeartbeatFlag' 'ffiExceptionResponse' ) includes: var ] ]
 ]
 
 { #category : 'translation' }

--- a/smalltalksrc/VMMaker/StackInterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreterPrimitives.class.st
@@ -10,6 +10,12 @@ Class {
 	#tag : 'Interpreter'
 }
 
+{ #category : 'translation' }
+StackInterpreterPrimitives class >> mustBeGlobalInFile: var [
+
+	^ #( #composedImageWriter #spurImageWriter ) includes: var
+]
+
 { #category : 'initialization' }
 StackInterpreterPrimitives >> allocateParameters: anInteger using: allocationBlock [
 	<inline: #always>

--- a/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
+++ b/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
@@ -430,7 +430,7 @@ StackToRegisterMappingCogit class >> mustBeGlobal: var [
 		     'realCECallCogCodePopReceiverArg0Regs'
 		     'realCECallCogCodePopReceiverArg1Arg0Regs'
 		     'ceCall0ArgsPIC' 'ceCall1ArgsPIC' 'ceCall2ArgsPIC'
-		     'generatorTable' ) includes: var ]
+		     'generatorTable' 'aMethodLabel' ) includes: var ]
 ]
 
 { #category : 'accessing' }

--- a/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
+++ b/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
@@ -424,10 +424,13 @@ StackToRegisterMappingCogit class >> isAcceptableAncilliaryClass: aClass [
 StackToRegisterMappingCogit class >> mustBeGlobal: var [
 	"Answer if a variable must be global and exported.  Used for inst vars that are accessed from VM support code."
 
-	^(super mustBeGlobal: var)
-	   or: [#('ceCallCogCodePopReceiverArg0Regs' 'ceCallCogCodePopReceiverArg1Arg0Regs'
-			'realCECallCogCodePopReceiverArg0Regs' 'realCECallCogCodePopReceiverArg1Arg0Regs'
-			'ceCall0ArgsPIC' 'ceCall1ArgsPIC' 'ceCall2ArgsPIC') includes: var]
+	^ (super mustBeGlobal: var) or: [
+		  #( 'ceCallCogCodePopReceiverArg0Regs'
+		     'ceCallCogCodePopReceiverArg1Arg0Regs'
+		     'realCECallCogCodePopReceiverArg0Regs'
+		     'realCECallCogCodePopReceiverArg1Arg0Regs'
+		     'ceCall0ArgsPIC' 'ceCall1ArgsPIC' 'ceCall2ArgsPIC'
+		     'generatorTable' ) includes: var ]
 ]
 
 { #category : 'accessing' }

--- a/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
+++ b/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
@@ -421,16 +421,22 @@ StackToRegisterMappingCogit class >> isAcceptableAncilliaryClass: aClass [
 ]
 
 { #category : 'translation' }
-StackToRegisterMappingCogit class >> mustBeGlobal: var [
+StackToRegisterMappingCogit class >> mustBeGlobalAndExport: var [
 	"Answer if a variable must be global and exported.  Used for inst vars that are accessed from VM support code."
 
-	^ (super mustBeGlobal: var) or: [
+	^ (super mustBeGlobalAndExport: var) or: [
 		  #( 'ceCallCogCodePopReceiverArg0Regs'
 		     'ceCallCogCodePopReceiverArg1Arg0Regs'
 		     'realCECallCogCodePopReceiverArg0Regs'
 		     'realCECallCogCodePopReceiverArg1Arg0Regs'
-		     'ceCall0ArgsPIC' 'ceCall1ArgsPIC' 'ceCall2ArgsPIC'
-		     'generatorTable' 'aMethodLabel' ) includes: var ]
+		     'ceCall0ArgsPIC' 'ceCall1ArgsPIC' 'ceCall2ArgsPIC' ) includes:
+			  var ]
+]
+
+{ #category : 'translation' }
+StackToRegisterMappingCogit class >> mustBeGlobalInFile: var [
+
+	^ #( #aMethodLabel #generatorTable ) includes: var
 ]
 
 { #category : 'accessing' }

--- a/smalltalksrc/VMMaker/VMClass.extension.st
+++ b/smalltalksrc/VMMaker/VMClass.extension.st
@@ -32,7 +32,6 @@ VMClass class >> initializeMiscConstants [
 
 	"Use ifAbsentPut: so that they will get copied back to the
 	 VMMaker's options and dead code will likely be eliminated."
-	PharoVM := InitializationOptions at: #PharoVM ifAbsentPut: [ false ].
 	FEATURE_FFI := InitializationOptions
 		               at: #FEATURE_FFI
 		               ifAbsentPut: [ false ].

--- a/src/unix/debugUnix.c
+++ b/src/unix/debugUnix.c
@@ -82,9 +82,6 @@ void sigusr1(int sig, siginfo_t *info, ucontext_t *uap)
 	errno = saved_errno;
 }
 
-
-static int inFault = 0;
-
 void sigsegv(int sig, siginfo_t *info, ucontext_t *uap)
 {
 	char *fault = strsignal(sig);


### PR DESCRIPTION
Fix a broken piece of code not removing global variables after updating their localization in a method.

Update the check on unused global to remove all their occurence in the CodeGenerator, leaving the declaration and usage count caused some unused globals to be emited.

Move the check to the super class because not all file uses the same CodeGenerator class.

The check need to explicitly avoid some globals that seems unused for Slang (only used in macro or for setting up other globals), since the check happens now in all the CodeGenerators, the PR implements the explicit checks for the concerned VM classes.
Separate clearly the global that will appear in the header files and those who won't.

Add Some Test for this type of global localization.

Clean parts of code in the non generated code.

Also, remove the PharoVM macro which is now always true and is producing dead code.

The PR also refactor some code related to AST transformation and add test for it.