### PR TITLE
Fix LargeIntegers segfault on allocation failure

### DIFF
--- a/plugins/LargeIntegers/src/common/LargeIntegers.c
+++ b/plugins/LargeIntegers/src/common/LargeIntegers.c
@@ -165,9 +165,9 @@ extern
 struct VirtualMachine* interpreterProxy;
 static const char *moduleName =
 #ifdef SQUEAK_BUILTIN_PLUGIN
-	"LargeIntegers v2.0 VMMaker.oscog-eem.2495 (i)"
+	"LargeIntegers v2.1 VMMaker.oscog-eem.2495 (i)"
 #else
-	"LargeIntegers v2.0 VMMaker.oscog-eem.2495 (e)"
+	"LargeIntegers v2.1 VMMaker.oscog-eem.2495 (e)"
 #endif
 ;
 static const int  orOpIndex = 1;
@@ -1588,6 +1588,9 @@ primDigitDivNegative(void)
 		div = popRemappableOop()
 #endif /* SPURVM */
 ;
+		if (!quo) {
+			return primitiveFailFor(PrimErrNoMemory);
+		}
 		/* begin cDigitDiv:len:rem:len:quo:len: */
 		pDiv = ((unsigned int *) (firstIndexableField(div)));
 		divLen = ((slotSizeOf(div)) + 3) / 4;

--- a/smalltalksrc/VMMaker/LargeIntegersPlugin.class.st
+++ b/smalltalksrc/VMMaker/LargeIntegersPlugin.class.st
@@ -27,6 +27,9 @@ Class vars:
 
 History
 --------
+v2.1
+
+- fix: >>digitDivLarge:with:negative: now checks out of memory
 
 v2.0
 
@@ -111,7 +114,7 @@ LargeIntegersPlugin class >> moduleNameAndVersion [
 LargeIntegersPlugin class >> version [
 	"Answer the receiver's version info as String."
 
-	^ 'v2.0'
+	^ 'v2.1'
 ]
 
 { #category : 'util' }
@@ -920,6 +923,7 @@ LargeIntegersPlugin >> digitDivLarge: firstInteger with: secondInteger negative:
 			 rem ifNil: [^rem]].
 	self remapOop: #(div rem)
 		in: [quo := self createLargeIntegerNeg: neg digitLength: quoDigitLen].
+	quo ifNil: [^interpreterProxy primitiveFailFor: PrimErrNoMemory].
 	self
 		cDigitDiv: (self pointerToFirstDigitOfLargeInt: div)
 		len: (self digitSizeOfLargeInt: div)


### PR DESCRIPTION
While running a benchmark, we encountered a consistent segmentation-error / null-pointer-dereference when doing computations with large LargeIntegers.

Snippet for reproducibility:
```smalltalk
| largeInteger largeInterval |
largeInteger := (2 raisedTo: 63245986).
largeInterval := 2 to: largeInteger.
largeInterval size
```

This PR adds the necessary OOM checks. The primitive now fails properly instead of crashing the VM. In our case, this would allow the testcase to timeout, but the remaining testcases could then still be executed