### PR TITLE
fix VM tests: Message not understood: Spur32BitMMLECoSimulator >> #specialObjectsArrayAddress

### DIFF
--- a/smalltalksrc/VMMaker/Spur32BitCoMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/Spur32BitCoMemoryManager.class.st
@@ -232,6 +232,13 @@ Spur32BitCoMemoryManager >> smallIntegerTag [
 	^1
 ]
 
+{ #category : 'trampoline support' }
+Spur32BitCoMemoryManager >> specialObjectsArrayAddress [
+	<api>
+	^self cCode: [(self addressOf: specialObjectsOop) asUnsignedInteger]
+		inSmalltalk: [cogit simulatedVariableAddress: #specialObjectsOop in: self]
+]
+
 { #category : 'simulation only' }
 Spur32BitCoMemoryManager >> unalignedLongAt: byteAddress [
 	<doNotGenerate>


### PR DESCRIPTION
fix for [current VM tests failing](https://ci.inria.fr/pharo-ci-jenkins2/job/pharo-vm/job/pharo-12/lastBuild/testReport/junit/MacOSX64.VMMakerTests/VMPushThisProcessTest/VM_Unit_Tests___testPushThisProcessBytecodePushesOnlyThisProcess__ISA___IA32__wordSize__4__useComposedImageFormat__true_/)

method duplicated into Spur32BitCoMemoryManager because sharing or inheritance is not possible
