### PR TITLE
Fixes #822 : functionPointerFor:inClass: has unused argument

### DIFF
--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -6897,12 +6897,11 @@ StackInterpreter >> functionForPrimitiveCallout [
 ]
 
 { #category : 'method lookup cache' }
-StackInterpreter >> functionPointerFor: primIdx inClass: theClass [
-	"Find an actual function pointer for this primitiveIndex.  This is an
-	opportunity to specialise the prim for the relevant class (format for
-	example).  Default for now is simply the entry in the base primitiveTable."
+StackInterpreter >> functionPointerFor: primIdx [
+	"Find an actual function pointer for this primitiveIndex.
+	Currently, no specialization per class exists, so we remove the unused argument."
 	<api>
-	<returnTypeC: 'void (*functionPointerForinClass(sqInt primIdx,sqInt theClass))(void)'>
+	<returnTypeC: 'void (*functionPointerFor(sqInt primIdx))(void)'>
 	^primIdx > MaxPrimitiveIndex ifTrue: [0] ifFalse: [primitiveTable at: primIdx]
 ]
 


### PR DESCRIPTION
Updated StackInterpreter.class.st by removing theClass as it was an unused parameter.


Here is the link to the issue: https://github.com/pharo-project/pharo-vm/issues/822 
