### PR TITLE
Tried to reduce compilation warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,11 +5,7 @@
 #  vmmaker: generates a Pharo development environment with the virtual machine code, Slang transpiler and machine code simulation
 #  generate-sources: generates the virtual machine source code in C, using the Slang-to-C transpiler
 
-cmake_minimum_required(VERSION 3.7.2)
-# Use new and simpler escape sequences
-cmake_policy(SET CMP0053 NEW)
-#RPATH settings on macOS do not affect install_name.
-cmake_policy(SET CMP0068 NEW)
+cmake_minimum_required(VERSION 3.10)
 
 include(cmake/BuildType.cmake)
 include(cmake/macros.cmake)
@@ -63,12 +59,12 @@ set(user_file "${CMAKE_SOURCE_DIR}/CMakeSettings.json" )
 set(template_file "${CMAKE_SOURCE_DIR}/CMakeSettings.json.template" )
 
 if(EXISTS "${user_file}")
-    # Get uuid from 'user_file' 
+    # Get uuid from 'user_file'
     file(READ "${user_file}" user_settings )
     string(REGEX MATCH ".*template-uuid[^a-zA-Z0-9]*([a-zA-Z0-9-]*).*" _ ${user_settings})
     set(user_uuid ${CMAKE_MATCH_1})
 
-    # Get uuid from 'template_file' 
+    # Get uuid from 'template_file'
     file(READ "${template_file}" template_settings )
     string(REGEX MATCH ".*template-uuid[^a-zA-Z0-9]*([a-zA-Z0-9-]*).*" _ ${template_settings})
     set(template_uuid ${CMAKE_MATCH_1})
@@ -103,7 +99,7 @@ if ((CMAKE_HOST_UNIX) AND (${CMAKE_HOST_SYSTEM_NAME} MATCHES "CYGWIN*"))
 
   # specify the cross compiler
   set(CMAKE_TOOLCHAIN_PREFIX x86_64-w64-mingw32)
-  
+
   SET(CMAKE_C_COMPILER   ${CMAKE_TOOLCHAIN_PREFIX}-clang)
   SET(CMAKE_CXX_COMPILER ${CMAKE_TOOLCHAIN_PREFIX}-clang++)
   SET(CMAKE_RC_COMPILER ${CMAKE_TOOLCHAIN_PREFIX}-windres)
@@ -192,12 +188,12 @@ if(MSVC)
     set(OS_TYPE "Win32")
     get_platform_name(VM_TARGET_OS)
     message(STATUS "Building for ${VM_TARGET_OS}")
-    
+
     # Define WIN32_LEAN_AND_MEAN to exclude APIs such as Cryptography, DDE, RPC, Shell, and Windows Sockets
     # They can be included if needed
     # https://docs.microsoft.com/en-us/windows/win32/winprog/using-the-windows-headers
     add_compile_definitions(WIN32_LEAN_AND_MEAN)
-    
+
 elseif(WIN)
     message(STATUS "Building for WINDOWS")
 
@@ -238,6 +234,8 @@ elseif(UNIX)
         set(OSX 1)
         set(OS_TYPE "Mac OS")
         set(VM_TARGET_OS "1000") # Used to recognise OS X
