### PR TITLE
Fix signal handler signature

### DIFF
--- a/extracted/plugins/UnixOSProcessPlugin/src/common/UnixOSProcessPlugin.c
+++ b/extracted/plugins/UnixOSProcessPlugin/src/common/UnixOSProcessPlugin.c
@@ -4398,7 +4398,7 @@ setInterpreter(struct VirtualMachine *anInterpreter)
 /* This wrapper is used to handle the new signature of the function */
 
 static void 
-reapChildProcessWrapper(int sigNum, struct __siginfo * sigInfo, void * userData){
+reapChildProcessWrapper(int sigNum, siginfo_t * sigInfo, void * userData){
 	reapChildProcess(sigNum);
 }
 # endif


### PR DESCRIPTION
Use the correct siginfo_t type for signal handlers. struct __siginfo is not exposed anymore in newer systems