### PR TITLE
Add back openssl 1.0 library for ssl plugin

### DIFF
--- a/cmake/plugins.cmake
+++ b/cmake/plugins.cmake
@@ -68,6 +68,9 @@ if(FEATURE_PLUGIN_SSL)
     else()
         find_package(OpenSSL REQUIRED)
         target_link_libraries(SqueakSSL PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+        # The VM builds on an ubuntu with openssl 1.0, thus the ssl plugin links to it.
+        # Ship ssl 1.0 with the VM, so the ssl plugin loads
+        add_third_party_dependency("openssl-1.0.2q")
     endif()
 endif()
 


### PR DESCRIPTION
The VM builds on an ubuntu with openssl 1.0, thus the ssl plugin links to it.
Ship ssl 1.0 with the VM, so the ssl plugin loads