### PR TITLE
Implementation of uint8At: added, senders of byteAt: replaced with uint8At:

### DIFF
--- a/include/pharovm/common/sqMemoryAccess.h
+++ b/include/pharovm/common/sqMemoryAccess.h
@@ -161,7 +161,7 @@ typedef unsigned long long usqIntptr_t;
   static inline char *pointerForOop(usqInt oop)			{ return sqMemoryBase + oop; }
   static inline sqInt oopForPointer(void *ptr)			{ return (sqInt)(ptr - sqMemoryBase); }
 # endif
-  static inline sqInt byteAt(sqInt oop)				{ return byteAtPointer(pointerForOop(oop)); }
+  static inline sqInt uint8At(sqInt oop)				{ return byteAtPointer(pointerForOop(oop)); }
   static inline sqInt byteAtput(sqInt oop, int val)		{ return byteAtPointerput(pointerForOop(oop), val); }
   static inline sqInt shortAt(sqInt oop)			{ return shortAtPointer(pointerForOop(oop)); }
   static inline sqInt shortAtput(sqInt oop, int val)		{ return shortAtPointerput(pointerForOop(oop), val); }
@@ -239,7 +239,7 @@ typedef unsigned long long usqIntptr_t;
 #  define oopForPointer(ptr)		((sqInt)(((char *)(ptr)) - (sqMemoryBase)))
 #  define atPointerArg(oop)			sqMemoryBase + (usqInt)(oop)
 # endif
-# define byteAt(oop)				byteAtPointer(atPointerArg(oop))
+# define uint8At(oop)				byteAtPointer(atPointerArg(oop))
 # define byteAtput(oop,val)			byteAtPointerput(atPointerArg(oop), val)
 # define shortAt(oop)				shortAtPointer(atPointerArg(oop))
 # define shortAtput(oop,val)		shortAtPointerput(atPointerArg(oop), val)

