### PR TITLE
Fixing a race condition introduced in v10.3.7

### DIFF
--- a/extracted/vm/src/win/aioWin.c
+++ b/extracted/vm/src/win/aioWin.c
@@ -193,8 +193,8 @@ void aioFileDescriptor_signal_withHandle(HANDLE event){
 			//We set the event to 0 so it is not recalled after
 			WSAEventSelect(element->fd, element->readEvent, 0);
 
-			element->handlerFn(element->fd, element->clientData, AIO_R);
 			element->mask = 0;
+			element->handlerFn(element->fd, element->clientData, AIO_R);
 			return;
 		}
 
@@ -213,8 +213,8 @@ void aioFileDescriptor_signal_withHandle(HANDLE event){
 			//We set the event to 0 so it is not recalled after
 			WSAEventSelect(element->fd, element->writeEvent, 0);
 
-			element->handlerFn(element->fd, element->clientData, AIO_W);
 			element->mask = 0;
+			element->handlerFn(element->fd, element->clientData, AIO_W);
 			return;
 		}
 


### PR DESCRIPTION
Fixing a race condition when the dataHanlder will block again