### PR TITLE
update cmake minimal version to enable build on recent cmake version

### DIFF
--- a/cmake/DownloadProject.CMakeLists.cmake.in
+++ b/cmake/DownloadProject.CMakeLists.cmake.in
@@ -1,7 +1,7 @@
 # Distributed under the OSI-approved MIT License.  See accompanying
 # file LICENSE or https://github.com/Crascit/DownloadProject for details.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.7.2)
 
 project(${DL_ARGS_PROJ}-download NONE)
 


### PR DESCRIPTION
small change that  complements https://github.com/pharo-project/libffi/pull/2