### PR TITLE
fix a small bug related to inlining of a method and fix another bug related to comment

### DIFF
--- a/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
+++ b/smalltalksrc/Slang-Tests/SlangBasicTranslationTest.class.st
@@ -1664,7 +1664,7 @@ methodCallingMethodExpressionList(void)
 {
 	sqInt _i;
 
-	_i == ((/* begin emptyMethod */ /* end emptyMethod */, bodyOfMethodWithoutInlinePragma(), /* begin methodWithoutInlinePragmaAndEmptyMethodCall */ /* begin emptyMethod */ /* end emptyMethod */, bodyOfMethodWithoutInlinePragma() /* end methodWithoutInlinePragmaAndEmptyMethodCall */, /* begin methodWithInlinePragma */ bodyOfMethodWithInlinePragma() /* end methodWithInlinePragma */));
+	_i == ((/* begin emptyMethod */ /* end emptyMethod */ bodyOfMethodWithoutInlinePragma(), /* begin methodWithoutInlinePragmaAndEmptyMethodCall */ /* begin emptyMethod */ /* end emptyMethod */ bodyOfMethodWithoutInlinePragma() /* end methodWithoutInlinePragmaAndEmptyMethodCall */, /* begin methodWithInlinePragma */ bodyOfMethodWithInlinePragma() /* end methodWithInlinePragma */));
 	return 0;
 }'
 ]

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -3523,9 +3523,6 @@ CCodeGenerator >> isConstantNode: aNode valueInto: aBlock [
 			ifTrue: [ ^ false ].
 		aBlock value: aNode value.
 		^ true ].
