### PR TITLE
p10-port-1023

### DIFF
--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -10655,7 +10655,7 @@ SpurMemoryManager >> postBecomeScanClassTable: effectsFlags [
 	 We can somehow avoid following classes from the classTable until after this mark phase."
 	self assert: self validClassTableRootPages.
 
-	(effectsFlags anyMask: BecamePointerObjectFlag) ifFalse: [^self].
+	(effectsFlags anyMask: BecameActiveClassFlag) ifFalse: [^self].
 
 	0 to: numClassTablePages - 1 do:
 		[:i| | page |


### PR DESCRIPTION
Only scan the class table if `become:` was performed to an active class object.