+        #RPATH settings on macOS do not affect install_name.
+        cmake_policy(SET CMP0068 NEW) # still useful?
     elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
         set(VM_TARGET_OS "linux-gnu")
     elseif(${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD")
@@ -256,7 +254,7 @@ else()
     set(GENERATED_SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR} CACHE STRING "Source directory where to find the generated source. Default value is CMAKE_CURRENT_BINARY_DIR")
 endif()
 
-set(PLUGIN_GENERATED_FILES 
+set(PLUGIN_GENERATED_FILES
   	${GENERATED_SOURCE_DIR}/generated/plugins/src/FilePlugin/FilePlugin.c
   	${GENERATED_SOURCE_DIR}/generated/plugins/src/NewFilePlugin/NewFilePlugin.c)
 
@@ -296,9 +294,15 @@ add_compile_options(
     -Wno-pointer-to-int-cast
     -Wno-compare-distinct-pointer-types
     -Wno-unknown-warning-option
+    -Wno-strict-aliasing
+    -Wno-unused-command-line-argument
+    -Wno-unused-but-set-variable
+    -Wno-unused-variable
+    -Wno-unused-value
+    -Wno-misleading-indentation
+    -Wno-incompatible-pointer-types-discards-qualifiers
+    -Wno-return-stack-address
 )
-
-
 
 add_compile_definitions(
     IMMUTABILITY=1
@@ -405,7 +409,7 @@ include(cmake/${CMAKE_SYSTEM_NAME}.cmake)
 
 set(GENERATED_SOURCES ${VMSOURCEFILES})
 
-list(APPEND SUPPORT_SOURCES	
+list(APPEND SUPPORT_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/src/debug.c
 	${CMAKE_CURRENT_SOURCE_DIR}/src/utils.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/errorCode.c
@@ -419,7 +423,7 @@ list(APPEND SUPPORT_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/parameters/parameters.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/semaphores/platformSemaphore.c
 
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/common/heartbeat.c    
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/common/heartbeat.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/common/sqHeapMap.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/common/sqVirtualMachine.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/common/sqNamedPrims.c
@@ -438,7 +442,7 @@ if(${FEATURE_FFI})
 
         # Single-threaded callout support
         ${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/sameThread/sameThread.c
-    
+
         # Callback support
         ${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/callbacks/callbackPrimitives.c
         ${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/callbacks/callbacks.c
@@ -467,7 +471,7 @@ add_executable(${VM_EXECUTABLE_NAME} ${VM_FRONTEND_APPLICATION_TYPE} ${VM_FRONTE
 addLibraryWithRPATH(${VM_LIBRARY_NAME} ${VM_SOURCES})
 
 if (${FEATURE_COMPILE_INLINE_MEMORY_ACCESSORS})
-	target_compile_definitions(${VM_LIBRARY_NAME} PRIVATE USE_INLINE_MEMORY_ACCESSORS=1) 
+	target_compile_definitions(${VM_LIBRARY_NAME} PRIVATE USE_INLINE_MEMORY_ACCESSORS=1)
 endif()
 
 if(${FEATURE_JIT_SIMD})
@@ -496,7 +500,7 @@ add_platform_headers()
 if (${FEATURE_FFI})
     target_include_directories(${VM_LIBRARY_NAME}
         PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include/pharovm/ffi)
-    target_compile_definitions(${VM_LIBRARY_NAME} 
+    target_compile_definitions(${VM_LIBRARY_NAME}
         PRIVATE FEATURE_FFI=1)
 
     if(${FEATURE_THREADED_FFI})
@@ -506,7 +510,7 @@ endif()
 
 
 if(${FEATURE_MESSAGE_COUNT})
-    target_compile_definitions(${VM_LIBRARY_NAME} 
+    target_compile_definitions(${VM_LIBRARY_NAME}
         PRIVATE FEATURE_MESSAGE_COUNT=1)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,10 @@
 
 cmake_minimum_required(VERSION 3.12)
 
-if(POLICY CMP0135)
-  cmake_policy(SET CMP0135 NEW)
+if(POLICY CMP0177)
+    # cmake --help-policy CMP0177
+    # install() DESTINATION paths are normalized
+    cmake_policy(SET CMP0177 NEW)
 endif()
 
 include(cmake/BuildType.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 #  vmmaker: generates a Pharo development environment with the virtual machine code, Slang transpiler and machine code simulation
 #  generate-sources: generates the virtual machine source code in C, using the Slang-to-C transpiler
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.24)
 
 if(POLICY CMP0177)
     # cmake --help-policy CMP0177

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,11 @@
 #  vmmaker: generates a Pharo development environment with the virtual machine code, Slang transpiler and machine code simulation
 #  generate-sources: generates the virtual machine source code in C, using the Slang-to-C transpiler
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.12)
+
+if(POLICY CMP0135)
+  cmake_policy(SET CMP0135 NEW)
+endif()
 
 include(cmake/BuildType.cmake)
 include(cmake/macros.cmake)

--- a/cmake/DownloadProject.CMakeLists.cmake.in
+++ b/cmake/DownloadProject.CMakeLists.cmake.in
@@ -1,7 +1,7 @@
 # Distributed under the OSI-approved MIT License.  See accompanying
 # file LICENSE or https://github.com/Crascit/DownloadProject for details.
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.12)
 
 project(${DL_ARGS_PROJ}-download NONE)
 
@@ -14,4 +14,6 @@ ExternalProject_Add(${DL_ARGS_PROJ}-download
                     BUILD_COMMAND       ""
                     INSTALL_COMMAND     ""
                     TEST_COMMAND        ""
+                    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+                    DOWNLOAD_NO_PROGRESS 1
 )

--- a/cmake/FindLibGit2.cmake
+++ b/cmake/FindLibGit2.cmake
@@ -12,7 +12,7 @@ find_library(LIBGIT2_LIBRARY NAMES git2)
 # handle the QUIETLY and REQUIRED arguments and set GIT2_FOUND to TRUE if
 # all listed variables are TRUE
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(libgit2 REQUIRED_VARS LIBGIT2_LIBRARY LIBGIT2_INCLUDE_PATH)
+find_package_handle_standard_args(LibGit2 REQUIRED_VARS LIBGIT2_LIBRARY LIBGIT2_INCLUDE_PATH)
 
 if(LIBGIT2_FOUND AND NOT TARGET git2)
     add_library(git2 SHARED IMPORTED)

--- a/cmake/macros.cmake
+++ b/cmake/macros.cmake
@@ -65,7 +65,7 @@ macro(add_third_party_dependency_with_baseurl NAME BASEURL)
 
     get_platform_name(PLATNAME)
     message("Adding third-party libraries for ${PLATNAME}: ${NAME}")
-    
+
     include(DownloadProject)
     download_project(PROJ ${NAME}
         URL         "${BASEURL}${NAME}.zip"
@@ -97,18 +97,3 @@ macro(add_third_party_dependency NAME)
     add_third_party_dependency_with_baseurl(${NAME} ${BASE_URL})
 endmacro()
 
-
-#
-# Compatibility with old CMAKE versions to remove, as fast as posible
-#
-
-if(${CMAKE_VERSION} VERSION_LESS "3.12.0") 
-    message(STATUS "Please consider to switch to CMake 3.12.0 or later")
-	
-	macro(add_compile_definitions)
-		foreach(loop_var ${ARGN})
-			add_definitions("-D'${loop_var}'")
-		endforeach()
-	endmacro()
-	
-endif()

--- a/cmake/vmmaker.cmake
+++ b/cmake/vmmaker.cmake
@@ -38,7 +38,7 @@ else()
   endif()
 endif()
 
-set(PLUGIN_GENERATED_FILES 
+set(PLUGIN_GENERATED_FILES
     ${PHARO_CURRENT_GENERATED}/plugins/src/FilePlugin/FilePlugin.c
     ${PHARO_CURRENT_GENERATED}/plugins/src/NewFilePlugin/NewFilePlugin.c
     ${PHARO_CURRENT_GENERATED}/plugins/src/SurfacePlugin/SurfacePlugin.c
@@ -58,8 +58,8 @@ if(GENERATE_SOURCES)
     endif()
 
     #Setting platform specific vmmaker virtual machine, with cached download or override
-    if (GENERATE_PHARO_VM) 
-        message("Overriding VM used for code generation")  
+    if (GENERATE_PHARO_VM)
+        message("Overriding VM used for code generation")
         set(VMMAKER_VM ${GENERATE_PHARO_VM})
         # add empty target because is required later when installing vmmaker
 	add_custom_target(vmmaker_vm)
@@ -102,18 +102,19 @@ if(GENERATE_SOURCES)
         #Download VM
         ExternalProject_Add(
             vmmaker_vm
-
+            DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+            DOWNLOAD_NO_PROGRESS TRUE
             URL ${VM_URL}
             URL_HASH ${VM_URL_HASH}
-	    BUILD_COMMAND       ""
-	    UPDATE_COMMAND      ""
-	    CONFIGURE_COMMAND   ""
-	    INSTALL_COMMAND     ""
+            BUILD_COMMAND       ""
+            UPDATE_COMMAND      ""
+            CONFIGURE_COMMAND   ""
+            INSTALL_COMMAND     ""
 
             PREFIX "${VMMAKER_DIR}"
             SOURCE_DIR "${VMMAKER_DIR}/vm"
             BUILD_IN_SOURCE True
-            )
+        )
     endif()
 
 	set(IMAGE_PATH ${VMMAKER_DIR}/image/Pharo12.0-SNAPSHOT-64bit-92f3bb989f.image)
@@ -125,14 +126,15 @@ if(GENERATE_SOURCES)
 
     if(GENERATE_VMMAKER)
         #Bootstrap VMMaker.image from downloaded plain Pharo image
-		
+
         ExternalProject_Add(
             vmmaker
-
+            DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+            DOWNLOAD_NO_PROGRESS TRUE
             URL https://files.pharo.org/image/120/Pharo12.0-SNAPSHOT.build.1551.sha.92f3bb989f.arch.64bit.zip
             URL_HASH SHA256=fd84c9f345d806389ecdad52f63eeb8bad7f983c99c5e010d83cf2d12ca97766
             BUILD_COMMAND ${VMMAKER_VM} --headless ${IMAGE_PATH_TO_USE} --no-default-preferences save VMMaker
-	    COMMAND ${VMMAKER_VM} --headless ${VMMAKER_IMAGE_TO_USE} --no-default-preferences --save --quit "${CMAKE_CURRENT_SOURCE_DIR_OUT}/scripts/installVMMaker.st" "${CMAKE_CURRENT_SOURCE_DIR_OUT}" "${ICEBERG_DEFAULT_REMOTE}"
+            COMMAND ${VMMAKER_VM} --headless ${VMMAKER_IMAGE_TO_USE} --no-default-preferences --save --quit "${CMAKE_CURRENT_SOURCE_DIR_OUT}/scripts/installVMMaker.st" "${CMAKE_CURRENT_SOURCE_DIR_OUT}" "${ICEBERG_DEFAULT_REMOTE}"
             UPDATE_COMMAND      ""
             CONFIGURE_COMMAND   ""
             INSTALL_COMMAND     ""
@@ -143,7 +145,7 @@ if(GENERATE_SOURCES)
             WORKING_DIRECTORY "${VMMAKER_DIR}"
 
             DEPENDS vmmaker_vm
-            )
+        )
 
     else()
         #Use the given vmimage

--- a/ffiTestLibrary/src/callbacks.c
+++ b/ffiTestLibrary/src/callbacks.c
@@ -14,11 +14,11 @@ EXPORT(int) singleCallToCallback(SIMPLE_CALLBACK fun, int base){
 EXPORT(int) callbackInALoop(SIMPLE_CALLBACK fun){
 	int i;
 	int acc = 0;
-	
+
 	for(i=0;i<42;i++){
 		acc = fun(acc);
 	}
-	
+
 	return acc;
 }
 
@@ -36,7 +36,7 @@ static int value = 0;
 #if FEATURE_THREADED_FFI
 void* otherThread(void* aFunction){
 	SIMPLE_CALLBACK f = (SIMPLE_CALLBACK) aFunction;
-	
+
 #ifdef _WIN32
 	Sleep(3);
 #else
@@ -44,6 +44,8 @@ void* otherThread(void* aFunction){
 #endif
 
 	value = f(42);
+
+    return NULL;
 }
 #endif //FEATURE_THREADED_FFI
 

--- a/packaging/linux/bin/launch.sh.in
+++ b/packaging/linux/bin/launch.sh.in
@@ -27,13 +27,13 @@ fi
 # and so it should take precedence over /lib libc.  This is done by setting
 # LD_LIBRARY_PATH appropriately, based on ldd's idea of the libc use by the VM.
 #Try extracting Libc
-LIBC_SO="`/usr/bin/ldd "$BIN/@VM_EXECUTABLE_NAME@" | /bin/fgrep /libc. | sed 's/^.*=> \([^ ]*\).*/\1/'`"
+LIBC_SO="`/usr/bin/ldd "$BIN/@VM_EXECUTABLE_NAME@" | grep -F "/libc." | sed 's/^.*=> \([^ ]*\).*/\1/'`"
 PLATFORMLIBDIR=`expr "$LIBC_SO" : '\(.*\)/libc.*'`
 
 #If empty try extracting Musl
 if [ "$PLATFORMLIBDIR" = "" ]; then
 {
-	LIBC_SO="`/usr/bin/ldd "$BIN/@VM_EXECUTABLE_NAME@" | /bin/fgrep libc. | sed 's/^.*=> \([^ ]*\).*/\1/'`"
+	LIBC_SO="`/usr/bin/ldd "$BIN/@VM_EXECUTABLE_NAME@" | grep -F "libc." | sed 's/^.*=> \([^ ]*\).*/\1/'`"
 	PLATFORMLIBDIR=`expr "$LIBC_SO" : '\(.*\)/ld-musl.*'`
 }
 fi

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -3762,8 +3762,7 @@ CCodeGenerator >> localizeGlobalVariables [
 			(localized at: name) do: [ :var |
 				logger
 					newLine;
-					show: var , ' localised to ' , name;
-					cr ] ] ].
+					show: var , ' localised to ' , name ] ] ].
 
 	elected do: [ :var | self removeVariable: var ]
 ]


### PR DESCRIPTION
- Hide C warnings using C_FLAGS
- Bump CMake min version to 3.12  and use CMake policy to remove cmake warnings

Now, compilation logs are a little less cluttered.
Those modifications should not break something but CI will check that.

