### PR TITLE
Honor CMAKE_INSTALL_PREFIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,14 @@ endif()
 #This needs to be at this point, after setting the toolchain configuration
 project(PharoVM)
 
+# Provide a default value for the installation prefix, without
+# clobbering a user-specified CMAKE_INSTALL_PREFIX.
+message(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT=${CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT})
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set_property(CACHE CMAKE_INSTALL_PREFIX PROPERTY VALUE
+        "${CMAKE_CURRENT_BINARY_DIR}/build/dist")
+endif()
+
 include(cmake/versionExtraction.cmake)
 
 set(BUILT_FROM "${PharoVM_VERSION_STRING_FULL} - Commit: ${PharoVM_VERSION_GIT_SHA} - Date: ${PharoVM_VERSION_GIT_COMMIT_DATE}")

--- a/cmake/Darwin.cmake
+++ b/cmake/Darwin.cmake
@@ -67,8 +67,6 @@ macro(add_third_party_dependencies_per_platform)
 endmacro()
 
 macro(configure_installables INSTALL_COMPONENT)
-  set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/build/dist")
-  
 	install(
 		DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/build/libffi/install/lib/"
 		DESTINATION "${VM_EXECUTABLE_NAME}.app/Contents/MacOS/Plugins"

--- a/cmake/FreeBSD.cmake
+++ b/cmake/FreeBSD.cmake
@@ -60,7 +60,6 @@ endmacro()
 
 
 macro(configure_installables INSTALL_COMPONENT)
-    set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/build/dist")
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/packaging/linux/launch.sh.in
         ${CMAKE_CURRENT_BINARY_DIR}/build/packaging/linux/${VM_EXECUTABLE_NAME} @ONLY)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/packaging/linux/bin/launch.sh.in

--- a/cmake/FreeBSD.cmake
+++ b/cmake/FreeBSD.cmake
@@ -1,4 +1,4 @@
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wl,-z,wxneeded,-rpath=. -I/usr/local/include -I/usr/X11R6/include -lexecinfo")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I/usr/local/include -I/usr/X11R6/include -lexecinfo")
 set(PHARO_BIN_LOCATION "default" CACHE STRING "The default location of the PHARO bin, used by the launch.sh.in")
 
 if(${PHARO_BIN_LOCATION} STREQUAL "default")

--- a/cmake/Linux.cmake
+++ b/cmake/Linux.cmake
@@ -76,19 +76,17 @@ macro(configure_installables INSTALL_COMPONENT)
       DESTINATION "lib"
       USE_SOURCE_PERMISSIONS
       COMPONENT ${INSTALL_COMPONENT})
-	install(
-		DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/build/libffi/install/lib/"
-		DESTINATION "lib"
-		USE_SOURCE_PERMISSIONS
-		COMPONENT ${INSTALL_COMPONENT}
-		FILES_MATCHING PATTERN ${DYLIB_EXT})
-
-
-	install(
-	    DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/extracted/vm/include/unix/"
-	    DESTINATION include/pharovm
-	    COMPONENT include
-	    FILES_MATCHING PATTERN *.h)
+    install(
+      DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/build/libffi/install/lib/"
+      DESTINATION "lib"
+      USE_SOURCE_PERMISSIONS
+      COMPONENT ${INSTALL_COMPONENT}
+      FILES_MATCHING PATTERN ${DYLIB_EXT})
+    install(
+      DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/unix/"
+      DESTINATION include/pharovm
+      COMPONENT include
+      FILES_MATCHING PATTERN *.h)
 endmacro()
 
 macro(add_required_libs_per_platform)

--- a/cmake/Linux.cmake
+++ b/cmake/Linux.cmake
@@ -60,7 +60,6 @@ endmacro()
 
 
 macro(configure_installables INSTALL_COMPONENT)
-    set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/build/dist")
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/packaging/linux/launch.sh.in
         ${CMAKE_CURRENT_BINARY_DIR}/build/packaging/linux/${VM_EXECUTABLE_NAME} @ONLY)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/packaging/linux/bin/launch.sh.in

--- a/cmake/Linux.cmake
+++ b/cmake/Linux.cmake
@@ -1,4 +1,3 @@
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wl,-rpath=.")
 set(PHARO_BIN_LOCATION "default" CACHE STRING "The default location of the PHARO bin, used by the launch.sh.in")
 
 if(${PHARO_BIN_LOCATION} STREQUAL "default")

--- a/cmake/OpenBSD.cmake
+++ b/cmake/OpenBSD.cmake
@@ -60,7 +60,6 @@ endmacro()
 
 
 macro(configure_installables INSTALL_COMPONENT)
-    set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/build/dist")
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/packaging/linux/launch.sh.in
         ${CMAKE_CURRENT_BINARY_DIR}/build/packaging/linux/${VM_EXECUTABLE_NAME} @ONLY)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/packaging/linux/bin/launch.sh.in

--- a/cmake/OpenBSD.cmake
+++ b/cmake/OpenBSD.cmake
@@ -1,4 +1,4 @@
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wl,-z,wxneeded,-rpath=. -I/usr/local/include -I/usr/X11R6/include")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I/usr/local/include -I/usr/X11R6/include")
 set(PHARO_BIN_LOCATION "default" CACHE STRING "The default location of the PHARO bin, used by the launch.sh.in")
 
 if(${PHARO_BIN_LOCATION} STREQUAL "default")

--- a/cmake/Windows.cmake
+++ b/cmake/Windows.cmake
@@ -98,8 +98,6 @@ macro(add_third_party_dependencies_per_platform)
 endmacro()
 
 macro(configure_installables INSTALL_COMPONENT)
-    set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/build/dist")
-
     install(
           DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/build/vm/"
           DESTINATION "./"


### PR DESCRIPTION
This is a first step toward making the build system more useful to install the pharo-vm as part of packaging.

Made while packaging it for GNU Guix.