### PR TITLE
Make next non blocking on linux

### DIFF
--- a/plugins/FilePlugin/src/unix/sqFilePluginBasicPrims.c
+++ b/plugins/FilePlugin/src/unix/sqFilePluginBasicPrims.c
@@ -618,6 +618,7 @@ sqFileReadIntoAt(SQFile *f, size_t count, char *byteArrayIndex, size_t startInde
 
 	int fd = fileno(file);
 	dst = byteArrayIndex + startIndex;
+	int originalFlags = 0;
 	if (f->isStdioStream) {
 #if COGMTVM
 		if (!(wasPinned = interpreterProxy->isPinned(bufferOop))) {
@@ -639,35 +640,31 @@ sqFileReadIntoAt(SQFile *f, size_t count, char *byteArrayIndex, size_t startInde
 			* until there is data.
 			*/
 		clearerr(file);
-		int originalFlags = fcntl(fd, F_GETFL);
+		originalFlags = fcntl(fd, F_GETFL);
 		fcntl(fd, F_SETFL, originalFlags | O_NONBLOCK);
-
+		} else {
+			/*sync libc internal buffer before read */
+			fseek(file, 0, SEEK_CUR);
+    	}
 		/*To remain coherent with the return value of read*/
 		ssize_t sReadBytes;
         do {sReadBytes = read(fd, dst, count);}	
-			while (sReadBytes <= 0 && ferror(file) && errno == EINTR);
-		
-		fcntl(fd, F_SETFL, originalFlags);
+			while (sReadBytes < 0 && errno == EINTR);
+		if (f->isStdioStream) {
+			fcntl(fd, F_SETFL, originalFlags);
+		}
 		
 		if (sReadBytes < 0) {
             bytesRead = 0; 
         } else {
             bytesRead = (size_t)sReadBytes;
         }
-
+		if (f->isStdioStream){
 #if COGMTVM
 		interpreterProxy->ownVM(myThreadIndex);
 		if (!wasPinned)
 			interpreterProxy->unpinObject(bufferOop);
 #endif /* COGMTVM */
-	}
-	else {
-		/* Use buffered fread for regular files to ensure UTF-8 encoding integrity */
-		do {
-			clearerr(file);
-			bytesRead = fread(dst, 1, count, file);
-		}
-		while (bytesRead <= 0 && ferror(file) && errno == EINTR);
 	}
 
 

--- a/plugins/FilePlugin/src/unix/sqFilePluginBasicPrims.c
+++ b/plugins/FilePlugin/src/unix/sqFilePluginBasicPrims.c
@@ -596,7 +596,7 @@ sqFileReadIntoAt(SQFile *f, size_t count, char *byteArrayIndex, size_t startInde
 	*/
 
 	char *dst;
-	ssize_t bytesRead;
+	size_t bytesRead;
 	FILE *file;
 #if COGMTVM
 	sqInt myThreadIndex;
@@ -642,12 +642,18 @@ sqFileReadIntoAt(SQFile *f, size_t count, char *byteArrayIndex, size_t startInde
 		int originalFlags = fcntl(fd, F_GETFL);
 		fcntl(fd, F_SETFL, originalFlags | O_NONBLOCK);
 
-		bytesRead = 0;
-
-		do { bytesRead = read(fd, dst, count); }
-			while (bytesRead <= 0 && ferror(file) && errno == EINTR);
+		/*To remain coherent with the return value of read*/
+		ssize_t sReadBytes;
+        do {sReadBytes = read(fd, dst, count);}	
+			while (sReadBytes <= 0 && ferror(file) && errno == EINTR);
 		
 		fcntl(fd, F_SETFL, originalFlags);
+		
+		if (sReadBytes < 0) {
+            bytesRead = 0; 
+        } else {
+            bytesRead = (size_t)sReadBytes;
+        }
 
 #if COGMTVM
 		interpreterProxy->ownVM(myThreadIndex);
@@ -656,15 +662,12 @@ sqFileReadIntoAt(SQFile *f, size_t count, char *byteArrayIndex, size_t startInde
 #endif /* COGMTVM */
 	}
 	else {
+		/* Use buffered fread for regular files to ensure UTF-8 encoding integrity */
 		do {
 			clearerr(file);
-			bytesRead = read(fd, dst, count);
+			bytesRead = fread(dst, 1, count, file);
 		}
 		while (bytesRead <= 0 && ferror(file) && errno == EINTR);
-	}
-	
-	if (bytesRead < 0) {
-		bytesRead = 0;
 	}
 
 

--- a/plugins/FilePlugin/src/unix/sqFilePluginBasicPrims.c
+++ b/plugins/FilePlugin/src/unix/sqFilePluginBasicPrims.c
@@ -596,7 +596,7 @@ sqFileReadIntoAt(SQFile *f, size_t count, char *byteArrayIndex, size_t startInde
 	*/
 
 	char *dst;
-	size_t bytesRead;
+	ssize_t bytesRead;
 	FILE *file;
 #if COGMTVM
 	sqInt myThreadIndex;
@@ -615,6 +615,8 @@ sqFileReadIntoAt(SQFile *f, size_t count, char *byteArrayIndex, size_t startInde
 		if (f->lastOp == WRITE_OP)
 			fseek(file, 0, SEEK_CUR);  /* seek between writing and reading */
 	}
+
+	int fd = fileno(file);
 	dst = byteArrayIndex + startIndex;
 	if (f->isStdioStream) {
 #if COGMTVM
@@ -624,31 +626,28 @@ sqFileReadIntoAt(SQFile *f, size_t count, char *byteArrayIndex, size_t startInde
 			dst = bufferOop + BaseHeaderSize + startIndex;
 		}
 		myThreadIndex = interpreterProxy->disownVM(0);
-#endif
+#endif	
+
+		/*
+			* To emulate the behavior of fread on a file we need to
+			* make the stdin non blocking.
+			* As this can produce a problem in Unix systems once
+			* Pharo ends (we are affecting the behavior of a shared FD)
+			* we need to restore it back to the original flags.
+			*
+			* With this the reading of the STDIN will not block
+			* until there is data.
+			*/
+		clearerr(file);
+		int originalFlags = fcntl(fd, F_GETFL);
+		fcntl(fd, F_SETFL, originalFlags | O_NONBLOCK);
 
 		bytesRead = 0;
-		do {
-			clearerr(file);
 
-			/*
-			 * To emulate the behavior of fread on a file we need to
-			 * make the stdin non blocking.
-			 * As this can produce a problem in Unix systems once
-			 * Pharo ends (we are affecting the behavior of a shared FD)
-			 * we need to restore it back to the original flags.
-			 *
-			 * With this the reading of the STDIN will not block
-			 * until there is data.
-			 */
-
-			int originalFlags = fcntl(fileno(file), F_GETFL);
-			fcntl(fileno(file), F_SETFL, originalFlags | O_NONBLOCK);
-
-			bytesRead = fread(dst, 1, count, file);
-
-			fcntl(fileno(file), F_SETFL, originalFlags);
-		}
-		while (bytesRead <= 0 && ferror(file) && errno == EINTR);
+		do { bytesRead = read(fd, dst, count); }
+			while (bytesRead <= 0 && ferror(file) && errno == EINTR);
+		
+		fcntl(fd, F_SETFL, originalFlags);
 
 #if COGMTVM
 		interpreterProxy->ownVM(myThreadIndex);
@@ -656,12 +655,19 @@ sqFileReadIntoAt(SQFile *f, size_t count, char *byteArrayIndex, size_t startInde
 			interpreterProxy->unpinObject(bufferOop);
 #endif /* COGMTVM */
 	}
-	else
+	else {
 		do {
 			clearerr(file);
-			bytesRead = fread(dst, 1, count, file);
+			bytesRead = read(fd, dst, count);
 		}
 		while (bytesRead <= 0 && ferror(file) && errno == EINTR);
+	}
+	
+	if (bytesRead < 0) {
+		bytesRead = 0;
+	}
+
+
 	/* support for skipping back 1 character for stdio streams */
 	if (f->isStdioStream)
 		if (bytesRead > 0)

--- a/plugins/FilePlugin/src/unix/sqFilePluginBasicPrims.c
+++ b/plugins/FilePlugin/src/unix/sqFilePluginBasicPrims.c
@@ -618,7 +618,6 @@ sqFileReadIntoAt(SQFile *f, size_t count, char *byteArrayIndex, size_t startInde
 
 	int fd = fileno(file);
 	dst = byteArrayIndex + startIndex;
-	int originalFlags = 0;
 	if (f->isStdioStream) {
 #if COGMTVM
 		if (!(wasPinned = interpreterProxy->isPinned(bufferOop))) {
@@ -640,31 +639,31 @@ sqFileReadIntoAt(SQFile *f, size_t count, char *byteArrayIndex, size_t startInde
 			* until there is data.
 			*/
 		clearerr(file);
-		originalFlags = fcntl(fd, F_GETFL);
+		int originalFlags = fcntl(fd, F_GETFL);
 		fcntl(fd, F_SETFL, originalFlags | O_NONBLOCK);
-		} else {
-			/*sync libc internal buffer before read */
-			fseek(file, 0, SEEK_CUR);
-    	}
 		/*To remain coherent with the return value of read*/
 		ssize_t sReadBytes;
         do {sReadBytes = read(fd, dst, count);}	
 			while (sReadBytes < 0 && errno == EINTR);
-		if (f->isStdioStream) {
-			fcntl(fd, F_SETFL, originalFlags);
-		}
+		fcntl(fd, F_SETFL, originalFlags);
 		
 		if (sReadBytes < 0) {
             bytesRead = 0; 
         } else {
             bytesRead = (size_t)sReadBytes;
         }
-		if (f->isStdioStream){
 #if COGMTVM
 		interpreterProxy->ownVM(myThreadIndex);
 		if (!wasPinned)
 			interpreterProxy->unpinObject(bufferOop);
 #endif /* COGMTVM */
+	}else {
+		/* Use buffered fread for regular files to ensure UTF-8 encoding integrity */
+		do {
+			clearerr(file);
+			bytesRead = fread(dst, 1, count, file);
+		}
+		while (bytesRead <= 0 && ferror(file) && errno == EINTR);
 	}
 
 

--- a/plugins/FilePlugin/src/unix/sqFilePluginBasicPrims.c
+++ b/plugins/FilePlugin/src/unix/sqFilePluginBasicPrims.c
@@ -588,91 +588,88 @@ sqInt sqFileDescriptorType(int fdNum) {
 
 size_t
 sqFileReadIntoAt(SQFile *f, size_t count, char *byteArrayIndex, size_t startIndex) {
-	/* Read count bytes from the given file into byteArray starting at
-	   startIndex. byteArray is the address of the first byte of a
-	   The library bytes object (e.g. String or ByteArray). startIndex
-	   is a zero-based index; that is a startIndex of 0 starts writing
-	   at the first byte of byteArray.
-	*/
+    /* Read count bytes from the given file into byteArray starting at
+       startIndex. byteArray is the address of the first byte of a
+       The library bytes object (e.g. String or ByteArray). startIndex
+       is a zero-based index; that is a startIndex of 0 starts writing
+       at the first byte of byteArray.
+    */
 
-	char *dst;
-	size_t bytesRead;
-	FILE *file;
+    char *dst;
+    size_t bytesRead;
+    FILE *file;
 #if COGMTVM
-	sqInt myThreadIndex;
-#endif
-#if COGMTVM
-	int wasPinned;
-	sqInt bufferOop = (sqInt)byteArrayIndex - BaseHeaderSize;
+    sqInt myThreadIndex;
+    int wasPinned;
+    sqInt bufferOop = (sqInt)byteArrayIndex - BaseHeaderSize;
 #endif
 
-	if (!sqFileValid(f))
-		return interpreterProxy->success(false);
-	file = getFile(f);
-	if (f->writable) {
-		if (f->isStdioStream)
-			return interpreterProxy->success(false);
-		if (f->lastOp == WRITE_OP)
-			fseek(file, 0, SEEK_CUR);  /* seek between writing and reading */
-	}
+    /*
+     * - For stdio streams We use a non-blocking, OS-level read() to prevent
+     * freezing the VM thread while waiting for interactive input.
+     * - Regular files: We strictly use fread() to preserve the libc internal buffer.
+	 * As the file is opened with fdopen which uses the libc internal buffer, using read() 
+	 * causes a gap between the position of the cursor of the read and the reality of the file 
+     * because the buffer is not known by read.
+     */
 
-	int fd = fileno(file);
-	dst = byteArrayIndex + startIndex;
-	if (f->isStdioStream) {
+    if (!sqFileValid(f))
+        return interpreterProxy->success(false);
+    file = getFile(f);
+    if (f->writable) {
+        if (f->isStdioStream)
+            return interpreterProxy->success(false);
+        if (f->lastOp == WRITE_OP)
+            fseek(file, 0, SEEK_CUR);  /* seek between writing and reading */
+    }
+
+    int fd = fileno(file);
+    dst = byteArrayIndex + startIndex;
+    if (f->isStdioStream) {
 #if COGMTVM
-		if (!(wasPinned = interpreterProxy->isPinned(bufferOop))) {
-			if (!(bufferOop = interpreterProxy->pinObject(bufferOop)))
-				return 0;
-			dst = bufferOop + BaseHeaderSize + startIndex;
-		}
-		myThreadIndex = interpreterProxy->disownVM(0);
-#endif	
+        if (!(wasPinned = interpreterProxy->isPinned(bufferOop))) {
+            if (!(bufferOop = interpreterProxy->pinObject(bufferOop)))
+                return 0;
+            dst = bufferOop + BaseHeaderSize + startIndex;
+        }
+        myThreadIndex = interpreterProxy->disownVM(0);
+#endif  
 
-		/*
-			* To emulate the behavior of fread on a file we need to
-			* make the stdin non blocking.
-			* As this can produce a problem in Unix systems once
-			* Pharo ends (we are affecting the behavior of a shared FD)
-			* we need to restore it back to the original flags.
-			*
-			* With this the reading of the STDIN will not block
-			* until there is data.
-			*/
-		clearerr(file);
-		int originalFlags = fcntl(fd, F_GETFL);
-		fcntl(fd, F_SETFL, originalFlags | O_NONBLOCK);
-		/*To remain coherent with the return value of read*/
-		ssize_t sReadBytes;
-        do {sReadBytes = read(fd, dst, count);}	
-			while (sReadBytes < 0 && errno == EINTR);
-		fcntl(fd, F_SETFL, originalFlags);
-		
-		if (sReadBytes < 0) {
+        clearerr(file);
+        int originalFlags = fcntl(fd, F_GETFL);
+        fcntl(fd, F_SETFL, originalFlags | O_NONBLOCK);
+        
+        ssize_t sReadBytes;
+        do {
+            sReadBytes = read(fd, dst, count);
+        } while (sReadBytes < 0 && errno == EINTR);
+        
+        fcntl(fd, F_SETFL, originalFlags);
+        
+        if (sReadBytes < 0) {
             bytesRead = 0; 
         } else {
             bytesRead = (size_t)sReadBytes;
         }
 #if COGMTVM
-		interpreterProxy->ownVM(myThreadIndex);
-		if (!wasPinned)
-			interpreterProxy->unpinObject(bufferOop);
+        interpreterProxy->ownVM(myThreadIndex);
+        if (!wasPinned)
+            interpreterProxy->unpinObject(bufferOop);
 #endif /* COGMTVM */
-	}else {
-		/* Use buffered fread for regular files to ensure UTF-8 encoding integrity */
-		do {
-			clearerr(file);
-			bytesRead = fread(dst, 1, count, file);
-		}
-		while (bytesRead <= 0 && ferror(file) && errno == EINTR);
-	}
+    } else {
+        /* Use buffered fread for regular files to ensure data integrity */
+        do {
+            clearerr(file);
+            bytesRead = fread(dst, 1, count, file);
+        } while (bytesRead <= 0 && ferror(file) && errno == EINTR);
+    }
 
-
-	/* support for skipping back 1 character for stdio streams */
-	if (f->isStdioStream)
-		if (bytesRead > 0)
-			f->lastChar = dst[bytesRead-1];
-	f->lastOp = READ_OP;
-	return bytesRead;
+    /* support for skipping back 1 character for stdio streams */
+    if (f->isStdioStream)
+        if (bytesRead > 0)
+            f->lastChar = dst[bytesRead-1];
+    f->lastOp = READ_OP;
+    return bytesRead;
 }
 
 sqInt


### PR DESCRIPTION
On linux, when reading on stdio stdin with next. It blocked the program.
We had to change the sqFileReadIntoAt function to change this behavior. 

For this, we use another API : read instead of fread 