### PR TITLE
Fix int boxing/loading

### DIFF
--- a/smalltalksrc/VMMaker-Tools/TParseNode.extension.st
+++ b/smalltalksrc/VMMaker-Tools/TParseNode.extension.st
@@ -1,44 +1,6 @@
 Extension { #name : 'TParseNode' }
 
 { #category : '*VMMaker-Tools' }
-TParseNode >> inspectNode [
-	<inspectorPresentationOrder: 912 title: 'C (Not Expr)'>
-
-	^  SpTextPresenter new 
-		text: (String streamContents: [ : stream | 
-			(self asCASTIn: self newCodeGeneratorForInspection) prettyPrintOn: stream ]);
-		yourself
-]
-
-{ #category : '*VMMaker-Tools' }
-TParseNode >> inspectNodeContext: aContext [
-
-	aContext active: self isExpression not.
-	aContext 
-		title: 'C';
-		withoutEvaluator
-]
-
-{ #category : '*VMMaker-Tools' }
-TParseNode >> inspectNodeExpression [
-	<inspectorPresentationOrder: 912 title: 'C (Expression)'>
-
-	^  SpTextPresenter new 
-		text: (String streamContents: [ : stream | 
-			(self asCASTExpressionIn: self newCodeGeneratorForInspection) prettyPrintOn: stream ]);
-		yourself
-]
-
-{ #category : '*VMMaker-Tools' }
-TParseNode >> inspectNodeExpressionContext: aContext [
-
-	aContext active: self isExpression.
-	aContext 
-		title: 'C (Expr)';
-		withoutEvaluator
-]
-
-{ #category : '*VMMaker-Tools' }
 TParseNode >> inspectionTree [
 	<inspectorPresentationOrder: 35 title: 'Tree'>
 

--- a/smalltalksrc/VMMaker/CogObjectRepresentationFor64BitSpur.class.st
+++ b/smalltalksrc/VMMaker/CogObjectRepresentationFor64BitSpur.class.st
@@ -698,7 +698,7 @@ CogObjectRepresentationFor64BitSpur >> genIntegerTo64BitSignedIntegerValue: valu
 	| jumpNotSmallInteger jumpMerge jumpFail |
 	cogit MoveR: valueReg R: scratch1.
 	cogit ArithmeticShiftRightCq: self numSmallIntegerBits R: scratch1. "If in range this is now 0 or -1"
-	cogit AndCq: 16rF R: scratch1.
+	cogit AddCq: 1 R: scratch1.
 	cogit CmpCq: 1 R: scratch1.
 	jumpNotSmallInteger := cogit JumpAbove: 0.
 	
@@ -1286,7 +1286,7 @@ CogObjectRepresentationFor64BitSpur >> genPrimitiveAtSigned: signedVersion [
 	signedVersion
 		ifTrue: "c.f. Spur64BitMemoryManager>>#isIntegerValue:"
 			[cogit ArithmeticShiftRightCq: self numSmallIntegerBits R: TempReg. "If in range this is now 0 or -1"
-			 cogit AndCq: 16rF R: TempReg.
+			 cogit AddCq: 1 R: TempReg.
 			 cogit CmpCq: 1 R: TempReg.
 			 jumpNotSmallInteger := cogit JumpAbove: 0.
 			 cogit MoveR: ClassReg R: ReceiverResultReg.

--- a/smalltalksrc/VMMaker/CogObjectRepresentationFor64BitSpur.class.st
+++ b/smalltalksrc/VMMaker/CogObjectRepresentationFor64BitSpur.class.st
@@ -180,7 +180,7 @@ CogObjectRepresentationFor64BitSpur >> genAlloc64BitPositiveIntegerValue: valueR
 { #category : 'primitive generators' }
 CogObjectRepresentationFor64BitSpur >> genAlloc64BitSignedIntegerValue: valueReg into: resultReg scratchReg: scratch1 scratchReg: scratch2 [
 	<returnTypeC: #'AbstractInstruction *'>
-	| allocSize newLNIHeader jumpFail jumpNeg |
+	| allocSize newLNIHeader jumpFail jumpNeg continue |
 	allocSize := objectMemory baseHeaderSize + objectMemory wordSize.
 	newLNIHeader := objectMemory
 							headerForSlots: 1
@@ -194,24 +194,22 @@ CogObjectRepresentationFor64BitSpur >> genAlloc64BitSignedIntegerValue: valueReg
 	cogit MoveCq: newLNIHeader R: scratch1.
 	cogit CmpCq: 0 R: valueReg.
 	jumpNeg := cogit JumpLess: 0.
+	
 	"We can avoid duplicating the large constant and a jump choosing between
 	 the alternatives by incrementing the single constant if positive.  The assert
 	 checks that the hack works. Compact code is to be preferred because it is
 	 an uncommon case; usually the value will fit in a SmallInteger."
 	self assert: (objectMemory headerForSlots: 0 format: 0 classIndex: 1) = 1.
 	cogit AddCq: ClassLargePositiveIntegerCompactIndex - ClassLargeNegativeIntegerCompactIndex R: scratch1.
-	jumpNeg jmpTarget:
-	(cogit MoveR: scratch1 Mw: 0 r: resultReg).
-	"The old less compact code was
-	cogit CmpCq: 0 R: valueReg.
-	jumpNeg := cogit JumpLess: 0.
-	cogit MoveCq: newLPIHeader R: scratch1.
-	jumpJoin := cogit Jump: 0.
-	jumpNeg jmpTarget:
-	(cogit MoveCq: newLNIHeader R: scratch1).
-	jumpJoin jmpTarget:
-	(cogit MoveR: scratch1 Mw: 0 r: resultReg)."
+	continue := cogit Jump: 0.
+	
+	"Now box the value into the object, this code below is for both positive and negative values"
+	jumpNeg jmpTarget: cogit Label.
 	cogit NegateR: valueReg.
+	
+	"Write the header, then the value"
+	continue jmpTarget: cogit Label.
+	cogit MoveR: scratch1 Mw: 0 r: resultReg.
 	cogit MoveR: valueReg Mw: objectMemory baseHeaderSize r: resultReg.
 	^jumpFail
 ]

--- a/smalltalksrc/VMMaker/CogObjectRepresentationFor64BitSpur.class.st
+++ b/smalltalksrc/VMMaker/CogObjectRepresentationFor64BitSpur.class.st
@@ -211,6 +211,7 @@ CogObjectRepresentationFor64BitSpur >> genAlloc64BitSignedIntegerValue: valueReg
 	(cogit MoveCq: newLNIHeader R: scratch1).
 	jumpJoin jmpTarget:
 	(cogit MoveR: scratch1 Mw: 0 r: resultReg)."
+	cogit NegateR: valueReg.
 	cogit MoveR: valueReg Mw: objectMemory baseHeaderSize r: resultReg.
 	^jumpFail
 ]
@@ -697,7 +698,7 @@ CogObjectRepresentationFor64BitSpur >> genIntegerTo64BitSignedIntegerValue: valu
 	| jumpNotSmallInteger jumpMerge jumpFail |
 	cogit MoveR: valueReg R: scratch1.
 	cogit ArithmeticShiftRightCq: self numSmallIntegerBits R: scratch1. "If in range this is now 0 or -1"
-	cogit AddCq: 1 R: scratch1.
+	cogit AndCq: 16rF R: scratch1.
 	cogit CmpCq: 1 R: scratch1.
 	jumpNotSmallInteger := cogit JumpAbove: 0.
 	

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -13295,7 +13295,7 @@ SpurMemoryManager >> unalignedLong64At: index put: aValue [
 
 	| odd hi lo mask |
 	aValue < 0 ifTrue:
-		[self unalignedLong64At: index put: (aValue bitAnd: 16rFFFFFFFFFFFFFFFF).
+		[self unalignedLong64At: index asInteger put: (aValue bitAnd: 16rFFFFFFFFFFFFFFFF).
 		 ^aValue].
 	(odd := index bitAnd: 7) = 0 ifTrue:
 		[^self long64At: index put: aValue].

--- a/smalltalksrc/VMMakerTests/UnicornARMv8Simulator.class.st
+++ b/smalltalksrc/VMMakerTests/UnicornARMv8Simulator.class.st
@@ -15,7 +15,7 @@ UnicornARMv8Simulator >> arg0Register [
 { #category : 'accessing-registers-abstract' }
 UnicornARMv8Simulator >> arg1Register [
 	
-	^ UcARM64Registers x1
+	^ UcARM64Registers x4
 ]
 
 { #category : 'accessing-registers-abstract' }

--- a/smalltalksrc/VMMakerTests/VMByteArrayAccessPrimitive.class.st
+++ b/smalltalksrc/VMMakerTests/VMByteArrayAccessPrimitive.class.st
@@ -1,0 +1,96 @@
+Class {
+	#name : 'VMByteArrayAccessPrimitive',
+	#superclass : 'VMInterpreterTests',
+	#category : 'VMMakerTests-InterpreterTests',
+	#package : 'VMMakerTests',
+	#tag : 'InterpreterTests'
+}
+
+{ #category : 'running' }
+VMByteArrayAccessPrimitive >> setUp [
+
+	super setUp.
+	self createLargeIntegerClasses.
+
+	stackBuilder
+		addNewFrame;
+		buildStack
+]
+
+{ #category : 'tests' }
+VMByteArrayAccessPrimitive >> testFFIntegerAtPutWithMin64bitLargeNegativeInteger [
+
+	| array1 largeIntegerOop |
+	
+	"
+	Hardcodes a byte array that has the same value as the following large negative integer.
+	largeIntegerObject := memory signed64BitIntegerFor: -9223372036854775808."
+	array1 := self new8BitIndexableOfSize: 8.
+	#[1 0 0 0 0 0 0 128] withIndexDo: [ :byte :index |
+		memory storeByte: index - 1 ofObject: array1 withValue: byte
+	].
+
+	interpreter push: array1.
+	interpreter push: (memory integerObjectOf: 0).
+	interpreter primitiveLoadInt64FromBytes.
+	self deny: interpreter failed.
+
+	largeIntegerOop := interpreter stackTop.
+	#[255 255 255 255 255 255 255 127] withIndexDo: [ :expectedByte :index |
+		self assert: (memory fetchByte: index - 1 ofObject: largeIntegerOop) equals: expectedByte.
+	]
+]
+
+{ #category : 'tests' }
+VMByteArrayAccessPrimitive >> testLoad64bitLargeNegativeIntegerInByteArray [
+
+	| array1 largeIntegerObject largeIntegerValue |
+	array1 := self new8BitIndexableOfSize: 8.
+	largeIntegerObject := memory signed64BitIntegerFor: -9223372036854775807.
+	
+	largeIntegerValue := interpreter signed64BitValueOf: largeIntegerObject.
+	interpreter int64AtPointer: (memory firstBytePointerOfDataObject: array1) put: largeIntegerValue.
+	
+	"Read the 64 bits at the array starting at offset 0 as a signed integer"
+	interpreter push: array1.
+	interpreter push: (memory integerObjectOf: 0).
+	interpreter primitiveLoadInt64FromBytes.
+
+	self assert: (interpreter signed64BitValueOf: interpreter stackTop) equals: largeIntegerValue
+]
+
+{ #category : 'tests' }
+VMByteArrayAccessPrimitive >> testLoadMin64bitLargeNegativeIntegerInByteArray [
+
+	| array1 largeIntegerObject largeIntegerValue |
+	array1 := self new8BitIndexableOfSize: 8.
+	largeIntegerObject := memory signed64BitIntegerFor: -9223372036854775808.
+	
+	largeIntegerValue := interpreter signed64BitValueOf: largeIntegerObject.
+	interpreter int64AtPointer: (memory firstBytePointerOfDataObject: array1) put: largeIntegerValue.
+	
+	"Read the 64 bits at the array starting at offset 0 as a signed integer"
+	interpreter push: array1.
+	interpreter push: (memory integerObjectOf: 0).
+	interpreter primitiveLoadInt64FromBytes.
+
+	self assert: (interpreter signed64BitValueOf: interpreter stackTop) equals: largeIntegerValue
+]
+
+{ #category : 'tests' }
+VMByteArrayAccessPrimitive >> testStoreMin64bitLargeNegativeIntegerInByteArray [
+
+	| array1 largeIntegerObject largeIntegerValue |
+	array1 := self new8BitIndexableOfSize: 8.
+	largeIntegerObject := memory signed64BitIntegerFor: -9223372036854775808.
+	
+	largeIntegerValue := interpreter signed64BitValueOf: largeIntegerObject.
+	
+	"Store the 64 bits at the array starting at offset 0 as a signed integer"
+	interpreter push: array1.
+	interpreter push: (memory integerObjectOf: 0).
+	interpreter push: largeIntegerObject.
+	interpreter primitiveStoreInt64IntoBytes.
+
+	self assert: interpreter failed
+]

--- a/smalltalksrc/VMMakerTests/VMByteArrayAccessPrimitive.class.st
+++ b/smalltalksrc/VMMakerTests/VMByteArrayAccessPrimitive.class.st
@@ -60,6 +60,28 @@ VMByteArrayAccessPrimitive >> testLoad64bitLargeNegativeIntegerInByteArray [
 ]
 
 { #category : 'tests' }
+VMByteArrayAccessPrimitive >> testLoad64bitPositiveSmallIntegerFromByteArray [
+
+	| array1 largeIntegerObject largeIntegerValue |
+	array1 := self new8BitIndexableOfSize: 8.
+	largeIntegerObject := memory signed64BitIntegerFor: 17.
+	
+	largeIntegerValue := interpreter signed64BitValueOf: largeIntegerObject.
+	interpreter int64AtPointer: (memory firstBytePointerOfDataObject: array1) put: largeIntegerValue.
+	#[17 0 0 0 0 0 0 0] withIndexDo: [ :byte :index |
+		self assert: (memory fetchByte: index - 1 ofObject: array1) equals: byte.
+	].
+
+	"Read the 64 bits at the array starting at offset 0 as a signed integer"
+	interpreter push: array1.
+	interpreter push: (memory integerObjectOf: 0).
+	interpreter primitiveLoadInt64FromBytes.
+
+	self assert: (memory isIntegerObject: interpreter stackTop).
+	self assert: (memory integerValueOf: interpreter stackTop) equals: 17
+]
+
+{ #category : 'tests' }
 VMByteArrayAccessPrimitive >> testLoadMin64bitLargeNegativeIntegerInByteArray [
 
 	| array1 largeIntegerObject largeIntegerValue |
@@ -75,6 +97,28 @@ VMByteArrayAccessPrimitive >> testLoadMin64bitLargeNegativeIntegerInByteArray [
 	interpreter primitiveLoadInt64FromBytes.
 
 	self assert: (interpreter signed64BitValueOf: interpreter stackTop) equals: largeIntegerValue
+]
+
+{ #category : 'tests' }
+VMByteArrayAccessPrimitive >> testPrimitiveLoadInt64LoadsNegative32bitSmallInteger [
+
+	| array1 largeIntegerObject largeIntegerValue |
+	array1 := self new8BitIndexableOfSize: 8.
+	largeIntegerObject := memory signed64BitIntegerFor: -2147483649.
+	
+	largeIntegerValue := interpreter signed64BitValueOf: largeIntegerObject.
+	interpreter int64AtPointer: (memory firstBytePointerOfDataObject: array1) put: largeIntegerValue.
+	#[255 255 255 127 255 255 255 255] withIndexDo: [ :byte :index |
+		self assert: (memory fetchByte: index - 1 ofObject: array1) equals: byte.
+	].
+
+	"Read the 64 bits at the array starting at offset 0 as a signed integer"
+	interpreter push: array1.
+	interpreter push: (memory integerObjectOf: 0).
+	interpreter primitiveLoadInt64FromBytes.
+
+	self assert: (memory isIntegerObject: interpreter stackTop).
+	self assert: (memory integerValueOf: interpreter stackTop) equals: -2147483649
 ]
 
 { #category : 'tests' }

--- a/smalltalksrc/VMMakerTests/VMByteArrayAccessPrimitive.class.st
+++ b/smalltalksrc/VMMakerTests/VMByteArrayAccessPrimitive.class.st
@@ -105,20 +105,38 @@ VMByteArrayAccessPrimitive >> testPrimitiveLoadInt64LoadsNegative32bitSmallInteg
 	| array1 largeIntegerObject largeIntegerValue |
 	array1 := self new8BitIndexableOfSize: 8.
 	largeIntegerObject := memory signed64BitIntegerFor: -2147483649.
-	
-	largeIntegerValue := interpreter signed64BitValueOf: largeIntegerObject.
-	interpreter int64AtPointer: (memory firstBytePointerOfDataObject: array1) put: largeIntegerValue.
-	#[255 255 255 127 255 255 255 255] withIndexDo: [ :byte :index |
-		self assert: (memory fetchByte: index - 1 ofObject: array1) equals: byte.
-	].
+
+	largeIntegerValue := interpreter signed64BitValueOf:
+		                     largeIntegerObject.
+	interpreter
+		int64AtPointer: (memory firstBytePointerOfDataObject: array1)
+		put: largeIntegerValue.
+	#[ 255 255 255 127 255 255 255 255 ] withIndexDo: [ :byte :index |
+		self
+			assert: (memory fetchByte: index - 1 ofObject: array1)
+			equals: byte ].
 
 	"Read the 64 bits at the array starting at offset 0 as a signed integer"
 	interpreter push: array1.
 	interpreter push: (memory integerObjectOf: 0).
 	interpreter primitiveLoadInt64FromBytes.
 
-	self assert: (memory isIntegerObject: interpreter stackTop).
-	self assert: (memory integerValueOf: interpreter stackTop) equals: -2147483649
+	memory wordSize = 8
+		ifTrue: [
+			self assert: (memory isIntegerObject: interpreter stackTop).
+			self
+				assert: (memory integerValueOf: interpreter stackTop)
+				equals: -2147483649 ]
+		ifFalse: [ "32bit"
+			| largeIntegerOop |
+			self deny: (memory isIntegerObject: interpreter stackTop).
+			largeIntegerOop := interpreter stackTop.
+			#[ 1 0 0 128 0 0 0 0 ] withIndexDo: [
+				:expectedByte
+				:index |
+				self
+					assert: (memory fetchByte: index - 1 ofObject: largeIntegerOop)
+					equals: expectedByte ] ]
 ]
 
 { #category : 'tests' }

--- a/smalltalksrc/VMMakerTests/VMJittedByteArrayAccessPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJittedByteArrayAccessPrimitiveTest.class.st
@@ -38,7 +38,6 @@ VMJittedByteArrayAccessPrimitiveTest >> assertEqualsTo: expectedValue bitSize: b
 			equals: (expectedValue twoComplementOfBitSize: bitSize) ].
 
 	bitSize = 64 ifTrue: [ 
-		1halt.
 		self
 			assert: (memory fetchLong64: 0 ofObject: targetReceiver)
 			equals: (expectedValue twoComplementOfBitSize: bitSize) ].
@@ -366,7 +365,6 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadInt64LoadsLargeNegative
 
 	self genPrimitive: #LoadInt64.
 	
-	1halt.
 	self 
 		executePrimitiveWithReceiver: receiver
 		withArgument: (self memory integerObjectOf: 0).
@@ -375,6 +373,26 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadInt64LoadsLargeNegative
 	#[255 255 255 255 255 255 255 127] withIndexDo: [ :expectedByte :index |
 		self assert: (memory fetchByte: index - 1 ofObject: largeIntegerOop) equals: expectedByte.
 	]
+]
+
+{ #category : 'tests - load integers' }
+VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadInt64LoadsNegative32bitSmallInteger [
+
+	| expectedValue |
+	expectedValue := -2147483649.
+	self newReceiverWithValue: expectedValue ofBitSize: 64.	
+	#[255 255 255 127 255 255 255 255] withIndexDo: [ :byte :index |
+		self assert: (memory fetchByte: index - 1 ofObject: receiver) equals: byte.
+	].
+
+	self genPrimitive: #LoadInt64.
+	
+	self 
+		executePrimitiveWithReceiver: receiver
+		withArgument: (self memory integerObjectOf: 0).
+
+	self assert: (memory isIntegerObject: machineSimulator receiverRegisterValue).
+	self assert: (memory integerValueOf: machineSimulator receiverRegisterValue) equals: -2147483649
 ]
 
 { #category : 'tests - load integers' }
@@ -396,6 +414,26 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadInt64LoadsNegativeValue
 		assert: (memory integerValueOf: machineSimulator receiverRegisterValue) 
 	 	equals: expectedValue
 
+]
+
+{ #category : 'tests - load integers' }
+VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadInt64LoadsPositiveSmallInteger [
+
+	| expectedValue |
+	expectedValue := 17.
+	self newReceiverWithValue: expectedValue ofBitSize: 64.	
+	#[17 0 0 0 0 0 0 0] withIndexDo: [ :byte :index |
+		self assert: (memory fetchByte: index - 1 ofObject: receiver) equals: byte.
+	].
+
+	self genPrimitive: #LoadInt64.
+	
+	self 
+		executePrimitiveWithReceiver: receiver
+		withArgument: (self memory integerObjectOf: 0).
+
+	self assert: (memory isIntegerObject: machineSimulator receiverRegisterValue).
+	self assert: (memory integerValueOf: machineSimulator receiverRegisterValue) equals: 17
 ]
 
 { #category : 'tests - load integers' }

--- a/smalltalksrc/VMMakerTests/VMJittedByteArrayAccessPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJittedByteArrayAccessPrimitiveTest.class.st
@@ -360,7 +360,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadInt64LoadsLargeNegative
 	expectedValue := -9223372036854775807.
 	self newReceiverWithValue: expectedValue ofBitSize: 64.	
 	#[1 0 0 0 0 0 0 128] withIndexDo: [ :byte :index |
-		self assert: (memory fetchByte: index - 1 ofObject: receiver) equals: byte.
+		self assert: (memory fetchByte: index - 1 ofObject: targetReceiver) equals: byte.
 	].
 
 	self genPrimitive: #LoadInt64.
@@ -379,10 +379,11 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadInt64LoadsLargeNegative
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadInt64LoadsLargePositiveValue [
 
 	| expectedValue largeIntegerOop |
+
 	expectedValue := 9223372036854775806.
 	self newReceiverWithValue: expectedValue ofBitSize: 64.	
 	#[254 255 255 255 255 255 255 127] withIndexDo: [ :byte :index |
-		self assert: (memory fetchByte: index - 1 ofObject: receiver) equals: byte.
+		self assert: (memory fetchByte: index - 1 ofObject: targetReceiver) equals: byte.
 	].
 
 	self genPrimitive: #LoadInt64.
@@ -404,7 +405,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadInt64LoadsNegative32bit
 	expectedValue := -2147483649.
 	self newReceiverWithValue: expectedValue ofBitSize: 64.	
 	#[255 255 255 127 255 255 255 255] withIndexDo: [ :byte :index |
-		self assert: (memory fetchByte: index - 1 ofObject: receiver) equals: byte.
+		self assert: (memory fetchByte: index - 1 ofObject: targetReceiver) equals: byte.
 	].
 
 	self genPrimitive: #LoadInt64.
@@ -445,7 +446,7 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadInt64LoadsPositiveSmall
 	expectedValue := 17.
 	self newReceiverWithValue: expectedValue ofBitSize: 64.	
 	#[17 0 0 0 0 0 0 0] withIndexDo: [ :byte :index |
-		self assert: (memory fetchByte: index - 1 ofObject: receiver) equals: byte.
+		self assert: (memory fetchByte: index - 1 ofObject: targetReceiver) equals: byte.
 	].
 
 	self genPrimitive: #LoadInt64.

--- a/smalltalksrc/VMMakerTests/VMJittedByteArrayAccessPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJittedByteArrayAccessPrimitiveTest.class.st
@@ -376,6 +376,28 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadInt64LoadsLargeNegative
 ]
 
 { #category : 'tests - load integers' }
+VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadInt64LoadsLargePositiveValue [
+
+	| expectedValue largeIntegerOop |
+	expectedValue := 9223372036854775806.
+	self newReceiverWithValue: expectedValue ofBitSize: 64.	
+	#[254 255 255 255 255 255 255 127] withIndexDo: [ :byte :index |
+		self assert: (memory fetchByte: index - 1 ofObject: receiver) equals: byte.
+	].
+
+	self genPrimitive: #LoadInt64.
+	
+	self 
+		executePrimitiveWithReceiver: receiver
+		withArgument: (self memory integerObjectOf: 0).
+
+	largeIntegerOop := machineSimulator receiverRegisterValue.
+	#[254 255 255 255 255 255 255 127] withIndexDo: [ :expectedByte :index |
+		self assert: (memory fetchByte: index - 1 ofObject: largeIntegerOop) equals: expectedByte.
+	]
+]
+
+{ #category : 'tests - load integers' }
 VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadInt64LoadsNegative32bitSmallInteger [
 
 	| expectedValue |

--- a/smalltalksrc/VMMakerTests/VMJittedByteArrayAccessPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJittedByteArrayAccessPrimitiveTest.class.st
@@ -3,7 +3,8 @@ Class {
 	#superclass : 'VMJittedPrimitivesTest',
 	#instVars : [
 		'receiver',
-		'targetReceiver'
+		'targetReceiver',
+		'stop'
 	],
 	#category : 'VMMakerTests-JitTests',
 	#package : 'VMMakerTests',
@@ -37,6 +38,7 @@ VMJittedByteArrayAccessPrimitiveTest >> assertEqualsTo: expectedValue bitSize: b
 			equals: (expectedValue twoComplementOfBitSize: bitSize) ].
 
 	bitSize = 64 ifTrue: [ 
+		1halt.
 		self
 			assert: (memory fetchLong64: 0 ofObject: targetReceiver)
 			equals: (expectedValue twoComplementOfBitSize: bitSize) ].
@@ -51,9 +53,17 @@ VMJittedByteArrayAccessPrimitiveTest >> genPrimitive: aString [
 	endPart := (aString beginsWith: 'Load') ifTrue: [ 'From' ] ifFalse: [ 'Into' ].
 	endPart := endPart , self trailingName.
 
-	self compile: [ cogit objectRepresentation 
-			perform: ('genPrimitive', aString, endPart) asSymbol ].
+	self compile: [ 
+		cogit objectRepresentation 
+			perform: ('genPrimitive', aString, endPart) asSymbol.
+		stop := cogit Stop ].
 
+]
+
+{ #category : 'tests - store integers' }
+VMJittedByteArrayAccessPrimitiveTest >> jitCompilerClass [
+
+	^ StackToRegisterMappingCogit
 ]
 
 { #category : 'utils' }
@@ -342,6 +352,29 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadInt32LoadsPositiveValue
 		assert: (memory integerValueOf: machineSimulator receiverRegisterValue) 
 	 	equals: expectedValue
 
+]
+
+{ #category : 'tests - load integers' }
+VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveLoadInt64LoadsLargeNegativeValue [
+
+	| expectedValue largeIntegerOop |
+	expectedValue := -9223372036854775807.
+	self newReceiverWithValue: expectedValue ofBitSize: 64.	
+	#[1 0 0 0 0 0 0 128] withIndexDo: [ :byte :index |
+		self assert: (memory fetchByte: index - 1 ofObject: receiver) equals: byte.
+	].
+
+	self genPrimitive: #LoadInt64.
+	
+	1halt.
+	self 
+		executePrimitiveWithReceiver: receiver
+		withArgument: (self memory integerObjectOf: 0).
+
+	largeIntegerOop := machineSimulator receiverRegisterValue.
+	#[255 255 255 255 255 255 255 127] withIndexDo: [ :expectedByte :index |
+		self assert: (memory fetchByte: index - 1 ofObject: largeIntegerOop) equals: expectedByte.
+	]
 ]
 
 { #category : 'tests - load integers' }
@@ -821,6 +854,55 @@ VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreInt32StoresPositiveVal
 	
 	4 to: 7 do: [ :i | 
 		self assert: (memory fetchByte: i ofObject: targetReceiver) equals: 16r90 + i + 1. ].
+]
+
+{ #category : 'tests - store integers' }
+VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreInt64StoresLargeNegativeValueFails [
+
+	| expectedValue target |
+	self createLargeIntegerClasses.
+
+	expectedValue := -9223372036854775807.
+	self genPrimitive: #StoreInt64.
+	self newReceiver.
+
+	"This primitive fails when the integer to write is not a small integer.
+	Thus, it should fall through and stop at the stop address.
+	If it does not stop (thus the behavior changes) we expect this test to eventually timeout or fail on simulation"
+	target := stop address.
+	self prepareStackForSendReceiver: receiver arguments: {
+			(self memory integerObjectOf: 0).
+			(self memory signed64BitIntegerFor: expectedValue) }.
+	self runFrom: cogInitialAddress until: target
+]
+
+{ #category : 'tests - store integers' }
+VMJittedByteArrayAccessPrimitiveTest >> testPrimitiveStoreInt64StoresLargeNegativeValueKeepsRegisterValues [
+
+	| expectedValue target receiverRegisterBefore arg0RegisterBefore arg1RegisterBefore |
+	self createLargeIntegerClasses.
+
+	expectedValue := -9223372036854775807.
+	self genPrimitive: #StoreInt64.
+	self newReceiver.
+
+	"This primitive fails when the integer to write is not a small integer.
+	Thus, it should fall through and stop at the stop address.
+	If it does not stop (thus the behavior changes) we expect this test to eventually timeout or fail on simulation"
+	target := stop address.
+	self prepareStackForSendReceiver: receiver arguments: {
+			(self memory integerObjectOf: 0).
+			(self memory signed64BitIntegerFor: expectedValue) }.
+	
+	receiverRegisterBefore := machineSimulator receiverRegisterValue.
+	arg0RegisterBefore := machineSimulator arg0RegisterValue.
+	arg1RegisterBefore := machineSimulator arg1RegisterValue.
+
+	self runFrom: cogInitialAddress until: target.
+	
+	self assert: receiverRegisterBefore equals: machineSimulator receiverRegisterValue.
+	self assert: arg0RegisterBefore equals: machineSimulator arg0RegisterValue.
+	self assert: arg1RegisterBefore equals: machineSimulator arg1RegisterValue.
 ]
 
 { #category : 'tests - store integers' }

--- a/smalltalksrc/VMMakerTests/VMJittedPrimitivesTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMJittedPrimitivesTest.class.st
@@ -56,6 +56,19 @@ VMJittedPrimitivesTest >> executePrimitiveWithReceiver: receiverOop withArgument
 	self runUntilReturn
 ]
 
+{ #category : 'utils' }
+VMJittedPrimitivesTest >> executePrimitiveWithReceiver: receiverOop withArgument: firstArgumentOop and: secondArgumentOop until: target [ 
+
+	"Simulate a primitive execution having an object as receiver and a single argument
+	  - the receiver goes to the receiver register
+	  - the arguments should be pushed to the stack
+	If we are in a system without a link register, we need to push the caller IP to the stack to simulate a call"
+
+	self prepareStackForSendReceiver: receiverOop arguments: { firstArgumentOop. secondArgumentOop }.
+	
+	self runFrom: cogInitialAddress until: target
+]
+
 { #category : 'helpers' }
 VMJittedPrimitivesTest >> prepareStackForSendReceiver: aReceiver [
 

--- a/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitAbstractTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitAbstractTest.class.st
@@ -641,7 +641,7 @@ VMSimpleStackBasedCogitAbstractTest >> prepareStackForSendReceiver: aReceiver ar
 	"If the cogit is the StackToRegisterMapping the arguments should go in the registers also"
 	(cogit isKindOf: StackToRegisterMappingCogit) ifTrue: [
 		arguments size >= 1 ifTrue: [ self machineSimulator arg0RegisterValue: (arguments at: 1) ].
-		arguments size > 1 ifTrue: [ self halt ]].
+		arguments size > 1 ifTrue: [ self machineSimulator arg1RegisterValue: (arguments at: 2) ]].
 	
 	self prepareCall
 ]


### PR DESCRIPTION
Fix the boxing of integers when extracting them from byte arrays:
 - fix conversions
 - keep sign
 - do not create large integers for small integers

Added tests and fixed some little things the simulator

With @Ducasse 