### PR TITLE
Removed unused temp in `findNewMethodOrdinaryIfFound:`

### DIFF
--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -6063,8 +6063,6 @@ StackInterpreter >> findNewMethodOrdinary [
 StackInterpreter >> findNewMethodOrdinaryIfFound: aBlock [
 	"Find the compiled method to be run when the current messageSelector is sent to the class 'lkupClass', setting the values of 'newMethod' and 'primitiveIndex'."
 
-	| classTag |
-	classTag := lkupClassTag.
 	^ self findNewMethodInClassTag: lkupClassTag ifFound: aBlock
 ]
 


### PR DESCRIPTION
This pull request is to fix issue [#820](https://github.com/pharo-project/pharo-vm/issues/820).