### PR TITLE
Feature: thisProcess jit

### DIFF
--- a/smalltalksrc/VMMaker-Tools/VMMachineCodeDebugger.class.st
+++ b/smalltalksrc/VMMaker-Tools/VMMachineCodeDebugger.class.st
@@ -213,7 +213,7 @@ VMMachineCodeDebugger >> highlightMCInstructions: aVMDebuggerIRInstruction [
 VMMachineCodeDebugger >> highlightPCInstruction [
 
 	| index |
-	index :=	(self initialDisassembly collect: [ :e | e address ]) indexOf: machineSimulator instructionPointerValue.
+	index :=	(self initialDisassembly collect: [ :e | e address ]) indexOf: machineSimulator instructionPointerRegisterValue.
 	instructions selection selectIndex: index
 
 ]

--- a/smalltalksrc/VMMaker/Cogit.class.st
+++ b/smalltalksrc/VMMaker/Cogit.class.st
@@ -6107,6 +6107,11 @@ Cogit >> extABytecode [
 	^0
 ]
 
+{ #category : 'accessing' }
+Cogit >> extB [
+	^ extB
+]
+
 { #category : 'bytecode generators' }
 Cogit >> extBBytecode [
 	"225		11100001	sbbbbbbb	Extend B (Ext B = Ext B prev * 256 + Ext B)"

--- a/smalltalksrc/VMMaker/SimpleStackBasedCogit.class.st
+++ b/smalltalksrc/VMMaker/SimpleStackBasedCogit.class.st
@@ -1288,8 +1288,8 @@ SimpleStackBasedCogit >> genExtPushPseudoVariable [
 		caseOf: {
 				([ 0 ] -> [ ^ self genPushActiveContextBytecode ]).
 				([ 1 ] -> [
-				 "Fetch the special objects array, read the scheduler association, its value, and the active process from it"
-				 self MoveAw: objectMemory specialObjectsOop R: TempReg.
+				 "Fetch the special objects array address, read the scheduler association, its value, and the active process from it"
+				 self MoveAw: objectMemory specialObjectsArrayAddress R: TempReg.
 				 self AddCq: SchedulerAssociation << 3 R: TempReg.
 				 self MoveMw: 1 * objectMemory wordSize r: TempReg R: TempReg.
 				 self AddCq: ValueIndex << objectMemory shiftForWord R: TempReg.

--- a/smalltalksrc/VMMaker/SimpleStackBasedCogit.class.st
+++ b/smalltalksrc/VMMaker/SimpleStackBasedCogit.class.st
@@ -1287,17 +1287,7 @@ SimpleStackBasedCogit >> genExtPushPseudoVariable [
 	ext
 		caseOf: {
 				([ 0 ] -> [ ^ self genPushActiveContextBytecode ]).
-				([ 1 ] -> [
-				 "Fetch the special objects array address, read the scheduler association, its value, and the active process from it"
-				 self MoveAw: objectMemory specialObjectsArrayAddress R: TempReg.
-				 self AddCq: SchedulerAssociation << 3 R: TempReg.
-				 self MoveMw: 1 * objectMemory wordSize r: TempReg R: TempReg.
-				 self AddCq: ValueIndex << objectMemory shiftForWord R: TempReg.
-				 self MoveMw: 1 * objectMemory wordSize r: TempReg R: TempReg.
-				 self AddCq: ActiveProcessIndex << objectMemory shiftForWord R: TempReg.
-				 self MoveMw: 1 * objectMemory wordSize r: TempReg R: TempReg.
-				 self PushR: TempReg.
-				 ^ 0 ]) }
+				([ 1 ] -> [ ^ self genPushActiveProcessBytecode ]) }
 		otherwise: [ ^ self unknownBytecode ].
 	^ 0
 ]
@@ -1983,6 +1973,12 @@ SimpleStackBasedCogit >> genPushActiveContextBytecode [
 		inBlock: inBlock.
 	self PushR: ReceiverResultReg.
 	^0
+]
+
+{ #category : 'bytecode generators' }
+SimpleStackBasedCogit >> genPushActiveProcessBytecode [
+
+	^ self unknownBytecode
 ]
 
 { #category : 'constant support' }

--- a/smalltalksrc/VMMaker/SimpleStackBasedCogit.class.st
+++ b/smalltalksrc/VMMaker/SimpleStackBasedCogit.class.st
@@ -1279,16 +1279,27 @@ SimpleStackBasedCogit >> genExtPushLiteralVariableBytecode [
 { #category : 'bytecode generators' }
 SimpleStackBasedCogit >> genExtPushPseudoVariable [
 	"SistaV1: *	82			01010010			Push thisContext, (then Extend B = 1 => push thisProcess)"
+
 	| ext |
 	ext := extB.
 	extB := 0.
 	numExtB := 0.
-	ext caseOf: {
-		[0]	->	[^self genPushActiveContextBytecode].
-		}
-		otherwise:
-			[^self unknownBytecode].
-	^0
+	ext
+		caseOf: {
+				([ 0 ] -> [ ^ self genPushActiveContextBytecode ]).
+				([ 1 ] -> [
+				 "Fetch the special objects array, read the scheduler association, its value, and the active process from it"
+				 self MoveAw: objectMemory specialObjectsOop R: TempReg.
+				 self AddCq: SchedulerAssociation << 3 R: TempReg.
+				 self MoveMw: 1 * objectMemory wordSize r: TempReg R: TempReg.
+				 self AddCq: ValueIndex << objectMemory shiftForWord R: TempReg.
+				 self MoveMw: 1 * objectMemory wordSize r: TempReg R: TempReg.
+				 self AddCq: ActiveProcessIndex << objectMemory shiftForWord R: TempReg.
+				 self MoveMw: 1 * objectMemory wordSize r: TempReg R: TempReg.
+				 self PushR: TempReg.
+				 ^ 0 ]) }
+		otherwise: [ ^ self unknownBytecode ].
+	^ 0
 ]
 
 { #category : 'bytecode generators' }

--- a/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
+++ b/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
@@ -2126,6 +2126,22 @@ StackToRegisterMappingCogit >> genPushActiveContextBytecode [
 	^self ssPushRegister: ReceiverResultReg
 ]
 
+{ #category : 'bytecode generators' }
+StackToRegisterMappingCogit >> genPushActiveProcessBytecode [
+
+	self MoveAw: objectMemory specialObjectsArrayAddress R: TempReg.
+	"Fetch the special objects array address, read the scheduler association, its value, and the active process from it"
+	self AddCq: SchedulerAssociation << 3 R: TempReg.
+	self MoveMw: 1 * objectMemory wordSize r: TempReg R: TempReg.
+	self AddCq: ValueIndex << objectMemory shiftForWord R: TempReg.
+	self MoveMw: 1 * objectMemory wordSize r: TempReg R: TempReg.
+	self
+		AddCq: ActiveProcessIndex << objectMemory shiftForWord
+		R: TempReg.
+	self ssPushBase: TempReg offset: 1 * objectMemory wordSize.
+	^ 0
+]
+
 { #category : 'mapped inline primitive generators - vectorial' }
 StackToRegisterMappingCogit >> genPushFloat32ArrayToRegister [
 

--- a/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
+++ b/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
@@ -2126,16 +2126,6 @@ StackToRegisterMappingCogit >> genPushActiveContextBytecode [
 	^self ssPushRegister: ReceiverResultReg
 ]
 
-{ #category : 'bytecode generator support' }
-StackToRegisterMappingCogit >> genPushEnclosingObjectAt: level [
-	"Uncached push enclosing object"
-	self voidReceiverResultRegContainsSelf.
-	self ssAllocateCallReg: SendNumArgsReg and: ReceiverResultReg.
-	self MoveCq: level R: SendNumArgsReg.
-	self CallRT: ceEnclosingObjectTrampoline.
-	^self ssPushRegister: ReceiverResultReg
-]
-
 { #category : 'mapped inline primitive generators - vectorial' }
 StackToRegisterMappingCogit >> genPushFloat32ArrayToRegister [
 

--- a/smalltalksrc/VMMakerTests/VMPushThisProcessTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPushThisProcessTest.class.st
@@ -1,0 +1,72 @@
+Class {
+	#name : 'VMPushThisProcessTest',
+	#superclass : 'VMStackToRegisterMappingCogitTest',
+	#category : 'VMMakerTests-JitTests',
+	#package : 'VMMakerTests',
+	#tag : 'JitTests'
+}
+
+{ #category : 'tests - thisContext' }
+VMPushThisProcessTest >> testPushThisProcessBytecodePushesOnlyThisProcess [
+
+	| method machineCodeBreakpoint |
+
+	self setUpScheduler.
+
+	method := self compile: [
+
+		cogit needsFrame: true.
+		cogit methodOrBlockNumTemps: 0.
+		cogit initSimStackPointer: nil.
+
+		cogit byte1: 1.
+		cogit extBBytecode.
+		self assert: cogit extB equals: 1.
+		cogit genExtPushPseudoVariable.
+		cogit ssFlushStack.
+
+		machineCodeBreakpoint := cogit Stop ].
+
+	"We test that before our pushed value we find the same badfood"
+	self pushAddress: 16rbadf00d.
+
+	"Push the active process and pop it back"
+	self
+		runFrom: method
+		until: machineCodeBreakpoint address.
+	self popAddress.
+
+	self
+		assert: self popAddress
+		equals: 16rbadf00d
+]
+
+{ #category : 'tests - thisContext' }
+VMPushThisProcessTest >> testPushThisProcessBytecodePushesThisProcess [
+
+	| method machineCodeBreakpoint |
+
+	self setUpScheduler.
+
+	method := self compile: [
+
+		cogit needsFrame: true.
+		cogit methodOrBlockNumTemps: 0.
+		cogit initSimStackPointer: nil.
+
+		cogit byte1: 1.
+		cogit extBBytecode.
+		self assert: cogit extB equals: 1.
+		cogit genExtPushPseudoVariable.
+		cogit ssFlushStack.
+
+		machineCodeBreakpoint := cogit Stop ].
+
+	self
+		runFrom: method
+		until: machineCodeBreakpoint address.
+
+	self
+		assert: self popAddress
+		equals: memory memoryActiveProcess
+]


### PR DESCRIPTION
JIT compile `thisProcess` pseudo variable, and thus enable compilation of methods containing it.

Pre-benchs

[thisProcess] bench.

```
no-JIT: "  267,125,795 iterations in 5 seconds 3 milliseconds. 53393123.126 per second"
   JIT: "2,039,559,714 iterations in 5 seconds 4 milliseconds. 407585874.101 per second"
```

so ~7.63x faster in just the micro benchmark


Compared to `Processor activeProcess`

```
[ Processor activeProcess ] bench.
"1,078,930,783 iterations in 5 seconds 3 milliseconds. 215656762.542 per second"
"1,099,617,392 iterations in 5 seconds 3 milliseconds. 219791603.438 per second"
"1,060,324,282 iterations in 5 seconds 1 millisecond. 212022451.910 per second"

[ thisProcess ] bench
"2,039,091,170 iterations in 5 seconds 1 millisecond. 407736686.663 per second"
"2,046,412,976 iterations in 5 seconds 1 millisecond. 409200755.049 per second"
"2,032,670,721 iterations in 5 seconds 3 milliseconds. 406290369.978 per second"
"1,992,535,072 iterations in 5 seconds 2 milliseconds. 398347675.330 per second"
```

Made with @javierlarre