### PR TITLE
Notify read semaphore as well on write

### DIFF
--- a/extracted/plugins/SocketPlugin/src/common/SocketPluginImpl.c
+++ b/extracted/plugins/SocketPlugin/src/common/SocketPluginImpl.c
@@ -594,6 +594,7 @@ static void sendHandler(sqInt fd, void *data, int flags)
 	pss->waitingToSend = false;
 
 	notify(pss, WRITE_NOTIFY);
+	notify(pss, READ_NOTIFY);
 }
 
 /* read data transfer is now possible for the socket. */


### PR DESCRIPTION
This resolves https://github.com/pharo-project/pharo/issues/11083.
We've been running this change at a large customer for almost 4 years without issue.  The patch for versions prior to 10.3.9 is https://github.com/feenkcom/pharo-vm/commit/e0b19ceb815350db8f6181d8b9052620ecab0b15