### PR TITLE
Allow `Cogit>>#mnuMethodOrNilFor:` to return non-`CompiledMethod` oops

### DIFF
--- a/smalltalksrc/VMMaker/CoInterpreter.class.st
+++ b/smalltalksrc/VMMaker/CoInterpreter.class.st
@@ -3785,26 +3785,30 @@ CoInterpreter >> mnuMethodOrNilFor: rcvr [
 	"Lookup the doesNotUnderstand: selector in the class of the argument rcvr.
 	 Answer either the matching method (cogged if appropriate), or nil, if not found."
 
-	| currentClass mnuSelector dictionary mnuMethod methodHeader |
+	| currentClass mnuSelector |
 	self deny: (objectMemory isOopForwarded: rcvr).
+
 	currentClass := objectMemory fetchClassOf: rcvr.
 	mnuSelector := objectMemory splObj: SelectorDoesNotUnderstand.
+
 	[ currentClass ~= objectMemory nilObject ] whileTrue: [
+		| dictionary mnuMethod |
 		dictionary := objectMemory
-			              fetchPointer: MethodDictionaryIndex
-			              ofObject: currentClass.
+			fetchPointer: MethodDictionaryIndex
+			ofObject: currentClass.
 		dictionary = objectMemory nilObject ifTrue: [ ^ nil ].
 		mnuMethod := self
-			             lookupMethodFor: mnuSelector
-			             InDictionary: dictionary.
-		(mnuMethod notNil and: [
-			 (objectMemory isImmediate: mnuMethod) not and: [
-				 objectMemory isCompiledMethod: mnuMethod ] ]) ifTrue: [
-			methodHeader := self rawHeaderOf: mnuMethod.
-			((self isCogMethodReference: methodHeader) not and: [
-				 self methodWithHeaderShouldBeCogged: methodHeader ]) ifTrue: [
-				cogit cog: mnuMethod selector: mnuSelector ].
+			lookupMethodFor: mnuSelector
+			InDictionary: dictionary.
+
+		mnuMethod ifNotNil: [
+			((objectMemory isImmediate: mnuMethod) not and: [ objectMemory isCompiledMethod: mnuMethod ]) ifTrue: [
+				| methodHeader |
+				methodHeader := self rawHeaderOf: mnuMethod.
+				((self isCogMethodReference: methodHeader) not and: [ self methodWithHeaderShouldBeCogged: methodHeader ]) ifTrue: [
+					cogit cog: mnuMethod selector: mnuSelector ] ].
 			^ mnuMethod ].
+
 		currentClass := self superclassOf: currentClass ].
 	^ nil
 ]

--- a/smalltalksrc/VMMakerTests/VMJittedLookupTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJittedLookupTest.class.st
@@ -95,7 +95,7 @@ VMJittedLookupTest >> setUpMethodDictionaryIn: aClass [
 { #category : 'tests' }
 VMJittedLookupTest >> testLookUpMNUShouldJItCompile [
 
-	| superclass superclassMethodDictionary foundMethod |
+	| superclass superclassMethodDictionary foundMethod compileCountStart |
 	
 	self setUpTrampolines.
 	cogit computeEntryOffsets.
@@ -120,15 +120,20 @@ VMJittedLookupTest >> testLookUpMNUShouldJItCompile [
 	
 	"Install the selector as a DNU selector"
 	memory splObj: SelectorDoesNotUnderstand put: selectorOop.
-	
+
+	self deny: (interpreter methodHasCogMethod: methodOop).
+	compileCountStart := cogit getMethodCompilationCount.
 	foundMethod := interpreter mnuMethodOrNilFor: receiver.
-	self assert: foundMethod equals: methodOop
+
+	self assert: foundMethod equals: methodOop.
+	self assert: (interpreter methodHasCogMethod: methodOop).
+	self assert: (cogit getMethodCompilationCount) equals: (memory integerObjectOf: (memory integerValueOf: compileCountStart) + 1)
 ]
 
 { #category : 'tests' }
 VMJittedLookupTest >> testLookUpMNUWithAnyNonMethodObjectShouldNotJItCompile [
 
-	| superclass superclassMethodDictionary foundMethod |
+	| superclass superclassMethodDictionary foundMethod compileCountStart |
 	
 	self setUpTrampolines.
 	cogit computeEntryOffsets.
@@ -153,7 +158,10 @@ VMJittedLookupTest >> testLookUpMNUWithAnyNonMethodObjectShouldNotJItCompile [
 	
 	"Install the selector as a DNU selector"
 	memory splObj: SelectorDoesNotUnderstand put: selectorOop.
-	
+
+	compileCountStart := cogit getMethodCompilationCount.
 	foundMethod := interpreter mnuMethodOrNilFor: receiver.
-	self assert: foundMethod isNil
+
+	self assert: foundMethod equals: (memory integerValueOf: 37).
+	self assert: (cogit getMethodCompilationCount) equals: compileCountStart
 ]


### PR DESCRIPTION
This should fix #935. The origin of this issue appears to be from a partially applied fix (previously we tried to compile method wrappers, then we just skipped them. Now we don't try to compile them but we properly return them as valid "methods" (given that we have the `#run:with:in` semantics for method invocation of regular objects).

See https://github.com/pharo-project/pharo-vm/pull/578 for more info.