### PR TITLE
Fix CASTParserTests>>#testParseSizeofTypeInt

### DIFF
--- a/smalltalksrc/CAST/CSizeofNode.class.st
+++ b/smalltalksrc/CAST/CSizeofNode.class.st
@@ -31,7 +31,7 @@ CSizeofNode >> child [
 
 { #category : 'accessing' }
 CSizeofNode >> child: anObject [
-	self assert: (anObject isExpression or: anObject isTypeNode).
+	self assert: (anObject isExpression or: [ anObject isTypeNode ]).
 	
 	child := anObject
 ]

--- a/smalltalksrc/CAST/CSizeofNode.class.st
+++ b/smalltalksrc/CAST/CSizeofNode.class.st
@@ -31,7 +31,7 @@ CSizeofNode >> child [
 
 { #category : 'accessing' }
 CSizeofNode >> child: anObject [
-	self assertExpression: anObject.
+	self assert: (anObject isExpression or: anObject isTypeNode).
 	
 	child := anObject
 ]


### PR DESCRIPTION
The `child:` setter of `CSizeofNode` expected its child to always be an expression. This is wrong, both an expression and a type node are valid arguments.