### PR TITLE
Only scan the class table if `become:` was performed to an active class object

### DIFF
--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -10695,7 +10695,7 @@ SpurMemoryManager >> postBecomeScanClassTable: effectsFlags [
 	 We can somehow avoid following classes from the classTable until after this mark phase."
 	self assert: self validClassTableRootPages.
 
-	(effectsFlags anyMask: BecamePointerObjectFlag) ifFalse: [^self].
+	(effectsFlags anyMask: BecameActiveClassFlag) ifFalse: [^self].
 
 	0 to: numClassTablePages - 1 do:
 		[:i| | page |


### PR DESCRIPTION
We (Lifeware) have some issues in Pharo with the performance of `become:`. This hurts us in some code that performs a very large number of calls to `become:`. The following code illustrates the issue:
```Smalltalk
Time millisecondsToRun:
        [| a b |
        a := (1 to: 1000) collect: [:e | ValueHolder new].
        b := (1 to: a size) collect: [:e | ValueHolder new].
        a with: b do: [:a1 :a2 | a1 become: a2]]
```
In vanilla Pharo it takes about 20 milliseconds on my machine. In a Pharo image with GT + Lifeware code (resulting in ~175000 classes) it takes about 1 second.

We found that the issue is that in the Pharo VM, `become:` scans through the complete class table (nearly) every time. This means the more classes there are in the image, the slower it will be. Note that the method comment in `SpurMemoryManager>>#postBecomeScanClassTable:` indicates that this should only happen when an active class object has been becomed.

In this pull request I try to make the change to only do the scan in case we actually becomed an active class object by changing the guard slightly. With this it only takes 7 milliseconds in the image with GT + Lifeware code (and 3 milliseconds in vanilla Pharo). While I think that should be correct, because it also aligns with the comment in the method I changed, this should definitely be reviewed by someone with more knowledge about the VM than me.