### PR TITLE
Object sender primitive

### DIFF
--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -1090,7 +1090,7 @@ StackInterpreter class >> initializePrimitiveTable [
 		(79 primitiveNewMethod)
 
 		"Control Primitives (80-89)"
-		(80 primitiveFail)
+		(80 primitiveSenderObject)
 		(81 primitiveFail)
 		(82 primitiveFail)
 		(83 primitivePerform)

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -11068,7 +11068,11 @@ StackInterpreter >> primitiveSenderObject [
 
 	(self isBaseFrame: framePointer) ifTrue: [ | callerFrameContext |
 		callerFrameContext := self frameCallerContext: framePointer.
-		(self isSingleContext: callerFrameContext) ifTrue: [ 1 halt. ] ifFalse: [
+		(self isSingleContext: callerFrameContext) ifTrue: [ | receiverObject |
+			receiverObject := objectMemory fetchPointer: ReceiverIndex ofObject: callerFrameContext.
+			self pop: 1 thenPush: receiverObject.
+			^ self
+		] ifFalse: [
 			callerFramePointer := self frameOfMarriedContext: callerFrameContext.
 		]
 	] ifFalse: [ callerFramePointer := self frameCallerFP: framePointer ].

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -11068,6 +11068,10 @@ StackInterpreter >> primitiveSenderObject [
 
 	(self isBaseFrame: framePointer) ifTrue: [ | callerFrameContext |
 		callerFrameContext := self frameCallerContext: framePointer.
+		(callerFrameContext = objectMemory nilObject) ifTrue: [
+			"case where there is no sender frame"
+			^ self primitiveFail	
+		].
 		(self isSingleContext: callerFrameContext) ifTrue: [ | receiverObject |
 			receiverObject := objectMemory fetchPointer: ReceiverIndex ofObject: callerFrameContext.
 			self pop: 1 thenPush: receiverObject.

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -11061,6 +11061,22 @@ StackInterpreter >> primitiveResume [
 			inInterpreter ]
 ]
 
+{ #category : 'primitives' }
+StackInterpreter >> primitiveSenderObject [
+
+	| callerFramePointer senderObject |
+
+	(self isBaseFrame: framePointer) ifTrue: [ | callerFrameContext |
+		callerFrameContext := self frameCallerContext: framePointer.
+		(self isSingleContext: callerFrameContext) ifTrue: [ 1 halt. ] ifFalse: [
+			callerFramePointer := self frameOfMarriedContext: callerFrameContext.
+		]
+	] ifFalse: [ callerFramePointer := self frameCallerFP: framePointer ].
+
+	senderObject := self frameReceiver: callerFramePointer.
+	self pop: 1 thenPush: senderObject
+]
+
 { #category : 'process primitives' }
 StackInterpreter >> primitiveSuspend [
 	"Primitive. Suspend the receiver, aProcess such that it can be executed again

--- a/smalltalksrc/VMMakerTests/VMContextReificationTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMContextReificationTest.class.st
@@ -10,10 +10,8 @@ Class {
 VMContextReificationTest >> testMissing [
 
 	"TO finish this implementation we need:
-		- A test with a base frame where we don't have a caller
 		- Plug this into the VM
 		- Bench the primitive overhead
-		- Fix the tests
 	"
 ]
 
@@ -113,5 +111,28 @@ VMContextReificationTest >> testSenderObjectWithCallerOutsideStack [
 
 	self assert: interpreter stackTop equals: callerReceiver
 	
+
+]
+
+{ #category : 'tests' }
+VMContextReificationTest >> testSenderObjectWithNoSenderFails [
+
+	| method frameCallee callerReceiver top |
+
+	callerReceiver := memory integerObjectOf: 11.
+	method := methodBuilder newMethod buildMethod.
+	top := memory integerObjectOf: 16rcafebabe.
+
+	frameCallee := stackBuilder addNewFrame
+		receiver: (memory integerObjectOf: 17);
+		stack: { top };
+		method: method; yourself.
+
+	stackBuilder buildStack.
+
+	interpreter primitiveSenderObject.	
+	
+	self assert: interpreter failed.
+	self assert: interpreter stackTop equals: top
 
 ]

--- a/smalltalksrc/VMMakerTests/VMContextReificationTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMContextReificationTest.class.st
@@ -26,15 +26,16 @@ VMContextReificationTest >> testSenderObjectWithCallerInDifferentPage [
 	method := methodBuilder newMethod buildMethod.
 	frameCaller := stackBuilder addNewFrame
 		receiver: callerReceiver;
-		stack: { memory integerObjectOf: 42 };
+		stack: { memory integerObjectOf: 17 };
 		method: method; yourself.
 
 	frameCallee := stackBuilder addNewFrame
 		receiver: (memory integerObjectOf: 17);
+		stack: { memory nilObject };
 		method: method; yourself.
 
 	stackBuilder buildStack.
-	
+
 	currentPage := interpreter stackPage.
 	interpreter ensureFrameIsMarried: frameCaller framePointer SP:frameCaller stackPointer. 
 	newPage := interpreter stackPages newStackPage.
@@ -42,8 +43,7 @@ VMContextReificationTest >> testSenderObjectWithCallerInDifferentPage [
 	newFP := interpreter moveFramesIn: currentPage through: frameCallee framePointer toPage: newPage.
 	interpreter setStackPageAndLimit: newPage.
 	interpreter setStackPointersFromPage: newPage.
-	
-	interpreter push: memory nilObject.
+
 	interpreter primitiveSenderObject.
 
 	self assert: interpreter stackTop equals: callerReceiver
@@ -60,16 +60,16 @@ VMContextReificationTest >> testSenderObjectWithCallerInTheSamePage [
 	method := methodBuilder newMethod buildMethod.
 	frameCaller := stackBuilder addNewFrame
 		receiver: callerReceiver;
-		stack: { memory integerObjectOf: 42 };
+		stack: { memory integerObjectOf: 17 };
 		method: method; yourself.
 
 	frameCallee := stackBuilder addNewFrame
 		receiver: (memory integerObjectOf: 17);
+		stack: { memory nilObject };
 		method: method; yourself.
 
 	stackBuilder buildStack.
 	
-	interpreter push: memory nilObject.
 	interpreter primitiveSenderObject.
 
 	self assert: interpreter stackTop equals: callerReceiver

--- a/smalltalksrc/VMMakerTests/VMContextReificationTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMContextReificationTest.class.st
@@ -89,11 +89,12 @@ VMContextReificationTest >> testSenderObjectWithCallerOutsideStack [
 		method: method;
 		beSuspendedAt: (interpreter initialIPForHeader:
 			(memory methodHeaderOf: method) method: method);
-		stack: { memory integerObjectOf: 42 };
+		stack: { memory integerObjectOf: 17 };
 		yourself.
 
 	frameCallee := stackBuilder addNewFrame
 		receiver: (memory integerObjectOf: 17);
+		stack: { memory nilObject };
 		method: method; yourself.
 
 	stackBuilder buildStack.
@@ -107,8 +108,7 @@ VMContextReificationTest >> testSenderObjectWithCallerOutsideStack [
 	interpreter setStackPointersFromPage: newPage.
 	
 	interpreter divorceFramesIn: oldPage.
-	
-	interpreter push: memory nilObject.
+
 	interpreter primitiveSenderObject.
 
 	self assert: interpreter stackTop equals: callerReceiver

--- a/smalltalksrc/VMMakerTests/VMContextReificationTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMContextReificationTest.class.st
@@ -1,0 +1,117 @@
+Class {
+	#name : 'VMContextReificationTest',
+	#superclass : 'VMBasicPrimitiveTest',
+	#category : 'VMMakerTests-InterpreterTests',
+	#package : 'VMMakerTests',
+	#tag : 'InterpreterTests'
+}
+
+{ #category : 'tests' }
+VMContextReificationTest >> testMissing [
+
+	"TO finish this implementation we need:
+		- A test with a base frame where we don't have a caller
+		- Plug this into the VM
+		- Bench the primitive overhead
+		- Fix the tests
+	"
+]
+
+{ #category : 'tests' }
+VMContextReificationTest >> testSenderObjectWithCallerInDifferentPage [
+
+	| method newFP frameCaller frameCallee callerReceiver currentPage newPage |
+
+	callerReceiver := memory integerObjectOf: 11.
+	method := methodBuilder newMethod buildMethod.
+	frameCaller := stackBuilder addNewFrame
+		receiver: callerReceiver;
+		stack: { memory integerObjectOf: 42 };
+		method: method; yourself.
+
+	frameCallee := stackBuilder addNewFrame
+		receiver: (memory integerObjectOf: 17);
+		method: method; yourself.
+
+	stackBuilder buildStack.
+	
+	currentPage := interpreter stackPage.
+	interpreter ensureFrameIsMarried: frameCaller framePointer SP:frameCaller stackPointer. 
+	newPage := interpreter stackPages newStackPage.
+	
+	newFP := interpreter moveFramesIn: currentPage through: frameCallee framePointer toPage: newPage.
+	interpreter setStackPageAndLimit: newPage.
+	interpreter setStackPointersFromPage: newPage.
+	
+	interpreter push: memory nilObject.
+	interpreter primitiveSenderObject.
+
+	self assert: interpreter stackTop equals: callerReceiver
+	
+
+]
+
+{ #category : 'tests' }
+VMContextReificationTest >> testSenderObjectWithCallerInTheSamePage [
+
+	| method frameCaller frameCallee callerReceiver |
+
+	callerReceiver := memory integerObjectOf: 11.
+	method := methodBuilder newMethod buildMethod.
+	frameCaller := stackBuilder addNewFrame
+		receiver: callerReceiver;
+		stack: { memory integerObjectOf: 42 };
+		method: method; yourself.
+
+	frameCallee := stackBuilder addNewFrame
+		receiver: (memory integerObjectOf: 17);
+		method: method; yourself.
+
+	stackBuilder buildStack.
+	
+	interpreter push: memory nilObject.
+	interpreter primitiveSenderObject.
+
+	self assert: interpreter stackTop equals: callerReceiver
+	
+
+]
+
+{ #category : 'tests' }
+VMContextReificationTest >> testSenderObjectWithCallerOutsideStack [
+
+	| method newFP frameCaller frameCallee callerReceiver oldPage newPage |
+
+	callerReceiver := memory integerObjectOf: 11.
+	method := methodBuilder newMethod buildMethod.
+	frameCaller := stackBuilder addNewFrame
+		receiver: callerReceiver;
+		method: method;
+		beSuspendedAt: (interpreter initialIPForHeader:
+			(memory methodHeaderOf: method) method: method);
+		stack: { memory integerObjectOf: 42 };
+		yourself.
+
+	frameCallee := stackBuilder addNewFrame
+		receiver: (memory integerObjectOf: 17);
+		method: method; yourself.
+
+	stackBuilder buildStack.
+
+	oldPage := interpreter stackPage.
+	
+	interpreter ensureFrameIsMarried: frameCaller framePointer SP:frameCaller stackPointer. 
+	newPage := interpreter stackPages newStackPage.
+	newFP := interpreter moveFramesIn: oldPage through: frameCallee framePointer toPage: newPage.
+	interpreter setStackPageAndLimit: newPage.
+	interpreter setStackPointersFromPage: newPage.
+	
+	interpreter divorceFramesIn: oldPage.
+	
+	interpreter push: memory nilObject.
+	interpreter primitiveSenderObject.
+
+	self assert: interpreter stackTop equals: callerReceiver
+	
+
+]

--- a/smalltalksrc/VMMakerTests/VMContextReificationTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMContextReificationTest.class.st
@@ -7,15 +7,6 @@ Class {
 }
 
 { #category : 'tests' }
-VMContextReificationTest >> testMissing [
-
-	"TO finish this implementation we need:
-		- Plug this into the VM
-		- Bench the primitive overhead
-	"
-]
-
-{ #category : 'tests' }
 VMContextReificationTest >> testSenderObjectWithCallerInDifferentPage [
 
 	| method newFP frameCaller frameCallee callerReceiver currentPage newPage |
@@ -45,8 +36,6 @@ VMContextReificationTest >> testSenderObjectWithCallerInDifferentPage [
 	interpreter primitiveSenderObject.
 
 	self assert: interpreter stackTop equals: callerReceiver
-	
-
 ]
 
 { #category : 'tests' }
@@ -71,8 +60,6 @@ VMContextReificationTest >> testSenderObjectWithCallerInTheSamePage [
 	interpreter primitiveSenderObject.
 
 	self assert: interpreter stackTop equals: callerReceiver
-	
-
 ]
 
 { #category : 'tests' }
@@ -110,8 +97,6 @@ VMContextReificationTest >> testSenderObjectWithCallerOutsideStack [
 	interpreter primitiveSenderObject.
 
 	self assert: interpreter stackTop equals: callerReceiver
-	
-
 ]
 
 { #category : 'tests' }
@@ -134,5 +119,4 @@ VMContextReificationTest >> testSenderObjectWithNoSenderFails [
 	
 	self assert: interpreter failed.
 	self assert: interpreter stackTop equals: top
-
 ]

--- a/smalltalksrc/VMMakerTests/VMFrameBuilder.class.st
+++ b/smalltalksrc/VMMakerTests/VMFrameBuilder.class.st
@@ -261,7 +261,7 @@ VMFrameBuilder >> pushFlags [
 { #category : 'building' }
 VMFrameBuilder >> pushFrame [
 	interpreter push: receiver.
-	
+
 	temps do: [ :oop |  interpreter push: oop ].
 ]
 
@@ -314,7 +314,7 @@ VMFrameBuilder >> setInstructionPointerBeforeFirstBytecode [
 
 	"If possible, setting IP to before the first bytecode, so it is ready for fetchNextBytecode"
 
-	(instructionPointer = 0 ) ifFalse: [ ^ self ]. 
+	(instructionPointer = 0) ifFalse: [ ^ self ]. 
 	instructionPointer := methodBuilder bytecodeAt: 0 forMethod: method.
 	interpreter instructionPointer: instructionPointer
 ]

--- a/smalltalksrc/VMMakerTests/VMStackBuilder.class.st
+++ b/smalltalksrc/VMMakerTests/VMStackBuilder.class.st
@@ -48,6 +48,10 @@ VMStackBuilder >> addFrame: aFrame [
 { #category : 'frames' }
 VMStackBuilder >> addNewFrame [
 	| frame |
+	
+	"Only the top frame should not be suspended"
+	frames ifNotEmpty: [ frames last beSuspended ].
+
 	"'add' a new frame in the sense of an OrderedCollection, which will be iterated with #do:
 	The last frame added, will be the stackTop"
 	frame := VMFrameBuilder new initializeWithInterpreter: interpreter andMemory: memory andMethodBuilder: methodBuilder.

--- a/smalltalksrc/VMMakerTests/VMStackBuilder.class.st
+++ b/smalltalksrc/VMMakerTests/VMStackBuilder.class.st
@@ -136,9 +136,11 @@ VMStackBuilder >> page: anObject [
 { #category : 'build' }
 VMStackBuilder >> preparePage [
 	"Page setup before the base frame"
-	interpreter push: memory nilObject.	"receiver"
+	interpreter push: memory nilObject.  "senderContext of baseFrame"
+	interpreter push: memory nilObject.  "frameContext of the current context"
+	interpreter push: frames first receiver.	"receiver"	
 	self pushArgs. "arguments"
-	interpreter push: memory nilObject.  "senderContext"
+	interpreter push: memory nilObject.  "savedCaller Instruction Pointer"
 	interpreter push: 0. "savedFp"
 	page baseFP: interpreter stackPointer.
 
@@ -152,7 +154,10 @@ VMStackBuilder >> pushAllButFirstFrames [
 			aFrame previousFrameArgsSize: ((frames at: anIndex - 1) argumentSize).
 			
 			interpreter push: interpreter framePointer.	
-				
+			
+			"When we are calling a method, we should push to the stack as many values as the number of arguments + 1 ( receiver )"
+			self assert: (aFrame argumentSize + 1) <= (frames at: anIndex - 1) stack size.
+			
 			self pushFrame: aFrame.
 			aFrame callerFrame: (frames at: anIndex - 1)."for better inspection"
 			]


### PR DESCRIPTION
### Object sender primitive

The idea of this is to reduce the overhead of some instrumentation frameworks that need to get access to the current call site. Today it is necessary to call `thisContext` and access the sender, which means reify the current stack frame and the caller one.

Having this as a primitive allows us to reduce the overhead of reifying the hold stack context and get access to only the object sender as a VM primitive ( **which should mean around 16 times less time** ).

In his PR, with @guillep @jordanmontt, and @renman-ymd we are:

- Implementing a primitive to access the object sender. 
- Added some tests for three different scenarios where the caller stack frame is stored in
     - the same page
     - a different page
     - not on a page
     - not sender

We added the new primitive on the primitive table with the `80` number.

We evaluated its performance by comparing the new primitive with the same using `thisContext`, and we observed that the primitive is around ~7/8 times faster.

```st
[ 17 foo ] bench. "801,773,681 iterations in 5 seconds 4 milliseconds. 160226554.956 per second"
[ 17 fooSlow ] bench. "125,776,696 iterations in 5 seconds 2 milliseconds. 25145281.088 per second".
```