### PR TITLE
Hi CogitDecompiler

### DIFF
--- a/smalltalksrc/VMMaker/CogAbstractInstruction.class.st
+++ b/smalltalksrc/VMMaker/CogAbstractInstruction.class.st
@@ -409,6 +409,17 @@ CogAbstractInstruction >> annotation: aByte [
 	^annotation := aByte
 ]
 
+{ #category : 'printing' }
+CogAbstractInstruction >> argumentNames [
+	<doNotGenerate>
+
+	| format argumentAsStrings |
+	argumentAsStrings := String streamContents: [ :aStream |
+		  format := self getFormatFromOpCodeName: self opCodeName.
+		  self printOperandsOn: aStream withFormat: format ].
+	^ Character space split: argumentAsStrings trim
+]
+
 { #category : 'coercion' }
 CogAbstractInstruction >> asInteger [
 	<doNotGenerate>
@@ -1401,6 +1412,13 @@ CogAbstractInstruction >> numIntRegArgs [
 { #category : 'multi-threading' }
 CogAbstractInstruction >> numLowLevelLockOpcodes [
 	self subclassResponsibility
+]
+
+{ #category : 'printing' }
+CogAbstractInstruction >> opCodeName [
+	<doNotGenerate>
+
+	^ self class nameForOpcode: opcode
 ]
 
 { #category : 'accessing' }

--- a/smalltalksrc/VMMakerTests/CogitDecompiler.class.st
+++ b/smalltalksrc/VMMakerTests/CogitDecompiler.class.st
@@ -1,0 +1,293 @@
+Class {
+	#name : 'CogitDecompiler',
+	#superclass : 'Object',
+	#instVars : [
+		'temporaries'
+	],
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
+}
+
+{ #category : 'ast building' }
+CogitDecompiler >> argumentNodesFor: argumentNames [
+
+	^ argumentNames collect: [ :arg |
+		  | argString |
+		  argString := arg.
+		  (argString includes: $/) ifTrue: [
+			  argString := ($/ split: argString) first ].
+
+		  argString isAllDigits
+			  ifTrue: [ self literalNumber: argString asNumber ]
+			  ifFalse: [ RBVariableNode named: argString ] ]
+]
+
+{ #category : 'api' }
+CogitDecompiler >> buildFrom: abstractInstructions [
+
+	| statements |
+	statements := abstractInstructions
+		              collect: [ :absInt | self statementFor: absInt ]
+		              thenReject: [ :statement | statement isNil ].
+
+	^ RBMethodNode selector: #foo arguments: {  } body: (RBSequenceNode
+			   temporaries: self temporariesNode
+			   statements: statements)
+]
+
+{ #category : 'ast building' }
+CogitDecompiler >> compilerNode [
+
+	^ RBVariableNode named: 'cogit'
+]
+
+{ #category : 'decompiling' }
+CogitDecompiler >> generateAdd: anAbstractInstruction [ 
+
+	| selector arguments |
+	selector := self selectorForOpCode: anAbstractInstruction opCodeName after: 'Add' size.
+	arguments := self argumentNodesFor: anAbstractInstruction argumentNames.
+	
+	^ RBMessageNode 
+		receiver: self compilerNode
+		selector:  selector
+		arguments: arguments
+]
+
+{ #category : 'decompiling' }
+CogitDecompiler >> generateAlignment: anAbstractInstruction [
+
+	^ RBMessageNode receiver: self compilerNode selector: #Nop
+]
+
+{ #category : 'decompiling' }
+CogitDecompiler >> generateAnd: anAbstractInstruction [ 
+
+	| selector arguments |
+	selector := self selectorForOpCode: anAbstractInstruction opCodeName after: 'And' size.
+	arguments := self argumentNodesFor: anAbstractInstruction argumentNames.
+	
+	^ RBMessageNode 
+		receiver: self compilerNode
+		selector:  selector
+		arguments: arguments
+]
+
+{ #category : 'decompiling' }
+CogitDecompiler >> generateCall: anAbstractInstruction [
+
+	| address |
+	address := anAbstractInstruction operands first.
+
+	^ RBMessageNode
+		  receiver: self compilerNode
+		  selector: #CallRT:
+		  arguments: { (self literalAddress: address) }
+]
+
+{ #category : 'decompiling' }
+CogitDecompiler >> generateCmp: anAbstractInstruction [ 
+
+	| selector arguments |
+	selector := self selectorForOpCode: anAbstractInstruction opCodeName after: 'Cmp' size.
+	arguments := self argumentNodesFor: anAbstractInstruction argumentNames.
+	
+	^ RBMessageNode 
+		receiver: self compilerNode
+		selector:  selector
+		arguments: arguments
+]
+
+{ #category : 'decompiling' }
+CogitDecompiler >> generateJump: anAbstractInstruction [
+
+	| selector label variableName |
+	selector := anAbstractInstruction opCodeName , ':'.
+	label := anAbstractInstruction operands first.
+	variableName := 'label' , label operands first asString.
+
+	^ RBMessageNode
+		  receiver: self compilerNode
+		  selector: selector
+		  arguments: { (RBVariableNode named: variableName) }
+]
+
+{ #category : 'decompiling' }
+CogitDecompiler >> generateLabel: anAbstractInstruction [
+
+	| index variableName |
+	index := anAbstractInstruction operands first.
+	variableName := 'label' , index asString.
+
+	temporaries add: variableName.
+
+	^ RBAssignmentNode
+		  variable: (RBVariableNode named: variableName)
+		  value:
+		  (RBMessageNode receiver: self compilerNode selector: #Label)
+]
+
+{ #category : 'decompiling' }
+CogitDecompiler >> generateMove: anAbstractInstruction [ 
+
+	| selector arguments opName |
+	opName := (anAbstractInstruction opCodeName includesSubstring: 'PatcheableC')
+					ifTrue: [ 'MovePatcheableC' ]
+					ifFalse: [ 'Move' ].
+	selector := self selectorForOpCode: anAbstractInstruction opCodeName after: opName size.
+	arguments := self argumentNodesFor: anAbstractInstruction argumentNames.
+
+	^ RBMessageNode 
+		receiver: self compilerNode
+		selector:  selector
+		arguments: arguments
+]
+
+{ #category : 'decompiling' }
+CogitDecompiler >> generatePop: anAbstractInstruction [ 
+
+	| selector arguments |
+	selector := self selectorForOpCode: anAbstractInstruction opCodeName after: 'Pop' size.
+	arguments := self argumentNodesFor: anAbstractInstruction argumentNames.
+	
+	^ RBMessageNode 
+		receiver: self compilerNode
+		selector:  selector
+		arguments: arguments
+]
+
+{ #category : 'decompiling' }
+CogitDecompiler >> generatePush: anAbstractInstruction [ 
+
+	| selector arguments |
+	selector := self selectorForOpCode: anAbstractInstruction opCodeName after: 'Push' size.
+	arguments := self argumentNodesFor: anAbstractInstruction argumentNames.
+	
+	^ RBMessageNode 
+		receiver: self compilerNode
+		selector:  selector
+		arguments: arguments
+]
+
+{ #category : 'decompiling' }
+CogitDecompiler >> generateRet: anAbstractInstruction [ 
+
+	| selector arguments |
+	selector := self selectorForOpCode: anAbstractInstruction opCodeName after: 'Ret' size.
+	arguments := self argumentNodesFor: anAbstractInstruction argumentNames.
+	
+	^ RBMessageNode 
+		receiver: self compilerNode
+		selector:  selector
+		arguments: arguments
+]
+
+{ #category : 'decompiling' }
+CogitDecompiler >> generateSub: anAbstractInstruction [ 
+
+	| selector arguments |
+	selector := self selectorForOpCode: anAbstractInstruction opCodeName after: 'Sub' size.
+	arguments := self argumentNodesFor: anAbstractInstruction argumentNames.
+	
+	^ RBMessageNode 
+		receiver: self compilerNode
+		selector:  selector
+		arguments: arguments
+]
+
+{ #category : 'decompiling' }
+CogitDecompiler >> generateTst: anAbstractInstruction [ 
+
+	| selector arguments |
+	selector := self selectorForOpCode: anAbstractInstruction opCodeName after: 'Tst' size.
+	arguments := self argumentNodesFor: anAbstractInstruction argumentNames.
+	
+	^ RBMessageNode 
+		receiver: self compilerNode
+		selector:  selector
+		arguments: arguments
+]
+
+{ #category : 'initialization' }
+CogitDecompiler >> initialize [
+
+	super initialize.
+	temporaries := OrderedCollection new
+]
+
+{ #category : 'as yet unclassified' }
+CogitDecompiler >> kindOfOpCode: opCodeName [
+	" #MoveCqR -> 'Move' "
+
+	[ :c | c isUppercase ]
+		split: opCodeName
+		indicesDo: [ :start :end |
+		end > 1 ifTrue: [ ^ opCodeName copyFrom: 1 to: end ] ].
+	
+	self unexplored
+]
+
+{ #category : 'ast building' }
+CogitDecompiler >> literalAddress: address [
+
+	^ RBLiteralValueNode new
+		  value: address
+		  start: 0
+		  stop: -1
+		  source: address hex
+]
+
+{ #category : 'ast building' }
+CogitDecompiler >> literalNumber: aNumber [
+
+	aNumber < 10000 ifTrue: [ ^ RBLiteralNode value: aNumber ].
+	^ self literalAddress: aNumber
+]
+
+{ #category : 'ast building' }
+CogitDecompiler >> selectorForOpCode: opCodeName after: index [
+
+	^ String streamContents: [ :s |
+		  opCodeName doWithIndex: [ :char :i |
+			  (i > (index + 1) and: [
+				   char isUppercase or: [
+					   char = $r and: [
+						   i = opCodeName size or: [ (opCodeName at: i + 1) = $R ] ] ] ])
+				  ifTrue: [ s << ':' ].
+			  s << char ].
+		  s << ':' ]
+]
+
+{ #category : 'as yet unclassified' }
+CogitDecompiler >> statementFor: anAbstractInstruction [
+	"a CogOutOfLineLiteralsARMv8Compiler (MoveCqR 0 ReceiverResultReg D2800017@320000520)"
+
+	| kind |
+	anAbstractInstruction address ifNil: [ ^ nil ].
+	
+	kind := self kindOfOpCode: anAbstractInstruction opCodeName.
+	^ kind asSymbol
+		caseOf: {
+				([ #Move ] -> [ self generateMove: anAbstractInstruction ]).
+				([ #Push ] -> [ self generatePush: anAbstractInstruction ]).
+				([ #Pop ] -> [ self generatePop: anAbstractInstruction ]).
+				([ #Call ] -> [ self generateCall: anAbstractInstruction ]).
+				([ #Label ] -> [ self generateLabel: anAbstractInstruction ]).
+				([ #And ] -> [ self generateAnd: anAbstractInstruction ]).
+				([ #Jump ] -> [ self generateJump: anAbstractInstruction ]).
+				([ #Cmp ] -> [ self generateCmp: anAbstractInstruction ]).
+				([ #Tst ] -> [ self generateTst: anAbstractInstruction ]).
+				([ #Add ] -> [ self generateAdd: anAbstractInstruction ]).
+				([ #Sub ] -> [ self generateSub: anAbstractInstruction ]).
+				([ #Ret ] -> [ self generateRet: anAbstractInstruction ]).
+				([ #Alignment ] -> [ self generateAlignment: anAbstractInstruction "?" ]).
+				([ #Literal ] -> [ "?" ]). }
+		otherwise: [ self shouldBeImplemented ]
+]
+
+{ #category : 'ast building' }
+CogitDecompiler >> temporariesNode [
+
+	^ temporaries collect: [ :name | RBVariableNode named: name ]
+]

--- a/smalltalksrc/VMMakerTests/VMJitMethodTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJitMethodTest.class.st
@@ -99,6 +99,19 @@ VMJitMethodTest >> filter: aGlyphForm [
 	^answer
 ]
 
+{ #category : 'as yet unclassified' }
+VMJitMethodTest >> genCogitMethod: aMethodObj [
+
+	| methodOop ast |
+	methodOop := self createMethodOopFromHostMethod: aMethodObj.
+	cogit cog: methodOop selector: memory nilObject.
+
+	ast := CogitDecompiler new buildFrom: cogit abstractOpcodes cPtrAsOop.
+	ast selector: #gen_ , aMethodObj selector.
+	ast arguments: aMethodObj ast arguments copy.
+	self writeAST: ast
+]
+
 { #category : 'running' }
 VMJitMethodTest >> initialCodeSize [
 
@@ -122,6 +135,12 @@ VMJitMethodTest >> setUpTrampolines [
 
 	cogit ceCheckForInterruptTrampoline: (self compileTrampoline: [ cogit RetN: 0 ] named:#ceCheckForInterruptTrampoline).
 	cogit ceReturnToInterpreterTrampoline: (self compileTrampoline: [ cogit Stop ] named:#ceReturnToInterpreterTrampoline).
+]
+
+{ #category : 'tests' }
+VMJitMethodTest >> testCogitDecompilerSmoteTest [
+
+	self genCogitMethod: SequenceableCollection >> #do:
 ]
 
 { #category : 'tests' }
@@ -165,4 +184,10 @@ VMJitMethodTest >> testMixedInlinedLiteralsSmoteTest [
 	callingMethod := self jitMethod: (self class>>#filter:).
 
 	self deny: callingMethod address equals: 0.
+]
+
+{ #category : 'writing' }
+VMJitMethodTest >> writeAST: aRBMethodNode [
+
+	self class compile: aRBMethodNode formattedCode classified: #'*generated'
 ]


### PR DESCRIPTION
This PR adds a decompiler from Cogit IR -> RTL.

I think that it is nice to debug the JIT compiler / analyze / learn about how is the JIT generates machine code for a complete method.
A big difference between this and the use of the machine code debugger is that:
- this is code. You can edit, add spaces, comments. It is easier to navigate.
- this is Cogit. If you develop the JIT compiler you don't need to learn details about the instructions of a particular architecture.

I added a _smoke test_ compiling the method `SequenceableCollection >> #do:` and you get this:
```st
gen_do: aBlock

	| label1 label2 label3 label4 label5 label6 label7 label8 label9 label10 label11 label12 label13 label14 |
	cogit MoveCq: 0 R: ReceiverResultReg.
	cogit PushR: LinkReg.
	cogit CallRT: 16r3200002D8.
	label1 := cogit Label.
	cogit AndCq: 7 R: ReceiverResultReg R: TempReg.
	cogit JumpNonZero: label2.
	cogit MoveMw: 0 r: ReceiverResultReg R: TempReg.
	cogit AndCq: 16r3FFFFF R: TempReg.
	label2 := cogit Label.
	cogit CmpR: ClassReg R: TempReg.
	cogit JumpNonZero: label30.
	label3 := cogit Label.
	cogit PushR: ReceiverResultReg.
	cogit PushR: Arg0Reg.
	cogit PushR: LinkReg.
	cogit PushR: FPReg.
	cogit MoveR: SPReg R: FPReg.
	cogit PushCw: 16r320000430.
	cogit MoveCq: 16r10000000000 R: SendNumArgsReg.
	cogit PushR: SendNumArgsReg.
	cogit PushR: ReceiverResultReg.
	cogit PushR: SendNumArgsReg.
	cogit PushR: SendNumArgsReg.
	cogit MoveAw: 16r7FFFFFFFFFFFFC88 R: TempReg.
	cogit CmpR: TempReg R: SPReg.
	cogit JumpBelow: label0.
	label4 := cogit Label.
	cogit MoveMw: -24 r: FPReg R: ReceiverResultReg.
	cogit MovePatcheableC32: -19 R: ClassReg.
	cogit CallRT: 16r3200002A8.
	label5 := cogit Label.
	cogit MoveR: ReceiverResultReg Mw: -32 r: FPReg.
	cogit MoveCq: 9 R: TempReg.
	cogit MoveR: TempReg Mw: -40 r: FPReg.
	cogit PushCq: 9.
	label6 := cogit Label.
	cogit MoveMw: -32 r: FPReg R: Arg0Reg.
	cogit MoveMw: -40 r: FPReg R: ReceiverResultReg.
	cogit MoveR: ReceiverResultReg R: TempReg.
	cogit AndR: Arg0Reg R: TempReg.
	cogit TstCq: 1 R: TempReg.
	cogit JumpZero: label7.
	cogit CmpR: Arg0Reg R: ReceiverResultReg.
	cogit JumpGreater: label14.
	cogit Jump: label9.
	label7 := cogit Label.
	cogit MovePatcheableC32: -5 R: ClassReg.
	cogit CallRT: 16r3200002B0.
	cogit MoveR: ReceiverResultReg R: TempReg.
	cogit SubCq: 16r10000000010 R: TempReg.
	cogit JumpZero: label14.
	cogit CmpCq: 16 R: TempReg.
	cogit JumpZero: label8.
	cogit CallRT: 16r3200002F8.
	label8 := cogit Label.
	label9 := cogit Label.
	cogit MoveMw: 16 r: FPReg R: TempReg.
	cogit PushR: TempReg.
	cogit MoveMw: -40 r: FPReg R: Arg0Reg.
	cogit MoveMw: -24 r: FPReg R: ReceiverResultReg.
	cogit MovePatcheableC32: -17 R: ClassReg.
	cogit CallRT: 16r3200002B0.
	cogit MoveR: ReceiverResultReg R: Arg0Reg.
	cogit MoveMw: -56 r: FPReg R: ReceiverResultReg.
	cogit AddCq: 8 R: SPReg.
	cogit MovePatcheableC32: -27 R: ClassReg.
	cogit CallRT: 16r3200002B0.
	cogit MoveMw: -40 r: FPReg R: ReceiverResultReg.
	cogit TstCq: 1 R: ReceiverResultReg.
	cogit JumpZero: label10.
	cogit AddCq: 8 R: ReceiverResultReg.
	cogit JumpNoOverflow: label11.
	cogit SubCq: 8 R: ReceiverResultReg.
	label10 := cogit Label.
	cogit MoveCq: 9 R: Arg0Reg.
	cogit MovePatcheableC32: -1 R: ClassReg.
	cogit CallRT: 16r3200002B0.
	label11 := cogit Label.
	label12 := cogit Label.
	cogit MoveR: ReceiverResultReg Mw: -40 r: FPReg.
	cogit MoveAw: 16r7FFFFFFFFFFFFC88 R: TempReg.
	cogit CmpR: TempReg R: SPReg.
	cogit JumpAboveOrEqual: label6.
	cogit CallRT: 16r320000308.
	label13 := cogit Label.
	cogit Jump: label6.
	cogit Nop.
	label14 := cogit Label.
	cogit AddCq: 8 R: SPReg.
	cogit MoveMw: -24 r: FPReg R: ReceiverResultReg.
	cogit MoveR: FPReg R: SPReg.
	cogit PopR: FPReg.
	cogit PopR: LinkReg.
	cogit RetN: 16.
	cogit Nop.
	cogit Nop
```