### PR TITLE
Add idle time to VM parameters

### DIFF
--- a/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/InterpreterPrimitives.class.st
@@ -2986,14 +2986,16 @@ InterpreterPrimitives >> primitiveRelinquishProcessor [
 
 	| microSecs |
 	microSecs := self stackIntegerValue: 0.
-	self successful ifTrue: [
+	self successful ifTrue: [ 
 		"DO NOT allow relinquishing the processor while we are profiling since this
 		may skew the time base for our measures (it may reduce processor speed etc).
 		Instead we go full speed, therefore measuring the precise time we spend in the
 		inner idle loop as a busy loop."
-		nextProfileTick = 0 ifTrue:[self ioRelinquishProcessorForMicroseconds: microSecs].
-		self pop: 1.  "microSecs; leave rcvr on stack"
-	]
+		nextProfileTick = 0 ifTrue: [ | startTime |
+			startTime := self ioUTCMicrosecondsNow.
+			self ioRelinquishProcessorForMicroseconds: microSecs.
+			self addIdleUsecs: (self ioUTCMicrosecondsNow - startTime) ].
+		self pop: 1 "microSecs; leave rcvr on stack" ]
 ]
 
 { #category : 'arithmetic largeint primitives' }

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -1924,7 +1924,7 @@ StackInterpreter >> addFloat64VectorBytecode [
 StackInterpreter >> addIdleUsecs: idleUsecs [
 	"The various poll/select calls in the VM should attempt to tally the ammount
 	 of time spent at idle here, so as to render the uptime value meaningful."
-	<api>
+	<inline: true>
 	statIdleUsecs := statIdleUsecs + idleUsecs
 ]
 


### PR DESCRIPTION
There already was a variable for this, but nobody was using it... 

The method annotated as `<api>`, so maybe it was designed to call it from outside, but in my image the time was always 0.
So I changed that, but maybe I shouldn't?

This PR update the value each time that the `primitiveRelinquishProcessor` is called.

## Before
<img width="438" height="47" alt="image" src="https://github.com/user-attachments/assets/ce26e582-1fe6-41e9-a034-da76c2d37124" />

## Now
<img width="460" height="48" alt="image" src="https://github.com/user-attachments/assets/c3ce841c-9334-4b8f-a2c3-cd173b6d5bbb" />

----

Made for the _Pharo sprint_ from Argentina 🇦🇷 