### PR TITLE
Fix Issue 982 - Pharo 10 branch

### DIFF
--- a/cmake/DownloadProject.CMakeLists.cmake.in
+++ b/cmake/DownloadProject.CMakeLists.cmake.in
@@ -1,7 +1,7 @@
 # Distributed under the OSI-approved MIT License.  See accompanying
 # file LICENSE or https://github.com/Crascit/DownloadProject for details.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.7)
 
 project(${DL_ARGS_PROJ}-download NONE)
 

--- a/smalltalksrc/VMMaker-Tools/Integer.extension.st
+++ b/smalltalksrc/VMMaker-Tools/Integer.extension.st
@@ -1,18 +1,18 @@
-Extension { #name : #Integer }
+Extension { #name : 'Integer' }
 
-{ #category : #'*VMMaker-Tools' }
+{ #category : '*VMMaker-Tools' }
 Integer >> aarch64Disassembled [
 	
 	^ self disassembleWith: LLVMARMDisassembler aarch64
 ]
 
-{ #category : #'*VMMaker-Tools' }
+{ #category : '*VMMaker-Tools' }
 Integer >> armv7Disassembled [
 	
 	^ self disassembleWith: LLVMARMDisassembler armv7
 ]
 
-{ #category : #'*VMMaker-Tools' }
+{ #category : '*VMMaker-Tools' }
 Integer >> disassembleWith: aLLVMDisassembler [ 
 	
 	"Create a byte array big enough to encode the instruction"

--- a/smalltalksrc/VMMaker-Tools/SpurMemoryManager.extension.st
+++ b/smalltalksrc/VMMaker-Tools/SpurMemoryManager.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #SpurMemoryManager }
+Extension { #name : 'SpurMemoryManager' }
 
-{ #category : #'*VMMaker-Tools' }
+{ #category : '*VMMaker-Tools' }
 SpurMemoryManager >> asVMOop: oop [
 	<doNotGenerate>
 
@@ -10,7 +10,7 @@ SpurMemoryManager >> asVMOop: oop [
 		yourself.
 ]
 
-{ #category : #'*VMMaker-Tools' }
+{ #category : '*VMMaker-Tools' }
 SpurMemoryManager >> inspectorEntities: composite [
 
 	<inspectorPresentationOrder: 2 title: 'Entities'>
@@ -41,7 +41,7 @@ SpurMemoryManager >> inspectorEntities: composite [
 
 ]
 
-{ #category : #'*VMMaker-Tools' }
+{ #category : '*VMMaker-Tools' }
 SpurMemoryManager >> inspectorFreeListIn: composite [
 
 	<inspectorPresentationOrder: 0 title: 'Free Lists'>
@@ -54,7 +54,7 @@ SpurMemoryManager >> inspectorFreeListIn: composite [
 
 ]
 
-{ #category : #'*VMMaker-Tools' }
+{ #category : '*VMMaker-Tools' }
 SpurMemoryManager >> inspectorHiddenRootsIn: composite [
 
 	<inspectorPresentationOrder: 0 title: 'HiddenRoots'>
@@ -67,7 +67,7 @@ SpurMemoryManager >> inspectorHiddenRootsIn: composite [
 
 ]
 
-{ #category : #'*VMMaker-Tools' }
+{ #category : '*VMMaker-Tools' }
 SpurMemoryManager >> inspectorOldSpaceEntities: composite [
 
 	<inspectorPresentationOrder: 3 title: 'Old Space Entities'>

--- a/smalltalksrc/VMMaker-Tools/StackInterpreter.extension.st
+++ b/smalltalksrc/VMMaker-Tools/StackInterpreter.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #StackInterpreter }
+Extension { #name : 'StackInterpreter' }
 
-{ #category : #'*VMMaker-Tools' }
+{ #category : '*VMMaker-Tools' }
 StackInterpreter >> stack [
 
 	framePointer = nil

--- a/smalltalksrc/VMMaker-Tools/TParseNode.extension.st
+++ b/smalltalksrc/VMMaker-Tools/TParseNode.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #TParseNode }
+Extension { #name : 'TParseNode' }
 
-{ #category : #'*VMMaker-Tools' }
+{ #category : '*VMMaker-Tools' }
 TParseNode >> inspectionTree [
 	<inspectorPresentationOrder: 35 title: 'Tree'>
 

--- a/smalltalksrc/VMMaker-Tools/VMBytecodeToIRMapping.class.st
+++ b/smalltalksrc/VMMaker-Tools/VMBytecodeToIRMapping.class.st
@@ -1,40 +1,41 @@
 Class {
-	#name : #VMBytecodeToIRMapping,
-	#superclass : #Object,
+	#name : 'VMBytecodeToIRMapping',
+	#superclass : 'Object',
 	#instVars : [
 		'bytecodeInstruction',
 		'irInstruction'
 	],
-	#category : #'VMMaker-Tools'
+	#category : 'VMMaker-Tools',
+	#package : 'VMMaker-Tools'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMBytecodeToIRMapping >> bytecodeInstruction [
 	^ bytecodeInstruction
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMBytecodeToIRMapping >> bytecodeInstruction: anObject [
 	bytecodeInstruction := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMBytecodeToIRMapping >> bytecodeString [
 	
 	^ bytecodeInstruction asString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMBytecodeToIRMapping >> irInstruction [
 	^ irInstruction
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMBytecodeToIRMapping >> irInstruction: anObject [
 	irInstruction := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMBytecodeToIRMapping >> irString [
 	
 	irInstruction ifNil: [ ^ '' ].

--- a/smalltalksrc/VMMaker-Tools/VMDebugger.class.st
+++ b/smalltalksrc/VMMaker-Tools/VMDebugger.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #VMDebugger,
-	#superclass : #SpPresenter,
+	#name : 'VMDebugger',
+	#superclass : 'SpPresenter',
 	#instVars : [
 		'virtualMachine',
 		'cogit',
@@ -13,10 +13,11 @@ Class {
 		'stack',
 		'frameContainer'
 	],
-	#category : #'VMMaker-Tools'
+	#category : 'VMMaker-Tools',
+	#package : 'VMMaker-Tools'
 }
 
-{ #category : #specs }
+{ #category : 'specs' }
 VMDebugger class >> defaultSpec [
 
 	^ SpBoxLayout newHorizontal
@@ -27,7 +28,7 @@ VMDebugger class >> defaultSpec [
 		yourself
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMDebugger class >> openOn: aVirtualMachine [
 
 	self new
@@ -35,17 +36,17 @@ VMDebugger class >> openOn: aVirtualMachine [
 		openWithSpec.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMDebugger >> cogit [
 	^ cogit
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMDebugger >> cogit: anObject [
 	cogit := anObject
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 VMDebugger >> connectPresenters [
 
 	| instructionsContextMenu |
@@ -73,14 +74,14 @@ VMDebugger >> connectPresenters [
 	instructions contextMenu: instructionsContextMenu
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 VMDebugger >> disassembleAtPC [
 
 	self initialInstructionToDisassemble:  machineSimulator instructionPointerRegisterValue.
 	self refreshInstructions.
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 VMDebugger >> initialDisassembly [
 
 	^ machineSimulator disassembler
@@ -94,26 +95,26 @@ VMDebugger >> initialDisassembly [
 		pc: machineSimulator instructionPointerRegisterValue 
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 VMDebugger >> initialExtent [ 
 
 	^ 1000@1000
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 VMDebugger >> initialInstructionToDisassemble [
 
 	^ initialInstructionToDisassemble
 		ifNil: [ machineSimulator instructionPointerRegisterValue ]
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 VMDebugger >> initialInstructionToDisassemble: anInstructionAddress [
 
 	initialInstructionToDisassemble := anInstructionAddress
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 VMDebugger >> initializePresenters [
 
 	machineState := self newTable.
@@ -150,17 +151,17 @@ VMDebugger >> initializePresenters [
 	disassembleAtPCButton label: 'Disassemble at PC'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMDebugger >> machineSimulator [
 	^ machineSimulator
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMDebugger >> machineSimulator: anObject [
 	machineSimulator := anObject
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 VMDebugger >> openWithSpec [
 
 "	self refreshRegisters.
@@ -170,25 +171,25 @@ VMDebugger >> openWithSpec [
 	super openWithSpec.
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 VMDebugger >> refreshInstructions [
 
 	instructions items: self initialDisassembly
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 VMDebugger >> refreshRegisters [
 
 	machineState items: machineSimulator registerDescriptors
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 VMDebugger >> refreshStack [
 
 	stack items: virtualMachine stack
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMDebugger >> runToSelectedInstruction [
 	
 	| selectedInstruction |
@@ -203,25 +204,25 @@ VMDebugger >> runToSelectedInstruction [
 	self refreshStack.
 ]
 
-{ #category : #events }
+{ #category : 'events' }
 VMDebugger >> selectFrame: aVMStackFrame [ 
 	
 	frameContainer text: aVMStackFrame sourceCode
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMDebugger >> selectedInstruction [
 
 	^ instructions selection selectedItem
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 VMDebugger >> setInstructionPointerToSelectedInstruction [
 	
 	machineSimulator instructionPointerRegisterValue: instructions selection selectedItem address
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 VMDebugger >> step [
 
 	machineSimulator step.
@@ -229,12 +230,12 @@ VMDebugger >> step [
 	self refreshRegisters
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMDebugger >> virtualMachine [
 	^ virtualMachine
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMDebugger >> virtualMachine: anObject [
 	virtualMachine := anObject
 ]

--- a/smalltalksrc/VMMaker-Tools/VMMachineCodeDebugger.class.st
+++ b/smalltalksrc/VMMaker-Tools/VMMachineCodeDebugger.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #VMMachineCodeDebugger,
-	#superclass : #SpPresenter,
+	#name : 'VMMachineCodeDebugger',
+	#superclass : 'SpPresenter',
 	#instVars : [
 		'cogit',
 		'machineSimulator',
@@ -15,10 +15,11 @@ Class {
 		'jumpToButton',
 		'abstractInstructions'
 	],
-	#category : #'VMMaker-Tools'
+	#category : 'VMMaker-Tools',
+	#package : 'VMMaker-Tools'
 }
 
-{ #category : #layout }
+{ #category : 'layout' }
 VMMachineCodeDebugger class >> defaultLayout [
 
 	^  SpBoxLayout newVertical
@@ -41,13 +42,13 @@ VMMachineCodeDebugger class >> defaultLayout [
 		yourself
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMMachineCodeDebugger class >> openOnCogit: aCogit [
 
 	self openOnCogit: aCogit ip: aCogit processor machineSimulator pc
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 VMMachineCodeDebugger class >> openOnCogit: aCogit ip: anInstructionPointer [
 
 	self new
@@ -57,29 +58,29 @@ VMMachineCodeDebugger class >> openOnCogit: aCogit ip: anInstructionPointer [
 		openWithSpec.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebugger >> abstractInstructions [
 
 	^ abstractInstructions
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebugger >> abstractInstructions: aCollection [
 
 	^ abstractInstructions := aCollection
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebugger >> cogit [
 	^ cogit
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebugger >> cogit: anObject [
 	cogit := anObject
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 VMMachineCodeDebugger >> connectButtons [
 
 	stepButton action: [ self step ].
@@ -87,7 +88,7 @@ VMMachineCodeDebugger >> connectButtons [
 	jumpToButton action: [ self jump ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 VMMachineCodeDebugger >> connectIRInstructionsPresenter [
 
 	|  irinstructionsContextMenu |
@@ -105,7 +106,7 @@ VMMachineCodeDebugger >> connectIRInstructionsPresenter [
 	irinstructions contextMenu: irinstructionsContextMenu
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 VMMachineCodeDebugger >> connectInstructionsPresenter [
 
 	| instructionsContextMenu |
@@ -133,7 +134,7 @@ VMMachineCodeDebugger >> connectInstructionsPresenter [
 	instructions contextMenu: instructionsContextMenu
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 VMMachineCodeDebugger >> connectMachineStatePresenter [
 
 	| contextMenu |
@@ -162,7 +163,7 @@ VMMachineCodeDebugger >> connectMachineStatePresenter [
 
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 VMMachineCodeDebugger >> connectPresenters [
 
 	self connectButtons.
@@ -171,14 +172,14 @@ VMMachineCodeDebugger >> connectPresenters [
 	self connectMachineStatePresenter
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 VMMachineCodeDebugger >> disassembleAtPC [
 
 	self initialInstructionToDisassemble:  machineSimulator instructionPointerRegisterValue.
 	self refreshInstructions.
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 VMMachineCodeDebugger >> doInitialDisassemble [
 
 	^ machineSimulator disassembler
@@ -192,7 +193,7 @@ VMMachineCodeDebugger >> doInitialDisassemble [
 		pc: machineSimulator instructionPointerRegisterValue
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 VMMachineCodeDebugger >> highlightMCInstructions: aVMDebuggerIRInstruction [
 
 	"Extract the machine code instructions from the IR instruction"
@@ -208,16 +209,16 @@ VMMachineCodeDebugger >> highlightMCInstructions: aVMDebuggerIRInstruction [
 
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 VMMachineCodeDebugger >> highlightPCInstruction [
 
 	| index |
-	index :=	(self initialDisassembly collect: [ :e | e address ]) indexOf: machineSimulator instructionPointerValue.
+	index :=	(self initialDisassembly collect: [ :e | e address ]) indexOf: machineSimulator instructionPointerRegisterValue.
 	instructions selection selectIndex: index
 
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 VMMachineCodeDebugger >> highlightRegisters: aVMDebuggerInstruction [
 
 	"Extract registers name from instruction assembly and highlight the corresponding lines"
@@ -232,7 +233,7 @@ VMMachineCodeDebugger >> highlightRegisters: aVMDebuggerInstruction [
 
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 VMMachineCodeDebugger >> highlightSelectedIRInstructionMCInstructions [
 
 	self selectedIRInstruction
@@ -241,14 +242,14 @@ VMMachineCodeDebugger >> highlightSelectedIRInstructionMCInstructions [
 
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 VMMachineCodeDebugger >> highlightSelectedInstructionRegisters [
 
 	self selectedInstruction ifNotNil: [
 		self highlightRegisters: self selectedInstruction ]
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 VMMachineCodeDebugger >> initialDisassembly [
 
 	^ self doInitialDisassemble collect: [ :anInstruction |
@@ -260,13 +261,13 @@ VMMachineCodeDebugger >> initialDisassembly [
 				yourself ]
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 VMMachineCodeDebugger >> initialExtent [
 
 	^ 1000@600
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 VMMachineCodeDebugger >> initialIRDisassembly [
 
 	^ self abstractInstructions collect: [ :anInstruction | VMMachineCodeDebuggerIRInstruction new
@@ -277,20 +278,20 @@ VMMachineCodeDebugger >> initialIRDisassembly [
 				yourself ]
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 VMMachineCodeDebugger >> initialInstructionToDisassemble [
 
 	^ initialInstructionToDisassemble
 		ifNil: [ machineSimulator instructionPointerRegisterValue ]
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 VMMachineCodeDebugger >> initialInstructionToDisassemble: anInstructionAddress [
 
 	initialInstructionToDisassemble := anInstructionAddress
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 VMMachineCodeDebugger >> initializeButtons [
 
 	stepButton := self newButton.
@@ -302,7 +303,7 @@ VMMachineCodeDebugger >> initializeButtons [
 	jumpToButton label: 'Jump to'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 VMMachineCodeDebugger >> initializeIRInstructionsPresenter [
 
 	irinstructions := self newTable.
@@ -336,7 +337,7 @@ VMMachineCodeDebugger >> initializeIRInstructionsPresenter [
 		whenSelectionChangedDo: [ self highlightSelectedIRInstructionMCInstructions ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 VMMachineCodeDebugger >> initializeInstructionsPresenter [
 
 	instructions := self newTable.
@@ -362,7 +363,7 @@ VMMachineCodeDebugger >> initializeInstructionsPresenter [
 		whenSelectionChangedDo: [ self highlightSelectedInstructionRegisters ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 VMMachineCodeDebugger >> initializeMachineStatePresenter [
 
 
@@ -382,7 +383,7 @@ VMMachineCodeDebugger >> initializeMachineStatePresenter [
 			evaluated: [ :register | register printString ])
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 VMMachineCodeDebugger >> initializePresenters [
 
 	self initializeIRInstructionsPresenter.
@@ -392,7 +393,7 @@ VMMachineCodeDebugger >> initializePresenters [
 	self initializeButtons
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 VMMachineCodeDebugger >> initializeStackPresenter [
 
 	stack := self newTable.
@@ -410,24 +411,24 @@ VMMachineCodeDebugger >> initializeStackPresenter [
 						 do: [ 'Error' ] ])
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 VMMachineCodeDebugger >> inspectSelectedIRInstruction [
 
 	irinstructions selection selectedItem inspect
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 VMMachineCodeDebugger >> inspectSelectedInstruction [
 
 	instructions selection selectedItem inspect
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebugger >> irinstructions: aCollection [
 	irinstructions := aCollection
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 VMMachineCodeDebugger >> jump [
 
 	machineSimulator instructionPointerRegisterValue: (NumberParser parse: ipInput text).
@@ -435,24 +436,24 @@ VMMachineCodeDebugger >> jump [
 	self refreshRegisters.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebugger >> machineSimulator [
 	^ machineSimulator
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebugger >> machineSimulator: anObject [
 	machineSimulator := anObject
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 VMMachineCodeDebugger >> openWithSpec [
 
 	self refreshAll.
 	super open
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 VMMachineCodeDebugger >> refreshAll [
 
 	self refreshIRInstructions.
@@ -461,31 +462,31 @@ VMMachineCodeDebugger >> refreshAll [
 	self refreshRegisters.
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 VMMachineCodeDebugger >> refreshIRInstructions [
 
 	irinstructions items: self initialIRDisassembly
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 VMMachineCodeDebugger >> refreshInstructions [
 
 	instructions items: self initialDisassembly
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 VMMachineCodeDebugger >> refreshRegisters [
 
 	machineState items: machineSimulator registerDescriptors
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 VMMachineCodeDebugger >> refreshStack [
 
 	stack items: machineSimulator stackValues
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 VMMachineCodeDebugger >> runToSelectedInstruction [
 
 	| selectedInstruction |
@@ -500,25 +501,25 @@ VMMachineCodeDebugger >> runToSelectedInstruction [
 	self refreshStack.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebugger >> selectedIRInstruction [
 
 	^ irinstructions selection selectedItem
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebugger >> selectedInstruction [
 
 	^ instructions selection selectedItem
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 VMMachineCodeDebugger >> setInstructionPointerToSelectedInstruction [	
 
   machineSimulator instructionPointerRegisterValue: instructions selection selectedItem address
 ]
 
-{ #category : #actions }
+{ #category : 'actions' }
 VMMachineCodeDebugger >> step [
 
 	machineSimulator step.
@@ -526,7 +527,7 @@ VMMachineCodeDebugger >> step [
 	self highlightPCInstruction
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebugger >> title [
    
 	^ 'VM Debugger'

--- a/smalltalksrc/VMMaker-Tools/VMMachineCodeDebuggerIRInstruction.class.st
+++ b/smalltalksrc/VMMaker-Tools/VMMachineCodeDebuggerIRInstruction.class.st
@@ -1,47 +1,48 @@
 Class {
-	#name : #VMMachineCodeDebuggerIRInstruction,
-	#superclass : #Object,
+	#name : 'VMMachineCodeDebuggerIRInstruction',
+	#superclass : 'Object',
 	#instVars : [
 		'irinstruction',
 		'machineSimulator',
 		'debugger',
 		'operands'
 	],
-	#category : #'VMMaker-Tools'
+	#category : 'VMMaker-Tools',
+	#package : 'VMMaker-Tools'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebuggerIRInstruction >> address [ 
 
 	^ irinstruction address
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebuggerIRInstruction >> addressString [
 
 	^ irinstruction address hex
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebuggerIRInstruction >> debugger: aVMMachineCodeDebugger [
 
 	debugger:= aVMMachineCodeDebugger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebuggerIRInstruction >> initialize [ 
 
 	super initialize.
 	operands := Array ofSize: 4.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebuggerIRInstruction >> irinstruction: aCogAbstractInstruction [
 
 	irinstruction := aCogAbstractInstruction
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebuggerIRInstruction >> machineCodeInstructionsAddresses [ 
 
 	| startAddress endAddress |	
@@ -50,48 +51,48 @@ VMMachineCodeDebuggerIRInstruction >> machineCodeInstructionsAddresses [
 	^ (startAddress to: endAddress by: 4) collect: [ :address |  address ].
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebuggerIRInstruction >> machineCodeSize [ 
 
 	^ irinstruction machineCodeSize
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebuggerIRInstruction >> machineSimulator: aMachineSimulator [ 
 
 	machineSimulator := aMachineSimulator 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebuggerIRInstruction >> opCodeName [ 
 
 	^ irinstruction class nameForOpcode: irinstruction opcode
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebuggerIRInstruction >> operand1 [ 
 
 	^ operands at: 1
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebuggerIRInstruction >> operand2 [
 
 	^ operands at: 2
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebuggerIRInstruction >> operand3 [
 
 	^ operands at: 3
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebuggerIRInstruction >> operands [
 	^ operands
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebuggerIRInstruction >> processOperands [ 
 
 	| format strOperands |

--- a/smalltalksrc/VMMaker-Tools/VMMachineCodeDebuggerInstruction.class.st
+++ b/smalltalksrc/VMMaker-Tools/VMMachineCodeDebuggerInstruction.class.st
@@ -1,45 +1,46 @@
 Class {
-	#name : #VMMachineCodeDebuggerInstruction,
-	#superclass : #Object,
+	#name : 'VMMachineCodeDebuggerInstruction',
+	#superclass : 'Object',
 	#instVars : [
 		'instruction',
 		'bytes',
 		'machineSimulator',
 		'debugger'
 	],
-	#category : #'VMMaker-Tools'
+	#category : 'VMMaker-Tools',
+	#package : 'VMMaker-Tools'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebuggerInstruction >> address [
 	
 	^ instruction address
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 VMMachineCodeDebuggerInstruction >> addressString [
 	
 	^ instruction address hex
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 VMMachineCodeDebuggerInstruction >> assemblyCodeString [
 
 	^ instruction assemblyCodeString 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebuggerInstruction >> branchTargetAddress [
 	
 	^ instruction branchTargetAddress
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebuggerInstruction >> bytes: aByteArray [ 
 	bytes := aByteArray
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 VMMachineCodeDebuggerInstruction >> bytesString [
 
 	^ String streamContents: [ :aStream |
@@ -52,13 +53,13 @@ VMMachineCodeDebuggerInstruction >> bytesString [
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebuggerInstruction >> debugger: aVMMachineCodeDebugger [ 
 	
 	debugger := aVMMachineCodeDebugger
 ]
 
-{ #category : #showing }
+{ #category : 'showing' }
 VMMachineCodeDebuggerInstruction >> icon [
 
 	self address = machineSimulator instructionPointerRegisterValue 
@@ -72,23 +73,23 @@ VMMachineCodeDebuggerInstruction >> icon [
 	^ nil
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebuggerInstruction >> instruction: aLLVMInstruction [ 
 	instruction := aLLVMInstruction
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebuggerInstruction >> machineSimulator [ 
 
 	^ machineSimulator
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebuggerInstruction >> machineSimulator: aProcessorSimulator [ 
 	machineSimulator := aProcessorSimulator
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebuggerInstruction >> usedRegisters [
 	"Detect any register name from an asm instruction"
 

--- a/smalltalksrc/VMMaker-Tools/VMMachineCodeDebuggerStackItem.class.st
+++ b/smalltalksrc/VMMaker-Tools/VMMachineCodeDebuggerStackItem.class.st
@@ -1,14 +1,15 @@
 Class {
-	#name : #VMMachineCodeDebuggerStackItem,
-	#superclass : #Object,
+	#name : 'VMMachineCodeDebuggerStackItem',
+	#superclass : 'Object',
 	#instVars : [
 		'address',
 		'machineSimulator'
 	],
-	#category : #'VMMaker-Tools'
+	#category : 'VMMaker-Tools',
+	#package : 'VMMaker-Tools'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 VMMachineCodeDebuggerStackItem class >> address: anInteger on: machineSimulator [ 
 	
 	^ self new
@@ -17,22 +18,22 @@ VMMachineCodeDebuggerStackItem class >> address: anInteger on: machineSimulator 
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebuggerStackItem >> address [
 	^ address
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebuggerStackItem >> address: anInteger [ 
 	address := anInteger
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMachineCodeDebuggerStackItem >> machineSimulator: anUnicornARMv8Simulator [ 
 	machineSimulator := anUnicornARMv8Simulator
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 VMMachineCodeDebuggerStackItem >> specialRegister [
 
 	machineSimulator smalltalkStackPointerRegisterValue = address ifTrue: [ ^ 'SP' ].
@@ -40,7 +41,7 @@ VMMachineCodeDebuggerStackItem >> specialRegister [
 	^ ''
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 VMMachineCodeDebuggerStackItem >> value [ 
 
 	^ machineSimulator wordAt: address

--- a/smalltalksrc/VMMaker-Tools/VMMethodBytecodeToIRMapping.class.st
+++ b/smalltalksrc/VMMaker-Tools/VMMethodBytecodeToIRMapping.class.st
@@ -1,15 +1,16 @@
 Class {
-	#name : #VMMethodBytecodeToIRMapping,
-	#superclass : #Object,
+	#name : 'VMMethodBytecodeToIRMapping',
+	#superclass : 'Object',
 	#instVars : [
 		'method',
 		'ir',
 		'mappingList'
 	],
-	#category : #'VMMaker-Tools'
+	#category : 'VMMaker-Tools',
+	#package : 'VMMaker-Tools'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 VMMethodBytecodeToIRMapping class >> on: aMethod [
 
 	^ self new
@@ -17,7 +18,7 @@ VMMethodBytecodeToIRMapping class >> on: aMethod [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMethodBytecodeToIRMapping >> computeIR [
 
 	| coggedResult cogit |
@@ -33,7 +34,7 @@ VMMethodBytecodeToIRMapping >> computeIR [
 	^ ir := (0 to: cogit getOpcodeIndex - 1) collect: [ :i | cogit abstractOpcodes at: i ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMethodBytecodeToIRMapping >> gtInspectorMappingIn: composite [
 	<gtInspectorPresentationOrder: 0>
 	^ composite fastTable
@@ -43,12 +44,12 @@ VMMethodBytecodeToIRMapping >> gtInspectorMappingIn: composite [
 		column: 'IR' evaluated: [ :aMapping | aMapping irString ]	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMethodBytecodeToIRMapping >> ir [
 	^ ir ifNil: [ self computeIR ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMethodBytecodeToIRMapping >> mappingList [
 	
 	| irStream mappings |
@@ -71,7 +72,7 @@ VMMethodBytecodeToIRMapping >> mappingList [
 	^ mappingList := mappings
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMMethodBytecodeToIRMapping >> method: aMethod [
 
 	method := aMethod

--- a/smalltalksrc/VMMaker-Tools/VMOop.class.st
+++ b/smalltalksrc/VMMaker-Tools/VMOop.class.st
@@ -7,30 +7,31 @@ They obviously *should not* be used for implementing runtime behavior.
 VMOops are also indented to be robust and capable of dealing with corrupted things (because we rarely debug uncorrupted memory), or during low-level operations (durring GC for instance).
 "
 Class {
-	#name : #VMOop,
-	#superclass : #Object,
+	#name : 'VMOop',
+	#superclass : 'Object',
 	#instVars : [
 		'oop',
 		'memory'
 	],
-	#category : #'VMMaker-Tools'
+	#category : 'VMMaker-Tools',
+	#package : 'VMMaker-Tools'
 }
 
-{ #category : #'object access' }
+{ #category : 'object access' }
 VMOop >> bytes [
 
 	self ifBroken: [ ^ nil ].
 	^ memory bytesInObject: oop
 ]
 
-{ #category : #'object access' }
+{ #category : 'object access' }
 VMOop >> classIndex [
 
 	self ifBroken: [ ^ nil ].
 	^ memory classIndexOf: oop
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 VMOop >> flags [
 
 	self ifBroken: [ ^ 'broken' ].
@@ -41,7 +42,7 @@ VMOop >> flags [
 			 ((memory isRemembered: oop) ifTrue: ['r'] ifFalse: ['.'])
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 VMOop >> format [
 
 	self ifBroken: [ ^ 'broken' ].
@@ -51,64 +52,64 @@ VMOop >> format [
 
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 VMOop >> ifBroken: aBlock [
 
 	^ self isBroken ifTrue: aBlock.
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 VMOop >> isBroken [
 
 	oop ifNil: [ ^true ].
 	^ (memory memoryManager isValidAddress: oop) not.
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 VMOop >> label [
 
 	self ifBroken: [ ^ 'broken' ].
 	^ memory labelOfOop: oop
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMOop >> memory [
 
 	^ memory
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMOop >> memory: anObject [
 
 	memory := anObject
 ]
 
-{ #category : #'object access' }
+{ #category : 'object access' }
 VMOop >> numSlots [
 
 	self ifBroken: [ ^ nil ].
 	^ memory numSlotsOfAny: oop
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMOop >> oop [
 
 	^ oop
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMOop >> oop: anObject [
 
 	oop := anObject
 ]
 
-{ #category : #'object access' }
+{ #category : 'object access' }
 VMOop >> pointer: idx [
 
 	^ memory asVMOop: (self rawPointer: idx)
 ]
 
-{ #category : #'object access' }
+{ #category : 'object access' }
 VMOop >> pointers [
 
 	"Return a collection of all pointed `VMOop` (in slots)"
@@ -120,20 +121,20 @@ VMOop >> pointers [
 	^ (1 to: n) collect: [ :i | self pointer: i-1 ].
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 VMOop >> printOn: aStream [
 
 	^ aStream print: oop
 ]
 
-{ #category : #'object access' }
+{ #category : 'object access' }
 VMOop >> rawNumSlots [
 
 	self ifBroken: [ ^ nil ].
 	^ memory rawNumSlotsOf: oop
 ]
 
-{ #category : #'object access' }
+{ #category : 'object access' }
 VMOop >> rawPointer: idx [
 
 	"0 based pointer, as a classic integer oop"
@@ -146,7 +147,7 @@ VMOop >> rawPointer: idx [
 
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 VMOop >> type [
 
 	self ifBroken: [ ^ 'broken' ].

--- a/smalltalksrc/VMMaker-Tools/VMTFreeListNode.class.st
+++ b/smalltalksrc/VMMaker-Tools/VMTFreeListNode.class.st
@@ -1,14 +1,15 @@
 Class {
-	#name : #VMTFreeListNode,
-	#superclass : #Object,
+	#name : 'VMTFreeListNode',
+	#superclass : 'Object',
 	#instVars : [
 		'nodeOop',
 		'memory'
 	],
-	#category : #'VMMaker-Tools'
+	#category : 'VMMaker-Tools',
+	#package : 'VMMaker-Tools'
 }
 
-{ #category : #'instance-creation' }
+{ #category : 'instance-creation' }
 VMTFreeListNode class >> on: anOop memory: aMemory [
 	
 	anOop = 0 ifTrue: [ self halt ].
@@ -18,19 +19,19 @@ VMTFreeListNode class >> on: anOop memory: aMemory [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTFreeListNode >> address [
 	
 	^ memory startOfObject: nodeOop
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTFreeListNode >> children [
 	
 	^ self edges
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTFreeListNode >> edges [
 	
 	| edges |
@@ -40,23 +41,23 @@ VMTFreeListNode >> edges [
 	^ edges
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTFreeListNode >> hasChildren [
 	
 	^ self nextOop ~= 0 or: [ self previousOop ~= 0 ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTFreeListNode >> memory [
 	^ memory
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTFreeListNode >> memory: anObject [
 	memory := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTFreeListNode >> nextOop [
 
 	^ memory
@@ -64,17 +65,17 @@ VMTFreeListNode >> nextOop [
 		ofFreeChunk: nodeOop
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTFreeListNode >> nodeOop [
 	^ nodeOop
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTFreeListNode >> nodeOop: anObject [
 	nodeOop := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTFreeListNode >> previousOop [
 
 	^ memory
@@ -82,7 +83,7 @@ VMTFreeListNode >> previousOop [
 		ofFreeChunk: nodeOop
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTFreeListNode >> printOn: aStream [
 
 	aStream
@@ -91,7 +92,7 @@ VMTFreeListNode >> printOn: aStream [
 		nextPutAll: ')'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTFreeListNode >> size [
 
 	^ memory bytesInObject: nodeOop

--- a/smalltalksrc/VMMaker-Tools/VMTFreeListNodeEdge.class.st
+++ b/smalltalksrc/VMMaker-Tools/VMTFreeListNodeEdge.class.st
@@ -1,15 +1,16 @@
 Class {
-	#name : #VMTFreeListNodeEdge,
-	#superclass : #Object,
+	#name : 'VMTFreeListNodeEdge',
+	#superclass : 'Object',
 	#instVars : [
 		'memory',
 		'label',
 		'nodeOop'
 	],
-	#category : #'VMMaker-Tools'
+	#category : 'VMMaker-Tools',
+	#package : 'VMMaker-Tools'
 }
 
-{ #category : #'instance-creation' }
+{ #category : 'instance-creation' }
 VMTFreeListNodeEdge class >> memory: aMemory label: aLabel oop: anOop [
 	
 	^ self new
@@ -19,55 +20,55 @@ VMTFreeListNodeEdge class >> memory: aMemory label: aLabel oop: anOop [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTFreeListNodeEdge >> address [
 
 	^ ''
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTFreeListNodeEdge >> children [
 	
 	^ { VMTFreeTreeNode on: nodeOop memory: memory }
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTFreeListNodeEdge >> hasChildren [
 	
 	^ nodeOop ~= 0
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTFreeListNodeEdge >> label [
 	^ label
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTFreeListNodeEdge >> label: anObject [
 	label := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTFreeListNodeEdge >> memory [
 	^ memory
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTFreeListNodeEdge >> memory: anObject [
 	memory := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTFreeListNodeEdge >> nodeOop [
 	^ nodeOop
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTFreeListNodeEdge >> nodeOop: anObject [
 	nodeOop := anObject
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 VMTFreeListNodeEdge >> printOn: aStream [
 
 	aStream
@@ -76,7 +77,7 @@ VMTFreeListNodeEdge >> printOn: aStream [
 		nextPutAll: nodeOop hex
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTFreeListNodeEdge >> size [
 
 	^ ''

--- a/smalltalksrc/VMMaker-Tools/VMTFreeLists.class.st
+++ b/smalltalksrc/VMMaker-Tools/VMTFreeLists.class.st
@@ -1,13 +1,14 @@
 Class {
-	#name : #VMTFreeLists,
-	#superclass : #Object,
+	#name : 'VMTFreeLists',
+	#superclass : 'Object',
 	#instVars : [
 		'memory'
 	],
-	#category : #'VMMaker-Tools'
+	#category : 'VMMaker-Tools',
+	#package : 'VMMaker-Tools'
 }
 
-{ #category : #'instance-creation' }
+{ #category : 'instance-creation' }
 VMTFreeLists class >> on: aMemory [
 
 	^ self new
@@ -15,7 +16,7 @@ VMTFreeLists class >> on: aMemory [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTFreeLists >> children [
 	
 	| children |
@@ -27,7 +28,7 @@ VMTFreeLists >> children [
 	^ children
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTFreeLists >> memory: aMemory [
 	memory := aMemory
 ]

--- a/smalltalksrc/VMMaker-Tools/VMTFreeTreeNode.class.st
+++ b/smalltalksrc/VMMaker-Tools/VMTFreeTreeNode.class.st
@@ -1,10 +1,11 @@
 Class {
-	#name : #VMTFreeTreeNode,
-	#superclass : #VMTFreeListNode,
-	#category : #'VMMaker-Tools'
+	#name : 'VMTFreeTreeNode',
+	#superclass : 'VMTFreeListNode',
+	#category : 'VMMaker-Tools',
+	#package : 'VMMaker-Tools'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTFreeTreeNode >> edges [
 	
 	| edges |
@@ -14,13 +15,13 @@ VMTFreeTreeNode >> edges [
 	^ edges
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 VMTFreeTreeNode >> hasChildren [
 	
 	^ self smallerOop ~= 0 or: [ self largerOop ~= 0 ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTFreeTreeNode >> largerOop [
 
 	^ memory
@@ -28,7 +29,7 @@ VMTFreeTreeNode >> largerOop [
 		ofFreeChunk: nodeOop
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTFreeTreeNode >> smallerOop [
 	
 	^ memory

--- a/smalltalksrc/VMMaker-Tools/VMTFreeTreeNodeEdge2.class.st
+++ b/smalltalksrc/VMMaker-Tools/VMTFreeTreeNodeEdge2.class.st
@@ -1,5 +1,6 @@
 Class {
-	#name : #VMTFreeTreeNodeEdge2,
-	#superclass : #VMTFreeListNodeEdge,
-	#category : #'VMMaker-Tools'
+	#name : 'VMTFreeTreeNodeEdge2',
+	#superclass : 'VMTFreeListNodeEdge',
+	#category : 'VMMaker-Tools',
+	#package : 'VMMaker-Tools'
 }

--- a/smalltalksrc/VMMaker-Tools/VMTHiddenRoot.class.st
+++ b/smalltalksrc/VMMaker-Tools/VMTHiddenRoot.class.st
@@ -1,51 +1,52 @@
 Class {
-	#name : #VMTHiddenRoot,
-	#superclass : #Object,
+	#name : 'VMTHiddenRoot',
+	#superclass : 'Object',
 	#instVars : [
 		'memory',
 		'index',
 		'label',
 		'oop'
 	],
-	#category : #'VMMaker-Tools'
+	#category : 'VMMaker-Tools',
+	#package : 'VMMaker-Tools'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTHiddenRoot >> index [
 	^ index
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTHiddenRoot >> index: anObject [
 	index := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTHiddenRoot >> label [
 	^ label
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTHiddenRoot >> label: anObject [
 	label := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTHiddenRoot >> memory [
 	^ memory
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTHiddenRoot >> memory: anObject [
 	memory := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTHiddenRoot >> oop [
 	^ oop
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTHiddenRoot >> oop: anObject [
 	oop := anObject
 ]

--- a/smalltalksrc/VMMaker-Tools/VMTHiddenRootTable.class.st
+++ b/smalltalksrc/VMMaker-Tools/VMTHiddenRootTable.class.st
@@ -1,13 +1,14 @@
 Class {
-	#name : #VMTHiddenRootTable,
-	#superclass : #Object,
+	#name : 'VMTHiddenRootTable',
+	#superclass : 'Object',
 	#instVars : [
 		'memory'
 	],
-	#category : #'VMMaker-Tools'
+	#category : 'VMMaker-Tools',
+	#package : 'VMMaker-Tools'
 }
 
-{ #category : #'instance-creation' }
+{ #category : 'instance-creation' }
 VMTHiddenRootTable class >> on: aMemory [ 
 
 	^ self new
@@ -15,7 +16,7 @@ VMTHiddenRootTable class >> on: aMemory [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTHiddenRootTable >> children [
 	| roots |
 	roots := OrderedCollection new.
@@ -60,7 +61,7 @@ VMTHiddenRootTable >> children [
 	^ roots
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTHiddenRootTable >> memory: aMemory [ 
 	memory := aMemory
 ]

--- a/smalltalksrc/VMMaker-Tools/VMTStackFrame.class.st
+++ b/smalltalksrc/VMMaker-Tools/VMTStackFrame.class.st
@@ -1,24 +1,25 @@
 Class {
-	#name : #VMTStackFrame,
-	#superclass : #Object,
+	#name : 'VMTStackFrame',
+	#superclass : 'Object',
 	#instVars : [
 		'memory',
 		'framePointer'
 	],
-	#category : #'VMMaker-Tools'
+	#category : 'VMMaker-Tools',
+	#package : 'VMMaker-Tools'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTStackFrame >> callerFP [
 	^ self interpreter frameCallerFP: framePointer
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTStackFrame >> callerIP [
 	^ self interpreter frameCallerSavedIP: framePointer
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTStackFrame >> descriptors [
 	^ OrderedCollection new 
 		add: #callerIP ->  self callerIP ;
@@ -27,17 +28,17 @@ VMTStackFrame >> descriptors [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTStackFrame >> framePointer [
 	^ framePointer
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTStackFrame >> framePointer: anObject [
 	framePointer := anObject
 ]
 
-{ #category : #debugging }
+{ #category : 'debugging' }
 VMTStackFrame >> gtStackFrameInspector: composite [
 	<gtInspectorPresentationOrder: 0>
 	^ composite fastTable
@@ -47,22 +48,22 @@ VMTStackFrame >> gtStackFrameInspector: composite [
 		column: 'Value' evaluated: [ :descriptor | descriptor value ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTStackFrame >> interpreter [
 	^ memory coInterpreter
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTStackFrame >> memory [
 	^ memory
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTStackFrame >> memory: anObject [
 	memory := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 VMTStackFrame >> method [
 	^ self interpreter iframeMethod: framePointer
 ]

--- a/smalltalksrc/VMMaker-Tools/package.st
+++ b/smalltalksrc/VMMaker-Tools/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'VMMaker-Tools' }
+Package { #name : 'VMMaker-Tools' }

--- a/smalltalksrc/VMMaker/CogMethod.class.st
+++ b/smalltalksrc/VMMaker/CogMethod.class.st
@@ -99,7 +99,7 @@ CogMethod class >> instVarNamesAndTypesForTranslationDo: aBinaryBlock [
 								['objectHeader']			-> [VMClass objectMemoryClass baseHeaderSize = 8
 																ifTrue: [#sqLong]
 																ifFalse: [#sqInt]].
-								['cmNumArgs']				-> [#'unsigned byte'].	
+								['cmNumArgs']				-> [#uint8_t].	
 								['cmType']					-> [#(unsigned ' : 3')].
 								['cmRefersToYoung']		-> [#(unsigned #Boolean ' : 1')].
 								['cpicHasMNUCaseOrCMIsFullBlock']

--- a/smalltalksrc/VMMaker/CogMethod.class.st
+++ b/smalltalksrc/VMMaker/CogMethod.class.st
@@ -99,7 +99,7 @@ CogMethod class >> instVarNamesAndTypesForTranslationDo: aBinaryBlock [
 								['objectHeader']			-> [VMClass objectMemoryClass baseHeaderSize = 8
 																ifTrue: [#sqLong]
 																ifFalse: [#sqInt]].
-								['cmNumArgs']				-> [#(unsigned ' : 8')].		"SqueakV3 needs only 5 bits"
+								['cmNumArgs']				-> [#'unsigned byte'].	
 								['cmType']					-> [#(unsigned ' : 3')].
 								['cmRefersToYoung']		-> [#(unsigned #Boolean ' : 1')].
 								['cpicHasMNUCaseOrCMIsFullBlock']

--- a/smalltalksrc/VMMaker/CogMethodSurrogate32.class.st
+++ b/smalltalksrc/VMMaker/CogMethodSurrogate32.class.st
@@ -40,10 +40,12 @@ CogMethodSurrogate32 class >> offsetOf: aByteSymbol [
 	| baseHeaderSize |
 	baseHeaderSize := self objectMemoryClass baseHeaderSize.
 	^aByteSymbol caseOf:
-		{	[#methodObject]		-> [8 + baseHeaderSize].
+		{
+			[#cmNumArgs]			-> [0 + baseHeaderSize].	
+			[#picUsage]			-> [6 + baseHeaderSize].
+			[#methodObject]		-> [8 + baseHeaderSize].
 			[#methodHeader]		-> [12 + baseHeaderSize].
-			[#selector]				-> [16 + baseHeaderSize].
-			[#picUsage]	-> [6 + baseHeaderSize].
+			[#selector]			-> [16 + baseHeaderSize].
 		}
 ]
 

--- a/smalltalksrc/VMMaker/CogMethodSurrogate64.class.st
+++ b/smalltalksrc/VMMaker/CogMethodSurrogate64.class.st
@@ -40,7 +40,9 @@ CogMethodSurrogate64 class >> offsetOf: aByteSymbol [
 	| baseHeaderSize |
 	baseHeaderSize := self objectMemoryClass baseHeaderSize.
 	^aByteSymbol caseOf:
-		{	[#methodObject]		-> [8 + baseHeaderSize].
+		{
+			[#cmNumArgs]		-> [0 + baseHeaderSize].	
+			[#methodObject]		-> [8 + baseHeaderSize].
 			[#methodHeader]		-> [16 + baseHeaderSize].
 			[#selector]				-> [24 + baseHeaderSize].
 			[#picUsage]	-> [6 + baseHeaderSize].

--- a/smalltalksrc/VMMaker/SimpleStackBasedCogit.class.st
+++ b/smalltalksrc/VMMaker/SimpleStackBasedCogit.class.st
@@ -1685,7 +1685,12 @@ SimpleStackBasedCogit >> genLookupForPerformNumArgs: numArgs [
 	objectRepresentation genLoadSlot: HeaderIndex sourceReg: SendNumArgsReg destReg: ClassReg.
 	jumpInterpret := objectRepresentation genJumpImmediate: ClassReg.
 	
-	"We are in machine code, we need to check arity!"
+	"We are in machine code, we need to check arity!
+	Load the target method number of arguments (zero extended by hand if needed).
+	Then compare it to the callsite one.
+	Jump to fail if not equal"
+	self backEnd byteReadsZeroExtend ifFalse:
+		[self MoveCq: 0 R: SendNumArgsReg].
 	self MoveMb: (self offset: CogMethod of: #cmNumArgs) r: ClassReg R: SendNumArgsReg.
 	"numArgs contains the number of arguments of perform, which contains the selector."
 	self CmpCq: numArgs - 1 R: SendNumArgsReg.

--- a/smalltalksrc/VMMaker/SimpleStackBasedCogit.class.st
+++ b/smalltalksrc/VMMaker/SimpleStackBasedCogit.class.st
@@ -1655,7 +1655,7 @@ SimpleStackBasedCogit >> genLookupForPerformNumArgs: numArgs [
 	"Compile the code for a probe of the first-level method cache for a perform primtiive.
 	 The selector is assumed to be in Arg0Reg.  Defer to adjustArgumentsForPerform: to
 	 adjust the arguments before the jump to the method."
-	| jumpSelectorMiss jumpClassMiss jumpInterpret itsAHit cacheBaseReg |
+	| jumpSelectorMiss jumpClassMiss jumpInterpret itsAHit cacheBaseReg jumpWrongArity |
 	<var: #jumpSelectorMiss type: #'AbstractInstruction *'>
 	<var: #jumpClassMiss type: #'AbstractInstruction *'>
 	<var: #jumpInterpret type: #'AbstractInstruction *'>
@@ -1684,6 +1684,13 @@ SimpleStackBasedCogit >> genLookupForPerformNumArgs: numArgs [
 	"If the method is not compiled fall back on the interpreter primitive."
 	objectRepresentation genLoadSlot: HeaderIndex sourceReg: SendNumArgsReg destReg: ClassReg.
 	jumpInterpret := objectRepresentation genJumpImmediate: ClassReg.
+	
+	"We are in machine code, we need to check arity!"
+	self MoveMb: (self offset: CogMethod of: #cmNumArgs) r: ClassReg R: SendNumArgsReg.
+	"numArgs contains the number of arguments of perform, which contains the selector."
+	self CmpCq: numArgs - 1 R: SendNumArgsReg.
+	jumpWrongArity := self JumpNonZero: 0.
+	
 	"Adjust arguments and jump to the method's unchecked entry-point."
 	self AddCq: cmNoCheckEntryOffset R: ClassReg.
 	self adjustArgumentsForPerform: numArgs.
@@ -1701,7 +1708,7 @@ SimpleStackBasedCogit >> genLookupForPerformNumArgs: numArgs [
 
 	"Last probe missed.  Caller will generate the call to fall back on the interpreter primitive."
 	jumpSelectorMiss jmpTarget:
-	(jumpInterpret jmpTarget: self Label).
+	(jumpInterpret jmpTarget: (jumpWrongArity jmpTarget: self Label)).
 	^0
 ]
 

--- a/smalltalksrc/VMMakerTests/VMJittedPrimitivePerform.class.st
+++ b/smalltalksrc/VMMakerTests/VMJittedPrimitivePerform.class.st
@@ -46,10 +46,65 @@ VMJittedPrimitivePerform >> setUp [
 
 	cogInitialAddress := self compile: [
 		"The perform has one argument: the selector"
-		cogit methodOrBlockNumArgs: 1.
+		cogit methodOrBlockNumArgs: 2.
 		cogit objectRepresentation genPrimitivePerform.
 		stop := cogit Stop ]
 	bytecodes: 10
+]
+
+{ #category : 'tests' }
+VMJittedPrimitivePerform >> setUpCompiledMethodWithArity: numberOfArguments [
+
+	| machineCodeMethod method |
+	method := methodBuilder
+		          numberOfArguments: numberOfArguments;
+		          buildMethod.
+	machineCodeMethod := targetMethodAddress.
+	(cogit cogMethodSurrogateAt: machineCodeMethod)
+		objectHeader: memory nullHeaderForMachineCodeMethod;
+		methodObject: method;
+		cmNumArgs: numberOfArguments;
+		methodHeader: (interpreter rawHeaderOf: method).
+	interpreter rawHeaderOf: method put: machineCodeMethod.
+	^ method
+]
+
+{ #category : 'tests' }
+VMJittedPrimitivePerform >> testPrimitivePerformFailsIfMethodFoundHasHigherArity [
+
+	| receiver selector method numberOfArguments |
+	"The target method has 1 argument, the perform callsite does not provide it
+		=> we expect check fail"
+	receiver := memory nilObject.
+	selector := memory integerObjectOf: 2.
+	
+	numberOfArguments := 2.
+	method := self setUpCompiledMethodWithArity: numberOfArguments.
+	
+	interpreter messageSelector: selector.
+	interpreter newMethod: method.
+	interpreter addNewMethodToCache: (memory fetchClassOf: receiver).
+	self prepareStackForSendReceiver: receiver arguments: { selector }.
+	self runFrom: cogInitialAddress until: stop address
+]
+
+{ #category : 'tests' }
+VMJittedPrimitivePerform >> testPrimitivePerformFailsIfMethodFoundHasLowerArity [
+
+	| receiver selector method numberOfArguments |
+	"The target method has 1 argument, the perform callsite does not provide it
+		=> we expect check fail"
+	receiver := memory nilObject.
+	selector := memory integerObjectOf: 2.
+	
+	numberOfArguments := 0.
+	method := self setUpCompiledMethodWithArity: numberOfArguments.
+	
+	interpreter messageSelector: selector.
+	interpreter newMethod: method.
+	interpreter addNewMethodToCache: (memory fetchClassOf: receiver).
+	self prepareStackForSendReceiver: receiver arguments: { selector }.
+	self runFrom: cogInitialAddress until: stop address
 ]
 
 { #category : 'tests' }
@@ -60,33 +115,6 @@ VMJittedPrimitivePerform >> testPrimitivePerformFailsIfMethodFoundIsNotJITCompil
 	selector := memory integerObjectOf: 2.
 
 	method := methodBuilder buildMethod.
-	interpreter messageSelector: selector.
-	interpreter newMethod: method.
-	interpreter addNewMethodToCache: (memory fetchClassOf: receiver).
-
-	self prepareStackForSendReceiver: receiver arguments: { selector }.
-
-	self runFrom: cogInitialAddress until: stop address
-]
-
-{ #category : 'tests' }
-VMJittedPrimitivePerform >> testPrimitivePerformFailsIfMethodFoundIsNotRightArity [
-
-	| receiver selector method machineCodeMethod |
-	receiver := memory nilObject.
-	selector := memory integerObjectOf: 2.
-
-	"The target method has 1 argument, the perform callsite does not provide it
-		=> we expect check fail"
-	method := methodBuilder numberOfArguments: 1; buildMethod.
-	machineCodeMethod := targetMethodAddress.
-	(cogit cogMethodSurrogateAt: machineCodeMethod)
-		objectHeader: memory nullHeaderForMachineCodeMethod;
-		methodObject: method;
-		cmNumArgs: 1;
-		methodHeader: (interpreter rawHeaderOf: method).
-	interpreter rawHeaderOf: method put: machineCodeMethod.
-	
 	interpreter messageSelector: selector.
 	interpreter newMethod: method.
 	interpreter addNewMethodToCache: (memory fetchClassOf: receiver).
@@ -112,16 +140,12 @@ VMJittedPrimitivePerform >> testPrimitivePerformFailsIfMethodNotInCache [
 { #category : 'tests' }
 VMJittedPrimitivePerform >> testPrimitivePerformJumpsToMethodIfCompiled [
 
-	| receiver selector method machineCodeMethod |
+	| receiver selector method numberOfArguments |
 	receiver := memory nilObject.
 	selector := memory integerObjectOf: 2.
 
-	machineCodeMethod := targetMethodAddress.
-	method := methodBuilder numberOfArguments:0; buildMethod.
-	(cogit cogMethodSurrogateAt: machineCodeMethod)
-		methodObject: method;
-		objectHeader: memory nullHeaderForMachineCodeMethod.
-	interpreter rawHeaderOf: method put: machineCodeMethod.
+	numberOfArguments := 1.
+	method := self setUpCompiledMethodWithArity: numberOfArguments.
 	
 	interpreter messageSelector: selector.
 	interpreter newMethod: method.

--- a/smalltalksrc/VMMakerTests/VMJittedPrimitivePerform.class.st
+++ b/smalltalksrc/VMMakerTests/VMJittedPrimitivePerform.class.st
@@ -1,0 +1,133 @@
+Class {
+	#name : 'VMJittedPrimitivePerform',
+	#superclass : 'VMPrimitiveCallAbstractTest',
+	#instVars : [
+		'stop',
+		'targetMethodAddress'
+	],
+	#pools : [
+		'VMMethodCacheConstants'
+	],
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
+}
+
+{ #category : 'running' }
+VMJittedPrimitivePerform >> jitCompilerClass [
+
+	^ StackToRegisterMappingCogit 
+]
+
+{ #category : 'running' }
+VMJittedPrimitivePerform >> setUp [
+
+	| nilClass |
+	super setUp.
+	self setUpTrampolines.
+	self setUpCogMethodEntry.
+
+	memory coInterpreter moveMethodCacheToMemoryAt:
+		(memory memoryManager allocate:
+			 MethodCacheEntrySize * MethodCacheSize
+			 * (interpreter sizeof: #sqInt)).
+
+	nilClass := self
+		            newClassInOldSpaceWithSlots: 0
+		            instSpec: memory nonIndexablePointerFormat.
+	memory
+		setClassIndexOf: memory nilObject
+		to: (memory ensureBehaviorHash: nilClass).
+
+	targetMethodAddress := self compile: [
+		stop := cogit Stop ]
+	bytecodes: 10
+	headerSize: cogit noCheckEntryOffset.
+
+	cogInitialAddress := self compile: [
+		"The perform has one argument: the selector"
+		cogit methodOrBlockNumArgs: 1.
+		cogit objectRepresentation genPrimitivePerform.
+		stop := cogit Stop ]
+	bytecodes: 10
+]
+
+{ #category : 'tests' }
+VMJittedPrimitivePerform >> testPrimitivePerformFailsIfMethodFoundIsNotJITCompiled [
+
+	| receiver selector method |
+	receiver := memory nilObject.
+	selector := memory integerObjectOf: 2.
+
+	method := methodBuilder buildMethod.
+	interpreter messageSelector: selector.
+	interpreter newMethod: method.
+	interpreter addNewMethodToCache: (memory fetchClassOf: receiver).
+
+	self prepareStackForSendReceiver: receiver arguments: { selector }.
+
+	self runFrom: cogInitialAddress until: stop address
+]
+
+{ #category : 'tests' }
+VMJittedPrimitivePerform >> testPrimitivePerformFailsIfMethodFoundIsNotRightArity [
+
+	| receiver selector method machineCodeMethod |
+	receiver := memory nilObject.
+	selector := memory integerObjectOf: 2.
+
+	"The target method has 1 argument, the perform callsite does not provide it
+		=> we expect check fail"
+	method := methodBuilder numberOfArguments: 1; buildMethod.
+	machineCodeMethod := targetMethodAddress.
+	(cogit cogMethodSurrogateAt: machineCodeMethod)
+		objectHeader: memory nullHeaderForMachineCodeMethod;
+		methodObject: method;
+		cmNumArgs: 1;
+		methodHeader: (interpreter rawHeaderOf: method).
+	interpreter rawHeaderOf: method put: machineCodeMethod.
+	
+	interpreter messageSelector: selector.
+	interpreter newMethod: method.
+	interpreter addNewMethodToCache: (memory fetchClassOf: receiver).
+
+	self prepareStackForSendReceiver: receiver arguments: { selector }.
+
+	self runFrom: cogInitialAddress until: stop address
+]
+
+{ #category : 'tests' }
+VMJittedPrimitivePerform >> testPrimitivePerformFailsIfMethodNotInCache [
+
+	| selector |
+	selector := 2.
+
+	self
+		prepareStackForSendReceiver: memory nilObject
+		arguments: { memory integerObjectOf: selector }.
+
+	self runFrom: cogInitialAddress until: stop address.
+]
+
+{ #category : 'tests' }
+VMJittedPrimitivePerform >> testPrimitivePerformJumpsToMethodIfCompiled [
+
+	| receiver selector method machineCodeMethod |
+	receiver := memory nilObject.
+	selector := memory integerObjectOf: 2.
+
+	machineCodeMethod := targetMethodAddress.
+	method := methodBuilder numberOfArguments:0; buildMethod.
+	(cogit cogMethodSurrogateAt: machineCodeMethod)
+		methodObject: method;
+		objectHeader: memory nullHeaderForMachineCodeMethod.
+	interpreter rawHeaderOf: method put: machineCodeMethod.
+	
+	interpreter messageSelector: selector.
+	interpreter newMethod: method.
+	interpreter addNewMethodToCache: (memory fetchClassOf: receiver).
+
+	self prepareStackForSendReceiver: receiver arguments: { selector }.
+
+	self runFrom: cogInitialAddress until: targetMethodAddress + cogit noCheckEntryOffset
+]


### PR DESCRIPTION
Fix #982 

The issue is that the machine code version of perform does not check the arity of the called method and activates it nevertheless (with wrong arguments).

This PR does:
 - introduce an arity check
 - add tests for positive case: method is in cache with right number of arguments
 - add tests for primitive failure 
     - target is not in cache
     - target is in cache but not compiled
     - target is in cache and compile but wrong arity

~Still to check: the load byte in x64 is not doing sign extension, so tests are breaking for x64.~

@janvrany @shingarov