-	(aNode isVariable and: [ aNode name = #nil ]) ifTrue: [ 
-		aBlock value: nil.
-		^ true ].
 	aNode isSend ifTrue: [ 
 		(self anyMethodNamed: aNode selector)
 			ifNil: [ 

--- a/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
+++ b/smalltalksrc/Slang/CSlangPrettyPrinter.class.st
@@ -32,40 +32,45 @@ CSlangPrettyPrinter >> expressionListHasNonCommentStatementAfter: expressions fu
 ]
 
 { #category : 'testing' }
-CSlangPrettyPrinter >> expressionListNeedAComma: expressions current: e futureIndex: futureIndex commentSeries: commentSeries [
-	"handle space, comma and comment in visitExpressionList, comments only comes from inlining in an expressionList. ensure comments are not considered as element of the list and are linked to theirs respective methods. if the list contains an empty inlined method we can have a potential series of comments  that shouldn't be considered as element, hence the boolean commentSeries. Return if a comma is needed and if the comment series continue/start.
-	"
+CSlangPrettyPrinter >> expressionListNeedAComma: expressions current: currentExpression futureIndex: futureIndex commentSeries: inCommentSeries [
+	"handle space, comma and comment in visitExpressionList, comments only comes from inlining in an expressionList. ensure comments are not considered as element of the list and are linked to their respective methods. if the list contains an empty inlined method we can have a potential series of comments  that shouldn't be considered as element, hence the boolean isCommentSeries. Return if a comma is needed and if the comment series continue/start."
 
-	| next currentRequiredEndSeparator futureRequireBeginningSeparator continueCommentSeries currentIsEndComment nextIsBeginComment |
+	| nextExpression futureRequireBeginningSeparator continueCommentSeries currentExpressionIsBeginComment currentExpressionIsEndComment nextExpressionIsBeginComment |
 	futureIndex > expressions size ifTrue: [ ^ { false. false } ].
-	next := expressions at: futureIndex.
 
-	currentIsEndComment := e isComment and: [
-		                       e comment beginsWith: #' end' ].
-	nextIsBeginComment := next isComment and: [
-		                      next comment beginsWith: #' begin' ].
+	nextExpression := expressions at: futureIndex.
 
-	(currentIsEndComment and: [
-		 nextIsBeginComment and: [ commentSeries ] ]) ifTrue: [
+	currentExpressionIsEndComment := currentExpression isComment and: [
+		                                 currentExpression comment
+			                                 beginsWith: #' end' ].
+	currentExpressionIsBeginComment := currentExpression isComment and: [
+		                                   currentExpression comment
+			                                   beginsWith: #' begin' ].
+
+	nextExpressionIsBeginComment := nextExpression isComment and: [
+		                                nextExpression comment beginsWith:
+			                                #' begin' ].
+
+	(currentExpressionIsEndComment and: [
+		 nextExpressionIsBeginComment and: [ inCommentSeries ] ]) ifTrue: [
 		^ { false. true } ].
 
-	continueCommentSeries := (commentSeries and: [
-		                          e isComment and: [ next isComment ] ])
-		                         or: [ nextIsBeginComment ].
-	currentRequiredEndSeparator := e isEmpty not and: [
-		                               e isComment not or: [
-			                               currentIsEndComment ] ].
-	futureRequireBeginningSeparator := next isEmpty not and: [
-		                                   next isComment not or: [
-			                                   nextIsBeginComment and: [
+	continueCommentSeries := (inCommentSeries and: [
+		                          currentExpression isComment ]) or: [
+		                         inCommentSeries not and: [
+			                         currentExpressionIsBeginComment ] ].
+
+
+	futureRequireBeginningSeparator := nextExpression isComment not or: [
+		                                   nextExpressionIsBeginComment
+			                                   and: [
 				                                   self
 					                                   expressionListHasNonCommentStatementAfter:
 					                                   expressions
-					                                   futureIndex: futureIndex ] ] ].
+					                                   futureIndex: futureIndex ] ].
 
 	^ {
-		  (currentRequiredEndSeparator and: [
-			   futureRequireBeginningSeparator ]).
+		  (continueCommentSeries not and: [ futureRequireBeginningSeparator ]).
 		  continueCommentSeries }
 ]
 
@@ -319,11 +324,11 @@ CSlangPrettyPrinter >> visitEmptyStatement: anEmptyStatement [
 { #category : 'generated' }
 CSlangPrettyPrinter >> visitExpressionList: anExpressionList [
 
-	| needCommaAndCommentSeries futureIndex expressions commentSeries |
+	| needCommaAndCommentSeries futureIndex expressions inCommentSeries |
 	stream nextPut: $(.
 	futureIndex := 1.
 	expressions := anExpressionList expressions.
-	commentSeries := true.
+	inCommentSeries := true.
 	expressions
 		do: [ :e |
 			e acceptVisitor: self.
@@ -332,8 +337,8 @@ CSlangPrettyPrinter >> visitExpressionList: anExpressionList [
 				                             expressionListNeedAComma: expressions
 				                             current: e
 				                             futureIndex: futureIndex
-				                             commentSeries: commentSeries.
-			commentSeries := needCommaAndCommentSeries second ]
+				                             commentSeries: inCommentSeries.
+			inCommentSeries := needCommaAndCommentSeries second ]
 		separatedBy: [
 			needCommaAndCommentSeries first
 				ifFalse: [ stream nextPutAll: ' ' ]

--- a/smalltalksrc/Slang/TMethod.class.st
+++ b/smalltalksrc/Slang/TMethod.class.st
@@ -959,8 +959,8 @@ TMethod >> exitVar: exitVar label: exitLabel [
 	eliminateReturnSelfs := ((definingClass inheritsFrom: SlangClass)
 		                         and: [ definingClass isStructClass ]) not
 		                        and: [
-		                        returnType = #void or: [
-			                        returnType = #sqInt ] ].
+		                        #( #void #sqInt ) includes: returnType ].
+
 	parseTree nodesDo: [ :node |
 		| replacement |
 		node isReturn ifTrue: [
@@ -1426,26 +1426,26 @@ TMethod >> inlineFunctionCall: aSendNode in: aCodeGen [
 		1. the method arguments are all substitutable nodes, and
 		2. the method to be inlined contains no additional embedded returns."
 
-	| sel meth doNotRename argsForInlining substitutionDict |
+	| sel meth parametersToReplaceByArgument argsForInlining substitutionDict |
 	sel := aSendNode selector.
 	meth := (aCodeGen methodNamed: sel) copy.
 	meth ifNil: [ ^ self inlineBuiltin: aSendNode in: aCodeGen ].
-	doNotRename := Set withAll: args.
+	parametersToReplaceByArgument := Set withAll: args.
 	argsForInlining := aSendNode argumentsForInliningCodeGenerator:
 		                   aCodeGen.
 	meth args with: argsForInlining do: [ :argName :exprNode |
-		exprNode isLeaf ifTrue: [ doNotRename add: argName ] ].
+		exprNode isLeaf ifTrue: [ parametersToReplaceByArgument add: argName ] ].
 	(meth statements size = 2 and: [
 		 meth statements first isSend and: [
 			 meth statements first selector == #flag: ] ]) ifTrue: [
 		meth statements removeFirst ].
-	meth renameVarsForInliningInto: self except: doNotRename in: aCodeGen.
+	meth renameVarsForInliningInto: self except: parametersToReplaceByArgument in: aCodeGen.
 	meth renameLabelsForInliningInto: self.
-	self addVarsDeclarationsAndLabelsOf: meth except: doNotRename.
+	self addVarsDeclarationsAndLabelsOf: meth except: parametersToReplaceByArgument.
 	substitutionDict := Dictionary new: meth args size * 2.
 	meth args with: argsForInlining do: [ :argName :exprNode |
 		substitutionDict at: argName put: exprNode.
-		(doNotRename includes: argName) ifFalse: [
+		(parametersToReplaceByArgument includes: argName) ifFalse: [
 			self removeLocal: argName ] ].
 	meth parseTree bindVariablesIn: substitutionDict.
 	meth parseTree parent: aSendNode parent.
@@ -1472,9 +1472,9 @@ TMethod >> inlineGuardingConditional: aSendNode in: aCodeGen [
 		                   inlineFunctionCall: aSendNode receiver
 		                   in: aCodeGen.
 	map := Dictionary new.
-	(replacementTree statements last isReturn and: [ 
-		 replacementTree statements last expression value = evaluateIfTrue ]) 
-		ifTrue: [ lastNode := replacementTree statements last ].
+	(replacementTree lastNonCommentStatement isReturn and: [ 
+		 replacementTree lastNonCommentStatement expression value = evaluateIfTrue ]) 
+		ifTrue: [ lastNode := replacementTree lastNonCommentStatement ].
 	skipLabel := TLabeledCommentNode new setLabel:
 		             (self unusedLabelForInlining: method).
 	replacementTree nodesDo: [ :node | 
@@ -1552,10 +1552,10 @@ TMethod >> inlineReturningConditional: aSendNode in: aCodeGen [
 		                   in: aCodeGen.
 	map := Dictionary new.
 	"The last node is either a return or a boolean constant."
-	lastNode := replacementTree statements last.
-	replacementTree statements last isReturn
+	lastNode := replacementTree lastNonCommentStatement.
+	lastNode isReturn
 		ifTrue: [
-			replacementTree statements last expression value == returnIfTrue
+			lastNode expression value == returnIfTrue
 				ifTrue: [
 					lastNode := nil "i.e. take the fall-through path and /don't/ return" ] ]
 		ifFalse: [
@@ -1801,22 +1801,21 @@ TMethod >> isComplete [
 
 { #category : 'inlining' }
 TMethod >> isConditionalToBeTransformedForAssignment: aSend in: aCodeGen [
-
 	"Answer if a send is of the form
 		e1
 			ifTrue: [e2 ifTrue: [self m1] ifFalse: [self m2]]
 			ifFalse: [self m3]
 	 such that at least one of the sends mN may be inlined.."
 
-	^ (#( #ifTrue:ifFalse: #ifFalse:ifTrue: ) includes: aSend selector) 
-		  and: [ 
-			  aSend arguments anySatisfy: [ :arg | 
+	^ (#( #ifTrue:ifFalse: #ifFalse:ifTrue: ) includes: aSend selector)
+		  and: [
+			  aSend arguments anySatisfy: [ :arg |
 				  | stmt |
 				  self assert: arg isStatementList.
-				  arg statements size > 1 or: [ 
-					  (stmt := arg statements first) isSwitch or: [ 
-						  stmt isSend and: [ 
-							  (aCodeGen mayInline: stmt selector) or: [ 
+				  arg statements size > 1 or: [
+					  (stmt := arg firstNonCommentStatement) isSwitch or: [
+						  stmt isSend and: [
+							  (aCodeGen mayInline: stmt selector) or: [
 								  self
 									  isConditionalToBeTransformedForAssignment: stmt
 									  in: aCodeGen ] ] ] ] ] ]
@@ -2121,7 +2120,7 @@ TMethod >> mergePropertiesOfSuperMethod: superTMethod [
 TMethod >> methodIsEffectivelyComplete: selector in: aCodeGen [
 	"Answer if selector is effectively not inlineable in the receiver.
 	 This is tricky because block inlining requires that certain methods must be inlined, which
-	 can be at odds wuth the opportunistic strategy the inliner takes.  Since the inliner only
+	 can be at odds with the opportunistic strategy the inliner takes.  Since the inliner only
 	 inlines complete methods and certain methods may never be marked as complete (e.g.
 	 recursive methods) we have to short-cut certain kinds of send.  In particular, short-cut
 	 sends that turn into jumps in the interpret routine (sharedCase and sharedLabel below)."

--- a/smalltalksrc/VMMaker/AbstractComposedImageAccess.class.st
+++ b/smalltalksrc/VMMaker/AbstractComposedImageAccess.class.st
@@ -207,15 +207,17 @@ AbstractComposedImageAccess >> readLineFrom: file into: lineBuffer ofSize: buffe
 { #category : 'segments' }
 AbstractComposedImageAccess >> segmentDataFile: segmentIndex inImage: imageFileName [
 
-	<inline: true>
+	<inline: #always>
 	<var: #buffer declareC: 'char buffer[255]'>
-
 	| buffer |
-		
 	self simulationOnly: [ buffer := nil ].
-		
-	^ self segmentFileName: segmentIndex withExtension: '.data' inImage: imageFileName into: buffer bufferSize: 255.
 
+	^ self
+		  segmentFileName: segmentIndex
+		  withExtension: '.data'
+		  inImage: imageFileName
+		  into: buffer
+		  bufferSize: 255
 ]
 
 { #category : 'segments' }


### PR DESCRIPTION
fix a bug by setting inline to always in segmentDataFile: inImage: 

fix a bug discovered by the change above related to comment in expressionList beginning with an empty inlined method (simulationOnly:) + update the concerning test

small refactor of some code handling comments or referencing the old way to handle nil