--- a/smalltalksrc/Melchor/VMClass.class.st
+++ b/smalltalksrc/Melchor/VMClass.class.st
@@ -1268,6 +1268,15 @@ VMClass >> uint64AtPointer: pointer put: value [
 ]
 
 { #category : 'memory access' }
+VMClass >> uint8At: pointer [
+	"This gets implemented by Macros in C, where its types will also be checked.
+	 pointer is a raw address, and the result is an 32 bit integer."
+	<doNotGenerate>
+
+	^memoryManager readIntegerAt: pointer size: 1 signed: false
+]
+
+{ #category : 'memory access' }
 VMClass >> uint8AtPointer: pointer [
 	"This gets implemented by Macros in C, where its types will also be checked.
 	 pointer is a raw address, and the result is an 16 bit integer."

--- a/smalltalksrc/VMMaker/CoInterpreter.class.st
+++ b/smalltalksrc/VMMaker/CoInterpreter.class.st
@@ -2815,7 +2815,7 @@ CoInterpreter >> getCurrentBytecode [
 
 	^((stackPages couldBeFramePointer: framePointer)
 	   and: [(self isMachineCodeFrame: framePointer) not])
-		ifTrue: [objectMemory byteAt: instructionPointer]
+		ifTrue: [objectMemory uint8At: instructionPointer]
 		ifFalse: [-1]
 ]
 
@@ -3112,7 +3112,7 @@ CoInterpreter >> iframeBackwardBranchByte: theFP [
 	"See encodeFrameFieldHasContext:numArgs: and ifBackwardsCheckForEvents:"
 	<inline: true>
 	<var: #theFP type: #'char *'>
-	^stackPages byteAt: theFP + (VMBIGENDIAN ifTrue: [FoxIFrameFlags + objectMemory wordSize - 1] ifFalse: [FoxIFrameFlags])
+	^stackPages uint8At: theFP + (VMBIGENDIAN ifTrue: [FoxIFrameFlags + objectMemory wordSize - 1] ifFalse: [FoxIFrameFlags])
 ]
 
 { #category : 'frame access' }
@@ -3794,7 +3794,7 @@ CoInterpreter >> mnuCompilationBreak: selectorOop point: selectorLength [
 	breakSelectorLength negated = selectorLength ifTrue:
 		[i := breakSelectorLength negated.
 		 [i > 0] whileTrue:
-			[(objectMemory byteAt: selectorOop + i + objectMemory baseHeaderSize - 1) = (breakSelector at: i) asInteger
+			[(objectMemory uint8At: selectorOop + i + objectMemory baseHeaderSize - 1) = (breakSelector at: i) asInteger
 				ifTrue: [(i := i - 1) = 0 ifTrue:
 							[self mnuCompilationBreakpointFor: selectorOop]]
 				ifFalse: [i := 0]]]

--- a/smalltalksrc/VMMaker/CogIA32Compiler.class.st
+++ b/smalltalksrc/VMMaker/CogIA32Compiler.class.st
@@ -3610,7 +3610,7 @@ CogIA32Compiler >> instructionSizeAt: pc [
 	"Answer the instruction size at pc.  This is very far from a full decode.
 	 It only has to cope with the instructions generated in a block dispatch."
 	| op |
-	op := objectMemory byteAt: pc.
+	op := objectMemory uint8At: pc.
 	^op caseOf:
 		{	[16r0F]	->	[self twoByteInstructionSizeAt: pc].
 			[16r3D]	->	[5]. "cmp EAX,imm32"
@@ -3647,18 +3647,18 @@ CogIA32Compiler >> isBigEndian [
 { #category : 'testing' }
 CogIA32Compiler >> isCallPrecedingReturnPC: mcpc [
 	"Assuming mcpc is a send return pc answer if the instruction before it is a call (not a CallFull)."
-	^(objectMemory byteAt: mcpc - 5) = 16rE8
+	^(objectMemory uint8At: mcpc - 5) = 16rE8
 ]
 
 { #category : 'disassembly' }
 CogIA32Compiler >> isJumpAt: pc [
 	| op |
-	op := objectMemory byteAt: pc.
+	op := objectMemory uint8At: pc.
 	^  (op between: 16r70 and: 16r7F) "short conditional jumps"
 	or: [op = 16rE9 "long unconditional jump"
 	or: [op = 16rEB "short unconditional jump"
 	or: [op = 16r0F "long conditional jumps"
-		and: [(objectMemory byteAt: pc + 1) between: 16r80 and: 16r8F]]]]
+		and: [(objectMemory uint8At: pc + 1) between: 16r80 and: 16r8F]]]]
 ]
 
 { #category : 'testing' }
@@ -3721,14 +3721,14 @@ CogIA32Compiler >> jumpTargetPCAt: pc [
 	size := self instructionSizeAt: pc.
 	size = 2
 		ifTrue:
-			[byte := objectMemory byteAt: pc + 1.
+			[byte := objectMemory uint8At: pc + 1.
 			 offset := (byte bitAnd: 16r80) = 0 ifTrue: [byte] ifFalse: [byte - 256]]
 		ifFalse:
-			[byte := objectMemory byteAt: pc + size - 1.
+			[byte := objectMemory uint8At: pc + size - 1.
 			 offset := (byte bitAnd: 16r80) = 0 ifTrue: [byte] ifFalse: [byte - 256].
-			 offset := offset << 8 + (objectMemory byteAt: pc + size - 2).
-			 offset := offset << 8 + (objectMemory byteAt: pc + size - 3).
-			 offset := offset << 8 + (objectMemory byteAt: pc + size - 4)].
+			 offset := offset << 8 + (objectMemory uint8At: pc + size - 2).
+			 offset := offset << 8 + (objectMemory uint8At: pc + size - 3).
+			 offset := offset << 8 + (objectMemory uint8At: pc + size - 4)].
 	^pc + size + offset
 ]
 
@@ -3744,10 +3744,10 @@ CogIA32Compiler >> leafCallStackPointerDelta [
 { #category : 'inline cacheing' }
 CogIA32Compiler >> literalBeforeFollowingAddress: followingAddress [
 	"Answer the literal embedded in the instruction immediately preceding followingAddress."
-	^  ((objectMemory byteAt: followingAddress - 1) << 24)
-	+  ((objectMemory byteAt: followingAddress - 2) << 16)
-	+  ((objectMemory byteAt: followingAddress - 3) << 8)
-	+   (objectMemory byteAt: followingAddress - 4)
+	^  ((objectMemory uint8At: followingAddress - 1) << 24)
+	+  ((objectMemory uint8At: followingAddress - 2) << 16)
+	+  ((objectMemory uint8At: followingAddress - 3) << 8)
+	+   (objectMemory uint8At: followingAddress - 4)
 ]
 
 { #category : 'inline cacheing' }
@@ -3854,10 +3854,10 @@ CogIA32Compiler >> prepareStackToCallCFunctionInSmalltalkStack: numberOfArgument
 CogIA32Compiler >> relocateCallBeforeReturnPC: retpc by: delta [
 	| distance |
 	delta ~= 0 ifTrue:
-		[distance :=    ((objectMemory byteAt: retpc - 1) << 24)
-					+  ((objectMemory byteAt: retpc - 2) << 16)
-					+  ((objectMemory byteAt: retpc - 3) << 8)
-					+   (objectMemory byteAt: retpc - 4).
+		[distance :=    ((objectMemory uint8At: retpc - 1) << 24)
+					+  ((objectMemory uint8At: retpc - 2) << 16)
+					+  ((objectMemory uint8At: retpc - 3) << 8)
+					+   (objectMemory uint8At: retpc - 4).
 		 distance := distance + delta.
 		 objectMemory
 			byteAt: retpc - 1 put: (distance >> 24 bitAnd: 16rFF);
@@ -4023,7 +4023,7 @@ CogIA32Compiler >> shiftSetsConditionCodesFor: aConditionalJumpOpcode [
 { #category : 'disassembly' }
 CogIA32Compiler >> sizeHasModrm: op at: pc [
 	| modrm mod ro rm |
-	modrm := objectMemory byteAt: pc + 1.
+	modrm := objectMemory uint8At: pc + 1.
 	mod := modrm >> 6.
 	ro := modrm >> 3 bitAnd: 7.
 	rm := modrm bitAnd: 7.
@@ -4044,7 +4044,7 @@ CogIA32Compiler >> sizeHasModrm: op at: pc [
 CogIA32Compiler >> sizeImmediateGroup1: op at: pc [
 	"see [1] p A-7, p A-13"
 	| modrm mod ro rm |
-	modrm := objectMemory byteAt: pc + 1.
+	modrm := objectMemory uint8At: pc + 1.
 	mod := modrm >> 6.
 	ro := modrm >> 3 bitAnd: 7.
 	rm := modrm bitAnd: 7.
@@ -4162,14 +4162,14 @@ CogIA32Compiler >> storeLiteral: literal beforeFollowingAddress: followingAddres
 { #category : 'disassembly' }
 CogIA32Compiler >> twoByteInstructionSizeAt: pc [
 	| op |
-	op := objectMemory byteAt: pc + 1. 
+	op := objectMemory uint8At: pc + 1. 
 	^(op bitAnd: 16rF0) caseOf:
 		{	[16r80]	->	[6 "long conditional jumps"] }
 ]
 
 { #category : 'accessing' }
 CogIA32Compiler >> unsignedShortAt: byteAddress [
-	^(objectMemory byteAt: byteAddress) + ((objectMemory byteAt: byteAddress + 1) bitShift: 8)
+	^(objectMemory uint8At: byteAddress) + ((objectMemory uint8At: byteAddress + 1) bitShift: 8)
 ]
 
 { #category : 'inline cacheing' }

--- a/smalltalksrc/VMMaker/CogInLineLiteralsARMCompiler.class.st
+++ b/smalltalksrc/VMMaker/CogInLineLiteralsARMCompiler.class.st
@@ -33,10 +33,10 @@ CogInLineLiteralsARMCompiler >> cogit: aCogit [
 { #category : 'testing' }
 CogInLineLiteralsARMCompiler >> extract32BitOperandFrom4InstructionsPreceding: addr [
 	<inline: true>
-	^(objectMemory byteAt: addr -4) 
-	 + ((objectMemory byteAt: addr - 8) << 8) 
-	 + ((objectMemory byteAt: addr - 12) << 16) 
-	 + ((objectMemory byteAt: addr - 16) << 24)
+	^(objectMemory uint8At: addr -4) 
+	 + ((objectMemory uint8At: addr - 8) << 8) 
+	 + ((objectMemory uint8At: addr - 12) << 16) 
+	 + ((objectMemory uint8At: addr - 16) << 24)
 ]
 
 { #category : 'accessing' }

--- a/smalltalksrc/VMMaker/CogInLineLiteralsX64Compiler.class.st
+++ b/smalltalksrc/VMMaker/CogInLineLiteralsX64Compiler.class.st
@@ -193,7 +193,7 @@ CogInLineLiteralsX64Compiler >> literalBeforeFollowingAddress: followingAddress 
 	 a (self mod: ModReg RM: rX RO: rY) ending the ArithCwR sequence, which is at least 16rC0."
 
 	| lastByte base |
-	lastByte := objectMemory byteAt: followingAddress - 1.
+	lastByte := objectMemory uint8At: followingAddress - 1.
 	base := followingAddress - (lastByte = 16r90
 		         ifTrue: [ "MoveCwR" 9 ]
 		         ifFalse: [
@@ -284,7 +284,7 @@ CogInLineLiteralsX64Compiler >> storeLiteral: literal beforeFollowingAddress: fo
 	 nop following the literal load in MoveCwR, a 16r50 + reg ending the PushCw sequence, and
 	 a (self mod: ModReg RM: rX RO: rY) ending the CmpCwR sequence, which is at least 16rC0."
 	| lastByte base |
-	lastByte := objectMemory byteAt: followingAddress - 1.
+	lastByte := objectMemory uint8At: followingAddress - 1.
 	base := followingAddress - (lastByte <= 16r90
 									ifTrue:
 										[lastByte = 16r90

--- a/smalltalksrc/VMMaker/CogVMSimulator.class.st
+++ b/smalltalksrc/VMMaker/CogVMSimulator.class.st
@@ -291,13 +291,6 @@ CogVMSimulator >> breakCount [
 ]
 
 { #category : 'memory access' }
-CogVMSimulator >> byteAt: byteAddress [
-	"This is really only for the C library simulations memcpy:_:_: et al in VMClass.
-	 Use objectMemory byteAt: directly where possible."
-	^objectMemory byteAt: byteAddress
-]
-
-{ #category : 'memory access' }
 CogVMSimulator >> byteAt: byteAddress put: byte [
 	^objectMemory byteAt: byteAddress put: byte
 ]
@@ -572,7 +565,7 @@ CogVMSimulator >> expectSends: anArray [
 
 { #category : 'interpreter shell' }
 CogVMSimulator >> fetchByte [
-	^objectMemory byteAt: (instructionPointer := instructionPointer + 1)
+	^objectMemory uint8At: (instructionPointer := instructionPointer + 1)
 ]
 
 { #category : 'interpreter access' }
@@ -687,7 +680,7 @@ CogVMSimulator >> imageNamePut: p Length: sz [
 	1 to: sz do: [ :i | 
 		newName
 			at: i
-			put: (Character value: (objectMemory byteAt: p + i - 1)) ].
+			put: (Character value: (objectMemory uint8At: p + i - 1)) ].
 	imageName := newName
 ]
 

--- a/smalltalksrc/VMMaker/CogX64Compiler.class.st
+++ b/smalltalksrc/VMMaker/CogX64Compiler.class.st
@@ -433,6 +433,13 @@ CogX64Compiler >> canZeroExtend [
 	^true
 ]
 
+{ #category : 'testing' }
+CogX64Compiler >> checkIs32bit: offset [
+
+	(offset between: -2147483648 and: 2147483647) ifFalse: [
+		self error: 'Cannot jump to distances larger than 32 bits' ]
+]
+
 { #category : 'accessing' }
 CogX64Compiler >> cmpC32RTempByteSize [
 	^5
@@ -4238,7 +4245,7 @@ CogX64Compiler >> instructionSizeAt: pc [
 	 to decode the jumps in block dispatch to discover where block methods
 	 occur within a larger method.   This is very far from a full decode."
 	| op |
-	op := objectMemory byteAt: pc.
+	op := objectMemory uint8At: pc.
 	(op bitAnd: 16rF8) = 16r48 ifTrue:
 		[^1 + (self instructionSizeAt: pc + 1)].
 	^op caseOf:
@@ -4277,13 +4284,6 @@ CogX64Compiler >> is32BitSignedImmediate: a64BitUnsignedOperand [
 ]
 
 { #category : 'testing' }
-CogX64Compiler >> checkIs32bit: offset [
-
-	(offset between: -2147483648 and: 2147483647) ifFalse: [
-		self error: 'Cannot jump to distances larger than 32 bits' ]
-]
-
-{ #category : 'testing' }
 CogX64Compiler >> isAddressRelativeToVarBase: varAddress [
 	"Support for addressing variables off the dedicated VarBaseReg.  Allow for 1Mb of variables.
 	 The x64 supports 32-bit offsets, but we choose not to address everything from VarBaseReg."
@@ -4304,22 +4304,22 @@ CogX64Compiler >> isBigEndian [
 { #category : 'testing' }
 CogX64Compiler >> isCallPrecedingReturnPC: mcpc [
 	"Assuming mcpc is a send return pc answer if the instruction before it is a call (not a CallFull)."
-	^(objectMemory byteAt: mcpc - 5) = 16rE8
+	^(objectMemory uint8At: mcpc - 5) = 16rE8
 ]
 
 { #category : 'disassembly' }
 CogX64Compiler >> isJumpAt: pc [
 	| op |
-	op := objectMemory byteAt: pc.
+	op := objectMemory uint8At: pc.
 	^  (op between: 16r70 and: 16r7F) "short conditional jumps"
 	or: [op = 16rE9 "long unconditional jump"
 	or: [op = 16rEB "short unconditional jump"
 	or: [(op = 16r0F "long conditional jumps"
-		and: [(objectMemory byteAt: pc + 1) between: 16r80 and: 16r8F])
+		and: [(objectMemory uint8At: pc + 1) between: 16r80 and: 16r8F])
 	or: [op = 16r48 "full unconditional jumps"
-		and: [(objectMemory byteAt: pc + 1) = 16rA1
-		and: [(objectMemory byteAt: pc + 10) = 16rFF
-		and: [(objectMemory byteAt: pc + 11) = 16rE0]]]]]]]
+		and: [(objectMemory uint8At: pc + 1) = 16rA1
+		and: [(objectMemory uint8At: pc + 10) = 16rFF
+		and: [(objectMemory uint8At: pc + 11) = 16rE0]]]]]]]
 ]
 
 { #category : 'testing' }
@@ -4382,14 +4382,14 @@ CogX64Compiler >> jumpTargetPCAt: pc [
 	size := self instructionSizeAt: pc.
 	size = 2
 		ifTrue:
-			[byte := objectMemory byteAt: pc + 1.
+			[byte := objectMemory uint8At: pc + 1.
 			 offset := (byte bitAnd: 16r80) = 0 ifTrue: [byte] ifFalse: [byte - 256]]
 		ifFalse:
-			[byte := objectMemory byteAt: pc + size - 1.
+			[byte := objectMemory uint8At: pc + size - 1.
 			 offset := (byte bitAnd: 16r80) = 0 ifTrue: [byte] ifFalse: [byte - 256].
-			 offset := offset << 8 + (objectMemory byteAt: pc + size - 2).
-			 offset := offset << 8 + (objectMemory byteAt: pc + size - 3).
-			 offset := offset << 8 + (objectMemory byteAt: pc + size - 4)].
+			 offset := offset << 8 + (objectMemory uint8At: pc + size - 2).
+			 offset := offset << 8 + (objectMemory uint8At: pc + size - 3).
+			 offset := offset << 8 + (objectMemory uint8At: pc + size - 4)].
 	^pc + size + offset
 ]
 
@@ -4507,10 +4507,10 @@ CogX64Compiler >> pushCwByteSize [
 CogX64Compiler >> relocateCallBeforeReturnPC: retpc by: delta [
 	| distance |
 	delta ~= 0 ifTrue:
-		[distance :=    ((objectMemory byteAt: retpc - 1) << 24)
-					+  ((objectMemory byteAt: retpc - 2) << 16)
-					+  ((objectMemory byteAt: retpc - 3) << 8)
-					+   (objectMemory byteAt: retpc - 4).
+		[distance :=    ((objectMemory uint8At: retpc - 1) << 24)
+					+  ((objectMemory uint8At: retpc - 2) << 16)
+					+  ((objectMemory uint8At: retpc - 3) << 8)
+					+   (objectMemory uint8At: retpc - 4).
 		 distance := distance + delta.
 		 objectMemory
 			byteAt: retpc - 1 put: (distance >> 24 bitAnd: 16rFF);
@@ -4525,10 +4525,10 @@ CogX64Compiler >> relocateMethodReferenceBeforeAddress: pc by: delta [
 	 Simply check that rip-relative addressing is being used. c.f.
 	 concretizeMoveCwR"
 	<inline: true>
-	self assert: (((objectMemory byteAt: pc - 6) = 16r8D "move"
-				and: [((objectMemory byteAt: pc - 5) bitOr: (self mod: 0 RM: 0 RO: 7)) = (self mod: ModRegInd RM: 5 RO: 7)])
-				or: [(objectMemory byteAt: pc - 8) = 16r8D "push"
-				and: [((objectMemory byteAt: pc - 7) bitOr: (self mod: 0 RM: 0 RO: 7)) = (self mod: ModRegInd RM: 5 RO: 7)]])
+	self assert: (((objectMemory uint8At: pc - 6) = 16r8D "move"
+				and: [((objectMemory uint8At: pc - 5) bitOr: (self mod: 0 RM: 0 RO: 7)) = (self mod: ModRegInd RM: 5 RO: 7)])
+				or: [(objectMemory uint8At: pc - 8) = 16r8D "push"
+				and: [((objectMemory uint8At: pc - 7) bitOr: (self mod: 0 RM: 0 RO: 7)) = (self mod: ModRegInd RM: 5 RO: 7)]])
 ]
 
 { #category : 'calling C function in Smalltalk stack' }
@@ -4587,7 +4587,7 @@ CogX64Compiler >> rewriteCallFullAt: callSiteReturnAddress target: callTargetAdd
 	 On x64 this is a rewrite of
 		movq #64bits, %rax : 48 A1 b0 b1 b2 b3 b4 b5 b6 b7
 		jmp %rax : FF E0 "
-	self assert: (objectMemory byteAt: callSiteReturnAddress - 12) = 16r48.
+	self assert: (objectMemory uint8At: callSiteReturnAddress - 12) = 16r48.
 	objectMemory unalignedLongAt: callSiteReturnAddress - 10 put: callTargetAddress.
 	self assert: (self callFullTargetFromReturnAddress: callSiteReturnAddress) signedIntToLong64 = callTargetAddress.
 	"self cCode: ''
@@ -4714,7 +4714,7 @@ CogX64Compiler >> sixtyFourBitLiteralBefore: followingAddress [
 { #category : 'disassembly' }
 CogX64Compiler >> sizeHasModrm: op at: pc [
 	| modrm mod ro rm |
-	modrm := objectMemory byteAt: pc + 1.
+	modrm := objectMemory uint8At: pc + 1.
 	mod := modrm >> 6.
 	ro := modrm >> 3 bitAnd: 7.
 	rm := modrm bitAnd: 7.
@@ -4735,7 +4735,7 @@ CogX64Compiler >> sizeHasModrm: op at: pc [
 CogX64Compiler >> sizeImmediateGroup1: op at: pc [
 	"see [1] p A-7, p A-13"
 	| modrm mod ro rm |
-	modrm := objectMemory byteAt: pc + 1.
+	modrm := objectMemory uint8At: pc + 1.
 	mod := modrm >> 6.
 	ro := modrm >> 3 bitAnd: 7.
 	rm := modrm bitAnd: 7.
@@ -4794,7 +4794,7 @@ CogX64Compiler >> storeLiteral32: literal beforeFollowingAddress: followingAddre
 { #category : 'disassembly' }
 CogX64Compiler >> twoByteInstructionSizeAt: pc [
 	| op |
-	op := objectMemory byteAt: pc + 1. 
+	op := objectMemory uint8At: pc + 1. 
 	^(op bitAnd: 16rF0) caseOf:
 		{	[16r80]	->	[6 "long conditional jumps"] }
 ]
@@ -4813,10 +4813,10 @@ CogX64Compiler >> unalignedLong32At: byteAddress [
 				_: (self sizeof: readValue).
 			^ readValue ]
 		inSmalltalk: [
-			^ (objectMemory byteAt: byteAddress + 3) << 24
-			  + ((objectMemory byteAt: byteAddress + 2) << 16)
-			  + ((objectMemory byteAt: byteAddress + 1) << 8)
-			  + (objectMemory byteAt: byteAddress) ]
+			^ (objectMemory uint8At: byteAddress + 3) << 24
+			  + ((objectMemory uint8At: byteAddress + 2) << 16)
+			  + ((objectMemory uint8At: byteAddress + 1) << 8)
+			  + (objectMemory uint8At: byteAddress) ]
 ]
 
 { #category : 'memory access' }

--- a/smalltalksrc/VMMaker/Cogit.class.st
+++ b/smalltalksrc/VMMaker/Cogit.class.st
@@ -3183,10 +3183,10 @@ Cogit >> annotationForMcpc: mcpc in: cogHomeMethod [
 	mapLocation := self findMapLocationForMcpc: mcpc inMethod: cogHomeMethod.
 	mapLocation = 0 ifTrue:
 		[^0].
-	mapByte := objectMemory byteAt: mapLocation.
+	mapByte := objectMemory uint8At: mapLocation.
 	annotation := mapByte >> AnnotationShift.
 	annotation = IsSendCall ifTrue:
-		[mapByte := objectMemory byteAt: mapLocation - 1.
+		[mapByte := objectMemory uint8At: mapLocation - 1.
 		 mapByte >> AnnotationShift = IsAnnotationExtension ifTrue:
 			[annotation := annotation + (mapByte bitAnd: DisplacementMask)]].
 	^annotation
@@ -6279,7 +6279,7 @@ Cogit >> findMapLocationForMcpc: targetMcpc inMethod: cogMethod [
 	mcpc := self firstMappedPCFor: cogMethod.
 	map := self mapStartFor: cogMethod.
 	mcpc = targetMcpc ifTrue: [^map].
-	[(mapByte := objectMemory byteAt: map) ~= MapEnd] whileTrue:
+	[(mapByte := objectMemory uint8At: map) ~= MapEnd] whileTrue:
 		[annotation := mapByte >> AnnotationShift.
 		 annotation ~= IsAnnotationExtension ifTrue:
 			[mcpc := mcpc + (backEnd codeGranularity
@@ -6290,7 +6290,7 @@ Cogit >> findMapLocationForMcpc: targetMcpc inMethod: cogMethod [
 			[self assert: mcpc = targetMcpc.
 			 annotation = IsDisplacementX2N ifTrue:
 				[map := map - 1.
-				 mapByte := objectMemory byteAt: map.
+				 mapByte := objectMemory uint8At: map.
 				 annotation := mapByte >> AnnotationShift.
 				 self assert: annotation > IsAnnotationExtension].
 			 ^map].
@@ -8855,7 +8855,7 @@ Cogit >> mapEndFor: cogMethod [
 	<inline: true>
 	| end |
 	end := self mapStartFor: cogMethod.
-	[(objectMemory byteAt: end) ~= MapEnd] whileTrue:
+	[(objectMemory uint8At: end) ~= MapEnd] whileTrue:
 		[end := end - 1.
 		 self assert: end > (self firstMappedPCFor: cogMethod)].
 	^end
@@ -8897,7 +8897,7 @@ Cogit >> mapFor: cogMethod bcpc: startbcpc performUntil: functionSymbol arg: arg
 	 homeMethod := self cCoerceSimple: cogMethod to: #'CogMethod *'.
 	 self assert: startbcpc = (coInterpreter startPCOfMethodHeader: homeMethod methodHeader).
 	 map := self mapStartFor: homeMethod.
-	 annotation := (objectMemory byteAt: map) >> AnnotationShift.
+	 annotation := (objectMemory uint8At: map) >> AnnotationShift.
 	 self assert: (annotation = IsAbsPCReference
 				 or: [annotation = IsObjectReference
 				 or: [annotation = IsRelativeCall
@@ -8913,10 +8913,10 @@ Cogit >> mapFor: cogMethod bcpc: startbcpc performUntil: functionSymbol arg: arg
 	self inlineCacheTagsAreIndexes ifTrue:
 		[enumeratingCogMethod := homeMethod].
 	"Now skip up through the bytecode pc map entry for the stack check." 
-	[(objectMemory byteAt: map) >> AnnotationShift ~= HasBytecodePC] whileTrue:
+	[(objectMemory uint8At: map) >> AnnotationShift ~= HasBytecodePC] whileTrue:
 		[map := map - 1].
 	map := map - 1.
-	[(mapByte := objectMemory byteAt: map) ~= MapEnd] whileTrue: "defensive; we exit on bcpc"
+	[(mapByte := objectMemory uint8At: map) ~= MapEnd] whileTrue: "defensive; we exit on bcpc"
 		[mapByte >= FirstAnnotation
 			ifTrue:
 				[| nextBcpc isBackwardBranch |
@@ -8924,7 +8924,7 @@ Cogit >> mapFor: cogMethod bcpc: startbcpc performUntil: functionSymbol arg: arg
 				mcpc := mcpc + ((mapByte bitAnd: DisplacementMask) * backEnd codeGranularity).
 				(self isPCMappedAnnotation: annotation) ifTrue:
 					[(annotation = IsSendCall
-					  and: [(mapByte := objectMemory byteAt: map - 1) >> AnnotationShift = IsAnnotationExtension]) ifTrue:
+					  and: [(mapByte := objectMemory uint8At: map - 1) >> AnnotationShift = IsAnnotationExtension]) ifTrue:
 						[annotation := annotation + (mapByte bitAnd: DisplacementMask).
 						 map := map - 1].
 					 [byte := objectMemory fetchByte: bcpc ofObject: aMethodObj.
@@ -8977,7 +8977,7 @@ Cogit >> mapFor: cogMethod performAllMapEntriesUntil: functionSymbol arg: arg [
 	| mcpc map mapByte result |
 	mcpc := self firstMappedPCFor: cogMethod.
 	map := self mapStartFor: cogMethod.
-	[(mapByte := objectMemory byteAt: map) ~= MapEnd] whileTrue:
+	[(mapByte := objectMemory uint8At: map) ~= MapEnd] whileTrue:
 		[mapByte >= FirstAnnotation
 			ifTrue:
 				[mcpc := mcpc + ((mapByte bitAnd: DisplacementMask) * backEnd codeGranularity)]
@@ -9005,13 +9005,13 @@ Cogit >> mapFor: cogMethod performUntil: functionSymbol arg: arg [
 	map := self mapStartFor: cogMethod.
 	self inlineCacheTagsAreIndexes ifTrue:
 		[enumeratingCogMethod := cogMethod].
-	[(mapByte := objectMemory byteAt: map) ~= MapEnd] whileTrue:
+	[(mapByte := objectMemory uint8At: map) ~= MapEnd] whileTrue:
 		[mapByte >= FirstAnnotation
 			ifTrue:
 				[mcpc := mcpc + ((mapByte bitAnd: DisplacementMask) * backEnd codeGranularity).
 				 "If this is an IsSendCall annotation, peek ahead for an IsAnnotationExtension, and consume it."
 				 ((annotation := mapByte >> AnnotationShift) = IsSendCall
-				  and: [(mapByte := objectMemory byteAt: map - 1) >> AnnotationShift = IsAnnotationExtension]) ifTrue:
+				  and: [(mapByte := objectMemory uint8At: map - 1) >> AnnotationShift = IsAnnotationExtension]) ifTrue:
 					[annotation := annotation + (mapByte bitAnd: DisplacementMask).
 					 map := map - 1].
 				 result := self perform: functionSymbol
@@ -10375,7 +10375,7 @@ Cogit >> printPCMapPairsFor: cogMethod [
 	| mcpc map mapByte annotation value |
 	mcpc := self firstMappedPCFor: cogMethod.
 	map := self mapStartFor: cogMethod.
-	[ (mapByte := objectMemory byteAt: map) ~= MapEnd ] whileTrue: [
+	[ (mapByte := objectMemory uint8At: map) ~= MapEnd ] whileTrue: [
 		annotation := mapByte >> AnnotationShift.
 		annotation = IsAnnotationExtension
 			ifTrue: [ value := (mapByte bitAnd: DisplacementMask) + IsSendCall ]
@@ -10443,7 +10443,7 @@ Cogit >> printPCMapPairsFor: cogMethod on: aStream [
 	| mcpc map mapByte annotation |
 	mcpc := self firstMappedPCFor: cogMethod.
 	map := self mapStartFor: cogMethod.
-	[(mapByte := objectMemory byteAt: map) ~= MapEnd] whileTrue:
+	[(mapByte := objectMemory uint8At: map) ~= MapEnd] whileTrue:
 		[annotation := mapByte >> AnnotationShift.
 		 annotation ~= IsAnnotationExtension ifTrue:
 			[mcpc := mcpc + (backEnd codeGranularity

--- a/smalltalksrc/VMMaker/FilePluginSimulator.class.st
+++ b/smalltalksrc/VMMaker/FilePluginSimulator.class.st
@@ -257,11 +257,11 @@ FilePluginSimulator >> sqFile: file Write: count From: byteArrayIndexArg At: sta
 	file isBinary
 		ifTrue:
 			[startIndex to: startIndex + count - 1 do:
-				[ :i | file nextPut: (interpreterProxy byteAt: byteArrayIndex + i)]]
+				[ :i | file nextPut: (interpreterProxy uint8At: byteArrayIndex + i)]]
 		ifFalse:
 			[startIndex to: startIndex + count - 1 do:
 				[ :i | | byte |
-				byte := interpreterProxy byteAt: byteArrayIndex + i.
+				byte := interpreterProxy uint8At: byteArrayIndex + i.
 				file nextPut: (Character value: (byte == 12 "lf" ifTrue: [15"cr"] ifFalse: [byte]))]].
 	self recordStateOf: file.
 	^count

--- a/smalltalksrc/VMMaker/Integer.extension.st
+++ b/smalltalksrc/VMMaker/Integer.extension.st
@@ -264,7 +264,7 @@ Integer >> signedIntFromLong [
 	(self >= -1073741824 and: [self <= 1073741823]) ifTrue: "These are known to be SmallIntegers..."
 		[^self].
 	bits := self bitAnd: 16rFFFFFFFF.
-	(bits byteAt: 4) <= 16r7F ifTrue: [^bits].
+	(bits uint8At: 4) <= 16r7F ifTrue: [^bits].
 	^bits - 16r100000000
 ]
 
@@ -277,7 +277,7 @@ Integer >> signedIntFromLong64 [
 	"(self >= -1073741824 and: [self <= 1073741823]) ifTrue:
 		[^self]."
 	bits := self bitAnd: 16rFFFFFFFFFFFFFFFF.
-	(bits byteAt: 8) <= 16r7F ifTrue: [^bits].
+	(bits uint8At: 8) <= 16r7F ifTrue: [^bits].
 	^bits - 16r10000000000000000
 ]
 

--- a/smalltalksrc/VMMaker/InterpreterProxy.class.st
+++ b/smalltalksrc/VMMaker/InterpreterProxy.class.st
@@ -63,18 +63,8 @@ InterpreterProxy >> booleanValueOf: obj [
 ]
 
 { #category : 'private' }
-InterpreterProxy >> byteAt: accessor [
-	^accessor byteAt: 0
-]
-
-{ #category : 'private' }
 InterpreterProxy >> byteAt: accessor put: value [
 	^accessor byteAt: 0 put: value
-]
-
-{ #category : 'private' }
-InterpreterProxy >> byteAtPointer: accessor [
-	^ self byteAt: accessor
 ]
 
 { #category : 'object access' }

--- a/smalltalksrc/VMMaker/Spur32BitMMLECoSimulator.class.st
+++ b/smalltalksrc/VMMaker/Spur32BitMMLECoSimulator.class.st
@@ -48,7 +48,7 @@ Spur32BitMMLECoSimulator >> byteAtPointer: pointer [
 	"This gets implemented by Macros in C, where its types will also be checked.
 	 pointer is a raw address."
 
-	^self byteAt: pointer
+	^self uint8At: pointer
 ]
 
 { #category : 'memory access' }

--- a/smalltalksrc/VMMaker/Spur32BitMMLESimulator.class.st
+++ b/smalltalksrc/VMMaker/Spur32BitMMLESimulator.class.st
@@ -48,7 +48,7 @@ Spur32BitMMLESimulator >> byteAtPointer: pointer [
 	"This gets implemented by Macros in C, where its types will also be checked.
 	 pointer is a raw address."
 
-	^self byteAt: pointer
+	^self uint8At: pointer
 ]
 
 { #category : 'memory access' }

--- a/smalltalksrc/VMMaker/Spur64BitMMLECoSimulator.class.st
+++ b/smalltalksrc/VMMaker/Spur64BitMMLECoSimulator.class.st
@@ -44,7 +44,7 @@ Spur64BitMMLECoSimulator >> byteAtPointer: pointer [
 	"This gets implemented by Macros in C, where its types will also be checked.
 	 pointer is a raw address."
 
-	^self byteAt: pointer
+	^self uint8At: pointer
 ]
 
 { #category : 'memory access' }

--- a/smalltalksrc/VMMaker/Spur64BitMMLESimulator.class.st
+++ b/smalltalksrc/VMMaker/Spur64BitMMLESimulator.class.st
@@ -48,7 +48,7 @@ Spur64BitMMLESimulator >> byteAtPointer: pointer [
 	"This gets implemented by Macros in C, where its types will also be checked.
 	 pointer is a raw address."
 
-	^self byteAt: pointer
+	^self uint8At: pointer
 ]
 
 { #category : 'memory access' }

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -5074,7 +5074,7 @@ SpurMemoryManager >> falseObject: anOop [
 { #category : 'object access' }
 SpurMemoryManager >> fetchByte: byteIndex ofObject: objOop [
 	<api>
-	^self byteAt: objOop + self baseHeaderSize + byteIndex
+	^self uint8At: objOop + self baseHeaderSize + byteIndex
 ]
 
 { #category : 'object access' }
@@ -11457,7 +11457,7 @@ SpurMemoryManager >> rawNumSlotsOf: objOop [
 	<returnTypeC: #usqInt>
 	<inline: true>
 	self flag: #endian.
-	^self byteAt: objOop + 7
+	^self uint8At: objOop + 7
 ]
 
 { #category : 'object access' }

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -6684,7 +6684,7 @@ StackInterpreter >> frameNumArgs: theFP [
 	"See encodeFrameFieldHasContext:numArgs:"
 	<inline: true>
 	<var: #theFP type: #'char *'>
-	^stackPages byteAt: theFP + FoxIFrameFlags + 1
+	^stackPages uint8At: theFP + FoxIFrameFlags + 1
 ]
 
 { #category : 'frame access' }
@@ -6934,7 +6934,7 @@ StackInterpreter >> getCogVMFlags [
 StackInterpreter >> getCurrentBytecode [
 	"currentBytecode will be private to the main dispatch loop in the generated code. This method allows the currentBytecode to be retrieved from global variables."
 
-	^objectMemory byteAt: instructionPointer
+	^objectMemory uint8At: instructionPointer
 ]
 
 { #category : 'internal interpreter access' }
@@ -7341,7 +7341,7 @@ StackInterpreter >> iframeHasContext: theFP [
 	"See encodeFrameFieldHasContext:numArgs:"
 	<inline: true>
 	<var: #theFP type: #'char *'>
-	^(stackPages byteAt: theFP + FoxIFrameFlags + 2) ~= 0
+	^(stackPages uint8At: theFP + FoxIFrameFlags + 2) ~= 0
 ]
 
 { #category : 'frame access' }
@@ -7356,7 +7356,7 @@ StackInterpreter >> iframeInstructionPointerForIndex: ip method: aMethod [
 StackInterpreter >> iframeIsBlockActivation: theFP [ "<Integer>"
 	<inline: true>
 	<var: #theFP type: #'char *'>
-	^(stackPages byteAt: theFP + FoxIFrameFlags + 3) ~= 0
+	^(stackPages uint8At: theFP + FoxIFrameFlags + 3) ~= 0
 ]
 
 { #category : 'frame access' }
@@ -7372,7 +7372,7 @@ StackInterpreter >> iframeNumArgs: theFP [
 	"See encodeFrameFieldHasContext:numArgs:"
 	<inline: true>
 	<var: #theFP type: #'char *'>
-	^stackPages byteAt: theFP + FoxIFrameFlags + 1
+	^stackPages uint8At: theFP + FoxIFrameFlags + 1
 ]
 
 { #category : 'frame access' }
@@ -7912,9 +7912,9 @@ StackInterpreter >> ioLoadExternalFunction: functionName OfLength: functionLengt
 	<doNotGenerate>
 	| pluginString functionString |
 	pluginString := String new: moduleLength.
-	1 to: moduleLength do:[:i| pluginString byteAt: i put: (objectMemory byteAt: moduleName+i-1)].
+	1 to: moduleLength do:[:i| pluginString byteAt: i put: (objectMemory uint8At: moduleName+i-1)].
 	functionString := String new: functionLength.
-	1 to: functionLength do:[:i| functionString byteAt: i put: (objectMemory byteAt: functionName+i-1)].
+	1 to: functionLength do:[:i| functionString byteAt: i put: (objectMemory uint8At: functionName+i-1)].
 	^self ioLoadFunction: functionString From: pluginString
 ]
 
@@ -7925,9 +7925,9 @@ StackInterpreter >> ioLoadExternalFunction: functionName OfLength: functionLengt
 	<doNotGenerate>
 	| pluginString functionString |
 	pluginString := String new: moduleLength.
-	(1 to: moduleLength) do:[:i| pluginString byteAt: i put: (objectMemory byteAt: moduleName+i-1)].
+	(1 to: moduleLength) do:[:i| pluginString byteAt: i put: (objectMemory uint8At: moduleName+i-1)].
 	functionString := String new: functionLength.
-	(1 to: functionLength) do:[:i| functionString byteAt: i put: (objectMemory byteAt: functionName+i-1)].
+	(1 to: functionLength) do:[:i| functionString byteAt: i put: (objectMemory uint8At: functionName+i-1)].
 	"We used to ignore loads of the SqueakFFIPrims plugin, but that means doing without integerAt:[put:]size:signed:
 	 which is too much of a limitation (not that these simulate unaligned accesses yet)."
 	
@@ -10965,8 +10965,8 @@ StackInterpreter >> primitiveIndexOfMethod: theMethod header: methodHeader [
 			  firstBytecode := self
 				                   firstBytecodeOfAlternateHeader: methodHeader
 				                   method: theMethod.
-			  (objectMemory byteAt: firstBytecode + 1)
-			  + ((objectMemory byteAt: firstBytecode + 2) << 8) ]
+			  (objectMemory uint8At: firstBytecode + 1)
+			  + ((objectMemory uint8At: firstBytecode + 2) << 8) ]
 		  ifFalse: [ 0 ]
 ]
 
@@ -12969,10 +12969,10 @@ StackInterpreter >> reapAndResetErrorCodeTo: theFP header: methodHeader [
 	self assert: primFailCode ~= 0.
 	initialPC := (self initialIPForHeader: methodHeader method: newMethod)
 	             + (self sizeOfCallPrimitiveBytecode: methodHeader).
-	(objectMemory byteAt: initialPC)
+	(objectMemory uint8At: initialPC)
 	= (self longStoreBytecodeForHeader: methodHeader) ifTrue: [ 
 		| temporaryIndex |
-		temporaryIndex := objectMemory byteAt: initialPC + 1.
+		temporaryIndex := objectMemory uint8At: initialPC + 1.
 		self
 			temporary: temporaryIndex
 			in: theFP
@@ -13416,7 +13416,7 @@ StackInterpreter >> sendBreak: selectorString point: selectorLength receiver: re
 	breakSelectorLength = selectorLength ifTrue:
 		[i := breakSelectorLength.
 		 [i > 0] whileTrue:
-			[(objectMemory byteAt: selectorString + i - 1) = (breakSelector at: i) asInteger
+			[(objectMemory uint8At: selectorString + i - 1) = (breakSelector at: i) asInteger
 				ifTrue: [(i := i - 1) = 0 ifTrue:
 							[self changed: #byteCountText.
 							 self halt: 'Send of '

--- a/smalltalksrc/VMMaker/StackInterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreterPrimitives.class.st
@@ -1267,7 +1267,7 @@ StackInterpreterPrimitives >> primitiveFFIIntegerAt [
 	byteSize <= 2
 		ifTrue:
 			[byteSize = 1
-				ifTrue: [value := self cCoerce: (objectMemory byteAt: addr) to: #'unsigned char']
+				ifTrue: [value := self cCoerce: (objectMemory uint8At: addr) to: #'unsigned char']
 				ifFalse: [value := self cCoerce: (objectMemory unalignedShortAt: addr) to: #'unsigned short']]
 		ifFalse:
 			[byteSize = 4

--- a/smalltalksrc/VMMaker/StackInterpreterSimulator.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreterSimulator.class.st
@@ -247,13 +247,6 @@ StackInterpreterSimulator >> breakCount [
 	^breakCount
 ]
 
-{ #category : 'memory access' }
-StackInterpreterSimulator >> byteAt: byteAddress [
-	"This is really only for the C library simulations memcpy:_:_: et al in VMClass.
-	 Use objectMemory byteAt: directly where possible."
-	^objectMemory byteAt: byteAddress
-]
-
 { #category : 'debug support' }
 StackInterpreterSimulator >> byteCount [
 	"So you can call this from temp debug statements in, eg, Interpreter, such as
@@ -525,7 +518,7 @@ StackInterpreterSimulator >> endPCOf: aMethod [
 
 { #category : 'interpreter shell' }
 StackInterpreterSimulator >> fetchByte [
-	^objectMemory byteAt: (instructionPointer := instructionPointer + 1).
+	^objectMemory uint8At: (instructionPointer := instructionPointer + 1).
 ]
 
 { #category : 'memory access' }
@@ -611,7 +604,7 @@ StackInterpreterSimulator >> imageNamePut: p Length: sz [
 	1 to: sz do: [ :i | 
 		newName
 			at: i
-			put: (Character value: (objectMemory byteAt: p + i - 1)) ].
+			put: (Character value: (objectMemory uint8At: p + i - 1)) ].
 	imageName := newName
 ]
 

--- a/smalltalksrc/VMMaker/VMStackPagesLSB.class.st
+++ b/smalltalksrc/VMMaker/VMStackPagesLSB.class.st
@@ -11,3 +11,9 @@ VMStackPagesLSB >> byteAt: byteAddress put: byte [
 
 	^ objectMemory byteAt: byteAddress put: byte
 ]
+
+{ #category : 'memory access' }
+VMStackPagesLSB >> uint8At: anAddress [
+
+	^ objectMemory uint8At: anAddress
+]

--- a/smalltalksrc/VMMaker/VMStackPagesLSB.class.st
+++ b/smalltalksrc/VMMaker/VMStackPagesLSB.class.st
@@ -7,12 +7,6 @@ Class {
 }
 
 { #category : 'memory access' }
-VMStackPagesLSB >> byteAt: byteAddress [
-
-	^ objectMemory byteAt: byteAddress
-]
-
-{ #category : 'memory access' }
 VMStackPagesLSB >> byteAt: byteAddress put: byte [
 
 	^ objectMemory byteAt: byteAddress put: byte

--- a/smalltalksrc/VMMakerTests/MethodBuilderTest.class.st
+++ b/smalltalksrc/VMMakerTests/MethodBuilderTest.class.st
@@ -53,7 +53,7 @@ MethodBuilderTest >> testBytecodeAtForMethodWithNoLiteral [
 
 	bytecodeAddress := methodBuilder bytecodeAt: 1 forMethod: method.
 	
-	self assert: (memory byteAt: bytecodeAddress) equals: 1
+	self assert: (memory uint8At: bytecodeAddress) equals: 1
 ]
 
 { #category : 'running' }
@@ -68,7 +68,7 @@ MethodBuilderTest >> testBytecodeAtForMethodWithOneLiteral [
 
 	bytecodeAddress := methodBuilder bytecodeAt: 1 forMethod: method.
 
-	self assert: (memory byteAt: bytecodeAddress) equals: 1
+	self assert: (memory uint8At: bytecodeAddress) equals: 1
 ]
 
 { #category : 'running' }
@@ -83,7 +83,7 @@ MethodBuilderTest >> testBytecodeAtForMethodWithTwoLiteral [
 
 	bytecodeAddress := methodBuilder bytecodeAt: 1 forMethod: method.
 
-	self assert: (memory byteAt: bytecodeAddress) equals: 1
+	self assert: (memory uint8At: bytecodeAddress) equals: 1
 ]
 
 { #category : 'running' }
@@ -143,5 +143,5 @@ MethodBuilderTest >> testSecondBytecodeAtForMethodWithOneLiteral [
 
 	bytecodeAddress := methodBuilder bytecodeAt: 2 forMethod: method.
 
-	self assert: (memory byteAt: bytecodeAddress) equals: 2
+	self assert: (memory uint8At: bytecodeAddress) equals: 2
 ]

--- a/smalltalksrc/VMMakerTests/VMFFIArgumentMarshallingTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMFFIArgumentMarshallingTest.class.st
@@ -40,7 +40,7 @@ VMFFIArgumentMarshallingTest >> newLargeIntegerForValue: aValue [
 		memory
 			storeByte: i
 			ofObject: newLargeInteger
-			withValue: (aValue byteAt: i + 1) ].
+			withValue: (aValue uint8At: i + 1) ].
 	^ newLargeInteger
 ]
 
@@ -217,7 +217,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithSINT64ArgumentWithLargePositiveHi
 							numSlots: (aValue size / memory bytesPerOop) ceiling asInteger.
 
 	0 to: 8 do: [ :i | 
-		memory storeByte: i ofObject: newLargeInteger withValue: (aValue byteAt: i + 1) ].
+		memory storeByte: i ofObject: newLargeInteger withValue: (aValue uint8At: i + 1) ].
 
 	self
 		doTestFuntionWithArgumentType: interpreter libFFI sint64
@@ -429,7 +429,7 @@ VMFFIArgumentMarshallingTest >> testCalloutWithUINT64ArgumentWithLargePositiveHi
 							numSlots: (aValue size / memory bytesPerOop) ceiling asInteger.
 
 	0 to: 8 do: [ :i | 
-		memory storeByte: i ofObject: newLargeInteger withValue: (aValue byteAt: i + 1) ].
+		memory storeByte: i ofObject: newLargeInteger withValue: (aValue uint8At: i + 1) ].
 
 	self
 		doTestFuntionWithArgumentType: interpreter libFFI uint64


### PR DESCRIPTION
fixes #406 

It is a partial fix to this issue. This covers byte reads. A separate pull request will cover other data types.
