### PR TITLE
Closed pics to pics

### DIFF
--- a/smalltalksrc/VMMaker/CoInterpreter.class.st
+++ b/smalltalksrc/VMMaker/CoInterpreter.class.st
@@ -1235,16 +1235,16 @@ CoInterpreter >> ceInterpretMethodFromPIC: aMethodObj receiver: rcvr [
 { #category : 'trampolines' }
 CoInterpreter >> ceMNUFromPICMNUMethod: aMethodObj receiver: rcvr [
 	<api>
-	| cPIC primitiveIndex |
-	<var: #cPIC type: #'CogMethod *'>
+	| aPIC primitiveIndex |
+	<var: #aPIC type: #'CogMethod *'>
 	self assert: (objectMemory addressCouldBeOop: rcvr).
 	self assert: (aMethodObj = 0
 				or: [(objectMemory addressCouldBeObj: aMethodObj)
 					and: [objectMemory isOopCompiledMethod: aMethodObj]]).
-	cPIC := self cCoerceSimple: self popStack - cogit mnuOffset to: #'CogMethod *'.
-	self assert: (cPIC cmType = CMPolymorphicIC or: [cPIC cmType = CMMegamorphicIC]).
-	argumentCount := cPIC cmNumArgs.
-	messageSelector := cPIC selector.
+	aPIC := self cCoerceSimple: self popStack - cogit mnuOffset to: #'CogMethod *'.
+	self assert: (aPIC cmType = CMPolymorphicIC or: [aPIC cmType = CMMegamorphicIC]).
+	argumentCount := aPIC cmNumArgs.
+	messageSelector := aPIC selector.
 	aMethodObj ~= 0 ifTrue:
 		[instructionPointer := self popStack.
 		self createActualMessageTo: (objectMemory fetchClassOf: rcvr).
@@ -4150,7 +4150,7 @@ CoInterpreter >> printCogMethod: cogMethod [
 			[self print: ' prim '; printNum: primitive]].
 	cogMethod cmType = CMPolymorphicIC ifTrue:
 		[self print: ': Closed PIC N: ';
-			printHex: cogMethod cPICNumCases].
+			printHex: cogMethod picNumCases].
 	cogMethod cmType = CMMegamorphicIC ifTrue:
 		[self print: ': Open PIC '].
 	self print: ' selector: '; printHex: cogMethod selector.

--- a/smalltalksrc/VMMaker/CogARMCompiler.class.st
+++ b/smalltalksrc/VMMaker/CogARMCompiler.class.st
@@ -3158,9 +3158,10 @@ CogARMCompiler >> rewritePICJumpAt: addressFollowingJump target: jumpTargetAddr 
 { #category : 'inline cacheing' }
 CogARMCompiler >> rewriteTransferAt: callSiteReturnAddress target: callTargetAddress [
 	"Rewrite a call/jump instruction to call a different target.  This variant is used to link PICs
-	 in ceSendMiss et al, and to rewrite call/jumps in CPICs.
+	 in ceSendMiss et al, and to rewrite call/jumps in PICs.
 	Answer the extent of
 	 the code change which is used to compute the range of the icache to flush."
+	
 	<var: #callSiteReturnAddress type: #usqInt>
 	<var: #callTargetAddress type: #usqInt>
 	| callDistance instr |

--- a/smalltalksrc/VMMaker/CogARMCompiler.class.st
+++ b/smalltalksrc/VMMaker/CogARMCompiler.class.st
@@ -3079,17 +3079,6 @@ CogARMCompiler >> returnFromCallCFunctionInSmalltalkStack: anObject [
 ]
 
 { #category : 'inline cacheing' }
-CogARMCompiler >> rewriteCPICJumpAt: addressFollowingJump target: jumpTargetAddr [
-	"Rewrite a jump instruction to call a different target.  This variant is used to reset the 
-	jumps in the prototype CPIC to suit each use,.   
-	Answer the extent of the code change which is used to compute the range of the icache to flush."
-	<var: #addressFollowingJump type: #usqInt>
-	<var: #jumpTargetAddr type: #usqInt>
-	<inline: true>
-	^self rewriteTransferAt: addressFollowingJump target: jumpTargetAddr
-]
-
-{ #category : 'inline cacheing' }
 CogARMCompiler >> rewriteCallAt: callSiteReturnAddress target: callTargetAddress [
 	"Rewrite a call instruction to call a different target.  This variant is used to link PICs
 	 in ceSendMiss et al,.   
@@ -3147,11 +3136,23 @@ CogARMCompiler >> rewriteJumpFullAt: callSiteReturnAddress target: callTargetAdd
 { #category : 'inline cacheing' }
 CogARMCompiler >> rewriteJumpLongAt: callSiteReturnAddress target: callTargetAddress [
 	"Rewrite a jump instruction to call a different target.  This variant is used to reset the 
-	jumps in the prototype CPIC to suit each use,.   
+	jumps in the prototype PIC to suit each use,.   
 	Answer the extent of the code change which is used to compute the range of the icache to flush."
+
 	<var: #callSiteReturnAddress type: #usqInt>
 	<var: #callTargetAddress type: #usqInt>
 	^self rewriteTransferAt: callSiteReturnAddress target: callTargetAddress
+]
+
+{ #category : 'inline cacheing' }
+CogARMCompiler >> rewritePICJumpAt: addressFollowingJump target: jumpTargetAddr [
+	"Rewrite a jump instruction to call a different target.  This variant is used to reset the 
+	jumps in the prototype PIC to suit each use,.   
+	Answer the extent of the code change which is used to compute the range of the icache to flush."
+	<var: #addressFollowingJump type: #usqInt>
+	<var: #jumpTargetAddr type: #usqInt>
+	<inline: true>
+	^self rewriteTransferAt: addressFollowingJump target: jumpTargetAddr
 ]
 
 { #category : 'inline cacheing' }

--- a/smalltalksrc/VMMaker/CogARMv8Compiler.class.st
+++ b/smalltalksrc/VMMaker/CogARMv8Compiler.class.st
@@ -5574,7 +5574,7 @@ CogARMv8Compiler >> rewriteCallFullAt: callSiteReturnAddress target: callTargetA
 { #category : 'inline cacheing' }
 CogARMv8Compiler >> rewriteConditionalJumpLongAt: callSiteReturnAddress target: callTargetAddress [
 	"Rewrite a jump instruction to call a different target.  This variant is used to reset the 
-	jumps in the prototype CPIC to suit each use,.   
+	jumps in the prototype PIC to suit each use,.   
 	Answer the extent of the code change which is used to compute the range of the icache to flush."
 	<var: #callSiteReturnAddress type: #usqInt>
 	<var: #callTargetAddress type: #usqInt>
@@ -5632,7 +5632,7 @@ CogARMv8Compiler >> rewriteJumpFullAt: callSiteReturnAddress target: callTargetA
 { #category : 'inline cacheing' }
 CogARMv8Compiler >> rewriteJumpLongAt: callSiteReturnAddress target: callTargetAddress [
 	"Rewrite a jump instruction to call a different target.  This variant is used to reset the 
-	jumps in the prototype CPIC to suit each use,.   
+	jumps in the prototype PIC to suit each use,.   
 	Answer the extent of the code change which is used to compute the range of the icache to flush."
 	<var: #callSiteReturnAddress type: #usqInt>
 	<var: #callTargetAddress type: #usqInt>
@@ -5668,7 +5668,7 @@ CogARMv8Compiler >> rewritePICJumpAt: callSiteReturnAddress target: callTargetAd
 { #category : 'inline cacheing' }
 CogARMv8Compiler >> rewriteTransferAt: callSiteReturnAddress target: callTargetAddress [
 	"Rewrite a call/jump instruction to call a different target.  This variant is used to link PICs
-	 in ceSendMiss et al, and to rewrite call/jumps in CPICs.
+	 in ceSendMiss et al, and to rewrite call/jumps in PICs.
 	Answer the extent of
 	 the code change which is used to compute the range of the icache to flush."
 	<var: #callSiteReturnAddress type: #usqInt>

--- a/smalltalksrc/VMMaker/CogARMv8Compiler.class.st
+++ b/smalltalksrc/VMMaker/CogARMv8Compiler.class.st
@@ -5548,32 +5548,6 @@ CogARMv8Compiler >> rewriteBranch: conditionalBranch withNewOffset: newOffset [
 ]
 
 { #category : 'inline cacheing' }
-CogARMv8Compiler >> rewriteCPICJumpAt: callSiteReturnAddress target: callTargetAddress [
-	"Rewrite a jump instruction to call a different target.  This variant is used to reset the 
-	jumps in the prototype CPIC to suit each use,.   
-	Answer the extent of the code change which is used to compute the range of the icache to flush."
-	<var: #callSiteReturnAddress type: #usqInt>
-	<var: #callTargetAddress type: #usqInt>
-	| callDistance instr |
-
-	callTargetAddress >= cogit minCallAddress
-		ifFalse: [self error: 'linking callsite to invalid address'].
-
-	callDistance := (callTargetAddress - (callSiteReturnAddress - 4 "return offset")).
-	self assert: (self isInImmediateJumpRange: callDistance). "we don't support long call updates, yet"
-
-	instr := self instructionBeforeAddress: callSiteReturnAddress.
-	self assert: (self instructionIsConditionalBranch: instr).
-
-	objectMemory
-		long32At: (self instructionAddressBefore: callSiteReturnAddress)
-		put: (self branchCondition: (self extractConditionFromB: instr) offset: callDistance).
-
-	self assert: (self extractOffsetFromConditionalBranch: ((self branchCondition: (self extractConditionFromB: instr) offset: callDistance))) = callDistance.
-	^4
-]
-
-{ #category : 'inline cacheing' }
 CogARMv8Compiler >> rewriteCallAt: callSiteReturnAddress target: callTargetAddress [
 	"Rewrite a call instruction to call a different target.  This variant is used to link PICs
 	 in ceSendMiss et al,.   
@@ -5663,6 +5637,32 @@ CogARMv8Compiler >> rewriteJumpLongAt: callSiteReturnAddress target: callTargetA
 	<var: #callSiteReturnAddress type: #usqInt>
 	<var: #callTargetAddress type: #usqInt>
 	^self rewriteTransferAt: callSiteReturnAddress target: callTargetAddress
+]
+
+{ #category : 'inline cacheing' }
+CogARMv8Compiler >> rewritePICJumpAt: callSiteReturnAddress target: callTargetAddress [
+	"Rewrite a jump instruction to call a different target.  This variant is used to reset the jumps in the prototype PIC to suit each use,.   
+	Answer the extent of the code change which is used to compute the range of the icache to flush."
+	
+	<var: #callSiteReturnAddress type: #usqInt>
+	<var: #callTargetAddress type: #usqInt>
+	| callDistance instr |
+
+	callTargetAddress >= cogit minCallAddress
+		ifFalse: [self error: 'linking callsite to invalid address'].
+
+	callDistance := (callTargetAddress - (callSiteReturnAddress - 4 "return offset")).
+	self assert: (self isInImmediateJumpRange: callDistance). "we don't support long call updates, yet"
+
+	instr := self instructionBeforeAddress: callSiteReturnAddress.
+	self assert: (self instructionIsConditionalBranch: instr).
+
+	objectMemory
+		long32At: (self instructionAddressBefore: callSiteReturnAddress)
+		put: (self branchCondition: (self extractConditionFromB: instr) offset: callDistance).
+
+	self assert: (self extractOffsetFromConditionalBranch: ((self branchCondition: (self extractConditionFromB: instr) offset: callDistance))) = callDistance.
+	^4
 ]
 
 { #category : 'inline cacheing' }

--- a/smalltalksrc/VMMaker/CogIA32Compiler.class.st
+++ b/smalltalksrc/VMMaker/CogIA32Compiler.class.st
@@ -3966,7 +3966,7 @@ CogIA32Compiler >> rewriteJumpLongAt: callSiteReturnAddress target: callTargetAd
 
 { #category : 'inline cacheing' }
 CogIA32Compiler >> rewritePICJumpAt: addressFollowingJump target: jumpTargetAddr [
-	"Rewrite the short jump instruction to jump to a new cpic case target. "
+	"Rewrite the short jump instruction to jump to a new pic case target. "
 	<var: #addressFollowingJump type: #usqInt>
 	<var: #jumpTargetAddr type: #usqInt>
 	<var: #callDistance type: #sqInt> "prevent type inference for avoiding warning on abs"

--- a/smalltalksrc/VMMaker/CogIA32Compiler.class.st
+++ b/smalltalksrc/VMMaker/CogIA32Compiler.class.st
@@ -3894,22 +3894,6 @@ CogIA32Compiler >> returnFromCallCFunctionInSmalltalkStack: numberOfArguments [
 ]
 
 { #category : 'inline cacheing' }
-CogIA32Compiler >> rewriteCPICJumpAt: addressFollowingJump target: jumpTargetAddr [
-	"Rewrite the short jump instruction to jump to a new cpic case target. "
-	<var: #addressFollowingJump type: #usqInt>
-	<var: #jumpTargetAddr type: #usqInt>
-	<var: #callDistance type: #sqInt> "prevent type inference for avoiding warning on abs"
-	| callDistance |
-	callDistance := jumpTargetAddr - addressFollowingJump.
-	self assert: callDistance abs < 128.
-	objectMemory
-		byteAt: addressFollowingJump - 1
-		put:  (callDistance bitAnd: 16rFF).
-	"self cCode: ''
-		inSmalltalk: [cogit disassembleFrom: addressFollowingJump - 10 to: addressFollowingJump - 1]."
-]
-
-{ #category : 'inline cacheing' }
 CogIA32Compiler >> rewriteCallAt: callSiteReturnAddress target: callTargetAddress [
 	"Rewrite a call instruction to call a different target.  This variant is used to link PICs
 	 in ceSendMiss et al, and to rewrite cached primitive calls.   Answer the extent of
@@ -3978,6 +3962,22 @@ CogIA32Compiler >> rewriteJumpLongAt: callSiteReturnAddress target: callTargetAd
 	 is used to rewrite cached primitive calls.   Answer the extent of the
 	 code change which is used to compute the range of the icache to flush."
 	^self rewriteCallAt: callSiteReturnAddress target: callTargetAddress
+]
+
+{ #category : 'inline cacheing' }
+CogIA32Compiler >> rewritePICJumpAt: addressFollowingJump target: jumpTargetAddr [
+	"Rewrite the short jump instruction to jump to a new cpic case target. "
+	<var: #addressFollowingJump type: #usqInt>
+	<var: #jumpTargetAddr type: #usqInt>
+	<var: #callDistance type: #sqInt> "prevent type inference for avoiding warning on abs"
+	| callDistance |
+	callDistance := jumpTargetAddr - addressFollowingJump.
+	self assert: callDistance abs < 128.
+	objectMemory
+		byteAt: addressFollowingJump - 1
+		put:  (callDistance bitAnd: 16rFF).
+	"self cCode: ''
+		inSmalltalk: [cogit disassembleFrom: addressFollowingJump - 10 to: addressFollowingJump - 1]."
 ]
 
 { #category : 'encoding' }

--- a/smalltalksrc/VMMaker/CogMIPSELCompiler.class.st
+++ b/smalltalksrc/VMMaker/CogMIPSELCompiler.class.st
@@ -2563,32 +2563,6 @@ CogMIPSELCompiler >> relocateMethodReferenceBeforeAddress: pc by: delta [
 ]
 
 { #category : 'inline cacheing' }
-CogMIPSELCompiler >> rewriteCPICJumpAt: addressFollowingJump target: jumpTargetAddr [
-	"Rewrite a jump instruction to call a different target.  This variant is used to reset the 
-	jumps in the prototype CPIC to suit each use,.   
-	Answer the extent of the code change which is used to compute the range of the icache to flush."
-	<var: #addressFollowingJump type: #usqInt>
-	<var: #jumpTargetAddr type: #usqInt>
-	
-	"self CmpR: ClassReg R: TempReg.
-	^self JumpNonZero: 0"
-	
-	"bne s5, s3, +156 ; =BE7C
-	 nop (delay slot)
-	 .... <-- addressFollowingJump"
-	
-	self assert: (self opcodeAtAddress: addressFollowingJump - 8) = BNE.
-	self assert: (objectMemory longAt: addressFollowingJump - 4) = self nop.
-	"cogit disassembleFrom: addressFollowingJump - 8 to: addressFollowingJump."
-	
-	self rewriteITypeBranchAtAddress: addressFollowingJump - 8 target: jumpTargetAddr.
-	
-	self assert: (self opcodeAtAddress: addressFollowingJump - 8) = BNE.
-	self assert: (objectMemory longAt: addressFollowingJump - 4) = self nop.
-	"cogit disassembleFrom: addressFollowingJump - 8 to: addressFollowingJump."
-]
-
-{ #category : 'inline cacheing' }
 CogMIPSELCompiler >> rewriteCallAt: callSiteReturnAddress target: callTargetAddress [
 	"Rewrite a call instruction to call a different target.  This variant is used to link PICs
 	 in ceSendMiss et al,.   
@@ -2795,6 +2769,32 @@ CogMIPSELCompiler >> rewriteOpcode: anOpcode with: left with: right [
 		"0 is target"
 		at: 1 put: left;
 		at: 2 put: right
+]
+
+{ #category : 'inline cacheing' }
+CogMIPSELCompiler >> rewritePICJumpAt: addressFollowingJump target: jumpTargetAddr [
+	"Rewrite a jump instruction to call a different target.  This variant is used to reset the 	jumps in the prototype PIC to suit each use,.   
+	Answer the extent of the code change which is used to compute the range of the icache to flush."
+	
+	<var: #addressFollowingJump type: #usqInt>
+	<var: #jumpTargetAddr type: #usqInt>
+	
+	"self CmpR: ClassReg R: TempReg.
+	^self JumpNonZero: 0"
+	
+	"bne s5, s3, +156 ; =BE7C
+	 nop (delay slot)
+	 .... <-- addressFollowingJump"
+	
+	self assert: (self opcodeAtAddress: addressFollowingJump - 8) = BNE.
+	self assert: (objectMemory longAt: addressFollowingJump - 4) = self nop.
+	"cogit disassembleFrom: addressFollowingJump - 8 to: addressFollowingJump."
+	
+	self rewriteITypeBranchAtAddress: addressFollowingJump - 8 target: jumpTargetAddr.
+	
+	self assert: (self opcodeAtAddress: addressFollowingJump - 8) = BNE.
+	self assert: (objectMemory longAt: addressFollowingJump - 4) = self nop.
+	"cogit disassembleFrom: addressFollowingJump - 8 to: addressFollowingJump."
 ]
 
 { #category : 'inline cacheing' }

--- a/smalltalksrc/VMMaker/CogMIPSELCompiler.class.st
+++ b/smalltalksrc/VMMaker/CogMIPSELCompiler.class.st
@@ -2597,7 +2597,7 @@ CogMIPSELCompiler >> rewriteCallAt: callSiteReturnAddress target: callTargetAddr
 { #category : 'inline cacheing' }
 CogMIPSELCompiler >> rewriteConditionalJumpLongAt: callSiteReturnAddress target: callTargetAddress [
 	"Rewrite a jump instruction to call a different target.  This variant is used to reset the 
-	jumps in the prototype CPIC to suit each use,.   
+	jumps in the prototype PIC to suit each use,.   
 	Answer the extent of the code change which is used to compute the range of the icache to flush."
 	<var: #callSiteReturnAddress type: #usqInt>
 	<var: #callTargetAddress type: #usqInt>
@@ -2731,7 +2731,7 @@ CogMIPSELCompiler >> rewriteJTypeAtAddress: mcpc target: newTarget [
 { #category : 'inline cacheing' }
 CogMIPSELCompiler >> rewriteJumpLongAt: callSiteReturnAddress target: callTargetAddress [
 	"Rewrite a jump instruction to call a different target.  This variant is used to reset the 
-	jumps in the prototype CPIC to suit each use,.   
+	jumps in the prototype PIC to suit each use,.   
 	Answer the extent of the code change which is used to compute the range of the icache to flush."
 	<var: #callSiteReturnAddress type: #usqInt>
 	<var: #callTargetAddress type: #usqInt>

--- a/smalltalksrc/VMMaker/CogMethod.class.st
+++ b/smalltalksrc/VMMaker/CogMethod.class.st
@@ -36,7 +36,6 @@ Class {
 		'cmNumArgs',
 		'cmType',
 		'cmRefersToYoung',
-		'cpicHasMNUCaseOrCMIsFullBlock',
 		'cmUsageCount',
 		'cmUsesPenultimateLit',
 		'cbUsesInstVars',
@@ -46,7 +45,8 @@ Class {
 		'picUsage',
 		'methodObject',
 		'methodHeader',
-		'selector'
+		'selector',
+		'picHasMNUCaseOrCMIsFullBlock'
 	],
 	#pools : [
 		'CogMethodConstants',
@@ -106,14 +106,14 @@ CogMethod class >> instVarNamesAndTypesForTranslationDo: aBinaryBlock [
 						 ([ 'cmNumArgs' ] -> [ #( unsigned ' : 8' ) ]). "SqueakV3 needs only 5 bits"
 						 ([ 'cmType' ] -> [ #( unsigned ' : 3' ) ]).
 						 ([ 'cmRefersToYoung' ] -> [ #( unsigned #Boolean ' : 1' ) ]).
-						 ([ 'cpicHasMNUCaseOrCMIsFullBlock' ]
+						 ([ 'picHasMNUCaseOrCMIsFullBlock' ]
 						  -> [ #( unsigned #Boolean ' : 1' ) ]).
 						 ([ 'cmUsageCount' ] -> [ #( unsigned ' : 3' ) ]). "See CMMaxUsageCount in initialize"
 						 ([ 'cmUsesPenultimateLit' ]
 						  -> [ #( unsigned #Boolean ' : 1' ) ]).
 						 ([ 'cbUsesInstVars' ] -> [ #( unsigned #Boolean ' : 1' ) ]).
 						 ([ 'cmUnusedFlags' ] -> [ #( unsigned ' : 2' ) ]).
-						 ([ 'stackCheckOffset' ] -> [ #( unsigned ' : 12' ) ]). "See MaxStackCheckOffset in initialize. a.k.a. cPICNumCases"
+						 ([ 'stackCheckOffset' ] -> [ #( unsigned ' : 12' ) ]). "See MaxStackCheckOffset in initialize. a.k.a. picNumCases"
 						 ([ 'blockSize' ] -> [ #'unsigned short' ]). "See MaxMethodSize in initialize"
 						 ([ 'picUsage' ] -> [ #'unsigned short' ]).
 						 ([ 'homeOffset' ] -> [ #'unsigned short' ]).
@@ -171,7 +171,7 @@ CogMethod >> cbUsesInstVars: anObject [
 
 { #category : 'accessing' }
 CogMethod >> cmIsFullBlock [
-	"Answer the value of cpicHasMNUCaseOrCMIsFullBlock"
+	"Answer the value of picHasMNUCaseOrCMIsFullBlock"
 	<inline: true>
 	^ self picHasMNUCaseOrCMIsFullBlock
 ]
@@ -260,13 +260,6 @@ CogMethod >> counters [
 ]
 
 { #category : 'accessing' }
-CogMethod >> cpicHasMNUCase: anObject [
-	"Set if the receiver has an MNU case."
-	<inline: true>
-	^cpicHasMNUCaseOrCMIsFullBlock := anObject
-]
-
-{ #category : 'accessing' }
 CogMethod >> methodHeader [
 	"Answer the value of methodHeader"
 
@@ -331,29 +324,36 @@ CogMethod >> picHasMNUCase [
 ]
 
 { #category : 'accessing' }
-CogMethod >> picHasMNUCaseOrCMIsFullBlock [
-	"Answer the value of cpicHasMNUCaseOrCMIsFullBlock"
+CogMethod >> picHasMNUCase: anObject [
+	"Set if the receiver has an MNU case."
+	<inline: true>
+	^picHasMNUCaseOrCMIsFullBlock := anObject
+]
 
-	^cpicHasMNUCaseOrCMIsFullBlock
+{ #category : 'accessing' }
+CogMethod >> picHasMNUCaseOrCMIsFullBlock [
+	"Answer the value of picHasMNUCaseOrCMIsFullBlock"
+
+	^picHasMNUCaseOrCMIsFullBlock
 ]
 
 { #category : 'accessing' }
 CogMethod >> picHasMNUCaseOrCMIsFullBlock: anObject [
-	"Set the value of cpicHasMNUCaseOrCMIsFullBlock"
+	"Set the value of picHasMNUCaseOrCMIsFullBlock"
 
-	^cpicHasMNUCaseOrCMIsFullBlock := anObject
+	^picHasMNUCaseOrCMIsFullBlock := anObject
 ]
 
 { #category : 'accessing' }
 CogMethod >> picNumCases [
-	"Answer the value of cPICNumCases (a.k.a. stackCheckOffset)"
+	"Answer the value of picNumCases (a.k.a. stackCheckOffset)"
 	<cmacro: ' stackCheckOffset'>
 	^stackCheckOffset
 ]
 
 { #category : 'accessing' }
 CogMethod >> picNumCases: anObject [
-	"Set the value of cPICNumCases (a.k.a. stackCheckOffset)"
+	"Set the value of picNumCases (a.k.a. stackCheckOffset)"
 	<cmacro: 'Hack hack hack hack i.e. the getter macro does all the work'>
 	^stackCheckOffset := anObject
 ]

--- a/smalltalksrc/VMMaker/CogMethod.class.st
+++ b/smalltalksrc/VMMaker/CogMethod.class.st
@@ -126,7 +126,7 @@ CogMethod class >> instVarNamesAndTypesForTranslationDo: aBinaryBlock [
 { #category : 'translation' }
 CogMethod class >> isAccessor: aSelector [
 	"Answer if aSelector is simply an accessor method for one of our fields."
-	^(#(cPICNumCases cPICNumCases: #nextMegamorphicIC #nextMegamorphicIC:) includes: aSelector)
+	^(#(#picNumCases #picNumCases: #nextMegamorphicIC #nextMegamorphicIC:) includes: aSelector)
 	  or: [super isAccessor: aSelector]
 ]
 
@@ -158,20 +158,6 @@ CogMethod >> blockSize: anObject [
 ]
 
 { #category : 'accessing' }
-CogMethod >> cPICNumCases [
-	"Answer the value of cPICNumCases (a.k.a. stackCheckOffset)"
-	<cmacro: ' stackCheckOffset'>
-	^stackCheckOffset
-]
-
-{ #category : 'accessing' }
-CogMethod >> cPICNumCases: anObject [
-	"Set the value of cPICNumCases (a.k.a. stackCheckOffset)"
-	<cmacro: 'Hack hack hack hack i.e. the getter macro does all the work'>
-	^stackCheckOffset := anObject
-]
-
-{ #category : 'accessing' }
 CogMethod >> cbUsesInstVars [
 
 	^cbUsesInstVars
@@ -187,7 +173,7 @@ CogMethod >> cbUsesInstVars: anObject [
 CogMethod >> cmIsFullBlock [
 	"Answer the value of cpicHasMNUCaseOrCMIsFullBlock"
 	<inline: true>
-	^ self cpicHasMNUCaseOrCMIsFullBlock
+	^ self picHasMNUCaseOrCMIsFullBlock
 ]
 
 { #category : 'accessing' }
@@ -274,31 +260,9 @@ CogMethod >> counters [
 ]
 
 { #category : 'accessing' }
-CogMethod >> cpicHasMNUCase [
-	"Answer if the receiver has an MNU case."
-	<inline: true>
-
-	^ self cpicHasMNUCaseOrCMIsFullBlock and: [self cmType = CMPolymorphicIC]
-]
-
-{ #category : 'accessing' }
 CogMethod >> cpicHasMNUCase: anObject [
 	"Set if the receiver has an MNU case."
 	<inline: true>
-	^cpicHasMNUCaseOrCMIsFullBlock := anObject
-]
-
-{ #category : 'accessing' }
-CogMethod >> cpicHasMNUCaseOrCMIsFullBlock [
-	"Answer the value of cpicHasMNUCaseOrCMIsFullBlock"
-
-	^cpicHasMNUCaseOrCMIsFullBlock
-]
-
-{ #category : 'accessing' }
-CogMethod >> cpicHasMNUCaseOrCMIsFullBlock: anObject [
-	"Set the value of cpicHasMNUCaseOrCMIsFullBlock"
-
 	^cpicHasMNUCaseOrCMIsFullBlock := anObject
 ]
 
@@ -356,6 +320,42 @@ CogMethod >> objectHeader: anObject [
 	"Set the value of objectHeader"
 
 	^objectHeader := anObject
+]
+
+{ #category : 'accessing' }
+CogMethod >> picHasMNUCase [
+	"Answer if the receiver has an MNU case."
+	<inline: true>
+
+	^ self picHasMNUCaseOrCMIsFullBlock and: [self cmType = CMPolymorphicIC]
+]
+
+{ #category : 'accessing' }
+CogMethod >> picHasMNUCaseOrCMIsFullBlock [
+	"Answer the value of cpicHasMNUCaseOrCMIsFullBlock"
+
+	^cpicHasMNUCaseOrCMIsFullBlock
+]
+
+{ #category : 'accessing' }
+CogMethod >> picHasMNUCaseOrCMIsFullBlock: anObject [
+	"Set the value of cpicHasMNUCaseOrCMIsFullBlock"
+
+	^cpicHasMNUCaseOrCMIsFullBlock := anObject
+]
+
+{ #category : 'accessing' }
+CogMethod >> picNumCases [
+	"Answer the value of cPICNumCases (a.k.a. stackCheckOffset)"
+	<cmacro: ' stackCheckOffset'>
+	^stackCheckOffset
+]
+
+{ #category : 'accessing' }
+CogMethod >> picNumCases: anObject [
+	"Set the value of cPICNumCases (a.k.a. stackCheckOffset)"
+	<cmacro: 'Hack hack hack hack i.e. the getter macro does all the work'>
+	^stackCheckOffset := anObject
 ]
 
 { #category : 'accessing' }

--- a/smalltalksrc/VMMaker/CogMethodSurrogate.class.st
+++ b/smalltalksrc/VMMaker/CogMethodSurrogate.class.st
@@ -122,7 +122,7 @@ CogMethodSurrogate >> at: anAddress objectMemory: objectMemory cogit: aCogit [
 
 { #category : 'accessing' }
 CogMethodSurrogate >> cmIsFullBlock [
-	"Answer the value of cpicHasMNUCaseOrCMIsFullBlock"
+	"Answer the value of picHasMNUCaseOrCMIsFullBlock"
 
 	^ self picHasMNUCaseOrCMIsFullBlock
 ]
@@ -131,13 +131,6 @@ CogMethodSurrogate >> cmIsFullBlock [
 CogMethodSurrogate >> containsAddress: anAddress [
 	^address <= anAddress asUnsignedInteger
 	  and: [address + self blockSize >= anAddress asUnsignedInteger]
-]
-
-{ #category : 'accessing' }
-CogMethodSurrogate >> cpicHasMNUCase: anObject [
-	"Set if the receiver has an MNU case."
-
-	^self picHasMNUCaseOrCMIsFullBlock: anObject
 ]
 
 { #category : 'testing' }
@@ -185,6 +178,13 @@ CogMethodSurrogate >> picHasMNUCase [
 	<inline: true>
 
 	^ self picHasMNUCaseOrCMIsFullBlock and: [self cmType = CMPolymorphicIC]
+]
+
+{ #category : 'accessing' }
+CogMethodSurrogate >> picHasMNUCase: anObject [
+	"Set if the receiver has an MNU case."
+
+	^self picHasMNUCaseOrCMIsFullBlock: anObject
 ]
 
 { #category : 'accessing' }

--- a/smalltalksrc/VMMaker/CogMethodSurrogate.class.st
+++ b/smalltalksrc/VMMaker/CogMethodSurrogate.class.st
@@ -121,20 +121,10 @@ CogMethodSurrogate >> at: anAddress objectMemory: objectMemory cogit: aCogit [
 ]
 
 { #category : 'accessing' }
-CogMethodSurrogate >> cPICNumCases [
-	^self stackCheckOffset
-]
-
-{ #category : 'accessing' }
-CogMethodSurrogate >> cPICNumCases: n [
-	^self stackCheckOffset: n
-]
-
-{ #category : 'accessing' }
 CogMethodSurrogate >> cmIsFullBlock [
 	"Answer the value of cpicHasMNUCaseOrCMIsFullBlock"
 
-	^ self cpicHasMNUCaseOrCMIsFullBlock
+	^ self picHasMNUCaseOrCMIsFullBlock
 ]
 
 { #category : 'testing' }
@@ -144,18 +134,10 @@ CogMethodSurrogate >> containsAddress: anAddress [
 ]
 
 { #category : 'accessing' }
-CogMethodSurrogate >> cpicHasMNUCase [
-	"Answer if the receiver has an MNU case."
-	<inline: true>
-
-	^ self cpicHasMNUCaseOrCMIsFullBlock and: [self cmType = CMPolymorphicIC]
-]
-
-{ #category : 'accessing' }
 CogMethodSurrogate >> cpicHasMNUCase: anObject [
 	"Set if the receiver has an MNU case."
 
-	^self cpicHasMNUCaseOrCMIsFullBlock: anObject
+	^self picHasMNUCaseOrCMIsFullBlock: anObject
 ]
 
 { #category : 'testing' }
@@ -195,6 +177,24 @@ CogMethodSurrogate >> objectHeader: aValue [
 	^baseHeaderSize = 8
 		ifTrue: [memory long64At: address put: aValue]
 		ifFalse: [memory longAt: address put: aValue]
+]
+
+{ #category : 'accessing' }
+CogMethodSurrogate >> picHasMNUCase [
+	"Answer if the receiver has an MNU case."
+	<inline: true>
+
+	^ self picHasMNUCaseOrCMIsFullBlock and: [self cmType = CMPolymorphicIC]
+]
+
+{ #category : 'accessing' }
+CogMethodSurrogate >> picNumCases [
+	^self stackCheckOffset
+]
+
+{ #category : 'accessing' }
+CogMethodSurrogate >> picNumCases: n [
+	^self stackCheckOffset: n
 ]
 
 { #category : 'printing' }

--- a/smalltalksrc/VMMaker/CogMethodSurrogate32.class.st
+++ b/smalltalksrc/VMMaker/CogMethodSurrogate32.class.st
@@ -152,19 +152,6 @@ CogMethodSurrogate32 >> cmUsesPenultimateLit: aValue [
 ]
 
 { #category : 'accessing' }
-CogMethodSurrogate32 >> cpicHasMNUCaseOrCMIsFullBlock [
-	^(((memory unsignedByteAt: address + 1 + baseHeaderSize) bitShift: -4) bitAnd: 16r1) ~= 0
-]
-
-{ #category : 'accessing' }
-CogMethodSurrogate32 >> cpicHasMNUCaseOrCMIsFullBlock: aValue [
-	memory
-		unsignedByteAt: address + baseHeaderSize + 1
-		put: (((memory unsignedByteAt: address + baseHeaderSize + 1) bitAnd: 16rEF) + ((aValue ifTrue: [1] ifFalse: [0]) bitShift: 4)).
-	^aValue
-]
-
-{ #category : 'accessing' }
 CogMethodSurrogate32 >> homeOffset [
 	^memory unsignedShortAt: address + 0
 ]
@@ -210,6 +197,19 @@ CogMethodSurrogate32 >> padToWord: aValue [
 	^memory
 		unsignedLong32At: address + 4
 		put: aValue
+]
+
+{ #category : 'accessing' }
+CogMethodSurrogate32 >> picHasMNUCaseOrCMIsFullBlock [
+	^(((memory unsignedByteAt: address + 1 + baseHeaderSize) bitShift: -4) bitAnd: 16r1) ~= 0
+]
+
+{ #category : 'accessing' }
+CogMethodSurrogate32 >> picHasMNUCaseOrCMIsFullBlock: aValue [
+	memory
+		unsignedByteAt: address + baseHeaderSize + 1
+		put: (((memory unsignedByteAt: address + baseHeaderSize + 1) bitAnd: 16rEF) + ((aValue ifTrue: [1] ifFalse: [0]) bitShift: 4)).
+	^aValue
 ]
 
 { #category : 'accessing' }

--- a/smalltalksrc/VMMaker/CogMethodSurrogate64.class.st
+++ b/smalltalksrc/VMMaker/CogMethodSurrogate64.class.st
@@ -152,19 +152,6 @@ CogMethodSurrogate64 >> cmUsesPenultimateLit: aValue [
 ]
 
 { #category : 'accessing' }
-CogMethodSurrogate64 >> cpicHasMNUCaseOrCMIsFullBlock [
-	^(((memory unsignedByteAt: address + 1 + baseHeaderSize) bitShift: -4) bitAnd: 16r1) ~= 0
-]
-
-{ #category : 'accessing' }
-CogMethodSurrogate64 >> cpicHasMNUCaseOrCMIsFullBlock: aValue [
-	memory
-		unsignedByteAt: address + baseHeaderSize + 1
-		put: (((memory unsignedByteAt: address + baseHeaderSize + 1) bitAnd: 16rEF) + ((aValue ifTrue: [1] ifFalse: [0]) bitShift: 4)).
-	^aValue
-]
-
-{ #category : 'accessing' }
 CogMethodSurrogate64 >> homeOffset [
 	^memory unsignedShortAt: address + 0
 ]
@@ -210,6 +197,19 @@ CogMethodSurrogate64 >> padToWord: aValue [
 	^memory
 		unsignedLong64At: address + 4
 		put: aValue
+]
+
+{ #category : 'accessing' }
+CogMethodSurrogate64 >> picHasMNUCaseOrCMIsFullBlock [
+	^(((memory unsignedByteAt: address + 1 + baseHeaderSize) bitShift: -4) bitAnd: 16r1) ~= 0
+]
+
+{ #category : 'accessing' }
+CogMethodSurrogate64 >> picHasMNUCaseOrCMIsFullBlock: aValue [
+	memory
+		unsignedByteAt: address + baseHeaderSize + 1
+		put: (((memory unsignedByteAt: address + baseHeaderSize + 1) bitAnd: 16rEF) + ((aValue ifTrue: [1] ifFalse: [0]) bitShift: 4)).
+	^aValue
 ]
 
 { #category : 'accessing' }

--- a/smalltalksrc/VMMaker/CogMethodZone.class.st
+++ b/smalltalksrc/VMMaker/CogMethodZone.class.st
@@ -620,7 +620,11 @@ CogMethodZone >> printCogMethods [
 			[CMMegamorphicIC]	->	[no:= no+ 1] }
 			otherwise: [nu := nu + 1].
 		 cogMethod := self methodAfter: cogMethod].
-	coInterpreter print: 'CMMethod '; printNum: nm;  print: ' CMClosedPIC '; printNum: nc;  print: ' CMMegamorphicIC '; printNum: no;  print: ' CMFree '; printNum: nf.
+	coInterpreter 
+		print: 'CMMethod '; printNum: nm;  
+		print: ' CMPIC '; printNum: nc;  
+		print: ' CMMegamorphicIC '; printNum: no;  
+		print: ' CMFree '; printNum: nf.
 	nu > 0 ifTrue:
 		[coInterpreter print: ' UNKNOWN '; printNum: nu].
 	coInterpreter print: ' total '; printNum: nm+nc+no+nf+nu; cr
@@ -804,7 +808,7 @@ CogMethodZone >> relocateMethodsPreCompaction [
 	[cogMethod asUnsignedInteger < mzFreeStart] whileTrue:
 		[cogMethod cmType ~= CMFree ifTrue:
 			[cogMethod cmType = CMPolymorphicIC
-				ifTrue: [cogit relocateCallsInClosedPIC: cogMethod]
+				ifTrue: [cogit relocateCallsInPIC: cogMethod]
 				ifFalse: [cogit relocateCallsAndSelfReferencesInMethod: cogMethod]].
 		 cogMethod := self methodAfter: cogMethod].
 	self relocateAndPruneYoungReferrers.

--- a/smalltalksrc/VMMaker/CogOutOfLineLiteralsRiscV64Compiler.class.st
+++ b/smalltalksrc/VMMaker/CogOutOfLineLiteralsRiscV64Compiler.class.st
@@ -5998,7 +5998,7 @@ CogOutOfLineLiteralsRiscV64Compiler >> rewriteBTypeBranchAtAddress: mcpc target:
 { #category : 'inline cacheing' }
 CogOutOfLineLiteralsRiscV64Compiler >> rewriteCallAt: callSiteReturnAddress target: callTargetAddress [
 	"Rewrite a call/jump instruction to call a different target.  This variant is used to link PICs
-	 in ceSendMiss et al, and to rewrite call/jumps in CPICs. Answer the extent of the code change 
+	 in ceSendMiss et al, and to rewrite call/jumps in PICs. Answer the extent of the code change 
 	 which is used to compute the range of the icache to flush.
 	
 	 auipc offsetHigh 
@@ -6058,7 +6058,7 @@ CogOutOfLineLiteralsRiscV64Compiler >> rewriteCallFullAt: callSiteReturnAddress 
 { #category : 'inline cacheing' }
 CogOutOfLineLiteralsRiscV64Compiler >> rewriteConditionalJumpLongAt: callSiteReturnAddress target: callTargetAddress [
 	"Rewrite a jump instruction to call a different target.  This variant is used to reset the 
-	jumps in the prototype CPIC to suit each use,.   
+	jumps in the prototype PIC to suit each use.   
 	Answer the extent of the code change which is used to compute the range of the icache to flush."
 	self flag: #TODO.
 	1halt.
@@ -6138,7 +6138,7 @@ CogOutOfLineLiteralsRiscV64Compiler >> rewriteJumpFullAt: jumpFullReturnAddress 
 { #category : 'inline cacheing' }
 CogOutOfLineLiteralsRiscV64Compiler >> rewriteJumpLongAt: jumpReturnAddress target: jumpTargetAddress [
 	"Rewrite a jump instruction to call a different target.  This variant is used to link PICs 
-	 in ceSendMiss et al, and to rewrite jumps in CPICs.
+	 in ceSendMiss et al, and to rewrite jumps in PICs.
 	 Answer the extent of the code change which is used to compute the range of the icache to flush."
 	<var: #jumpReturnAddress type: #usqInt>
 	<var: #jumpTargetAddress type: #usqInt>

--- a/smalltalksrc/VMMaker/CogOutOfLineLiteralsRiscV64Compiler.class.st
+++ b/smalltalksrc/VMMaker/CogOutOfLineLiteralsRiscV64Compiler.class.st
@@ -5996,33 +5996,6 @@ CogOutOfLineLiteralsRiscV64Compiler >> rewriteBTypeBranchAtAddress: mcpc target:
 ]
 
 { #category : 'inline cacheing' }
-CogOutOfLineLiteralsRiscV64Compiler >> rewriteCPICJumpAt: addressFollowingJump target: jumpTargetAddr [
-	"Rewrite a jump instruction to call a different target.  This variant is used to reset the 
-	jumps in the prototype CPIC to suit each use,.   
-	Answer the extent of the code change which is used to compute the range of the icache to flush."
-	<var: #addressFollowingJump type: #usqInt>
-	<var: #jumpTargetAddr type: #usqInt>
-	| callOffset |
-	"self CmpR: ClassReg R: TempReg.
-	^self JumpNonZero: 0"
-	
-	"bne r1, r2, offset
-	 .... <-- addressFollowingJump
-	 
-	 ...  <-- jumpTargetAddress"
-	callOffset := jumpTargetAddr - addressFollowingJump + 4.
-	self assertValue: callOffset isContainedIn: 12. 
-	
- 	self assert: (self instructionIsB: (self instructionBeforeAddress: addressFollowingJump) withCondition: NE).
-	self rewriteBTypeBranchAtAddress: addressFollowingJump - 4 offset: callOffset withCondition: NE.
-	
-	self assert: (self instructionIsB: (self instructionBeforeAddress: addressFollowingJump) withCondition: NE).
-	self assert: (self extractOffsetFromConditionalBranch: (self instructionBeforeAddress: addressFollowingJump)) = callOffset.
-
-	^4
-]
-
-{ #category : 'inline cacheing' }
 CogOutOfLineLiteralsRiscV64Compiler >> rewriteCallAt: callSiteReturnAddress target: callTargetAddress [
 	"Rewrite a call/jump instruction to call a different target.  This variant is used to link PICs
 	 in ceSendMiss et al, and to rewrite call/jumps in CPICs. Answer the extent of the code change 
@@ -6207,6 +6180,33 @@ CogOutOfLineLiteralsRiscV64Compiler >> rewriteOpcode: anOpcode with: left with: 
 		"0 is target"
 		at: 1 put: left;
 		at: 2 put: right
+]
+
+{ #category : 'inline cacheing' }
+CogOutOfLineLiteralsRiscV64Compiler >> rewritePICJumpAt: addressFollowingJump target: jumpTargetAddr [
+	"Rewrite a jump instruction to call a different target.  This variant is used to reset the jumps in the prototype PIC to suit each use,.   
+	Answer the extent of the code change which is used to compute the range of the icache to flush."
+	
+	<var: #addressFollowingJump type: #usqInt>
+	<var: #jumpTargetAddr type: #usqInt>
+	| callOffset |
+	"self CmpR: ClassReg R: TempReg.
+	^self JumpNonZero: 0"
+	
+	"bne r1, r2, offset
+	 .... <-- addressFollowingJump
+	 
+	 ...  <-- jumpTargetAddress"
+	callOffset := jumpTargetAddr - addressFollowingJump + 4.
+	self assertValue: callOffset isContainedIn: 12. 
+	
+ 	self assert: (self instructionIsB: (self instructionBeforeAddress: addressFollowingJump) withCondition: NE).
+	self rewriteBTypeBranchAtAddress: addressFollowingJump - 4 offset: callOffset withCondition: NE.
+	
+	self assert: (self instructionIsB: (self instructionBeforeAddress: addressFollowingJump) withCondition: NE).
+	self assert: (self extractOffsetFromConditionalBranch: (self instructionBeforeAddress: addressFollowingJump)) = callOffset.
+
+	^4
 ]
 
 { #category : 'machine code instruction' }

--- a/smalltalksrc/VMMaker/CogX64Compiler.class.st
+++ b/smalltalksrc/VMMaker/CogX64Compiler.class.st
@@ -4542,22 +4542,6 @@ CogX64Compiler >> returnFromCallCFunctionInSmalltalkStack: anInteger [
 ]
 
 { #category : 'inline cacheing' }
-CogX64Compiler >> rewriteCPICJumpAt: addressFollowingJump target: jumpTargetAddr [
-	"Rewrite the short jump instruction to jump to a new cpic case target. "
-	<var: #addressFollowingJump type: #usqInt>
-	<var: #jumpTargetAddr type: #usqInt>
-	<var: #callDistance type: #sqInt> "prevent type inference for avoiding warning on abs"
-	| callDistance |
-	callDistance := jumpTargetAddr - addressFollowingJump.
-	self assert: callDistance abs < 128.
-	objectMemory
-		byteAt: addressFollowingJump - 1
-		put:  (callDistance bitAnd: 16rFF).
-	"self cCode: ''
-		inSmalltalk: [cogit disassembleFrom: addressFollowingJump - 10 to: addressFollowingJump - 1]."
-]
-
-{ #category : 'inline cacheing' }
 CogX64Compiler >> rewriteCallAt: callSiteReturnAddress target: callTargetAddress [
 	"Rewrite a call instruction to call a different target.  This variant is used to link PICs
 	 in ceSendMiss et al, and to rewrite cached primitive calls.   Answer the extent of
@@ -4650,6 +4634,23 @@ CogX64Compiler >> rewriteJumpLongAt: addressFollowingJump target: jumpTargetAddr
 	 code change which is used to compute the range of the icache to flush."
 	<inline: true>
 	^self rewriteCallAt: addressFollowingJump target: jumpTargetAddr
+]
+
+{ #category : 'inline cacheing' }
+CogX64Compiler >> rewritePICJumpAt: addressFollowingJump target: jumpTargetAddr [
+	"Rewrite the short jump instruction to jump to a new PIC case target. "
+	
+	<var: #addressFollowingJump type: #usqInt>
+	<var: #jumpTargetAddr type: #usqInt>
+	<var: #callDistance type: #sqInt> "prevent type inference for avoiding warning on abs"
+	| callDistance |
+	callDistance := jumpTargetAddr - addressFollowingJump.
+	self assert: callDistance abs < 128.
+	objectMemory
+		byteAt: addressFollowingJump - 1
+		put:  (callDistance bitAnd: 16rFF).
+	"self cCode: ''
+		inSmalltalk: [cogit disassembleFrom: addressFollowingJump - 10 to: addressFollowingJump - 1]."
 ]
 
 { #category : 'encoding' }

--- a/smalltalksrc/VMMaker/Cogit.class.st
+++ b/smalltalksrc/VMMaker/Cogit.class.st
@@ -162,12 +162,6 @@ Class {
 		'cbNoSwitchEntryOffset',
 		'picMNUAbort',
 		'picInterpretAbort',
-		'endCPICCase0',
-		'endCPICCase1',
-		'firstCPICCaseOffset',
-		'cPICCaseSize',
-		'cPICEndSize',
-		'closedPICSize',
 		'fixups',
 		'abstractOpcodes',
 		'generatorTable',
@@ -236,9 +230,6 @@ Class {
 		'cogMethodSurrogateClass',
 		'CStackPointer',
 		'CFramePointer',
-		'cPICPrototype',
-		'cPICEndOfCodeOffset',
-		'cPICEndOfCodeLabel',
 		'ceMallocTrampoline',
 		'ceFreeTrampoline',
 		'disassemblingMethod',
@@ -250,7 +241,16 @@ Class {
 		'statCompileMethodCount',
 		'statCompileMethodUsecs',
 		'jitCodeZoneWriteEnabled',
-		'megamorphicICSize'
+		'megamorphicICSize',
+		'picSize',
+		'endPICCase0',
+		'endPICCase1',
+		'firstPICCaseOffset',
+		'picCaseSize',
+		'picEndSize',
+		'picEndOfCodeLabel',
+		'picEndOfCodeOffset',
+		'picPrototype'
 	],
 	#classVars : [
 		'AnnotationConstantNames',
@@ -273,9 +273,9 @@ Class {
 		'IsSendCall',
 		'IsSuperSend',
 		'MapEnd',
-		'MaxCPICCases',
 		'MaxCompiledPrimitiveIndex',
 		'MaxNumberOfAbstractOpcodes',
+		'MaxPICCases',
 		'MaxX2NDisplacement',
 		'NumObjRefsInRuntime',
 		'NumSpecialSelectors',
@@ -830,7 +830,7 @@ Cogit class >> initializeMiscConstants [
 	"Currently not even the ceImplicitReceiverTrampoline contains object references."
 	NumObjRefsInRuntime := 0.
 	"6 is a fine number for the max number of PCI entries.  8 is too large."
-	MaxCPICCases := 6.
+	MaxPICCases := 6.
 
 	"One variable defines whether in a block and whether in a vanilla or full block."
 	InFullBlock := 2.
@@ -1376,8 +1376,8 @@ Cogit class >> specialValueForConstant: constantName default: defaultValue [
 Cogit class >> structureOfACogMethod [
 	"A CogMethod is the machine code for executable code in the Cog VM, and in the simulator these are
 	 instances of CogMethod.  In actuality they are structures in memory in the CogMethodZone..  There
-	 are four real kinds, defined by the cmType field, free space: CMFree, methods: CMMethod, closed
-	 PICs: CMClosedPIC (finite polymorphic inline caches with up to 6 entries), and megamorphic ICs: CMMegamorphicPIC (infinite megamorphic inline caches that probe the first-level method lookup cache).  There is a fifth
+	 are four real kinds, defined by the cmType field, free space: CMFree, methods: CMMethod,
+	 PICs: CMPIC (finite polymorphic inline caches with up to 6 entries), and megamorphic ICs: CMMegamorphicIC (infinite megamorphic inline caches that probe the first-level method lookup cache).  There is a fifth
 	 kind of method, which is merely a header, for blocks: CMBlock, one which exists only within CMMethods,
 	 and exist only to allow block activations to refer to something that looks like a CogMethod.
 
@@ -3032,14 +3032,14 @@ Cogit >> addressIsInInstructions: address [
 ]
 
 { #category : 'in-line cacheing' }
-Cogit >> addressOfEndOfCase: n inCPIC: cPIC [ 
-	"calculate the end of the n'th case statement - which is complicated because we have case 1 right at the top of our CPIC and then build up from the last one. Yes I know this sounds strange, but trust me - I'm an Engineer, we do things backwards all the emit"
+Cogit >> addressOfEndOfCase: n inPIC: aPIC [ 
+	"calculate the end of the n'th case statement - which is complicated because we have case 1 right at the top of our PIC and then build up from the last one. Yes I know this sounds strange, but trust me - I'm an Engineer, we do things backwards all the emit"
 
-	<var: #cPIC type: #'CogMethod *'>
-	self assert: (n >= 1and: [n <= MaxCPICCases]).
+	<var: #aPIC type: #'CogMethod *'>
+	self assert: (n >= 1and: [n <= MaxPICCases]).
 	^n = 1
-		ifTrue: [cPIC asInteger + firstCPICCaseOffset]
-		ifFalse: [cPIC asInteger + firstCPICCaseOffset + (MaxCPICCases + 1 - n * cPICCaseSize)]
+		ifTrue: [aPIC asInteger + firstPICCaseOffset]
+		ifFalse: [aPIC asInteger + firstPICCaseOffset + (MaxPICCases + 1 - n * picCaseSize)]
 ]
 
 { #category : 'accessing' }
@@ -3087,7 +3087,7 @@ Cogit >> allMachineCodeObjectReferencesValid [
 				[(self asserta: (objectRepresentation checkValidDerivedObjectReference: cogMethod counters)) ifFalse:
 					[ok := false]]].
 		cogMethod cmType = CMPolymorphicIC ifTrue:
-			[(self asserta: (self noTargetsFreeInClosedPIC: cogMethod)) ifFalse:
+			[(self asserta: (self noTargetsFreeInPIC: cogMethod)) ifFalse:
 				[ok := false]].
 		cogMethod := methodZone methodAfter: cogMethod].
 	^ok
@@ -3230,12 +3230,12 @@ Cogit >> assertExtsAreConsumed: descriptor [
 Cogit >> assertSaneJumpTarget: jumpTarget [
 	<var: #jumpTarget type: #'AbstractInstruction *'>
 
-	self assert: (closedPICSize isNil "don't whinge when producing the PIC prototypes"
+	self assert: (picSize isNil "don't whinge when producing the PIC prototypes"
 			or: [megamorphicICSize isNil
 			or: [(self addressIsInInstructions: jumpTarget)
 			or: [(jumpTarget asUnsignedInteger
 					between: codeBase
-					and: methodZone limitZony asInteger + (closedPICSize max: megamorphicICSize))]]])
+					and: methodZone limitZony asInteger + (picSize max: megamorphicICSize))]]])
 ]
 
 { #category : 'trampoline support' }
@@ -3456,138 +3456,6 @@ Cogit >> cFramePointerAddress [
 		ifFalse: [coInterpreter inMemoryCFramePointerAddress]
 ]
 
-{ #category : 'in-line cacheing' }
-Cogit >> cPIC: cPIC HasTarget: targetMethod [
-	"Are any of the jumps from this CPIC to targetMethod?"
-	<var: #cPIC type: #'CogMethod *'>
-	<var: #targetMethod type: #'CogMethod *'>
-	| pc target |
-	target := targetMethod asUnsignedInteger + cmNoCheckEntryOffset.
-	pc := cPIC asInteger + firstCPICCaseOffset.
-	"Since this is a fast test doing simple compares we don't need to care that some
-	cases have nonsense addresses in there. Just zip on through."
-	"First jump is unconditional; subsequent ones are conditional"
-	target = (backEnd jumpLongTargetBeforeFollowingAddress: pc) ifTrue:
-		[^true].
-	2 to: MaxCPICCases do:
-		[:i|
-		pc := pc + cPICCaseSize.
-		target = (backEnd jumpLongConditionalTargetBeforeFollowingAddress: pc) ifTrue:
-			[^true]].
-	^false
-]
-
-{ #category : 'in-line cacheing' }
-Cogit >> cPICCompactAndIsNowEmpty: cPIC [
-	"Scan the CPIC for target methods that have been freed and eliminate them.
-	 Since the first entry cannot be eliminated, answer that the PIC should be
-	 freed if the first entry is to a free target.  Answer if the PIC is now empty or should be freed."
-	<var: #cPIC type: #'CogMethod *'>
-	| pc entryPoint targetMethod targets tags methods used |
-	<var: #targetMethod	type: #'CogMethod *'>
-	<var: #tags			declareC: 'int tags[MaxCPICCases]'>
-	<var: #targets			declareC: 'sqInt targets[MaxCPICCases]'>
-	<var: #methods		declareC: 'sqInt methods[MaxCPICCases]'>
-	self cCode: [] inSmalltalk:
-		[tags := CArrayAccessor on: (Array new: MaxCPICCases).
-		 targets := CArrayAccessor on: (Array new: MaxCPICCases).
-		 methods := CArrayAccessor on: (Array new: MaxCPICCases)].
-	used := 0.
-	1 to: cPIC cPICNumCases do:
-		[:i| | valid |
-		 pc := self addressOfEndOfCase: i inCPIC: cPIC.
-		 entryPoint := i = 1
-						ifTrue: [backEnd jumpLongTargetBeforeFollowingAddress: pc]
-						ifFalse: [backEnd jumpLongConditionalTargetBeforeFollowingAddress: pc].
-		 valid := true.
-		 "Collect all target triples except for triples whose entry-point is a freed method"
-		 (cPIC containsAddress: entryPoint) ifFalse:
-			[targetMethod := self cCoerceSimple: entryPoint - cmNoCheckEntryOffset to: #'CogMethod *'.
-			 self assert: (targetMethod cmType = CMMethod or: [targetMethod cmType = CMFree]).
-			 targetMethod cmType = CMFree ifTrue:
-				[i = 1 ifTrue: [^true]. "cannot filter out the first entry cuz classTag is at pont of send."
-				 valid := false]].
-		 valid ifTrue:
-			[tags at: used put: (i > 1 ifTrue: [backEnd literal32BeforeFollowingAddress: pc - backEnd jumpLongConditionalByteSize]).
-			 targets at: used put: entryPoint.
-			 methods at: used put: (backEnd literalBeforeFollowingAddress: pc - (i = 1
-																				ifTrue: [backEnd jumpLongByteSize]
-																				ifFalse: [backEnd jumpLongConditionalByteSize + backEnd cmpC32RTempByteSize])).
-			 used := used + 1]].
-	used = cPIC cPICNumCases ifTrue:
-		[^false].
-	used = 0 ifTrue:
-		[^true].
-	cPIC cPICNumCases: used.
-	used = 1 ifTrue:
-		[pc := self addressOfEndOfCase: 2 inCPIC: cPIC.
-		 self rewriteCPIC: cPIC caseJumpTo: pc.
-		 ^false].
-	"the first entry cannot change..."
-	1 to: used - 1 do:
-		[:i|
-		 pc := self addressOfEndOfCase: i + 1 inCPIC: cPIC.
-		 self rewritePICCaseAt: pc tag: (tags at: i) objRef: (methods at: i) target: (targets at: i)].
-
-	"finally, rewrite the jump 3 instr  before firstCPICCaseOffset to jump to the beginning of this new case"
-	self rewriteCPIC: cPIC caseJumpTo: pc - cPICCaseSize.
-	^false
-]
-
-{ #category : 'in-line cacheing' }
-Cogit >> cPICHasForwardedClass: cPIC [ 
-	"The first case in a CPIC doesn't have a class reference so we need only step over actually usd subsequent cases."
-	| pc |
-	<var: #cPIC type: #'CogMethod *'>
-	"start by finding the address of the topmost case, the cPICNumCases'th one"
-	pc := (self addressOfEndOfCase: cPIC cPICNumCases inCPIC: cPIC)
-				- backEnd jumpLongConditionalByteSize.
-	2 to: cPIC cPICNumCases do: 
-			[:i |  | classIndex |
-			classIndex := backEnd literal32BeforeFollowingAddress: pc.
-			(objectMemory isForwardedClassIndex: classIndex)
-				ifTrue: [^ true].
-			"since we started at the top, we can just add the case size each time to move on to the next case"
-			pc := pc + cPICCaseSize].
-	^ false
-]
-
-{ #category : 'in-line cacheing' }
-Cogit >> cPICHasFreedTargets: cPIC [
-	"scan the CPIC for target methods that have been freed. "
-	<var: #cPIC type: #'CogMethod *'>
-	| pc entryPoint targetMethod |
-	<var: #targetMethod type: #'CogMethod *'>
-
-	1 to: cPIC cPICNumCases do:
-		[:i|
-		pc := self addressOfEndOfCase: i inCPIC: cPIC.
-		entryPoint := i = 1
-						ifTrue: [backEnd jumpLongTargetBeforeFollowingAddress: pc]
-						ifFalse: [backEnd jumpLongConditionalTargetBeforeFollowingAddress: pc].
-		"Find target from jump.  Ignore jumps to the interpret and MNU calls within this PIC"
-		(cPIC containsAddress: entryPoint) ifFalse:
-			[targetMethod := self cCoerceSimple: entryPoint - cmNoCheckEntryOffset to: #'CogMethod *'.
-			 self assert: (targetMethod cmType = CMMethod or: [targetMethod cmType = CMFree]).
-			 targetMethod cmType = CMFree ifTrue:
-				[^true]]].
-	^false
-]
-
-{ #category : 'accessing' }
-Cogit >> cPICPrototype [
-	"For Cogit clas>>#genAndDisPICoptions:"
-	<doNotGenerate>
-	^cPICPrototype
-]
-
-{ #category : 'in-line cacheing' }
-Cogit >> cPICPrototypeCaseOffset [
-	"Whimsey; we want 16rCA5E10 + cPICPrototypeCaseOffset to be somewhere in the middle of the zone."
-	<inline: true>
-	^methodZoneBase + methodZone youngReferrers / 2 - 16rCA5E10
-]
-
 { #category : 'trampoline support' }
 Cogit >> cStackPointerAddress [
 	<cmacro: '() ((usqIntptr_t)&CStackPointer)'>
@@ -3671,7 +3539,7 @@ Cogit >> ceCPICMiss: cPIC receiver: receiver [
 		= self isMNUPicAbortDiscriminatorValue.
 
 	"Transition to megamorphic if the PIC is full"
-	MaxCPICCases <= cPIC cPICNumCases ifTrue: [
+	MaxPICCases <= cPIC picNumCases ifTrue: [
 		self
 			patchToMegamorphicICFor: cPIC selector
 			numArgs: cPIC cmNumArgs
@@ -4007,7 +3875,7 @@ Cogit >> ceSICMiss: receiver [
 					linkingSucceeded ifTrue: [
 						self
 							flushICacheFrom: inlineCache asUnsignedInteger
-							to: inlineCache asUnsignedInteger + closedPICSize.
+							to: inlineCache asUnsignedInteger + picSize.
 						self
 							flushICacheFrom: callerReturnAddress asUnsignedInteger - extent
 							to: callerReturnAddress asUnsignedInteger ] ] ].
@@ -4278,7 +4146,7 @@ Cogit >> checkIntegrityOfObjectReferencesInCode: gcModes [
 				ifFalse:
 					[cogMethod cmType = CMPolymorphicIC
 						ifTrue:
-							[(self checkValidObjectReferencesInClosedPIC: cogMethod) ifFalse:
+							[(self checkValidObjectReferencesInPIC: cogMethod) ifFalse:
 								[ok := false]]
 						ifFalse:
 							[cogMethod cmType = CMMegamorphicIC
@@ -4292,7 +4160,7 @@ Cogit >> checkIntegrityOfObjectReferencesInCode: gcModes [
 ]
 
 { #category : 'garbage collection' }
-Cogit >> checkMaybeObjRefInClosedPIC: maybeObject [
+Cogit >> checkMaybeObjRefInPIC: maybeObject [
 	maybeObject = 0 ifTrue:
 		[^true].
 	(objectRepresentation couldBeObject: maybeObject) ifFalse:
@@ -4307,35 +4175,35 @@ Cogit >> checkStackDepthOnSend [
 ]
 
 { #category : 'garbage collection' }
-Cogit >> checkValidObjectReferencesInClosedPIC: cPIC [
-	<var: #cPIC type: #'CogMethod *'>
+Cogit >> checkValidObjectReferencesInPIC: aPIC [
+	<var: #aPIC type: #'CogMethod *'>
 	| ok pc |
 	ok := true.
-	pc := cPIC asInteger + firstCPICCaseOffset.
+	pc := aPIC asInteger + firstPICCaseOffset.
 	
 	"first we check the obj ref at the beginning of the CPIC"
-	(self checkMaybeObjRefInClosedPIC: (backEnd literalBeforeFollowingAddress: pc - backEnd jumpLongByteSize)) ifFalse:
-		[self print: 'object leak in CPIC '; printHex: cPIC asInteger;
+	(self checkMaybeObjRefInPIC: (backEnd literalBeforeFollowingAddress: pc - backEnd jumpLongByteSize)) ifFalse:
+		[self print: 'object leak in PIC '; printHex: aPIC asInteger;
 			print: ' @ '; printHex: pc - backEnd jumpLongByteSize; cr.
 		 ok := false].
 	
 	"Next we step over each case that is in use. We find the end address of the cPICNumCases'th case and can then just step forward by the case size thereafter"
-	pc := self addressOfEndOfCase: cPIC cPICNumCases inCPIC: cPIC.
+	pc := self addressOfEndOfCase: aPIC picNumCases inPIC: aPIC.
 	
 	"For each case we check any object reference at the end address - sizeof(conditional instruction) and then increment the end address by case size"
-	2 to: cPIC cPICNumCases do:
+	2 to: aPIC picNumCases do:
 		[:i|
 		(self inlineCacheTagsAreIndexes not
 		 and: [objectRepresentation inlineCacheTagsMayBeObjects]) ifTrue:
-			[(self checkMaybeObjRefInClosedPIC: (backEnd literal32BeforeFollowingAddress: pc - backEnd jumpLongConditionalByteSize)) ifFalse:
-				[self print: 'object leak in CPIC '; printHex: cPIC asInteger;
+			[(self checkMaybeObjRefInPIC: (backEnd literal32BeforeFollowingAddress: pc - backEnd jumpLongConditionalByteSize)) ifFalse:
+				[self print: 'object leak in PIC '; printHex: aPIC asInteger;
 					print: ' @ '; printHex: pc - backEnd jumpLongConditionalByteSize - backEnd loadLiteralByteSize; cr.
 				 ok := false]].
-		(self checkMaybeObjRefInClosedPIC: (backEnd literalBeforeFollowingAddress: pc - backEnd jumpLongConditionalByteSize - backEnd cmpC32RTempByteSize)) ifFalse:
-			[self print: 'object leak in CPIC '; printHex: cPIC asInteger;
+		(self checkMaybeObjRefInPIC: (backEnd literalBeforeFollowingAddress: pc - backEnd jumpLongConditionalByteSize - backEnd cmpC32RTempByteSize)) ifFalse:
+			[self print: 'object leak in PIC '; printHex: aPIC asInteger;
 				print: ' @ '; printHex: pc - backEnd jumpLongConditionalByteSize; cr.
 			 ok := false].
-		pc := pc + cPICCaseSize].
+		pc := pc + picCaseSize].
 	^ok
 ]
 
@@ -4354,54 +4222,6 @@ Cogit >> cleanUpFailingCogCodeConstituents: cogMethodArg [
 		self assert: self allMachineCodeObjectReferencesValid."
 	coInterpreter popRemappableOop.
 	^nil
-]
-
-{ #category : 'garbage collection' }
-Cogit >> closedPICRefersToUnmarkedObject: cPIC [
-	"Answer if the ClosedPIC refers to any unmarked objects or freed/freeable target methods,
-	 applying markAndTraceOrFreeCogMethod:firstVisit: to those targets to determine if freed/freeable."
-	<var: #cPIC type: #'CogMethod *'>
-	| pc object |
-	((objectMemory isImmediate: cPIC selector)
-	or: [objectMemory isMarkedOrPermanent: cPIC selector]) ifFalse:
-		[^true].
-
-	"First jump is unconditional; subsequent ones are conditional."
-	"Check the potential method oop for the first case only.
-	 Inline cache tags for the 1st case are at the send site."
-	pc := self addressOfEndOfCase: 1 inCPIC: cPIC.
-	(objectRepresentation couldBeObject: (object := backEnd literalBeforeFollowingAddress: pc - backEnd jumpLongByteSize)) ifTrue:
-		[(objectMemory isMarkedOrPermanent: object) ifFalse:
-			[^true]].
-
-	"Check the first target"
-	(self markAndTraceOrFreePICTarget: (backEnd jumpLongTargetBeforeFollowingAddress: pc) in: cPIC) ifTrue:
-		[^true].
-
-	2 to: cPIC cPICNumCases do:
-		[:i| 
-		pc := self addressOfEndOfCase: i inCPIC: cPIC.
-		(self inlineCacheTagsAreIndexes not
-		 and: [objectRepresentation inlineCacheTagsMayBeObjects
-		 and: [objectRepresentation couldBeObject: (object := backEnd literal32BeforeFollowingAddress: pc - backEnd jumpLongConditionalByteSize)]]) ifTrue:
-			[(objectMemory isMarkedOrPermanent: object) ifFalse:
-				[^true]].
-		"Check the potential method oop for subsequent cases."
-		(objectRepresentation couldBeObject: (object := backEnd literalBeforeFollowingAddress: pc - backEnd jumpLongConditionalByteSize - backEnd cmpC32RTempByteSize)) ifTrue:
-			[(objectMemory isMarkedOrPermanent: object) ifFalse:
-				[^true]].
-		"Check subsequent targets"
-		(self markAndTraceOrFreePICTarget: (backEnd jumpLongConditionalTargetBeforeFollowingAddress: pc) in: cPIC) ifTrue:
-			[^true]].
-
-	^false
-]
-
-{ #category : 'accessing' }
-Cogit >> closedPICSize [
-	"For Cogit clas>>#genAndDisPICoptions:"
-	<doNotGenerate>
-	^closedPICSize
 ]
 
 { #category : 'accessing' }
@@ -4623,17 +4443,17 @@ Cogit >> cogExtendPIC: cPIC CaseNMethod: caseNMethod tag: caseNTag isMNUCase: is
 							[target := cPIC asInteger + self picInterpretAbortOffset]].
 
 			"find the end address of the new case"
-			address := self addressOfEndOfCase: cPIC cPICNumCases +1 inCPIC: cPIC.
+			address := self addressOfEndOfCase: cPIC picNumCases +1 inPIC: cPIC.
 			
 			self rewritePICCaseAt: address tag: caseNTag objRef: operand target: target.
 
 			"finally, rewrite the jump 3 instr  before firstCPICCaseOffset to jump to the beginning of this new case"
-			self rewriteCPIC: cPIC caseJumpTo: address - cPICCaseSize. 
+			self rewritePIC: cPIC caseJumpTo: address - picCaseSize. 
 
 			"update the header flag for the number of cases"
-			cPIC cPICNumCases: cPIC cPICNumCases + 1]
+			cPIC picNumCases: cPIC picNumCases + 1]
 
-		flushingCacheWith:  [self flushICacheFrom: cPIC asUnsignedInteger to: cPIC asUnsignedInteger + closedPICSize].
+		flushingCacheWith:  [self flushICacheFrom: cPIC asUnsignedInteger to: cPIC asUnsignedInteger + picSize].
 
 	^0
 ]
@@ -4690,9 +4510,9 @@ Cogit >> cogMNUPICSelector: selector receiver: rcvr methodOperand: methodOperand
 		 (objectRepresentation inlineCacheTagForInstance: rcvr)
 		 = self isMNUPicAbortDiscriminatorValue ]) ifTrue: [ ^ 0 ].
 
-	self assert: endCPICCase0 notNil.
+	self assert: endPICCase0 notNil.
 	"get memory in the code zone for the CPIC; if that fails we return an error code for the sender to use to work out how to blow up"
-	startAddress := methodZone allocate: closedPICSize.
+	startAddress := methodZone allocate: picSize.
 	startAddress = 0 ifTrue: [
 		coInterpreter callForCogCompiledCodeCompaction.
 		^ 0 ].
@@ -4702,13 +4522,13 @@ Cogit >> cogMNUPICSelector: selector receiver: rcvr methodOperand: methodOperand
 		enableCodeZoneWriteDuring: [ "memcpy the prototype across to our allocated space; because anything else would be silly"
 			self
 				initializePIC: pic
-				atDelta: startAddress - cPICPrototype
+				atDelta: startAddress - picPrototype
 				numArgs: numArgs.
 
 			self configureMNUCPIC: pic methodOperand: methodOperand.
 
 			self
-				fillInCPICHeader: pic
+				fillInPICHeader: pic
 				numArgs: numArgs
 				numCases: 1
 				hasMNUCase: true
@@ -4716,7 +4536,7 @@ Cogit >> cogMNUPICSelector: selector receiver: rcvr methodOperand: methodOperand
 		flushingCacheWith: [
 			self
 				flushICacheFrom: pic asUnsignedInteger
-				to: pic asUnsignedInteger + closedPICSize ].
+				to: pic asUnsignedInteger + picSize ].
 
 	^ pic
 ]
@@ -4800,9 +4620,9 @@ Cogit >> cogMethodDoesntLookKosher: cogMethod [
 		 ^0].
 
 	cogMethod cmType = CMPolymorphicIC ifTrue:
-		[cogMethod blockSize ~= closedPICSize ifTrue:
+		[cogMethod blockSize ~= picSize ifTrue:
 			[^31].
-		 (cogMethod cPICNumCases between: 1 and: MaxCPICCases) ifFalse:
+		 (cogMethod picNumCases between: 1 and: MaxPICCases) ifFalse:
 			[^32].
 		 cogMethod methodHeader ~= 0 ifTrue:
 			[^33].
@@ -4856,24 +4676,24 @@ Cogit >> cogPICSelector: selector numArgs: numArgs Case0Method: case0CogMethod C
 		^ self cCoerceSimple: YoungSelectorInPIC to: #'CogMethod *' ].
 
 	"get memory in the code zone for the CPIC; if that fails we return an error code for the sender to use to work out how to blow up"
-	startAddress := methodZone allocate: closedPICSize.
+	startAddress := methodZone allocate: picSize.
 	pic := self cCoerceSimple: startAddress to: #'CogMethod *'.
 	startAddress = 0 ifTrue: [
 		^ self cCoerceSimple: InsufficientCodeSpace to: #'CogMethod *' ].
 
 	self
 		initializePIC: pic
-		atDelta: startAddress - cPICPrototype
+		atDelta: startAddress - picPrototype
 		numArgs: numArgs.
 	self
-		configureCPIC: pic
+		configurePIC: pic
 		Case0: case0CogMethod
 		Case1Method: case1MethodOrNil
 		tag: case1Tag
 		isMNUCase: isMNUCase.
 
 	self
-		fillInCPICHeader: pic
+		fillInPICHeader: pic
 		numArgs: numArgs
 		numCases: 2
 		hasMNUCase: isMNUCase
@@ -5036,7 +4856,7 @@ Cogit >> compactPICsWithFreedTargets [
 	count := 0.
 	[cogMethod < methodZone limitZony] whileTrue:
 		[(cogMethod cmType = CMPolymorphicIC
-		  and: [self cPICCompactAndIsNowEmpty: cogMethod]) ifTrue:
+		  and: [self picCompactAndIsNowEmpty: cogMethod]) ifTrue:
 			[cogMethod cmType: CMFree].
 		 cogMethod := methodZone methodAfter: cogMethod.
 		 count := count + 1].
@@ -5444,21 +5264,21 @@ Cogit >> compilePolymorphicICPrototype [
 	"At the end of the entry code we need to jump to the first case code, which is actually the last chunk.
 	 On each entension we must update this jump to move back one case."
 	self MoveUniqueCw: self firstPrototypeMethodOop R: SendNumArgsReg.
-	self JumpLong: self cPICPrototypeCaseOffset + 16rCA5E10.
-	endCPICCase0 := self Label.
-	1 to: MaxCPICCases - 1 do:
+	self JumpLong: self picPrototypeCaseOffset + 16rCA5E10.
+	endPICCase0 := self Label.
+	1 to: MaxPICCases - 1 do:
 		[:h|
-		h = (MaxCPICCases - 1) ifTrue:
+		h = (MaxPICCases - 1) ifTrue:
 			[jumpNext jmpTarget: self Label]. "this is where we jump to for the first case"
 		self MoveUniqueCw: self subsequentPrototypeMethodOop + h R: SendNumArgsReg.
 		"16rBABE1F15+h is the class tag for the Nth case"
 		self CmpC32: 16rBABE1F15+h R: TempReg.
-		self JumpLongZero: self cPICPrototypeCaseOffset + 16rCA5E10 + (h * 16).
+		self JumpLongZero: self picPrototypeCaseOffset + 16rCA5E10 + (h * 16).
 		h = 1 ifTrue:
-			[endCPICCase1 := self Label]].
+			[endPICCase1 := self Label]].
 	self MoveCw: methodLabel address R: ClassReg.
 	self JumpLong: (self cPICMissTrampolineFor: numArgs).	"Will get rewritten to appropriate arity when configuring."
-	cPICEndOfCodeLabel := self Label.
+	picEndOfCodeLabel := self Label.
 	literalsManager dumpLiterals: false.
 	^0
 ]
@@ -5613,7 +5433,38 @@ Cogit >> computeMaximumSizes [
 ]
 
 { #category : 'in-line cacheing' }
-Cogit >> configureCPIC: aPIC Case0: case0CogMethod Case1Method: case1Method tag: case1Tag isMNUCase: isMNUCase [
+Cogit >> configureMNUCPIC: aPIC methodOperand: methodOop [
+	"Configure a copy of the prototype CPIC for a one-case MNU CPIC that calls ceMNUFromPIC for
+	 case0Tag The tag for case0 is at the send site and so doesn't need to be generated.
+	 addDelta is the address change from the prototype to the new CPIC location, needed
+	 because the loading of the CPIC label at the end may be a literal instead of a pc-relative load."
+
+	<var: #aPIC type: #'CogMethod *'>
+	| operand |	
+	"We do not scavenge PICs, hence we cannot cache the MNU method if it is in new space."
+	operand := (methodOop isNil or: [
+		            objectMemory getMemoryMap isYoungObject: methodOop ])
+		           ifTrue: [ 0 ]
+		           ifFalse: [ methodOop ].
+
+	"set the jump to the case0 method"
+	backEnd
+		rewriteJumpLongAt: aPIC asInteger + firstPICCaseOffset
+		target: (self picAbortAddress: aPIC).
+
+	"finally, rewrite the jump 3 instr before firstCPICCaseOffset to jump to the end of case 2, missing the actual case"
+	backEnd
+		storeLiteral: operand
+		beforeFollowingAddress:
+		aPIC asInteger + firstPICCaseOffset - backEnd jumpLongByteSize.
+	self
+		rewritePIC: aPIC
+		caseJumpTo: (self addressOfEndOfCase: 2 inPIC: aPIC).
+	^ 0
+]
+
+{ #category : 'in-line cacheing' }
+Cogit >> configurePIC: aPIC Case0: case0CogMethod Case1Method: case1Method tag: case1Tag isMNUCase: isMNUCase [
 	"Configure a copy of the prototype CPIC for a two-case PIC for 
 	case0CogMethod and
 	case1Method
@@ -5626,7 +5477,7 @@ Cogit >> configureCPIC: aPIC Case0: case0CogMethod Case1Method: case1Method tag:
 	addDelta is the address change from the prototype to the new CPIC location, needed
 	because the loading of the CPIC label at the end may use a literal instead of a pc relative load."
 
-	"self disassembleFrom: cPIC asInteger + (self sizeof: CogMethod) to: cPIC asInteger + closedPICSize"
+	"self disassembleFrom: cPIC asInteger + (self sizeof: CogMethod) to: aPIC asInteger + picSize"
 
 	<var: #aPIC type: #'CogMethod *'>
 	<var: #case0CogMethod type: #'CogMethod *'>
@@ -5650,11 +5501,11 @@ Cogit >> configureCPIC: aPIC Case0: case0CogMethod Case1Method: case1Method tag:
 				               aPIC asInteger + self picInterpretAbortOffset ] ].
 	"set the jump to the case0 method"
 	backEnd
-		rewriteJumpLongAt: aPIC asInteger + firstCPICCaseOffset
+		rewriteJumpLongAt: aPIC asInteger + firstPICCaseOffset
 		target: case0CogMethod asInteger + cmNoCheckEntryOffset.
 	
 	"update the cpic case"
-	caseEndAddress := self addressOfEndOfCase: 2 inCPIC: aPIC.
+	caseEndAddress := self addressOfEndOfCase: 2 inPIC: aPIC.
 	self
 		rewritePICCaseAt: caseEndAddress
 		tag: case1Tag
@@ -5665,37 +5516,6 @@ Cogit >> configureCPIC: aPIC Case0: case0CogMethod Case1Method: case1Method tag:
 	^ 0
 ]
 
-{ #category : 'in-line cacheing' }
-Cogit >> configureMNUCPIC: aPIC methodOperand: methodOop [
-	"Configure a copy of the prototype CPIC for a one-case MNU CPIC that calls ceMNUFromPIC for
-	 case0Tag The tag for case0 is at the send site and so doesn't need to be generated.
-	 addDelta is the address change from the prototype to the new CPIC location, needed
-	 because the loading of the CPIC label at the end may be a literal instead of a pc-relative load."
-
-	<var: #aPIC type: #'CogMethod *'>
-	| operand |	
-	"We do not scavenge PICs, hence we cannot cache the MNU method if it is in new space."
-	operand := (methodOop isNil or: [
-		            objectMemory getMemoryMap isYoungObject: methodOop ])
-		           ifTrue: [ 0 ]
-		           ifFalse: [ methodOop ].
-
-	"set the jump to the case0 method"
-	backEnd
-		rewriteJumpLongAt: aPIC asInteger + firstCPICCaseOffset
-		target: (self picAbortAddress: aPIC).
-
-	"finally, rewrite the jump 3 instr before firstCPICCaseOffset to jump to the end of case 2, missing the actual case"
-	backEnd
-		storeLiteral: operand
-		beforeFollowingAddress:
-		aPIC asInteger + firstCPICCaseOffset - backEnd jumpLongByteSize.
-	self
-		rewriteCPIC: aPIC
-		caseJumpTo: (self addressOfEndOfCase: 2 inCPIC: aPIC).
-	^ 0
-]
-
 { #category : 'printing' }
 Cogit >> cr [
 	<cmacro: '() putchar(''\n'')'>
@@ -5703,21 +5523,21 @@ Cogit >> cr [
 ]
 
 { #category : 'profiling primitives' }
-Cogit >> createCPICData: cPIC [
+Cogit >> createPICData: aPIC [
 	"Answer an Array of the PIC's selector, followed by class and targetMethod/doesNotUnderstand: for each entry in the PIC."
-	<var: #cPIC type: #'CogMethod *'>
+	<var: #aPIC type: #'CogMethod *'>
 	| picData |
 	<var: #targetMethod type: #'CogMethod *'>
-	self assert: (cPIC methodObject = 0 or: [objectMemory addressCouldBeOop: cPIC methodObject]).
-	picData := objectMemory instantiateClass: objectMemory classArray indexableSize: cPIC cPICNumCases * 2 + 1.
+	self assert: (aPIC methodObject = 0 or: [objectMemory addressCouldBeOop: aPIC methodObject]).
+	picData := objectMemory instantiateClass: objectMemory classArray indexableSize: aPIC picNumCases * 2 + 1.
 	picData ifNil: [^picData].
-      objectMemory storePointerUnchecked: 0 ofObject: picData withValue: cPIC selector.
-	1 to: cPIC cPICNumCases do:
+      objectMemory storePointerUnchecked: 0 ofObject: picData withValue: aPIC selector.
+	1 to: aPIC picNumCases do:
 		[:i| | pc entryPoint target targetMethod class |
-		pc := self addressOfEndOfCase: i inCPIC: cPIC.
+		pc := self addressOfEndOfCase: i inPIC: aPIC.
 		i = 1
 			ifTrue:
-				[class := cPIC methodObject. "first case may have been collected and stored here by collectCogConstituentFor:Annotation:Mcpc:Bcpc:Method:"
+				[class := aPIC methodObject. "first case may have been collected and stored here by collectCogConstituentFor:Annotation:Mcpc:Bcpc:Method:"
 				 class = 0 ifTrue: [class := objectMemory nilObject]. "cPIC is unreferenced; likely evolved to megamorphicIC"
 				 entryPoint := backEnd jumpLongTargetBeforeFollowingAddress: pc]
 			ifFalse:
@@ -5725,7 +5545,7 @@ Cogit >> createCPICData: cPIC [
 							(backEnd literal32BeforeFollowingAddress: pc - backEnd jumpLongConditionalByteSize).
 				 entryPoint := backEnd jumpLongConditionalTargetBeforeFollowingAddress: pc].
 		"Find target from jump.  A jump to the MNU entry-point should collect #doesNotUnderstand:"
-		(cPIC containsAddress: entryPoint)
+		(aPIC containsAddress: entryPoint)
 			ifTrue:
 				[target := objectMemory splObj: SelectorDoesNotUnderstand]
 			ifFalse:
@@ -5736,7 +5556,7 @@ Cogit >> createCPICData: cPIC [
 			storePointerUnchecked: i * 2 - 1 ofObject: picData withValue: class;
 			storePointerUnchecked: i * 2 ofObject: picData withValue: target].
 	objectMemory beRootIfOld: picData.
-	cPIC methodObject: 0. "restore invariant."
+	aPIC methodObject: 0. "restore invariant."
 	^picData
 ]
 
@@ -6008,19 +5828,18 @@ Cogit >> exclude: aMethodObj selector: aSelectorOop [
 ]
 
 { #category : 'in-line cacheing' }
-Cogit >> expectedClosedPICPrototype: cPIC [
+Cogit >> expectedPICPrototype: aPIC [
 
-	"Use asserts to check if the ClosedPICPrototype is as expected from compileClosedPICPrototype,
-	 and can be updated as required via rewriteCPICCaseAt:tag:objRef:target:.  If all asserts pass, answer
+	"Use asserts to check if the PICPrototype is as expected from compilePICPrototype, and can be updated as required via rewritePICCaseAt:tag:objRef:target:.  If all asserts pass, answer
 	 0, otherwise answer a bit mask identifying all the errors."
 
-	"self disassembleFrom: methodZoneBase + (self sizeof: CogMethod) to: methodZoneBase + closedPICSize"
+	"self disassembleFrom: methodZoneBase + (self sizeof: CogMethod) to: methodZoneBase + picSize"
 
-	<var: #cPIC type: #'CogMethod *'>
+	<var: #aPIC type: #'CogMethod *'>
 	| pc errors object classTag entryPoint |
 
 	errors := 0.
-	pc := cPIC asUnsignedInteger + firstCPICCaseOffset.
+	pc := aPIC asUnsignedInteger + firstPICCaseOffset.
 	"First jump is unconditional; subsequent ones are conditional"
 	object := backEnd literalBeforeFollowingAddress:
 		          pc - backEnd jumpLongByteSize.
@@ -6029,12 +5848,12 @@ Cogit >> expectedClosedPICPrototype: cPIC [
 
 	entryPoint := backEnd jumpLongTargetBeforeFollowingAddress: pc.
 	(self asserta:
-		 entryPoint = (self cPICPrototypeCaseOffset + 16rCA5E10)) ifFalse: [ 
+		 entryPoint = (self picPrototypeCaseOffset + 16rCA5E10)) ifFalse: [ 
 		errors := errors + 2 ].
 
-	1 to: MaxCPICCases - 1 do: [ :i | 
+	1 to: MaxPICCases - 1 do: [ :i | 
 		| methodObjPC classTagPC |
-		pc := pc + cPICCaseSize.
+		pc := pc + picCaseSize.
 
 		"verify information in case is as expected."
 		methodObjPC := pc - backEnd jumpLongConditionalByteSize
@@ -6052,7 +5871,7 @@ Cogit >> expectedClosedPICPrototype: cPIC [
 			              jumpLongConditionalTargetBeforeFollowingAddress: pc.
 		(self asserta:
 			 entryPoint
-			 = (self cPICPrototypeCaseOffset + 16rCA5E10 + (i * 16))) 
+			 = (self picPrototypeCaseOffset + 16rCA5E10 + (i * 16))) 
 			ifFalse: [ errors := errors bitOr: 16 ].
 
 		"change case via rewriteCPICCaseAt:tag:objRef:target:"
@@ -6075,7 +5894,7 @@ Cogit >> expectedClosedPICPrototype: cPIC [
 			              jumpLongConditionalTargetBeforeFollowingAddress: pc.
 		(self asserta: entryPoint
 			 =
-			 (self cPICPrototypeCaseOffset + 16rCA5E10 + (i * 16) bitXor:
+			 (self picPrototypeCaseOffset + 16rCA5E10 + (i * 16) bitXor:
 				  16r5AA50)) ifFalse: [ errors := errors bitOr: 128 ].
 
 		"finally restore case to the original state"
@@ -6086,7 +5905,7 @@ Cogit >> expectedClosedPICPrototype: cPIC [
 			target: (entryPoint bitXor: 16r5AA50) ].
 
 	entryPoint := backEnd jumpLongTargetBeforeFollowingAddress:
-		              pc + cPICEndSize - literalsManager endSizeOffset.
+		              pc + picEndSize - literalsManager endSizeOffset.
 	(self asserta: entryPoint = (self cPICMissTrampolineFor: 0)) 
 		ifFalse: [ errors := errors + 256 ] .
 
@@ -6144,33 +5963,6 @@ Cogit >> fillFrom: startMemoryAddr until: endMemoryAddr with: fillReg usingVr: v
 ]
 
 { #category : 'generate machine code' }
-Cogit >> fillInCPICHeader: pic numArgs: numArgs numCases: numCases hasMNUCase: hasMNUCase selector: selector [
-	<returnTypeC: #'CogMethod *'>
-	<var: #pic type: #'CogMethod *'>
-	<inline: true>
-	self assert: (objectMemory isYoung: selector) not.
-	pic cmType: CMPolymorphicIC.
-	pic objectHeader: 0.
-	pic blockSize: closedPICSize.
-	pic methodObject: 0.
-	pic methodHeader: 0.
-	pic selector: selector.
-	pic cmNumArgs: numArgs.
-	pic cmRefersToYoung: false.
-	pic cmUsageCount: self initialClosedPICUsageCount.
-	pic cpicHasMNUCase: hasMNUCase.
-	pic cPICNumCases: numCases.
-	pic picUsage: 0.
-	self assert: pic cmType = CMPolymorphicIC.
-	self assert: pic selector = selector.
-	self assert: pic cmNumArgs = numArgs.
-	self assert: pic cPICNumCases = numCases.
-	self assert: (backEnd callTargetFromReturnAddress: pic asInteger + missOffset) = (self picAbortTrampolineFor: numArgs).
-	self assert: closedPICSize = (methodZone roundUpLength: closedPICSize).
-	^pic
-]
-
-{ #category : 'generate machine code' }
 Cogit >> fillInMegamorphicICHeader: pic numArgs: numArgs selector: selector [
 	<returnTypeC: #'CogMethod *'>
 	<var: #pic type: #'CogMethod *'>
@@ -6187,7 +5979,7 @@ Cogit >> fillInMegamorphicICHeader: pic numArgs: numArgs selector: selector [
 		[methodZone addToYoungReferrers: pic].
 	pic cmUsageCount: self initialMegamorphicICUsageCount.
 	pic cpicHasMNUCase: false.
-	pic cPICNumCases: 0.
+	pic picNumCases: 0.
 	pic picUsage: 0.
 	self assert: pic cmType = CMMegamorphicIC.
 	self assert: pic selector = selector.
@@ -6237,6 +6029,33 @@ Cogit >> fillInMethodHeader: method size: size selector: selector [
 				= (self methodAbortTrampolineFor: method cmNumArgs).
 	self assert: size = (methodZone roundUpLength: size).
 	^method
+]
+
+{ #category : 'generate machine code' }
+Cogit >> fillInPICHeader: pic numArgs: numArgs numCases: numCases hasMNUCase: hasMNUCase selector: selector [
+	<returnTypeC: #'CogMethod *'>
+	<var: #pic type: #'CogMethod *'>
+	<inline: true>
+	self assert: (objectMemory isYoung: selector) not.
+	pic cmType: CMPolymorphicIC.
+	pic objectHeader: 0.
+	pic blockSize: picSize.
+	pic methodObject: 0.
+	pic methodHeader: 0.
+	pic selector: selector.
+	pic cmNumArgs: numArgs.
+	pic cmRefersToYoung: false.
+	pic cmUsageCount: self initialPICUsageCount.
+	pic cpicHasMNUCase: hasMNUCase.
+	pic picNumCases: numCases.
+	pic picUsage: 0.
+	self assert: pic cmType = CMPolymorphicIC.
+	self assert: pic selector = selector.
+	self assert: pic cmNumArgs = numArgs.
+	self assert: pic picNumCases = numCases.
+	self assert: (backEnd callTargetFromReturnAddress: pic asInteger + missOffset) = (self picAbortTrampolineFor: numArgs).
+	self assert: picSize = (methodZone roundUpLength: picSize).
+	^pic
 ]
 
 { #category : 'method map' }
@@ -6392,7 +6211,7 @@ Cogit >> followForwardedMethods [
 					(objectMemory getMemoryMap isYoungObject: cogMethod methodObject) 
 						ifTrue: [ methodZone ensureInYoungReferrers: cogMethod ] ] ].
 			cogMethod cmType = CMPolymorphicIC ifTrue: [ 
-				(self followMethodReferencesInClosedPIC: cogMethod) ifTrue: [ 
+				(self followMethodReferencesInPIC: cogMethod) ifTrue: [ 
 					freedPIC := true.
 					methodZone freeMethod: cogMethod ] ].
 			cogMethod := methodZone methodAfter: cogMethod ].
@@ -6403,12 +6222,12 @@ Cogit >> followForwardedMethods [
 ]
 
 { #category : 'garbage collection' }
-Cogit >> followMaybeObjRefInClosedPICAt: mcpc [
-	"Follow a potential object reference from a closed PIC.
+Cogit >> followMaybeObjRefInPICAt: mcpc [
+	"Follow a potential object reference from a PIC.
 	 This may be a method reference or null.
 	 Answer if the followed literal is young.
-	'mcpc' refers to the jump/branch instruction at the end of
-	each cpic case"
+	'mcpc' refers to the jump/branch instruction at the end of	each pic case"
+		
 	| object subject |
 	object := backEnd literalBeforeFollowingAddress: mcpc.
 	(objectRepresentation couldBeObject: object) ifFalse:
@@ -6422,25 +6241,26 @@ Cogit >> followMaybeObjRefInClosedPICAt: mcpc [
 ]
 
 { #category : 'garbage collection' }
-Cogit >> followMethodReferencesInClosedPIC: cPIC [
-	"Remap all object references in the closed PIC.  Answer if any references are young.
+Cogit >> followMethodReferencesInPIC: aPIC [
+	"Remap all object references in the PIC.  Answer if any references are young.
 	Set codeModified if any modifications are made."
-	<var: #cPIC type: #'CogMethod *'>
+	
+	<var: #aPIC type: #'CogMethod *'>
 	| pc refersToYoung |
-	pc := self addressOfEndOfCase: 1 inCPIC: cPIC.
+	pc := self addressOfEndOfCase: 1 inPIC: aPIC.
 
 	"first we check the potential method oop load at the beginning of the CPIC"
-	refersToYoung := self followMaybeObjRefInClosedPICAt: pc - backEnd jumpLongByteSize.
+	refersToYoung := self followMaybeObjRefInPICAt: pc - backEnd jumpLongByteSize.
 
 	"We find the end address of the cPICNumCases'th case and can then just step forward by the case size thereafter"
-	pc := self addressOfEndOfCase:  cPIC cPICNumCases inCPIC: cPIC.
+	pc := self addressOfEndOfCase:  aPIC picNumCases inPIC: aPIC.
 	
 	"Next we check the potential potential method oop load for each case."
-	2 to: cPIC cPICNumCases do:
+	2 to: aPIC picNumCases do:
 		[:i|
-		(self followMaybeObjRefInClosedPICAt: pc - backEnd jumpLongConditionalByteSize - backEnd cmpC32RTempByteSize) ifTrue:
+		(self followMaybeObjRefInPICAt: pc - backEnd jumpLongConditionalByteSize - backEnd cmpC32RTempByteSize) ifTrue:
 			[refersToYoung := true].
-		pc := pc + cPICCaseSize].
+		pc := pc + picCaseSize].
 	^refersToYoung
 ]
 
@@ -6465,7 +6285,7 @@ Cogit >> freePICsWithFreedTargets [
 	count := 0.
 	[cogMethod < methodZone limitZony] whileTrue:
 		[(cogMethod cmType = CMPolymorphicIC
-		 and: [self cPICHasFreedTargets: cogMethod]) ifTrue:
+		 and: [self picHasFreedTargets: cogMethod]) ifTrue:
 			[cogMethod cmType: CMFree].
 		 cogMethod := methodZone methodAfter: cogMethod.
 		 count := count + 1].
@@ -6496,7 +6316,7 @@ Cogit >> freeUnmarkedMachineCode [
 				[freedMethod := true.
 				 methodZone freeMethod: cogMethod].
 			 (cogMethod cmType = CMPolymorphicIC
-			  and: [self closedPICRefersToUnmarkedObject: cogMethod]) ifTrue:
+			  and: [self picRefersToUnmarkedObject: cogMethod]) ifTrue:
 				[freedMethod := true.
 				 methodZone freeMethod: cogMethod].
 			 cogMethod := methodZone methodAfter: cogMethod].
@@ -6860,7 +6680,8 @@ Cogit >> genInnerPICAbortTrampoline: name [
 	 This poses a problem in 32-bit Spur, where zero is the cache tag for immediate
 	 characters (tag pattern 2r10) because SmallIntegers have tag patterns 2r11
 	 and 2r01, so anding with 1 reduces these to 0 & 1.  We solve the ambiguity by
-	 patching send sites with a 0 cache tag to open PICs instead of closed PICs."
+	 patching send sites with a 0 cache tag to megamorphic ICs instead of PICs."
+	
 	<var: #name type: #'char *'>
 	| jumpMNUCase |
 	<var: #jumpMNUCase type: #'AbstractInstruction *'>
@@ -7444,46 +7265,6 @@ Cogit >> generateCaptureCStackPointers: captureFramePointer [
 	ceCaptureCStackPointers := self cCoerceSimple: startAddress to: #'void (*)(void)'
 ]
 
-{ #category : 'initialization' }
-Cogit >> generateClosedPICPrototype [
-	"Generate the prototype ClosedPIC to determine how much space as full PIC takes.
-	 When we first allocate a closed PIC it only has one or two cases and we want to grow it.
-	 So we have to determine how big a full one is before hand."
-	| cPIC endAddress |
-	<var: 'cPIC' type: #'CogMethod *'>
-	"stack allocate the various collections so that they
-	 are effectively garbage collected on return."
-	self allocateOpcodes: MaxCPICCases * 9 bytecodes: 0.
-	methodLabel address: methodZoneBase; dependent: nil. "for pc-relative MoveCw: cPIC R: ClassReg"
-	self compilePolymorphicICPrototype.
-	self computeMaximumSizes.
-	cPIC := (self cCoerceSimple: methodZoneBase to: #'CogMethod *').
-	closedPICSize := (self sizeof: CogMethod) + (self generateInstructionsAt: methodZoneBase + (self sizeof: CogMethod)).
-
-	self enableCodeZoneWriteDuring: [ endAddress := self outputInstructionsAt: methodZoneBase + (self sizeof: CogMethod) ].
-
-	self assert: methodZoneBase + closedPICSize = endAddress.
-	firstCPICCaseOffset := endCPICCase0 address - methodZoneBase.
-	cPICEndOfCodeOffset := cPICEndOfCodeLabel address - methodZoneBase.
-	cPICCaseSize := endCPICCase1 address - endCPICCase0 address.
-	cPICEndSize := closedPICSize - (MaxCPICCases - 1 * cPICCaseSize + firstCPICCaseOffset).
-	closedPICSize := methodZone roundUpLength: closedPICSize.
-	self assert: picInterpretAbort address = (methodLabel address + self picInterpretAbortOffset).
-	
-	self enableCodeZoneWriteDuring: [
-		self assert: (self expectedClosedPICPrototype: cPIC) = 0.
-	"tpr this is a little tiresome but after any assert checking we need to 0 out the case0 objRef rather than leaving 16r5EAF00D lying around"
-		backEnd storeLiteral: 0 beforeFollowingAddress: endCPICCase0 address - backEnd jumpLongByteSize].
-	
-	"update the methodZoneBase so we keep the prototype around for later use"
-	methodZoneBase := self alignUptoRoutineBoundary: endAddress.
-	cPICPrototype := cPIC.
-	"self cCode: ''
-		inSmalltalk:
-			[self disassembleFrom: cPIC + (self sizeof: CogMethod) to: cPIC + closedPICSize - 1.
-			 self halt]"
-]
-
 { #category : 'generate machine code' }
 Cogit >> generateCogFullBlock [
 	"We handle jump sizing simply.  First we make a pass that asks each
@@ -7524,7 +7305,7 @@ Cogit >> generateCogFullBlock [
 			method := self fillInMethodHeader: (self cCoerceSimple: startAddress to: #'CogMethod *')
 							size: totalSize
 							selector: objectMemory nilObject.
-			method cpicHasMNUCaseOrCMIsFullBlock: true.
+			method picHasMNUCaseOrCMIsFullBlock: true.
 			postCompileHook ifNotNil:
 				[self perform: postCompileHook with: method.
 				 postCompileHook := nil]] 
@@ -7706,9 +7487,10 @@ Cogit >> generateMapAt: addressOrNull start: startAddress [
 
 { #category : 'initialization' }
 Cogit >> generateMegamorphicICPrototype [
-	"Generate the prototype ClosedPIC to determine how much space as full PIC takes.
-	 When we first allocate a closed PIC it only has one or two cases and we want to grow it.
+	"Generate the prototype PIC to determine how much space as full PIC takes.
+	 When we first allocate a PIC it only has one or two cases and we want to grow it.
 	 So we have to determine how big a full one is before hand."
+
 	| codeSize mapSize |
 	"stack allocate the various collections so that they
 	 are effectively garbage collected on return."
@@ -7742,6 +7524,47 @@ Cogit >> generateMissAbortTrampolines [
 	 Read the class-side method trampolines for documentation on the various trampolines"
 
 	self subclassResponsibility
+]
+
+{ #category : 'initialization' }
+Cogit >> generatePICPrototype [
+	"Generate the prototype PIC to determine how much space as full PIC takes.
+	 When we first allocate a PIC it only has one or two cases and we want to grow it.
+	 So we have to determine how big a full one is before hand."
+	
+	| aPIC endAddress |
+	<var: 'aPIC' type: #'CogMethod *'>
+	"stack allocate the various collections so that they
+	 are effectively garbage collected on return."
+	self allocateOpcodes: MaxPICCases * 9 bytecodes: 0.
+	methodLabel address: methodZoneBase; dependent: nil. "for pc-relative MoveCw: aPIC R: ClassReg"
+	self compilePolymorphicICPrototype.
+	self computeMaximumSizes.
+	aPIC := (self cCoerceSimple: methodZoneBase to: #'CogMethod *').
+	picSize := (self sizeof: CogMethod) + (self generateInstructionsAt: methodZoneBase + (self sizeof: CogMethod)).
+
+	self enableCodeZoneWriteDuring: [ endAddress := self outputInstructionsAt: methodZoneBase + (self sizeof: CogMethod) ].
+
+	self assert: methodZoneBase + picSize = endAddress.
+	firstPICCaseOffset := endPICCase0 address - methodZoneBase.
+	picEndOfCodeOffset := picEndOfCodeLabel address - methodZoneBase.
+	picCaseSize := endPICCase1 address - endPICCase0 address.
+	picEndSize := picSize - (MaxPICCases - 1 * picCaseSize + firstPICCaseOffset).
+	picSize := methodZone roundUpLength: picSize.
+	self assert: picInterpretAbort address = (methodLabel address + self picInterpretAbortOffset).
+	
+	self enableCodeZoneWriteDuring: [
+		self assert: (self expectedPICPrototype: aPIC) = 0.
+	"tpr this is a little tiresome but after any assert checking we need to 0 out the case0 objRef rather than leaving 16r5EAF00D lying around"
+		backEnd storeLiteral: 0 beforeFollowingAddress: endPICCase0 address - backEnd jumpLongByteSize].
+	
+	"update the methodZoneBase so we keep the prototype around for later use"
+	methodZoneBase := self alignUptoRoutineBoundary: endAddress.
+	picPrototype := aPIC.
+	"self cCode: ''
+		inSmalltalk:
+			[self disassembleFrom: cPIC + (self sizeof: CogMethod) to: cPIC + picSize - 1.
+			 self halt]"
 ]
 
 { #category : 'initialization' }
@@ -8281,12 +8104,6 @@ Cogit >> indexForSelector: selector in: cogMethod at: mcpc [
 ]
 
 { #category : 'generate machine code' }
-Cogit >> initialClosedPICUsageCount [
-	"Answer a usage count that reflects likely long-term usage."
-	^CMMaxUsageCount // 2
-]
-
-{ #category : 'generate machine code' }
 Cogit >> initialMegamorphicICUsageCount [
 	"Answer a usage count that reflects likely long-term usage."
 	^CMMaxUsageCount - 1
@@ -8303,6 +8120,12 @@ Cogit >> initialMethodUsageCount [
 	self primitiveDescriptor primitiveGenerator ifNil:
 		[^2].
 	^3
+]
+
+{ #category : 'generate machine code' }
+Cogit >> initialPICUsageCount [
+	"Answer a usage count that reflects likely long-term usage."
+	^CMMaxUsageCount // 2
 ]
 
 { #category : 'initialization' }
@@ -8359,7 +8182,7 @@ Cogit >> initializeCodeZoneFrom: startAddress upTo: endAddress [
 	self generateTrampolines.
 	self computeEntryOffsets.
 	self computeFullBlockEntryOffsets.
-	self generateClosedPICPrototype.
+	self generatePICPrototype.
 	"repeat so that now the methodZone ignores the generated run-time"
 	methodZone manageFrom: methodZoneBase to: endAddress.
 	"N.B. this is assumed to be the last thing done in initialization; see Cogit>>initialized"
@@ -8381,8 +8204,8 @@ Cogit >> initializePIC: aPIC atDelta: addrDelta numArgs: numArgs [
 	<var: #aPIC type: #'CogMethod *'>
 	objectMemory
 		memcpy: aPIC
-		_: (self cCoerceSimple: cPICPrototype to: #'CogMethod *')
-		_: closedPICSize.
+		_: (self cCoerceSimple: picPrototype to: #'CogMethod *')
+		_: picSize.
 
 	backEnd
 		rewriteCallAt: aPIC asInteger + missOffset
@@ -8391,12 +8214,12 @@ Cogit >> initializePIC: aPIC atDelta: addrDelta numArgs: numArgs [
 	"update the loading of the CPIC address"
 	backEnd
 		relocateMethodReferenceBeforeAddress:
-		aPIC asInteger + cPICEndOfCodeOffset - backEnd jumpLongByteSize
+		aPIC asInteger + picEndOfCodeOffset - backEnd jumpLongByteSize
 		by: addrDelta.
 
 	"write the final desperate jump to cePICMissXArgs"
 	backEnd
-		rewriteJumpLongAt: aPIC asInteger + cPICEndOfCodeOffset
+		rewriteJumpLongAt: aPIC asInteger + picEndOfCodeOffset
 		target: (self cPICMissTrampolineFor: numArgs)
 ]
 
@@ -9036,33 +8859,6 @@ Cogit >> mapFor: cogMethod performUntil: functionSymbol arg: arg [
 ]
 
 { #category : 'garbage collection' }
-Cogit >> mapObjectReferencesInClosedPIC: cPIC [
-	"Remap all object references in the closed PIC.  Answer if any references are young.
-	Set codeModified if any modifications are made."
-	<var: #cPIC type: #'CogMethod *'>
-	| pc refersToYoung |
-	pc := self addressOfEndOfCase:1 inCPIC:cPIC.
-
-	"first we check the potential method oop load at the beginning of the CPIC"
-	refersToYoung := self remapMaybeObjRefInClosedPICAt: pc - backEnd jumpLongByteSize.
-
-	"We find the end address of the cPICNumCases'th case and can then just step forward by the case size thereafter"
-	pc := self addressOfEndOfCase: cPIC cPICNumCases inCPIC: cPIC.
-	
-	"Next we check the potential class ref in the compare instruction, and the potential method oop load for each case."
-	2 to: cPIC cPICNumCases do:
-		[:i|
-		(self inlineCacheTagsAreIndexes not
-		 and: [objectRepresentation inlineCacheTagsMayBeObjects]) ifTrue:
-			[(self remapMaybeObjRefInClosedPICAt: pc - backEnd jumpLongConditionalByteSize) ifTrue:
-				[refersToYoung := true]].
-		(self remapMaybeObjRefInClosedPICAt: pc - backEnd jumpLongConditionalByteSize - backEnd cmpC32RTempByteSize) ifTrue:
-			[refersToYoung := true].
-		pc := pc + cPICCaseSize].
-	^refersToYoung
-]
-
-{ #category : 'garbage collection' }
 Cogit >> mapObjectReferencesInGeneratedRuntime [
 	"Update all references to objects in the generated runtime."
 	0 to: runtimeObjectRefIndex - 1 do:
@@ -9113,7 +8909,7 @@ Cogit >> mapObjectReferencesInMachineCodeForBecome [
 				 cogMethod cmType = CMPolymorphicIC
 					ifTrue:
 						[((objectMemory isYoung: cogMethod selector)
-						   or: [self mapObjectReferencesInClosedPIC: cogMethod]) ifTrue:
+						   or: [self mapObjectReferencesInPIC: cogMethod]) ifTrue:
 							[freedPIC := true.
 							 methodZone freeMethod: cogMethod]]
 					ifFalse:
@@ -9195,7 +8991,7 @@ Cogit >> mapObjectReferencesInMachineCodeForFullGC [
 				 cogMethod cmType = CMPolymorphicIC
 					ifTrue:
 						[self assert: cogMethod cmRefersToYoung not.
-						 self mapObjectReferencesInClosedPIC: cogMethod]
+						 self mapObjectReferencesInPIC: cogMethod]
 					ifFalse:
 						[cogMethod cmType = CMMethod ifTrue:
 							[self assert: cogMethod objectHeader = objectMemory nullHeaderForMachineCodeMethod.
@@ -9259,6 +9055,34 @@ Cogit >> mapObjectReferencesInMachineCodeForYoungGC [
 		codeModified ifTrue: "After updating oops in inline caches we need to flush the icache."
 			[self flushICacheFrom: codeBase asUnsignedInteger to: methodZone limitZony asUnsignedInteger] ]
 
+]
+
+{ #category : 'garbage collection' }
+Cogit >> mapObjectReferencesInPIC: aPIC [
+	"Remap all object references in the PIC.  Answer if any references are young.
+	Set codeModified if any modifications are made."
+	
+	<var: #aPIC type: #'CogMethod *'>
+	| pc refersToYoung |
+	pc := self addressOfEndOfCase:1 inPIC:aPIC.
+
+	"first we check the potential method oop load at the beginning of the CPIC"
+	refersToYoung := self remapMaybeObjRefInPICAt: pc - backEnd jumpLongByteSize.
+
+	"We find the end address of the cPICNumCases'th case and can then just step forward by the case size thereafter"
+	pc := self addressOfEndOfCase: aPIC picNumCases inPIC: aPIC.
+	
+	"Next we check the potential class ref in the compare instruction, and the potential method oop load for each case."
+	2 to: aPIC picNumCases do:
+		[:i|
+		(self inlineCacheTagsAreIndexes not
+		 and: [objectRepresentation inlineCacheTagsMayBeObjects]) ifTrue:
+			[(self remapMaybeObjRefInPICAt: pc - backEnd jumpLongConditionalByteSize) ifTrue:
+				[refersToYoung := true]].
+		(self remapMaybeObjRefInPICAt: pc - backEnd jumpLongConditionalByteSize - backEnd cmpC32RTempByteSize) ifTrue:
+			[refersToYoung := true].
+		pc := pc + picCaseSize].
+	^refersToYoung
 ]
 
 { #category : 'simulation only' }
@@ -9403,7 +9227,7 @@ Cogit >> markAndTraceOrFreeCogMethod: cogMethod firstVisit: firstVisit [
 			frees if the bytecode method isnt marked,
 			marks and traces object literals and selectors,
 			unlinks sends to targets that should be freed.
-	 For a CMClosedPIC this
+	 For a CMPolymorphicIC this
 			frees if it refers to anything that should be freed or isn't marked.
 	 For a CMMegamorphicIC this
 			frees if the selector isn't marked."
@@ -9421,7 +9245,7 @@ Cogit >> markAndTraceOrFreeCogMethod: cogMethod firstVisit: firstVisit [
 			[self markLiteralsAndUnlinkUnmarkedSendsIn: cogMethod].
 		^false].
 	cogMethod cmType = CMPolymorphicIC ifTrue:
-		[(self closedPICRefersToUnmarkedObject: cogMethod) ifFalse:
+		[(self picRefersToUnmarkedObject: cogMethod) ifFalse:
 			[^false].
 		 methodZone freeMethod: cogMethod.
 		 ^true].
@@ -9976,10 +9800,11 @@ Cogit >> noCogMethodsMaximallyMarked [
 ]
 
 { #category : 'compaction' }
-Cogit >> noTargetsFreeInClosedPIC: cPIC [
+Cogit >> noTargetsFreeInPIC: aPIC [
 	"Answer if all targets in the PIC are in-use methods."
-	<var: #cPIC type: #'CogMethod *'>
-	^(self cPICHasFreedTargets: cPIC) not
+	
+	<var: #aPIC type: #'CogMethod *'>
+	^(self picHasFreedTargets: aPIC) not
 ]
 
 { #category : 'initialization' }
@@ -10156,6 +9981,126 @@ Cogit >> picAbortTrampolineFor: numArgs [
 	^ self subclassResponsibility
 ]
 
+{ #category : 'in-line cacheing' }
+Cogit >> picCompactAndIsNowEmpty: aPIC [
+	"Scan the PIC for target methods that have been freed and eliminate them.
+	 Since the first entry cannot be eliminated, answer that the PIC should be
+	 freed if the first entry is to a free target.  Answer if the PIC is now empty or should be freed."
+	
+	<var: #aPIC type: #'CogMethod *'>
+	| pc entryPoint targetMethod targets tags methods used |
+	<var: #targetMethod	type: #'CogMethod *'>
+	<var: #tags			declareC: 'int tags[MaxCPICCases]'>
+	<var: #targets			declareC: 'sqInt targets[MaxCPICCases]'>
+	<var: #methods		declareC: 'sqInt methods[MaxCPICCases]'>
+	self cCode: [] inSmalltalk:
+		[tags := CArrayAccessor on: (Array new: MaxPICCases).
+		 targets := CArrayAccessor on: (Array new: MaxPICCases).
+		 methods := CArrayAccessor on: (Array new: MaxPICCases)].
+	used := 0.
+	1 to: aPIC picNumCases do:
+		[:i| | valid |
+		 pc := self addressOfEndOfCase: i inPIC: aPIC.
+		 entryPoint := i = 1
+						ifTrue: [backEnd jumpLongTargetBeforeFollowingAddress: pc]
+						ifFalse: [backEnd jumpLongConditionalTargetBeforeFollowingAddress: pc].
+		 valid := true.
+		 "Collect all target triples except for triples whose entry-point is a freed method"
+		 (aPIC containsAddress: entryPoint) ifFalse:
+			[targetMethod := self cCoerceSimple: entryPoint - cmNoCheckEntryOffset to: #'CogMethod *'.
+			 self assert: (targetMethod cmType = CMMethod or: [targetMethod cmType = CMFree]).
+			 targetMethod cmType = CMFree ifTrue:
+				[i = 1 ifTrue: [^true]. "cannot filter out the first entry cuz classTag is at pont of send."
+				 valid := false]].
+		 valid ifTrue:
+			[tags at: used put: (i > 1 ifTrue: [backEnd literal32BeforeFollowingAddress: pc - backEnd jumpLongConditionalByteSize]).
+			 targets at: used put: entryPoint.
+			 methods at: used put: (backEnd literalBeforeFollowingAddress: pc - (i = 1
+																				ifTrue: [backEnd jumpLongByteSize]
+																				ifFalse: [backEnd jumpLongConditionalByteSize + backEnd cmpC32RTempByteSize])).
+			 used := used + 1]].
+	used = aPIC picNumCases ifTrue:
+		[^false].
+	used = 0 ifTrue:
+		[^true].
+	aPIC picNumCases: used.
+	used = 1 ifTrue:
+		[pc := self addressOfEndOfCase: 2 inPIC: aPIC.
+		 self rewritePIC: aPIC caseJumpTo: pc.
+		 ^false].
+	"the first entry cannot change..."
+	1 to: used - 1 do:
+		[:i|
+		 pc := self addressOfEndOfCase: i + 1 inPIC: aPIC.
+		 self rewritePICCaseAt: pc tag: (tags at: i) objRef: (methods at: i) target: (targets at: i)].
+
+	"finally, rewrite the jump 3 instr  before firstCPICCaseOffset to jump to the beginning of this new case"
+	self rewritePIC: aPIC caseJumpTo: pc - picCaseSize.
+	^false
+]
+
+{ #category : 'in-line cacheing' }
+Cogit >> picHasForwardedClass: aPIC [ 
+	"The first case in a PIC doesn't have a class reference so we need only step over actually usd subsequent cases."
+	| pc |
+	<var: #aPIC type: #'CogMethod *'>
+	"start by finding the address of the topmost case, the cPICNumCases'th one"
+	pc := (self addressOfEndOfCase: aPIC picNumCases inPIC: aPIC)
+				- backEnd jumpLongConditionalByteSize.
+	2 to: aPIC picNumCases do: 
+			[:i |  | classIndex |
+			classIndex := backEnd literal32BeforeFollowingAddress: pc.
+			(objectMemory isForwardedClassIndex: classIndex)
+				ifTrue: [^ true].
+			"since we started at the top, we can just add the case size each time to move on to the next case"
+			pc := pc + picCaseSize].
+	^ false
+]
+
+{ #category : 'in-line cacheing' }
+Cogit >> picHasFreedTargets: aPIC [
+	"scan the CPIC for target methods that have been freed. "
+	<var: #aPIC type: #'CogMethod *'>
+	| pc entryPoint targetMethod |
+	<var: #targetMethod type: #'CogMethod *'>
+
+	1 to: aPIC picNumCases do:
+		[:i|
+		pc := self addressOfEndOfCase: i inPIC: aPIC.
+		entryPoint := i = 1
+						ifTrue: [backEnd jumpLongTargetBeforeFollowingAddress: pc]
+						ifFalse: [backEnd jumpLongConditionalTargetBeforeFollowingAddress: pc].
+		"Find target from jump.  Ignore jumps to the interpret and MNU calls within this PIC"
+		(aPIC containsAddress: entryPoint) ifFalse:
+			[targetMethod := self cCoerceSimple: entryPoint - cmNoCheckEntryOffset to: #'CogMethod *'.
+			 self assert: (targetMethod cmType = CMMethod or: [targetMethod cmType = CMFree]).
+			 targetMethod cmType = CMFree ifTrue:
+				[^true]]].
+	^false
+]
+
+{ #category : 'in-line cacheing' }
+Cogit >> picI: aPIC hasTarget: targetMethod [
+	"Are any of the jumps from this PIC to targetMethod?"
+	
+	<var: #aPIC type: #'CogMethod *'>
+	<var: #targetMethod type: #'CogMethod *'>
+	| pc target |
+	target := targetMethod asUnsignedInteger + cmNoCheckEntryOffset.
+	pc := aPIC asInteger + firstPICCaseOffset.
+	"Since this is a fast test doing simple compares we don't need to care that some
+	cases have nonsense addresses in there. Just zip on through."
+	"First jump is unconditional; subsequent ones are conditional"
+	target = (backEnd jumpLongTargetBeforeFollowingAddress: pc) ifTrue:
+		[^true].
+	2 to: MaxPICCases do:
+		[:i|
+		pc := pc + picCaseSize.
+		target = (backEnd jumpLongConditionalTargetBeforeFollowingAddress: pc) ifTrue:
+			[^true]].
+	^false
+]
+
 { #category : 'debugging' }
 Cogit >> picInterpretAbortOffset [
 	"Answer the start of the abort sequence for invoking the interpreter in a closed PIC."
@@ -10163,6 +10108,70 @@ Cogit >> picInterpretAbortOffset [
 	 - (backEnd hasLinkRegister
 		ifTrue: [backEnd pushLinkRegisterByteSize + backEnd callInstructionByteSize]
 		ifFalse: [backEnd callInstructionByteSize])
+]
+
+{ #category : 'accessing' }
+Cogit >> picPrototype [
+	"For Cogit clas>>#genAndDisPICoptions:"
+	<doNotGenerate>
+	^picPrototype
+]
+
+{ #category : 'in-line cacheing' }
+Cogit >> picPrototypeCaseOffset [
+	"We want 16rCA5E10 + cPICPrototypeCaseOffset to be somewhere in the middle of the zone."
+	
+	<inline: true>
+	^methodZoneBase + methodZone youngReferrers / 2 - 16rCA5E10
+]
+
+{ #category : 'garbage collection' }
+Cogit >> picRefersToUnmarkedObject: aPIC [
+	"Answer if the PIC refers to any unmarked objects or freed/freeable target methods,
+	 applying markAndTraceOrFreeCogMethod:firstVisit: to those targets to determine if freed/freeable."
+	
+	<var: #aPIC type: #'CogMethod *'>
+	| pc object |
+	((objectMemory isImmediate: aPIC selector)
+	or: [objectMemory isMarkedOrPermanent: aPIC selector]) ifFalse:
+		[^true].
+
+	"First jump is unconditional; subsequent ones are conditional."
+	"Check the potential method oop for the first case only.
+	 Inline cache tags for the 1st case are at the send site."
+	pc := self addressOfEndOfCase: 1 inPIC: aPIC.
+	(objectRepresentation couldBeObject: (object := backEnd literalBeforeFollowingAddress: pc - backEnd jumpLongByteSize)) ifTrue:
+		[(objectMemory isMarkedOrPermanent: object) ifFalse:
+			[^true]].
+
+	"Check the first target"
+	(self markAndTraceOrFreePICTarget: (backEnd jumpLongTargetBeforeFollowingAddress: pc) in: aPIC) ifTrue:
+		[^true].
+
+	2 to: aPIC picNumCases do:
+		[:i| 
+		pc := self addressOfEndOfCase: i inPIC: aPIC.
+		(self inlineCacheTagsAreIndexes not
+		 and: [objectRepresentation inlineCacheTagsMayBeObjects
+		 and: [objectRepresentation couldBeObject: (object := backEnd literal32BeforeFollowingAddress: pc - backEnd jumpLongConditionalByteSize)]]) ifTrue:
+			[(objectMemory isMarkedOrPermanent: object) ifFalse:
+				[^true]].
+		"Check the potential method oop for subsequent cases."
+		(objectRepresentation couldBeObject: (object := backEnd literalBeforeFollowingAddress: pc - backEnd jumpLongConditionalByteSize - backEnd cmpC32RTempByteSize)) ifTrue:
+			[(objectMemory isMarkedOrPermanent: object) ifFalse:
+				[^true]].
+		"Check subsequent targets"
+		(self markAndTraceOrFreePICTarget: (backEnd jumpLongConditionalTargetBeforeFollowingAddress: pc) in: aPIC) ifTrue:
+			[^true]].
+
+	^false
+]
+
+{ #category : 'accessing' }
+Cogit >> picSize [
+	"For Cogit clas>>#genAndDisPICoptions:"
+	<doNotGenerate>
+	^picSize
 ]
 
 { #category : 'profiling primitives' }
@@ -10176,10 +10185,8 @@ Cogit >> positiveMachineIntegerFor: value [
 
 { #category : 'compile abstract instructions' }
 Cogit >> preenMethodLabel [
-	"The methodLabel serves as the reference to the start of the current code object
-	 being produced (CMMethod, CMClosedPIC etc), but it also carries type flags for
-	 the frame method field, set via the labelOffset.  So we must clean the flags on each
-	 compilation to avoid stale lags being left behind from previous compilations."
+	"The methodLabel serves as the reference to the start of the current code object  being produced (CMMethod, CMPolymorphicIC, etc), but it also carries type flags for  the frame method field, set via the labelOffset.  So we must clean the flags on each compilation to avoid stale lags being left behind from previous compilations."
+	
 	<inline: true>
 	methodLabel setLabelOffset: 0
 ]
@@ -10321,11 +10328,11 @@ Cogit >> printMethodHeader: cogMethod on: aStream [
 				newLine;
 				tab;
 				nextPutAll: 'cPICNumCases: '.
-			cogMethod cPICNumCases printOn: aStream base: 16.
+			cogMethod picNumCases printOn: aStream base: 16.
 			aStream
 				tab;
 				nextPutAll: 'cpicHasMNUCase: ';
-				nextPutAll: (cogMethod cpicHasMNUCase
+				nextPutAll: (cogMethod picHasMNUCase
 						 ifTrue: [ 'yes' ]
 						 ifFalse: [ 'no' ]) ]
 		ifFalse: [
@@ -10602,7 +10609,7 @@ Cogit >> profileDataFor: cogMethod withDetails: withDetails [
 	^cogMethod cmType = CMMethod 
 		ifTrue: [cogMethod methodObject]
 		ifFalse: [(withDetails and: [cogMethod cmType = CMPolymorphicIC])
-					ifTrue: [self createCPICData: cogMethod]
+					ifTrue: [self createPICData: cogMethod]
 					ifFalse: [cogMethod selector]]
 ]
 
@@ -10794,25 +10801,26 @@ Cogit >> relocateCallsAndSelfReferencesInMethod: cogMethod [
 ]
 
 { #category : 'compaction' }
-Cogit >> relocateCallsInClosedPIC: cPIC [
-	<var: #cPIC type: #'CogMethod *'>
+Cogit >> relocateCallsInPIC: aPIC [
+
+	<var: #aPIC type: #'CogMethod *'>
 	| refDelta callDelta pc entryPoint targetMethod |
 	<var: #targetMethod type: #'CogMethod *'>
-	refDelta := cPIC objectHeader.
+	refDelta := aPIC objectHeader.
 	callDelta := backEnd zoneCallsAreRelative ifTrue: [refDelta] ifFalse: [0].
 	
-	self assert: (backEnd callTargetFromReturnAddress: cPIC asInteger + missOffset)
-					= (self picAbortTrampolineFor: cPIC cmNumArgs).
-	backEnd relocateCallBeforeReturnPC: cPIC asInteger + missOffset by: callDelta negated.
+	self assert: (backEnd callTargetFromReturnAddress: aPIC asInteger + missOffset)
+					= (self picAbortTrampolineFor: aPIC cmNumArgs).
+	backEnd relocateCallBeforeReturnPC: aPIC asInteger + missOffset by: callDelta negated.
 
-	pc := cPIC asInteger + firstCPICCaseOffset.
-	1 to: cPIC cPICNumCases do:
+	pc := aPIC asInteger + firstPICCaseOffset.
+	1 to: aPIC picNumCases do:
 		[:i|
-		pc := self addressOfEndOfCase: i inCPIC: cPIC.
+		pc := self addressOfEndOfCase: i inPIC: aPIC.
 		entryPoint := i = 1
 						ifTrue: [backEnd jumpLongTargetBeforeFollowingAddress: pc]
 						ifFalse: [backEnd jumpLongConditionalTargetBeforeFollowingAddress: pc].
-		(cPIC containsAddress: entryPoint) 
+		(aPIC containsAddress: entryPoint) 
 			ifTrue: 
 			["Interpret/MNU"
 			backEnd zoneCallsAreRelative ifFalse: [
@@ -10835,11 +10843,11 @@ Cogit >> relocateCallsInClosedPIC: cPIC [
 				[backEnd
 					relocateJumpLongConditionalBeforeFollowingAddress: pc
 					by: (callDelta - targetMethod objectHeader) negated]]].
-	self assert: cPIC cPICNumCases > 0.
+	self assert: aPIC picNumCases > 0.
 
 	"Finally relocate the load of the PIC and the jump to the overflow routine ceCPICMiss:receiver:"
-	backEnd relocateMethodReferenceBeforeAddress: (self addressOfEndOfCase: 2 inCPIC: cPIC)+ backEnd loadPICLiteralByteSize by: refDelta.
-	backEnd relocateJumpLongBeforeFollowingAddress: cPIC asInteger + cPICEndOfCodeOffset by: callDelta negated
+	backEnd relocateMethodReferenceBeforeAddress: (self addressOfEndOfCase: 2 inPIC: aPIC)+ backEnd loadPICLiteralByteSize by: refDelta.
+	backEnd relocateJumpLongBeforeFollowingAddress: aPIC asInteger + picEndOfCodeOffset by: callDelta negated
 ]
 
 { #category : 'compaction' }
@@ -10953,7 +10961,7 @@ Cogit >> remapIfObjectRef: annotation pc: mcpc hasYoung: hasYoungPtr [
 ]
 
 { #category : 'garbage collection' }
-Cogit >> remapMaybeObjRefInClosedPICAt: mcpc [
+Cogit >> remapMaybeObjRefInPICAt: mcpc [
 	"Remap a potential object reference from a closed PIC.
 	 This may be an object reference, an inline cache tag or null.
 	 Answer if the updated literal is young.
@@ -10991,16 +10999,16 @@ Cogit >> resolveToOopOrNil: proxyOrSpecialSelector [
 ]
 
 { #category : 'in-line cacheing' }
-Cogit >> rewriteCPIC: cPIC caseJumpTo: target [ 
-	"adding a new CPIC case, or making an MNU CPIC, requires altering the jump that takes us to the first case to be used"
+Cogit >> rewritePIC: aPIC caseJumpTo: target [ 
+	"adding a new PIC case, or making an MNU PIC, requires altering the jump that takes us to the first case to be used"
 	<inline: true>
-	backEnd rewriteCPICJumpAt: cPIC asInteger + firstCPICCaseOffset - backEnd jumpLongByteSize - backEnd loadLiteralByteSize target: target
+	backEnd rewritePICJumpAt: aPIC asInteger + firstPICCaseOffset - backEnd jumpLongByteSize - backEnd loadLiteralByteSize target: target
 ]
 
 { #category : 'in-line cacheing' }
 Cogit >> rewritePICCaseAt: followingAddress tag: newTag objRef: newObjRef target: newTarget [
-	"Rewrite the three values involved in a CPIC case.  Used by the initialize & extend CPICs.
-	 c.f. expectedClosedPICPrototype:"
+	"Rewrite the three values involved in a CPIC case.  Used by the initialize & extend PICs.
+	 c.f. expectedPICPrototype:"
 
 	"write the obj ref/operand via the second ldr"
 	| classTagPC methodObjPC |
@@ -11831,7 +11839,7 @@ self enableCodeZoneWriteDuring:  [
 					 arg: 0]
 			ifFalse:
 				[(cogMethod cmType = CMPolymorphicIC
-				  and: [self cPICHasForwardedClass: cogMethod]) ifTrue:
+				  and: [self picHasForwardedClass: cogMethod]) ifTrue:
 					[methodZone freeMethod: cogMethod.
 					 freedPIC := true]].
 		cogMethod := methodZone methodAfter: cogMethod].
@@ -11861,7 +11869,7 @@ Cogit >> unlinkSendsOf: selector isMNUSelector: isMNUSelector [
 			ifTrue:
 				[[cogMethod < methodZone limitZony] whileTrue:
 					[cogMethod cmType ~= CMFree ifTrue:
-						[cogMethod cpicHasMNUCase
+						[cogMethod picHasMNUCase
 							ifTrue:
 								[self assert: cogMethod cmType = CMPolymorphicIC.
 								 methodZone freeMethod: cogMethod.
@@ -11924,7 +11932,7 @@ Cogit >> unlinkSendsTo: targetMethodObject andFreeIf: freeIfTrue [
 							 arg: targetMethod asInteger]
 					ifFalse:
 						[(cogMethod cmType = CMPolymorphicIC
-						  and: [self cPIC: cogMethod HasTarget: targetMethod]) ifTrue:
+						  and: [self picI: cogMethod hasTarget: targetMethod]) ifTrue:
 							[methodZone freeMethod: cogMethod.
 							 freedPIC := true]].
 				cogMethod := methodZone methodAfter: cogMethod].
@@ -11938,7 +11946,6 @@ Cogit >> unlinkSendsTo: targetMethodObject andFreeIf: freeIfTrue [
 
 { #category : 'garbage collection' }
 Cogit >> unlinkSendsToFree [
-
 	"Unlink all sends in cog methods to free methods and/or pics."
 
 	<api>
@@ -11957,7 +11964,7 @@ Cogit >> unlinkSendsToFree [
 					 arg: 0]
 			ifFalse:
 				[cogMethod cmType = CMPolymorphicIC ifTrue:
-					[self assert: (self noTargetsFreeInClosedPIC: cogMethod)]].
+					[self assert: (self noTargetsFreeInPIC: cogMethod)]].
 		cogMethod := methodZone methodAfter: cogMethod]
 ]
 

--- a/smalltalksrc/VMMaker/Cogit.class.st
+++ b/smalltalksrc/VMMaker/Cogit.class.st
@@ -181,7 +181,6 @@ Class {
 		'ceMethodAbortTrampoline',
 		'cePICAbortTrampoline',
 		'ceCheckForInterruptTrampoline',
-		'ceCPICMissTrampoline',
 		'ceReturnToInterpreterTrampoline',
 		'ceBaseFrameReturnTrampoline',
 		'ceReapAndResetErrorCodeTrampoline',
@@ -250,7 +249,8 @@ Class {
 		'picEndSize',
 		'picEndOfCodeLabel',
 		'picEndOfCodeOffset',
-		'picPrototype'
+		'picPrototype',
+		'cePICMissTrampoline'
 	],
 	#classVars : [
 		'AnnotationConstantNames',
@@ -493,8 +493,8 @@ Cogit class >> declareCVarsIn: aCCodeGenerator [
 			#( abstractOpcodes stackCheckLabel blockEntryLabel blockEntryNoContextSwitch
 			   stackOverflowCall sendMiss entry noCheckEntry selfSendEntry
 			   dynSuperEntry fullBlockNoContextSwitchEntry
-			   fullBlockEntry picMNUAbort picInterpretAbort endCPICCase0
-			   endCPICCase1 cPICEndOfCodeLabel )
+			   fullBlockEntry picMNUAbort picInterpretAbort endPICCase0
+			   endPICCase1 picEndOfCodeLabel )
 		as: #'AbstractInstruction *'
 		in: aCCodeGenerator.
 	aCCodeGenerator declareVar: #fixups type: #'BytecodeFixup *'.
@@ -1300,7 +1300,7 @@ Cogit class >> runtime [
 		ceActiveContext => ReceiverResultReg
 		ceBaseFrameReturn: returnValue (ReceiverResultReg)
 		ceBaseFrameReturnPC
-		ceCPICMiss: cPIC (ClassReg) receiver: receiver (ReceiverResultReg)
+		cePICMiss: aPIC (ClassReg) receiver: receiver (ReceiverResultReg)
 		ceCall0ArgsPIC
 		ceCall1ArgsPIC
 		ceCall2ArgsPIC
@@ -1473,7 +1473,7 @@ ceSendMustBeBooleanTrampoline
 ceCheckForInterruptsTrampoline
 	pops return pc into instructionPointer
 
-ceCPICMissTrampoline
+cePICMissTrampoline
 	return pc left on stack because it is used to locate the failing send target PIC of a linked send
 
 ceSendFromInLineCacheMissTrampoline
@@ -3511,89 +3511,6 @@ Cogit >> ceBaseFrameReturnTrampoline: anInteger [
 	ceBaseFrameReturnTrampoline := anInteger
 ]
 
-{ #category : 'in-line cacheing' }
-Cogit >> ceCPICMiss: cPIC receiver: receiver [
-	"Code entry closed PIC miss.  A send has fallen
-	 through a closed (finite) polymorphic inline cache.
-	 Either extend it or patch the send site to an megamorphic IC.
-	 The stack looks like:
-			receiver
-			args
-	  sp=>	sender return address"
-
-	<api>
-	<story: #pic>
-	<var: #cPIC type: #'CogMethod *'>
-	| callerReturnAddress newTargetMethodOrNil errorSelectorOrNil |
-	self simulationOnly: [
-		cPIC isInteger ifTrue: [
-			^ self
-				  ceCPICMiss: (self cogMethodSurrogateAt: cPIC)
-				  receiver: receiver ] ].
-
-	(objectMemory isOopForwarded: receiver) ifTrue: [
-		^ coInterpreter ceSendFromInLineCacheMiss: cPIC ].
-
-	callerReturnAddress := coInterpreter stackTop.
-	self deny: (backEnd inlineCacheTagAt: callerReturnAddress)
-		= self isMNUPicAbortDiscriminatorValue.
-
-	"Transition to megamorphic if the PIC is full"
-	MaxPICCases <= cPIC picNumCases ifTrue: [
-		self
-			patchToMegamorphicICFor: cPIC selector
-			numArgs: cPIC cmNumArgs
-			receiver: receiver.
-		^ coInterpreter ceSendFromInLineCacheMiss: cPIC ].
-
-	self
-		lookup: cPIC selector
-		for: receiver
-		methodAndErrorSelectorInto: [ :method :errsel |
-			newTargetMethodOrNil := method.
-			errorSelectorOrNil := errsel ].
-
-	"      method | errorSelector             | situation
-	 -------------+---------------------------+-------------------------------------------------------------
-	          nil | SelectorCannotInterpret   | There was an error during the lookup (ill-formed class)
-	          nil | SelectorDoesNotUnderstand | Didn't find the method nor the DNU implementation
-	  foundMethod | SelectorCannotInterpret   | Found something that isn't a CompiledMethod (#run:with:in:)
-	  foundMethod | *                         | foundMethod is young (may not be a CompiledMethod!)"
-	(errorSelectorOrNil = SelectorCannotInterpret or: [
-		 newTargetMethodOrNil isNil or: [
-			 objectMemory isYoung: newTargetMethodOrNil ] ]) ifTrue: [
-		self
-			patchToMegamorphicICFor: cPIC selector
-			numArgs: cPIC cmNumArgs
-			receiver: receiver.
-		^ coInterpreter ceSendFromInLineCacheMiss: cPIC ].
-
-	"      method | errorSelector             | situation
-	 -------------+---------------------------+---------------------------------------------------------
-	  foundMethod | SelectorDoesNotUnderstand | Didn't find the method but found the DNU implementation
-	  foundMethod | nil                       | Found the method
-
-	Now extend the PIC with the new case."
-	self
-		cogExtendPIC: cPIC
-		CaseNMethod: newTargetMethodOrNil
-		tag: (objectRepresentation inlineCacheTagForInstance: receiver)
-		isMNUCase: errorSelectorOrNil = SelectorDoesNotUnderstand.
-
-	"Jump back into the pic at its entry in case this is an MNU."
-	coInterpreter
-		executeCogPIC: cPIC
-		fromLinkedSendWithReceiver: receiver
-		andCacheTag: (backEnd inlineCacheTagAt: callerReturnAddress).
-	self unreachable
-]
-
-{ #category : 'accessing' }
-Cogit >> ceCPICMissTrampoline [
-	<doNotGenerate>
-	^ ceCPICMissTrampoline
-]
-
 { #category : 'simulation only' }
 Cogit >> ceCallCogCodePopReceiverAndClassRegs [
 	<api: 'extern void (*ceCallCogCodePopReceiverAndClassRegs)()'>
@@ -3737,6 +3654,89 @@ Cogit >> cePICAbortTrampoline [
 Cogit >> cePICAbortTrampoline: anInteger [ 
 	<doNotGenerate>
 	cePICAbortTrampoline := anInteger
+]
+
+{ #category : 'in-line cacheing' }
+Cogit >> cePICMiss: aPIC receiver: receiver [
+	"Code entry closed PIC miss.  A send has fallen
+	 through a closed (finite) polymorphic inline cache.
+	 Either extend it or patch the send site to an megamorphic IC.
+	 The stack looks like:
+			receiver
+			args
+	  sp=>	sender return address"
+
+	<api>
+	<story: #pic>
+	<var: #aPIC type: #'CogMethod *'>
+	| callerReturnAddress newTargetMethodOrNil errorSelectorOrNil |
+	self simulationOnly: [
+		aPIC isInteger ifTrue: [
+			^ self
+				  cePICMiss: (self cogMethodSurrogateAt: aPIC)
+				  receiver: receiver ] ].
+
+	(objectMemory isOopForwarded: receiver) ifTrue: [
+		^ coInterpreter ceSendFromInLineCacheMiss: aPIC ].
+
+	callerReturnAddress := coInterpreter stackTop.
+	self deny: (backEnd inlineCacheTagAt: callerReturnAddress)
+		= self isMNUPicAbortDiscriminatorValue.
+
+	"Transition to megamorphic if the PIC is full"
+	MaxPICCases <= aPIC picNumCases ifTrue: [
+		self
+			patchToMegamorphicICFor: aPIC selector
+			numArgs: aPIC cmNumArgs
+			receiver: receiver.
+		^ coInterpreter ceSendFromInLineCacheMiss: aPIC ].
+
+	self
+		lookup: aPIC selector
+		for: receiver
+		methodAndErrorSelectorInto: [ :method :errsel |
+			newTargetMethodOrNil := method.
+			errorSelectorOrNil := errsel ].
+
+	"      method | errorSelector             | situation
+	 -------------+---------------------------+-------------------------------------------------------------
+	          nil | SelectorCannotInterpret   | There was an error during the lookup (ill-formed class)
+	          nil | SelectorDoesNotUnderstand | Didn't find the method nor the DNU implementation
+	  foundMethod | SelectorCannotInterpret   | Found something that isn't a CompiledMethod (#run:with:in:)
+	  foundMethod | *                         | foundMethod is young (may not be a CompiledMethod!)"
+	(errorSelectorOrNil = SelectorCannotInterpret or: [
+		 newTargetMethodOrNil isNil or: [
+			 objectMemory isYoung: newTargetMethodOrNil ] ]) ifTrue: [
+		self
+			patchToMegamorphicICFor: aPIC selector
+			numArgs: aPIC cmNumArgs
+			receiver: receiver.
+		^ coInterpreter ceSendFromInLineCacheMiss: aPIC ].
+
+	"      method | errorSelector             | situation
+	 -------------+---------------------------+---------------------------------------------------------
+	  foundMethod | SelectorDoesNotUnderstand | Didn't find the method but found the DNU implementation
+	  foundMethod | nil                       | Found the method
+
+	Now extend the PIC with the new case."
+	self
+		cogExtendPIC: aPIC
+		CaseNMethod: newTargetMethodOrNil
+		tag: (objectRepresentation inlineCacheTagForInstance: receiver)
+		isMNUCase: errorSelectorOrNil = SelectorDoesNotUnderstand.
+
+	"Jump back into the pic at its entry in case this is an MNU."
+	coInterpreter
+		executeCogPIC: aPIC
+		fromLinkedSendWithReceiver: receiver
+		andCacheTag: (backEnd inlineCacheTagAt: callerReturnAddress).
+	self unreachable
+]
+
+{ #category : 'accessing' }
+Cogit >> cePICMissTrampoline [
+	<doNotGenerate>
+	^ cePICMissTrampoline
 ]
 
 { #category : 'accessing' }
@@ -4181,13 +4181,13 @@ Cogit >> checkValidObjectReferencesInPIC: aPIC [
 	ok := true.
 	pc := aPIC asInteger + firstPICCaseOffset.
 	
-	"first we check the obj ref at the beginning of the CPIC"
+	"first we check the obj ref at the beginning of the PIC"
 	(self checkMaybeObjRefInPIC: (backEnd literalBeforeFollowingAddress: pc - backEnd jumpLongByteSize)) ifFalse:
 		[self print: 'object leak in PIC '; printHex: aPIC asInteger;
 			print: ' @ '; printHex: pc - backEnd jumpLongByteSize; cr.
 		 ok := false].
 	
-	"Next we step over each case that is in use. We find the end address of the cPICNumCases'th case and can then just step forward by the case size thereafter"
+	"Next we step over each case that is in use. We find the end address of the picNumCases'th case and can then just step forward by the case size thereafter"
 	pc := self addressOfEndOfCase: aPIC picNumCases inPIC: aPIC.
 	
 	"For each case we check any object reference at the end address - sizeof(conditional instruction) and then increment the end address by case size"
@@ -4419,12 +4419,13 @@ Cogit >> cogCodeConstituents: withDetails [
 ]
 
 { #category : 'in-line cacheing' }
-Cogit >> cogExtendPIC: cPIC CaseNMethod: caseNMethod tag: caseNTag isMNUCase: isMNUCase [
-	"Extend the cPIC with the supplied case.  If caseNMethod is cogged dispatch direct to
+Cogit >> cogExtendPIC: aPIC CaseNMethod: caseNMethod tag: caseNTag isMNUCase: isMNUCase [
+	"Extend the aPIC with the supplied case.  If caseNMethod is cogged dispatch direct to
 	 its unchecked entry-point.  If caseNMethod is not cogged, jump to the fast interpreter
-	 dispatch, and if isMNUCase then dispatch to fast MNU invocation and mark the cPIC as
+	 dispatch, and if isMNUCase then dispatch to fast MNU invocation and mark the aPIC as
 	 having the MNU case for cache flushing."
- 	<var: #cPIC type: #'CogMethod *'>
+	
+ 	<var: #aPIC type: #'CogMethod *'>
 	| operand target address |
 	self enableCodeZoneWriteDuring: [  
 			"Caller patches to megamorphicIC if caseNMethod is young."
@@ -4436,24 +4437,24 @@ Cogit >> cogExtendPIC: cPIC CaseNMethod: caseNMethod tag: caseNTag isMNUCase: is
 				ifFalse: 
 					[operand := caseNMethod.
 					 isMNUCase
-						ifTrue: "this is an MNU so tag the CPIC header and setup a jump to the MNUAbort"
-							[cPIC cpicHasMNUCase: true.
-							 target := self picAbortAddress: cPIC]
+						ifTrue: "this is an MNU so tag the PIC header and setup a jump to the MNUAbort"
+							[aPIC picHasMNUCase: true.
+							 target := self picAbortAddress: aPIC]
 						ifFalse: "setup a jump to the interpretAbort so we can cog the target method"
-							[target := cPIC asInteger + self picInterpretAbortOffset]].
+							[target := aPIC asInteger + self picInterpretAbortOffset]].
 
 			"find the end address of the new case"
-			address := self addressOfEndOfCase: cPIC picNumCases +1 inPIC: cPIC.
+			address := self addressOfEndOfCase: aPIC picNumCases +1 inPIC: aPIC.
 			
 			self rewritePICCaseAt: address tag: caseNTag objRef: operand target: target.
 
-			"finally, rewrite the jump 3 instr  before firstCPICCaseOffset to jump to the beginning of this new case"
-			self rewritePIC: cPIC caseJumpTo: address - picCaseSize. 
+			"finally, rewrite the jump 3 instr  before firstPICCaseOffset to jump to the beginning of this new case"
+			self rewritePIC: aPIC caseJumpTo: address - picCaseSize. 
 
 			"update the header flag for the number of cases"
-			cPIC picNumCases: cPIC picNumCases + 1]
+			aPIC picNumCases: aPIC picNumCases + 1]
 
-		flushingCacheWith:  [self flushICacheFrom: cPIC asUnsignedInteger to: cPIC asUnsignedInteger + picSize].
+		flushingCacheWith:  [self flushICacheFrom: aPIC asUnsignedInteger to: aPIC asUnsignedInteger + picSize].
 
 	^0
 ]
@@ -4511,7 +4512,7 @@ Cogit >> cogMNUPICSelector: selector receiver: rcvr methodOperand: methodOperand
 		 = self isMNUPicAbortDiscriminatorValue ]) ifTrue: [ ^ 0 ].
 
 	self assert: endPICCase0 notNil.
-	"get memory in the code zone for the CPIC; if that fails we return an error code for the sender to use to work out how to blow up"
+	"get memory in the code zone for the PIC; if that fails we return an error code for the sender to use to work out how to blow up"
 	startAddress := methodZone allocate: picSize.
 	startAddress = 0 ifTrue: [
 		coInterpreter callForCogCompiledCodeCompaction.
@@ -4525,7 +4526,7 @@ Cogit >> cogMNUPICSelector: selector receiver: rcvr methodOperand: methodOperand
 				atDelta: startAddress - picPrototype
 				numArgs: numArgs.
 
-			self configureMNUCPIC: pic methodOperand: methodOperand.
+			self configureMNUPIC: pic methodOperand: methodOperand.
 
 			self
 				fillInPICHeader: pic
@@ -4675,7 +4676,7 @@ Cogit >> cogPICSelector: selector numArgs: numArgs Case0Method: case0CogMethod C
 	(objectMemory isYoung: selector) ifTrue: [
 		^ self cCoerceSimple: YoungSelectorInPIC to: #'CogMethod *' ].
 
-	"get memory in the code zone for the CPIC; if that fails we return an error code for the sender to use to work out how to blow up"
+	"get memory in the code zone for the PIC; if that fails we return an error code for the sender to use to work out how to blow up"
 	startAddress := methodZone allocate: picSize.
 	pic := self cCoerceSimple: startAddress to: #'CogMethod *'.
 	startAddress = 0 ifTrue: [
@@ -4925,15 +4926,6 @@ Cogit >> compileAbstractInstructionsFrom: start through: end [
 			[nExts := descriptor isExtension ifTrue: [nExts + 1] ifFalse: [0]].
 	self checkEnoughOpcodes.
 	^result
-]
-
-{ #category : 'in-line cacheing' }
-Cogit >> compileCPICEntry [
-	<returnTypeC: #'AbstractInstruction *'>
-	"Compile the cache tag computation and the first comparison.  Answer the address of that comparison."
-	entry := objectRepresentation genGetInlineCacheClassTagFrom: ReceiverResultReg into: TempReg.
-	self CmpR: ClassReg R: TempReg.
-	^self JumpNonZero: 0
 ]
 
 { #category : 'initialization' }
@@ -5214,6 +5206,15 @@ Cogit >> compilePICAbort: numArgs [
 ]
 
 { #category : 'in-line cacheing' }
+Cogit >> compilePICEntry [
+	<returnTypeC: #'AbstractInstruction *'>
+	"Compile the cache tag computation and the first comparison.  Answer the address of that comparison."
+	entry := objectRepresentation genGetInlineCacheClassTagFrom: ReceiverResultReg into: TempReg.
+	self CmpR: ClassReg R: TempReg.
+	^self JumpNonZero: 0
+]
+
+{ #category : 'in-line cacheing' }
 Cogit >> compilePolymorphicICPrototype [
 	"Compile the abstract instructions for a PIC, used to generate the chunk of code
 	 which is copied to form each PIC.  A Polymorphic Inline Cache is a small jump
@@ -5260,7 +5261,7 @@ Cogit >> compilePolymorphicICPrototype [
 	| numArgs jumpNext |
 	<var: #jumpNext type: #'AbstractInstruction *'>
 	self compilePICAbort: (numArgs := 0). "Will get rewritten to appropriate arity when configuring."
-	jumpNext := self compileCPICEntry.
+	jumpNext := self compilePICEntry.
 	"At the end of the entry code we need to jump to the first case code, which is actually the last chunk.
 	 On each entension we must update this jump to move back one case."
 	self MoveUniqueCw: self firstPrototypeMethodOop R: SendNumArgsReg.
@@ -5277,7 +5278,7 @@ Cogit >> compilePolymorphicICPrototype [
 		h = 1 ifTrue:
 			[endPICCase1 := self Label]].
 	self MoveCw: methodLabel address R: ClassReg.
-	self JumpLong: (self cPICMissTrampolineFor: numArgs).	"Will get rewritten to appropriate arity when configuring."
+	self JumpLong: (self picMissTrampolineFor: numArgs).	"Will get rewritten to appropriate arity when configuring."
 	picEndOfCodeLabel := self Label.
 	literalsManager dumpLiterals: false.
 	^0
@@ -5433,11 +5434,11 @@ Cogit >> computeMaximumSizes [
 ]
 
 { #category : 'in-line cacheing' }
-Cogit >> configureMNUCPIC: aPIC methodOperand: methodOop [
-	"Configure a copy of the prototype CPIC for a one-case MNU CPIC that calls ceMNUFromPIC for
+Cogit >> configureMNUPIC: aPIC methodOperand: methodOop [
+	"Configure a copy of the prototype PIC for a one-case MNU PIC that calls ceMNUFromPIC for
 	 case0Tag The tag for case0 is at the send site and so doesn't need to be generated.
-	 addDelta is the address change from the prototype to the new CPIC location, needed
-	 because the loading of the CPIC label at the end may be a literal instead of a pc-relative load."
+	 addDelta is the address change from the prototype to the new PIC location, needed
+	 because the loading of the PIC label at the end may be a literal instead of a pc-relative load."
 
 	<var: #aPIC type: #'CogMethod *'>
 	| operand |	
@@ -5452,7 +5453,7 @@ Cogit >> configureMNUCPIC: aPIC methodOperand: methodOop [
 		rewriteJumpLongAt: aPIC asInteger + firstPICCaseOffset
 		target: (self picAbortAddress: aPIC).
 
-	"finally, rewrite the jump 3 instr before firstCPICCaseOffset to jump to the end of case 2, missing the actual case"
+	"finally, rewrite the jump 3 instr before firstPICCaseOffset to jump to the end of case 2, missing the actual case"
 	backEnd
 		storeLiteral: operand
 		beforeFollowingAddress:
@@ -5465,7 +5466,7 @@ Cogit >> configureMNUCPIC: aPIC methodOperand: methodOop [
 
 { #category : 'in-line cacheing' }
 Cogit >> configurePIC: aPIC Case0: case0CogMethod Case1Method: case1Method tag: case1Tag isMNUCase: isMNUCase [
-	"Configure a copy of the prototype CPIC for a two-case PIC for 
+	"Configure a copy of the prototype PIC for a two-case PIC for 
 	case0CogMethod and
 	case1Method
 	case1Tag.
@@ -5474,10 +5475,10 @@ Cogit >> configurePIC: aPIC Case0: case0CogMethod Case1Method: case1Method tag: 
 		- a Cog method; jump to its unchecked entry-point
 		- a CompiledMethod; jump to the ceInterpretFromPIC trampoline
 		- nil; call ceMNUFromPIC
-	addDelta is the address change from the prototype to the new CPIC location, needed
-	because the loading of the CPIC label at the end may use a literal instead of a pc relative load."
+	addDelta is the address change from the prototype to the new PIC location, needed
+	because the loading of the PIC label at the end may use a literal instead of a pc relative load."
 
-	"self disassembleFrom: cPIC asInteger + (self sizeof: CogMethod) to: aPIC asInteger + picSize"
+	"self disassembleFrom: pic asInteger + (self sizeof: CogMethod) to: aPIC asInteger + picSize"
 
 	<var: #aPIC type: #'CogMethod *'>
 	<var: #case0CogMethod type: #'CogMethod *'>
@@ -5504,7 +5505,7 @@ Cogit >> configurePIC: aPIC Case0: case0CogMethod Case1Method: case1Method tag: 
 		rewriteJumpLongAt: aPIC asInteger + firstPICCaseOffset
 		target: case0CogMethod asInteger + cmNoCheckEntryOffset.
 	
-	"update the cpic case"
+	"update the pic case"
 	caseEndAddress := self addressOfEndOfCase: 2 inPIC: aPIC.
 	self
 		rewritePICCaseAt: caseEndAddress
@@ -5538,7 +5539,7 @@ Cogit >> createPICData: aPIC [
 		i = 1
 			ifTrue:
 				[class := aPIC methodObject. "first case may have been collected and stored here by collectCogConstituentFor:Annotation:Mcpc:Bcpc:Method:"
-				 class = 0 ifTrue: [class := objectMemory nilObject]. "cPIC is unreferenced; likely evolved to megamorphicIC"
+				 class = 0 ifTrue: [class := objectMemory nilObject]. "PIC is unreferenced; likely evolved to megamorphicIC"
 				 entryPoint := backEnd jumpLongTargetBeforeFollowingAddress: pc]
 			ifFalse:
 				[class := objectRepresentation classForInlineCacheTag:
@@ -5874,7 +5875,7 @@ Cogit >> expectedPICPrototype: aPIC [
 			 = (self picPrototypeCaseOffset + 16rCA5E10 + (i * 16))) 
 			ifFalse: [ errors := errors bitOr: 16 ].
 
-		"change case via rewriteCPICCaseAt:tag:objRef:target:"
+		"change case via rewritePICCaseAt:tag:objRef:target:"
 		self
 			rewritePICCaseAt: pc
 			tag: (classTag bitXor: 16r5A5A5A5A)
@@ -5906,7 +5907,7 @@ Cogit >> expectedPICPrototype: aPIC [
 
 	entryPoint := backEnd jumpLongTargetBeforeFollowingAddress:
 		              pc + picEndSize - literalsManager endSizeOffset.
-	(self asserta: entryPoint = (self cPICMissTrampolineFor: 0)) 
+	(self asserta: entryPoint = (self picMissTrampolineFor: 0)) 
 		ifFalse: [ errors := errors + 256 ] .
 
 	^ errors
@@ -5978,7 +5979,7 @@ Cogit >> fillInMegamorphicICHeader: pic numArgs: numArgs selector: selector [
 	(pic cmRefersToYoung: (objectMemory isYoung: selector)) ifTrue:
 		[methodZone addToYoungReferrers: pic].
 	pic cmUsageCount: self initialMegamorphicICUsageCount.
-	pic cpicHasMNUCase: false.
+	pic picHasMNUCase: false.
 	pic picNumCases: 0.
 	pic picUsage: 0.
 	self assert: pic cmType = CMMegamorphicIC.
@@ -6014,7 +6015,7 @@ Cogit >> fillInMethodHeader: method size: size selector: selector [
 	(method cmRefersToYoung: hasYoungReferent) ifTrue:
 		[methodZone addToYoungReferrers: method].
 	method cmUsageCount: self initialMethodUsageCount.
-	method cpicHasMNUCase: false.
+	method picHasMNUCase: false.
 	method cmUsesPenultimateLit: maxLitIndex >= ((objectMemory literalCountOfMethodHeader: methodHeader) - 2).
 	method picUsage: 0.
 	"This can be an error check since a large stackCheckOffset is caused by compiling
@@ -6046,7 +6047,7 @@ Cogit >> fillInPICHeader: pic numArgs: numArgs numCases: numCases hasMNUCase: ha
 	pic cmNumArgs: numArgs.
 	pic cmRefersToYoung: false.
 	pic cmUsageCount: self initialPICUsageCount.
-	pic cpicHasMNUCase: hasMNUCase.
+	pic picHasMNUCase: hasMNUCase.
 	pic picNumCases: numCases.
 	pic picUsage: 0.
 	self assert: pic cmType = CMPolymorphicIC.
@@ -6249,10 +6250,10 @@ Cogit >> followMethodReferencesInPIC: aPIC [
 	| pc refersToYoung |
 	pc := self addressOfEndOfCase: 1 inPIC: aPIC.
 
-	"first we check the potential method oop load at the beginning of the CPIC"
+	"first we check the potential method oop load at the beginning of the PIC"
 	refersToYoung := self followMaybeObjRefInPICAt: pc - backEnd jumpLongByteSize.
 
-	"We find the end address of the cPICNumCases'th case and can then just step forward by the case size thereafter"
+	"We find the end address of the picNumCases'th case and can then just step forward by the case size thereafter"
 	pc := self addressOfEndOfCase:  aPIC picNumCases inPIC: aPIC.
 	
 	"Next we check the potential potential method oop load for each case."
@@ -7563,7 +7564,7 @@ Cogit >> generatePICPrototype [
 	picPrototype := aPIC.
 	"self cCode: ''
 		inSmalltalk:
-			[self disassembleFrom: cPIC + (self sizeof: CogMethod) to: cPIC + picSize - 1.
+			[self disassembleFrom: aPIC + (self sizeof: CogMethod) to: aPIC + picSize - 1.
 			 self halt]"
 ]
 
@@ -8211,7 +8212,7 @@ Cogit >> initializePIC: aPIC atDelta: addrDelta numArgs: numArgs [
 		rewriteCallAt: aPIC asInteger + missOffset
 		target: (self picAbortTrampolineFor: numArgs). "adjust the call at missOffset, the ceAbortXArgs"
 
-	"update the loading of the CPIC address"
+	"update the loading of the PIC address"
 	backEnd
 		relocateMethodReferenceBeforeAddress:
 		aPIC asInteger + picEndOfCodeOffset - backEnd jumpLongByteSize
@@ -8220,7 +8221,7 @@ Cogit >> initializePIC: aPIC atDelta: addrDelta numArgs: numArgs [
 	"write the final desperate jump to cePICMissXArgs"
 	backEnd
 		rewriteJumpLongAt: aPIC asInteger + picEndOfCodeOffset
-		target: (self cPICMissTrampolineFor: numArgs)
+		target: (self picMissTrampolineFor: numArgs)
 ]
 
 { #category : 'initialization' }
@@ -9066,10 +9067,10 @@ Cogit >> mapObjectReferencesInPIC: aPIC [
 	| pc refersToYoung |
 	pc := self addressOfEndOfCase:1 inPIC:aPIC.
 
-	"first we check the potential method oop load at the beginning of the CPIC"
+	"first we check the potential method oop load at the beginning of the PIC"
 	refersToYoung := self remapMaybeObjRefInPICAt: pc - backEnd jumpLongByteSize.
 
-	"We find the end address of the cPICNumCases'th case and can then just step forward by the case size thereafter"
+	"We find the end address of the picNumCases'th case and can then just step forward by the case size thereafter"
 	pc := self addressOfEndOfCase: aPIC picNumCases inPIC: aPIC.
 	
 	"Next we check the potential class ref in the compare instruction, and the potential method oop load for each case."
@@ -9285,19 +9286,19 @@ Cogit >> markAndTraceOrFreeMachineCodeForFullGC [
 ]
 
 { #category : 'garbage collection' }
-Cogit >> markAndTraceOrFreePICTarget: entryPoint in: cPIC [
+Cogit >> markAndTraceOrFreePICTarget: entryPoint in: aPIC [
 	"If entryPoint is that of some method, then mark and trace objects in it and free if it is appropriate.
 	 Answer if the method has been freed."
-	<var: #cPIC type: #'CogMethod *'>
+	<var: #aPIC type: #'CogMethod *'>
 	| targetMethod |
 	<var: #targetMethod type: #'CogMethod *'>
 	self assert: (entryPoint > methodZoneBase and: [entryPoint < methodZone freeStart]).
-	(cPIC containsAddress: entryPoint) ifTrue:
+	(aPIC containsAddress: entryPoint) ifTrue:
 		[^false].
 	targetMethod := self cCoerceSimple: entryPoint - cmNoCheckEntryOffset to: #'CogMethod *'.
 	self assert: (targetMethod cmType = CMMethod or: [targetMethod cmType = CMFree]).
 	^self markAndTraceOrFreeCogMethod: targetMethod
-		  firstVisit: targetMethod asUnsignedInteger > cPIC asUnsignedInteger
+		  firstVisit: targetMethod asUnsignedInteger > aPIC asUnsignedInteger
 ]
 
 { #category : 'garbage collection' }
@@ -9966,13 +9967,13 @@ Cogit >> patchToMegamorphicICFor: selector numArgs: numArgs receiver: receiver [
 ]
 
 { #category : 'in-line cacheing' }
-Cogit >> picAbortAddress: cPIC [
+Cogit >> picAbortAddress: aPIC [
 
-	<var: #cPIC type: #'CogMethod *'>
+	<var: #aPIC type: #'CogMethod *'>
 	"The PIC starts with a header of meta-data followed by machine code.
 	The first thing in the machine code stream is the abort section."
 
-	^ cPIC asInteger + (self sizeof: CogMethod)
+	^ aPIC asInteger + (self sizeof: CogMethod)
 ]
 
 { #category : 'trampoline support' }
@@ -9990,9 +9991,9 @@ Cogit >> picCompactAndIsNowEmpty: aPIC [
 	<var: #aPIC type: #'CogMethod *'>
 	| pc entryPoint targetMethod targets tags methods used |
 	<var: #targetMethod	type: #'CogMethod *'>
-	<var: #tags			declareC: 'int tags[MaxCPICCases]'>
-	<var: #targets			declareC: 'sqInt targets[MaxCPICCases]'>
-	<var: #methods		declareC: 'sqInt methods[MaxCPICCases]'>
+	<var: #tags			declareC: 'int tags[MaxPICCases]'>
+	<var: #targets			declareC: 'sqInt targets[MaxPICCases]'>
+	<var: #methods		declareC: 'sqInt methods[MaxPICCases]'>
 	self cCode: [] inSmalltalk:
 		[tags := CArrayAccessor on: (Array new: MaxPICCases).
 		 targets := CArrayAccessor on: (Array new: MaxPICCases).
@@ -10034,7 +10035,7 @@ Cogit >> picCompactAndIsNowEmpty: aPIC [
 		 pc := self addressOfEndOfCase: i + 1 inPIC: aPIC.
 		 self rewritePICCaseAt: pc tag: (tags at: i) objRef: (methods at: i) target: (targets at: i)].
 
-	"finally, rewrite the jump 3 instr  before firstCPICCaseOffset to jump to the beginning of this new case"
+	"finally, rewrite the jump 3 instr  before firstPICCaseOffset to jump to the beginning of this new case"
 	self rewritePIC: aPIC caseJumpTo: pc - picCaseSize.
 	^false
 ]
@@ -10042,9 +10043,10 @@ Cogit >> picCompactAndIsNowEmpty: aPIC [
 { #category : 'in-line cacheing' }
 Cogit >> picHasForwardedClass: aPIC [ 
 	"The first case in a PIC doesn't have a class reference so we need only step over actually usd subsequent cases."
+	
 	| pc |
 	<var: #aPIC type: #'CogMethod *'>
-	"start by finding the address of the topmost case, the cPICNumCases'th one"
+	"start by finding the address of the topmost case, the picNumCases'th one"
 	pc := (self addressOfEndOfCase: aPIC picNumCases inPIC: aPIC)
 				- backEnd jumpLongConditionalByteSize.
 	2 to: aPIC picNumCases do: 
@@ -10059,7 +10061,8 @@ Cogit >> picHasForwardedClass: aPIC [
 
 { #category : 'in-line cacheing' }
 Cogit >> picHasFreedTargets: aPIC [
-	"scan the CPIC for target methods that have been freed. "
+	"scan the PIC for target methods that have been freed. "
+	
 	<var: #aPIC type: #'CogMethod *'>
 	| pc entryPoint targetMethod |
 	<var: #targetMethod type: #'CogMethod *'>
@@ -10119,7 +10122,7 @@ Cogit >> picPrototype [
 
 { #category : 'in-line cacheing' }
 Cogit >> picPrototypeCaseOffset [
-	"We want 16rCA5E10 + cPICPrototypeCaseOffset to be somewhere in the middle of the zone."
+	"We want 16rCA5E10 + picPrototypeCaseOffset to be somewhere in the middle of the zone."
 	
 	<inline: true>
 	^methodZoneBase + methodZone youngReferrers / 2 - 16rCA5E10
@@ -10327,11 +10330,11 @@ Cogit >> printMethodHeader: cogMethod on: aStream [
 			aStream
 				newLine;
 				tab;
-				nextPutAll: 'cPICNumCases: '.
+				nextPutAll: 'picNumCases: '.
 			cogMethod picNumCases printOn: aStream base: 16.
 			aStream
 				tab;
-				nextPutAll: 'cpicHasMNUCase: ';
+				nextPutAll: 'picHasMNUCase: ';
 				nextPutAll: (cogMethod picHasMNUCase
 						 ifTrue: [ 'yes' ]
 						 ifFalse: [ 'no' ]) ]
@@ -10845,7 +10848,7 @@ Cogit >> relocateCallsInPIC: aPIC [
 					by: (callDelta - targetMethod objectHeader) negated]]].
 	self assert: aPIC picNumCases > 0.
 
-	"Finally relocate the load of the PIC and the jump to the overflow routine ceCPICMiss:receiver:"
+	"Finally relocate the load of the PIC and the jump to the overflow routine cePICMiss:receiver:"
 	backEnd relocateMethodReferenceBeforeAddress: (self addressOfEndOfCase: 2 inPIC: aPIC)+ backEnd loadPICLiteralByteSize by: refDelta.
 	backEnd relocateJumpLongBeforeFollowingAddress: aPIC asInteger + picEndOfCodeOffset by: callDelta negated
 ]
@@ -11007,7 +11010,7 @@ Cogit >> rewritePIC: aPIC caseJumpTo: target [
 
 { #category : 'in-line cacheing' }
 Cogit >> rewritePICCaseAt: followingAddress tag: newTag objRef: newObjRef target: newTarget [
-	"Rewrite the three values involved in a CPIC case.  Used by the initialize & extend PICs.
+	"Rewrite the three values involved in a PIC case.  Used by the initialize & extend PICs.
 	 c.f. expectedPICPrototype:"
 
 	"write the obj ref/operand via the second ldr"

--- a/smalltalksrc/VMMaker/InLineLiteralsManager.class.st
+++ b/smalltalksrc/VMMaker/InLineLiteralsManager.class.st
@@ -61,7 +61,7 @@ InLineLiteralsManager >> dumpLiterals: generateBranchAround [
 
 { #category : 'closed PIC parsing' }
 InLineLiteralsManager >> endSizeOffset [
-	"return the offset need from the cPICEndSize in order to point to just after the last instruction - here that means 0"
+	"return the offset need from the picEndSize in order to point to just after the last instruction - here that means 0"
 	^0
 ]
 

--- a/smalltalksrc/VMMaker/InLineLiteralsManager.class.st
+++ b/smalltalksrc/VMMaker/InLineLiteralsManager.class.st
@@ -76,12 +76,12 @@ InLineLiteralsManager >> fetchLiteralAtAnnotatedAddress: address using: instruct
 ]
 
 { #category : 'garbage collection' }
-InLineLiteralsManager >> literalBytesFollowingBranchInClosedPIC [
+InLineLiteralsManager >> literalBytesFollowingBranchInPIC [
 	^0
 ]
 
 { #category : 'garbage collection' }
-InLineLiteralsManager >> literalBytesFollowingJumpInClosedPIC [
+InLineLiteralsManager >> literalBytesFollowingJumpInPIC [
 	^0
 ]
 

--- a/smalltalksrc/VMMaker/OutOfLineLiteralsManager.class.st
+++ b/smalltalksrc/VMMaker/OutOfLineLiteralsManager.class.st
@@ -159,7 +159,7 @@ OutOfLineLiteralsManager >> dumpLiterals: generateBranchAround [
 
 { #category : 'closed PIC parsing' }
 OutOfLineLiteralsManager >> endSizeOffset [
-	"return the offset need from the cPICEndSize in order to point to just after the last instruction - here that means bytesPerOop * list size"
+	"return the offset need from the picEndSize in order to point to just after the last instruction - here that means bytesPerOop * list size"
 	^nextLiteralIndex * objectMemory bytesPerOop
 ]
 

--- a/smalltalksrc/VMMaker/SimpleStackBasedCogit.class.st
+++ b/smalltalksrc/VMMaker/SimpleStackBasedCogit.class.st
@@ -263,15 +263,10 @@ SimpleStackBasedCogit >> bytecodePC: anInteger [
 	bytecodePC := anInteger 
 ]
 
-{ #category : 'trampolines' }
-SimpleStackBasedCogit >> cPICMissTrampolineFor: numArgs [
-	^ceCPICMissTrampoline
-]
-
 { #category : 'accessing' }
-SimpleStackBasedCogit >> ceCPICMissTrampoline: anAddress [ 
+SimpleStackBasedCogit >> cePICMissTrampoline: anAddress [ 
 	
-	ceCPICMissTrampoline := anAddress
+	cePICMissTrampoline := anAddress
 ]
 
 { #category : 'simulation only' }
@@ -2796,8 +2791,8 @@ SimpleStackBasedCogit >> generateMissAbortTrampolines [
 
 	ceMethodAbortTrampoline := self genMethodAbortTrampoline.
 	cePICAbortTrampoline := self genPICAbortTrampoline.
-	ceCPICMissTrampoline := self genTrampolineFor: #ceCPICMiss:receiver:
-								called: 'ceCPICMissTrampoline'
+	cePICMissTrampoline := self genTrampolineFor: #cePICMiss:receiver:
+								called: 'cePICMissTrampoline'
 								arg: ClassReg
 								arg: ReceiverResultReg.
 	ceReapAndResetErrorCodeTrampoline := self genTrampolineFor: #ceReapAndResetErrorCodeFor:
@@ -3008,6 +3003,11 @@ SimpleStackBasedCogit >> pcDataFor: descriptor Annotation: isBackwardBranchAndAn
 { #category : 'trampolines' }
 SimpleStackBasedCogit >> picAbortTrampolineFor: numArgs [
 	^cePICAbortTrampoline
+]
+
+{ #category : 'trampolines' }
+SimpleStackBasedCogit >> picMissTrampolineFor: numArgs [
+	^cePICMissTrampoline
 ]
 
 { #category : 'primitive generators' }

--- a/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
+++ b/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
@@ -3715,15 +3715,16 @@ StackToRegisterMappingCogit >> picMissTrampolines [
 ]
 
 { #category : 'method introspection' }
-StackToRegisterMappingCogit >> populate: tuple withPICInfoFor: cPIC firstCacheTag: firstCacheTag [
-	"Populate tuple (which must be large enough) with the ClosedPIC's target method class pairs.
-	 The first entry in tuple contains the bytecode pc for the send, so skip the tuple's first field."
-	<var: #cPIC type: #'CogMethod *'>
+StackToRegisterMappingCogit >> populate: tuple withPICInfoFor: aPIC firstCacheTag: firstCacheTag [
+	"Populate tuple (which must be large enough) with the PIC's target method class pairs.
+	 The first entry in tuple contains the bytecode pc for the send, so skip the tuple's first field.
+	"
+	<var: #aPIC type: #'CogMethod *'>
 	| picCaseMachineCodePC cacheTag classOop entryPoint targetMethod value |
 	<var: #targetMethod type: #'CogMethod *'>
 
-	1 to: cPIC cPICNumCases do: [:i|
-		picCaseMachineCodePC := self addressOfEndOfCase: i inCPIC: cPIC.
+	1 to: aPIC picNumCases do: [:i|
+		picCaseMachineCodePC := self addressOfEndOfCase: i inPIC: aPIC.
 		cacheTag := i = 1
 						ifTrue: [firstCacheTag]
 						ifFalse: [backEnd literal32BeforeFollowingAddress: picCaseMachineCodePC - backEnd jumpLongConditionalByteSize].
@@ -3734,7 +3735,7 @@ StackToRegisterMappingCogit >> populate: tuple withPICInfoFor: cPIC firstCacheTa
 						ifTrue: [backEnd jumpLongTargetBeforeFollowingAddress: picCaseMachineCodePC]
 						ifFalse: [backEnd jumpLongConditionalTargetBeforeFollowingAddress: picCaseMachineCodePC].
 		"Find target from jump.  A jump to the MNU entry-point should collect #doesNotUnderstand:"
-		(cPIC containsAddress: entryPoint)
+		(aPIC containsAddress: entryPoint)
 			ifTrue: [ value := objectMemory splObj: SelectorDoesNotUnderstand ]
 			ifFalse: [
 				targetMethod := self cCoerceSimple: entryPoint - cmNoCheckEntryOffset to: #'CogMethod *'.
@@ -3958,7 +3959,7 @@ StackToRegisterMappingCogit >> profilingDataForSendTo: cogCodeSendTarget methodC
 					eeInstantiateClassIndex: ClassArrayCompactIndex
 					format: objectMemory arrayFormat
 					numSlots: (cogCodeSendTarget cmType = CMPolymorphicIC
-								ifTrue: [2 * cogCodeSendTarget cPICNumCases + 1]
+								ifTrue: [2 * cogCodeSendTarget picNumCases + 1]
 								ifFalse: [3]).
 	tuple = 0 ifTrue:
 		[^0].

--- a/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
+++ b/smalltalksrc/VMMaker/StackToRegisterMappingCogit.class.st
@@ -864,11 +864,6 @@ StackToRegisterMappingCogit >> bytecodeFixupClass [
 	^CogSSBytecodeFixup
 ]
 
-{ #category : 'trampolines' }
-StackToRegisterMappingCogit >> cPICMissTrampolineFor: numArgs [
-	^picMissTrampolines at: (numArgs min: self numRegArgs + 1)
-]
-
 { #category : 'debugging' }
 StackToRegisterMappingCogit >> callCogCodePopReceiverArg0Regs [
 	"This is a static version of ceCallCogCodePopReceiverArg0Regs
@@ -2056,7 +2051,7 @@ StackToRegisterMappingCogit >> genPICMissTrampolineFor: numArgs [
 	self zeroOpcodeIndex.
 	"N.B. a closed PIC jumps to the miss routine, not calls it, so there is only one retpc on the stack."
 	backEnd genPushRegisterArgsForNumArgs: numArgs scratchReg: SendNumArgsReg.
-	self genTrampolineFor: #ceCPICMiss:receiver:
+	self genTrampolineFor: #cePICMiss:receiver:
 		called: (self trampolineName: 'cePICMiss' numRegArgs: numArgs)
 		numArgs: 2
 		arg: ClassReg
@@ -3704,6 +3699,11 @@ StackToRegisterMappingCogit >> picAbortTrampolines [
 
 	<doNotGenerate>
 	^ picAbortTrampolines
+]
+
+{ #category : 'trampolines' }
+StackToRegisterMappingCogit >> picMissTrampolineFor: numArgs [
+	^picMissTrampolines at: (numArgs min: self numRegArgs + 1)
 ]
 
 { #category : 'accessing' }

--- a/smalltalksrc/VMMakerTests/VMCodeCompactionTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMCodeCompactionTest.class.st
@@ -325,7 +325,7 @@ VMCodeCompactionTest >> testCompactingShouldRelocateMonomorphicCallsite [
 ]
 
 { #category : 'tests' }
-VMCodeCompactionTest >> testCompactingShouldRelocatePolymorphicPICCallsite [
+VMCodeCompactionTest >> testCompactingShouldRelocatePICCallsite [
 
 	"This method sets up a method A that is linked to a polymorphic PIC linked to B and C.
 	Code compaction is launched so both A, B, C and the PIC are moved and remapped.
@@ -422,13 +422,13 @@ VMCodeCompactionTest >> testCompactingShouldRelocatePolymorphicPICCallsite [
 ]
 
 { #category : 'tests' }
-VMCodeCompactionTest >> testCompactingShouldRelocatePolymorphicPICInterpreterAbortCallsite [
+VMCodeCompactionTest >> testCompactingShouldRelocatePICInterpreterAbortCallsite [
 
 	"This method sets up a method A that is linked to a polymorphic PIC linked to B and C.
 	Code compaction is launched so both A, B, C and the PIC are moved and remapped.
 	Re-sending a message should still work and arrive to all cases of the PIC after remap."
 
-	| firstMethod callerMethodOop calleeCogMethod selector callerCogMethod calleeMethodOop calleeCogMethod2 calleeMethodOop2 pic |
+	| firstMethod callerMethodOop calleeCogMethod selector callerCogMethod calleeMethodOop calleeMethodOop2 pic |
 	"Create a method that will be collected and force compaction of all the next ones"
 	firstMethod := self
 		               jitMethod: (self findMethod: #methodToCompile1)
@@ -512,7 +512,7 @@ VMCodeCompactionTest >> testCompactingShouldRelocatePolymorphicPICInterpreterAbo
 ]
 
 { #category : 'tests' }
-VMCodeCompactionTest >> testCompactingShouldRelocatePolymorphicPICMNUAbortCallsite [
+VMCodeCompactionTest >> testCompactingShouldRelocatePICMNUAbortCallsite [
 
 	"This method sets up a method A that is linked to a polymorphic PIC linked to B and C.
 	Code compaction is launched so both A, B, C and the PIC are moved and remapped.

--- a/smalltalksrc/VMMakerTests/VMCodeCompactionTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMCodeCompactionTest.class.st
@@ -414,11 +414,11 @@ VMCodeCompactionTest >> testCompactingShouldRelocatePolymorphicPICCallsite [
 	
 	self
 		runFrom: (interpreter cogMethodOf: callerMethodOop) address + cogit noCheckEntryOffset
-		until: cogit ceCPICMissTrampoline.
+		until: cogit cePICMissTrampoline.
 
 	self
 		assert: machineSimulator instructionPointerRegisterValue
-		equals: cogit ceCPICMissTrampoline
+		equals: cogit cePICMissTrampoline
 ]
 
 { #category : 'tests' }

--- a/smalltalksrc/VMMakerTests/VMPrimitiveCallAbstractTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveCallAbstractTest.class.st
@@ -189,10 +189,10 @@ VMPrimitiveCallAbstractTest >> setUpTrampolines [
 	cogit methodAbortTrampolines at: 2 put: cogit ceMethodAbortTrampoline.
 	cogit methodAbortTrampolines at: 3 put: cogit ceMethodAbortTrampoline.
 	
-	cogit picMissTrampolines at: 0 put: cogit ceCPICMissTrampoline.
-	cogit picMissTrampolines at: 1 put: cogit ceCPICMissTrampoline.
-	cogit picMissTrampolines at: 2 put: cogit ceCPICMissTrampoline.
-	cogit picMissTrampolines at: 3 put: cogit ceCPICMissTrampoline.
+	cogit picMissTrampolines at: 0 put: cogit cePICMissTrampoline.
+	cogit picMissTrampolines at: 1 put: cogit cePICMissTrampoline.
+	cogit picMissTrampolines at: 2 put: cogit cePICMissTrampoline.
+	cogit picMissTrampolines at: 3 put: cogit cePICMissTrampoline.
 
 	cogit picAbortTrampolines at: 0 put: cogit cePICAbortTrampoline.
 	cogit picAbortTrampolines at: 1 put: cogit cePICAbortTrampoline.

--- a/smalltalksrc/VMMakerTests/VMPrimitiveCallAbstractTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveCallAbstractTest.class.st
@@ -162,7 +162,7 @@ VMPrimitiveCallAbstractTest >> setUp [
 	super setUp.
 	
 	self setUpCogMethodEntry.
-	cogit generateClosedPICPrototype.
+	cogit generatePICPrototype.
 	cogit methodZone manageFrom: cogit methodZoneBase to: cogit methodZone effectiveLimit.
 
 	"Initializing the accessor depth table with a value for the first primitive"

--- a/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitAbstractTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitAbstractTest.class.st
@@ -867,7 +867,7 @@ VMSimpleStackBasedCogitAbstractTest >> setUpTrampolines [
 	cogit ordinarySendTrampolineAt: 3 "args" put: send3TrampolineAddress.
 
 
-	cogit ceCPICMissTrampoline: (self compileTrampoline: [ cogit RetN: 0 ] named:#ceCPICMissTrampoline).
+	cogit cePICMissTrampoline: (self compileTrampoline: [ cogit RetN: 0 ] named:#cePICMissTrampoline).
 	cogit cePICAbortTrampoline: (self compileTrampoline: [ cogit RetN: 0 ] named:#cePICAbortTrampoline).
 	cogit ceMethodAbortTrampoline: (self compileTrampoline: [ cogit RetN: 0 ] named:#ceMethodAbortTrampoline).
 

--- a/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitMegamorphicPICTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitMegamorphicPICTest.class.st
@@ -28,9 +28,9 @@ VMSimpleStackBasedCogitMegamorphicPICTest >> setUp [
 ]
 
 { #category : 'tests - PIC' }
-VMSimpleStackBasedCogitMegamorphicPICTest >> testLookupExistingMegamorphicPICReturnsPIC [
+VMSimpleStackBasedCogitMegamorphicPICTest >> testLookupExistingMegamorphicICReturnsPIC [
 
-	| selector createdPic specialObjectsArray |
+	| selector createdPic |
 	selector := memory trueObject.
 	
 	createdPic := cogit cogMegamorphicICSelector: selector numArgs: 1.
@@ -39,7 +39,7 @@ VMSimpleStackBasedCogitMegamorphicPICTest >> testLookupExistingMegamorphicPICRet
 ]
 
 { #category : 'tests - PIC' }
-VMSimpleStackBasedCogitMegamorphicPICTest >> testLookupNonExistingMegamorphicPICReturnsNil [
+VMSimpleStackBasedCogitMegamorphicPICTest >> testLookupNonExistingMegamorphicICReturnsNil [
 
 	self assert: (cogit methodZone megamorphicICWithSelector: memory trueObject) equals: nil
 ]
@@ -77,7 +77,7 @@ VMSimpleStackBasedCogitMegamorphicPICTest >> testMiss [
 ]
 
 { #category : 'tests - metadata' }
-VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicPICHasTheCorrectPicAbortTrampoline [
+VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicICHasTheCorrectPicAbortTrampoline [
 
 	| createdPic selector |
 
@@ -90,7 +90,7 @@ VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicPICHasTheCorrectP
 ]
 
 { #category : 'tests - metadata' }
-VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicPICNumArgs: numArgs [
+VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicICNumArgs: numArgs [
 
 	| selector createdPic |
 	selector := memory trueObject.
@@ -99,43 +99,43 @@ VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicPICNumArgs: numAr
 ]
 
 { #category : 'tests - metadata' }
-VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicPICNumArgsWith1 [
+VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicICNumArgsWith1 [
 
-	self testNewMegamorphicPICNumArgs: 1
+	self testNewMegamorphicICNumArgs: 1
 ]
 
 { #category : 'tests - metadata' }
-VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicPICNumArgsWith16 [
+VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicICNumArgsWith16 [
 
-	self testNewMegamorphicPICNumArgs: 16
+	self testNewMegamorphicICNumArgs: 16
 ]
 
 { #category : 'tests - metadata' }
-VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicPICNumArgsWith2 [
+VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicICNumArgsWith2 [
 
-	self testNewMegamorphicPICNumArgs: 2
+	self testNewMegamorphicICNumArgs: 2
 ]
 
 { #category : 'tests - metadata' }
-VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicPICNumArgsWith4 [
+VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicICNumArgsWith4 [
 
-	self testNewMegamorphicPICNumArgs: 4
+	self testNewMegamorphicICNumArgs: 4
 ]
 
 { #category : 'tests - metadata' }
-VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicPICNumArgsWith8 [
+VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicICNumArgsWith8 [
 
-	self testNewMegamorphicPICNumArgs: 8
+	self testNewMegamorphicICNumArgs: 8
 ]
 
 { #category : 'tests - metadata' }
-VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicPICNumArgsWithoutArgs [
+VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicICNumArgsWithoutArgs [
 
-	self testNewMegamorphicPICNumArgs: 0
+	self testNewMegamorphicICNumArgs: 0
 ]
 
 { #category : 'tests - metadata' }
-VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicPICSelector [
+VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicICSelector [
 	| createdPic selector |
 
 	selector := memory trueObject.
@@ -144,7 +144,7 @@ VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicPICSelector [
 ]
 
 { #category : 'tests - metadata' }
-VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicPICSize [
+VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicICSize [
 	| createdPic selector |
 
 	selector := memory trueObject.
@@ -153,7 +153,7 @@ VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicPICSize [
 ]
 
 { #category : 'tests - metadata' }
-VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicPICType [
+VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicICType [
 
 	| selector createdPic |
 	selector := memory trueObject.
@@ -163,7 +163,7 @@ VMSimpleStackBasedCogitMegamorphicPICTest >> testNewMegamorphicPICType [
 ]
 
 { #category : 'tests - PIC' }
-VMSimpleStackBasedCogitMegamorphicPICTest >> testRelinkCallSiteToMegamorphicPICCallsNewPIC [
+VMSimpleStackBasedCogitMegamorphicPICTest >> testRelinkCallSiteToMegamorphicICCallsNewPIC [
 
 	| selector literalIndex method createdPic returnAfterCallAddress patchedCogMethod startAddress |
 	sendTrampolineAddress := self compile: [ cogit RetN: 0 ].

--- a/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitMonomorphicPICTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitMonomorphicPICTest.class.st
@@ -11,9 +11,9 @@ VMSimpleStackBasedCogitMonomorphicPICTest >> testCalculateClosePICSize [
 
 	"Calculate the size of the Closed Pic"
 	self setUpCogMethodEntry.
-	cogit generateClosedPICPrototype.
+	cogit generatePICPrototype.
 	
-	self assert: cogit closedPICSize isNotNil
+	self assert: cogit picSize isNotNil
 ]
 
 { #category : 'tests - PIC' }

--- a/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitPolymorphicPICTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitPolymorphicPICTest.class.st
@@ -35,7 +35,7 @@ VMSimpleStackBasedCogitPolymorphicPICTest >> assertHitAtCase: aCase [
 	aCase < self configuredPicCases ifFalse: [ ^ self skip ].
 	
 	picTypeTags at: aCase put: receiverTag.
-	pic := self makePolymorphicPIC.
+	pic := self makePIC.
 	self assertPIC: pic hits: (cogMethods at: aCase)
 ]
 
@@ -105,7 +105,7 @@ VMSimpleStackBasedCogitPolymorphicPICTest >> extendPIC: aPic [
 ]
 
 { #category : 'helpers' }
-VMSimpleStackBasedCogitPolymorphicPICTest >> makePolymorphicPIC [
+VMSimpleStackBasedCogitPolymorphicPICTest >> makePIC [
 
 	| pic |
 	pic := cogit cogPICSelector: selector
@@ -164,7 +164,7 @@ VMSimpleStackBasedCogitPolymorphicPICTest >> setUp [
 VMSimpleStackBasedCogitPolymorphicPICTest >> testHasConfiguredCases [
 	| pic |	
 
-	pic := self makePolymorphicPIC.
+	pic := self makePIC.
 
 	self assert: pic picNumCases equals: self configuredPicCases
 ]
@@ -172,7 +172,7 @@ VMSimpleStackBasedCogitPolymorphicPICTest >> testHasConfiguredCases [
 { #category : 'tests - metadata' }
 VMSimpleStackBasedCogitPolymorphicPICTest >> testHasJumpToAbortTrampoline [
 	| pic |	
-	pic := self makePolymorphicPIC.
+	pic := self makePIC.
 
 	self assert: (cogit backend callTargetFromReturnAddress: pic asInteger + cogit missOffset) equals: (cogit picAbortTrampolineFor: numArgs)
 ]
@@ -216,7 +216,7 @@ VMSimpleStackBasedCogitPolymorphicPICTest >> testHitCase5 [
 { #category : 'tests - metadata' }
 VMSimpleStackBasedCogitPolymorphicPICTest >> testIsPIC [
 	| pic |	
-	pic := self makePolymorphicPIC.
+	pic := self makePIC.
 
 	self assert: pic cmType equals: CMPolymorphicIC. 
 ]
@@ -226,7 +226,7 @@ VMSimpleStackBasedCogitPolymorphicPICTest >> testMiss [
 
 	| pic |	
 
-	pic := self makePolymorphicPIC.
+	pic := self makePIC.
 
 	self assertPICMiss: pic
 ]
@@ -235,18 +235,18 @@ VMSimpleStackBasedCogitPolymorphicPICTest >> testMiss [
 VMSimpleStackBasedCogitPolymorphicPICTest >> testNumberOfArgumentsInHeader [
 	| pic |
 	
-	pic := self makePolymorphicPIC.
+	pic := self makePIC.
 
 	self assert: pic cmNumArgs equals: numArgs
 ]
 
 { #category : 'tests - hit/miss' }
-VMSimpleStackBasedCogitPolymorphicPICTest >> testPolymorphicPICHitDoesNotCallEntryOffset [
+VMSimpleStackBasedCogitPolymorphicPICTest >> testPICHitDoesNotCallEntryOffset [
 
 	| pic methodCheckEntryPoint methodNoCheckEntryPoint passedByCheckEntryPoint |	
 	picTypeTags at: 0 put: receiverTag.
 	
-	pic := self makePolymorphicPIC.
+	pic := self makePIC.
 
 	"Receiver is nil, class tag of the first entry is the receiver's class tag.
 	 - the receiver matches class tag for case 0
@@ -275,7 +275,7 @@ VMSimpleStackBasedCogitPolymorphicPICTest >> testPolymorphicPICHitDoesNotCallEnt
 VMSimpleStackBasedCogitPolymorphicPICTest >> testSelectorInHeader [
 	| pic |	
 
-	pic := self makePolymorphicPIC.
+	pic := self makePIC.
 
 	self assert: pic selector equals: selector
 ]

--- a/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitPolymorphicPICTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitPolymorphicPICTest.class.st
@@ -99,8 +99,8 @@ VMSimpleStackBasedCogitPolymorphicPICTest >> extendPIC: aPic [
 
 	cogit
 		cogExtendPIC: aPic
-		CaseNMethod: (compiledMethods at: aPic cPICNumCases)
-		tag: (picTypeTags at: aPic cPICNumCases)
+		CaseNMethod: (compiledMethods at: aPic picNumCases)
+		tag: (picTypeTags at: aPic picNumCases)
 		isMNUCase: false.
 ]
 
@@ -124,7 +124,7 @@ VMSimpleStackBasedCogitPolymorphicPICTest >> setUp [
 
 	super setUp.
 	self setUpCogMethodEntry.
-	cogit generateClosedPICPrototype.
+	cogit generatePICPrototype.
 
 	cogit methodZone
 		manageFrom: cogit methodZoneBase
@@ -166,7 +166,7 @@ VMSimpleStackBasedCogitPolymorphicPICTest >> testHasConfiguredCases [
 
 	pic := self makePolymorphicPIC.
 
-	self assert: pic cPICNumCases equals: self configuredPicCases
+	self assert: pic picNumCases equals: self configuredPicCases
 ]
 
 { #category : 'tests - metadata' }
@@ -214,7 +214,7 @@ VMSimpleStackBasedCogitPolymorphicPICTest >> testHitCase5 [
 ]
 
 { #category : 'tests - metadata' }
-VMSimpleStackBasedCogitPolymorphicPICTest >> testIsClosedPic [
+VMSimpleStackBasedCogitPolymorphicPICTest >> testIsPIC [
 	| pic |	
 	pic := self makePolymorphicPIC.
 

--- a/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitPolymorphicPICTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMSimpleStackBasedCogitPolymorphicPICTest.class.st
@@ -71,13 +71,13 @@ VMSimpleStackBasedCogitPolymorphicPICTest >> assertPICMiss: pic [
 	machineSimulator receiverRegisterValue: receiver.
 	machineSimulator classRegisterValue: (picTypeTags at: 0).
 
-	self runFrom: pic address + cogit entryOffset until: cogit ceCPICMissTrampoline.
+	self runFrom: pic address + cogit entryOffset until: cogit cePICMissTrampoline.
 
 	"Failing all two PIC cases calls the pic trampoline.
 	 - The instruction pointer is at the trampoline
 	 - The class register value contains the pic
 	 - the receiver register value contains the receiver"	
-	self assert: machineSimulator instructionPointerRegisterValue equals: cogit ceCPICMissTrampoline.
+	self assert: machineSimulator instructionPointerRegisterValue equals: cogit cePICMissTrampoline.
 	self assert: machineSimulator classRegisterValue equals: pic address.
 	self assert: machineSimulator receiverRegisterValue equals: receiver
 ]


### PR DESCRIPTION
renam all the references to closed PiCs as PICs

- closedPIC -> pic
- cpic 
- cPIC
- closed
  
the only references so far are in the tests selectors and I will treat them in the following commit