### PR TITLE
fixing-build-in-windows

### DIFF
--- a/smalltalksrc/VMMaker/CogMethod.class.st
+++ b/smalltalksrc/VMMaker/CogMethod.class.st
@@ -99,7 +99,7 @@ CogMethod class >> instVarNamesAndTypesForTranslationDo: aBinaryBlock [
 								['objectHeader']			-> [VMClass objectMemoryClass baseHeaderSize = 8
 																ifTrue: [#sqLong]
 																ifFalse: [#sqInt]].
-								['cmNumArgs']				-> [#uint8_t].	
+								['cmNumArgs']				-> [#(unsigned ' : 8')].	
 								['cmType']					-> [#(unsigned ' : 3')].
 								['cmRefersToYoung']		-> [#(unsigned #Boolean ' : 1')].
 								['cpicHasMNUCaseOrCMIsFullBlock']

--- a/smalltalksrc/VMMaker/CogMethodSurrogate32.class.st
+++ b/smalltalksrc/VMMaker/CogMethodSurrogate32.class.st
@@ -41,6 +41,7 @@ CogMethodSurrogate32 class >> offsetOf: aByteSymbol [
 	baseHeaderSize := self objectMemoryClass baseHeaderSize.
 	^aByteSymbol caseOf:
 		{
+			[#objectHeader]		-> [0].
 			[#cmNumArgs]			-> [0 + baseHeaderSize].	
 			[#picUsage]			-> [6 + baseHeaderSize].
 			[#methodObject]		-> [8 + baseHeaderSize].

--- a/smalltalksrc/VMMaker/CogMethodSurrogate64.class.st
+++ b/smalltalksrc/VMMaker/CogMethodSurrogate64.class.st
@@ -41,6 +41,7 @@ CogMethodSurrogate64 class >> offsetOf: aByteSymbol [
 	baseHeaderSize := self objectMemoryClass baseHeaderSize.
 	^aByteSymbol caseOf:
 		{
+			[#objectHeader] -> [0].
 			[#cmNumArgs]		-> [0 + baseHeaderSize].	
 			[#methodObject]		-> [8 + baseHeaderSize].
 			[#methodHeader]		-> [16 + baseHeaderSize].

--- a/smalltalksrc/VMMaker/CogSistaMethodSurrogate32.class.st
+++ b/smalltalksrc/VMMaker/CogSistaMethodSurrogate32.class.st
@@ -8,7 +8,7 @@ Class {
 
 { #category : 'accessing' }
 CogSistaMethodSurrogate32 class >> alignedByteSize [
-	^24 + self baseHeaderSize
+	^28 + self baseHeaderSize
 ]
 
 { #category : 'accessing' }
@@ -21,12 +21,12 @@ CogSistaMethodSurrogate32 class >> offsetOf: aByteSymbol [
 
 { #category : 'accessing' }
 CogSistaMethodSurrogate32 >> counters [
-	^memory unsignedLong32At: address + 20 + baseHeaderSize
+	^memory unsignedLong32At: address + 23 + baseHeaderSize
 ]
 
 { #category : 'accessing' }
 CogSistaMethodSurrogate32 >> counters: aValue [
 	^memory
-		unsignedLong32At: address + baseHeaderSize + 20
+		unsignedLong32At: address + baseHeaderSize + 23
 		put: aValue
 ]

--- a/smalltalksrc/VMMaker/CogSistaMethodSurrogate64.class.st
+++ b/smalltalksrc/VMMaker/CogSistaMethodSurrogate64.class.st
@@ -8,7 +8,7 @@ Class {
 
 { #category : 'accessing' }
 CogSistaMethodSurrogate64 class >> alignedByteSize [
-	^40 + self baseHeaderSize
+	^48 + self baseHeaderSize
 ]
 
 { #category : 'accessing' }
@@ -21,12 +21,12 @@ CogSistaMethodSurrogate64 class >> offsetOf: aByteSymbol [
 
 { #category : 'accessing' }
 CogSistaMethodSurrogate64 >> counters [
-	^memory unsignedLong64At: address + 32 + baseHeaderSize
+	^memory unsignedLong64At: address + 39 + baseHeaderSize
 ]
 
 { #category : 'accessing' }
 CogSistaMethodSurrogate64 >> counters: aValue [
 	^memory
-		unsignedLong64At: address + baseHeaderSize + 32
+		unsignedLong64At: address + baseHeaderSize + 39
 		put: aValue
 ]

--- a/smalltalksrc/VMMaker/SimpleStackBasedCogit.class.st
+++ b/smalltalksrc/VMMaker/SimpleStackBasedCogit.class.st
@@ -1691,7 +1691,8 @@ SimpleStackBasedCogit >> genLookupForPerformNumArgs: numArgs [
 	Jump to fail if not equal"
 	self backEnd byteReadsZeroExtend ifFalse:
 		[self MoveCq: 0 R: SendNumArgsReg].
-	self MoveMb: (self offset: CogMethod of: #cmNumArgs) r: ClassReg R: SendNumArgsReg.
+	"We need the offset of cmNumArgs, but as it is a bit field, we have to get the offset of the previous element plus its size. It works because the previous one is a sqLong"
+	self MoveMb: ((self offset: CogMethod of: #objectHeader) + (self sizeof: #sqLong)) r: ClassReg R: SendNumArgsReg.
 	"numArgs contains the number of arguments of perform, which contains the selector."
 	self CmpCq: numArgs - 1 R: SendNumArgsReg.
 	jumpWrongArity := self JumpNonZero: 0.


### PR DESCRIPTION
We need to keep the field cmNumArgs as a bitfield. Because if not, in windows with the rules of alignments the structure size changes and we have crashes in the VM.