### PR TITLE
Relocate codeZone/newSpace/stackPages above the macOS dyld shared cache

### DIFF
--- a/smalltalksrc/VMMaker/VMMemoryMapConfigurationFor64Bits.class.st
+++ b/smalltalksrc/VMMaker/VMMemoryMapConfigurationFor64Bits.class.st
@@ -10,6 +10,7 @@ Class {
 VMMemoryMapConfigurationFor64Bits >> codeZoneInitialAddress [
 
 	"self cppIf: WIN32 ifTrue: [ ^ 16r440000000 ""17GB"" ]."
+	self cppIf: __APPLE__ ifTrue: [ ^ 16rE000000000 "896GB" ].
 
 	^ 16r320000000 "12.5GB"
 ]
@@ -26,7 +27,8 @@ VMMemoryMapConfigurationFor64Bits >> confWordSize [
 VMMemoryMapConfigurationFor64Bits >> newSpaceInitialAddress [
 
 "	self cppIf: WIN32 ifTrue: [ ^ 16r480000000 ""18GB"" ]."
-	
+	self cppIf: __APPLE__ ifTrue: [ ^ 16rF000000000 "960GB" ].
+
 	^ 16r360000000 "13.5GB"
 ]
 
@@ -48,6 +50,7 @@ VMMemoryMapConfigurationFor64Bits >> permSpaceInitialAddress [
 VMMemoryMapConfigurationFor64Bits >> stackPagesInitialAddress [
 
 	"self cppIf: WIN32 ifTrue: [ ^ 16r400000000 ""16GB"" ]."
+	self cppIf: __APPLE__ ifTrue: [ ^ 16rD000000000 "832GB" ].
 
 	^ 16r300000000 "12GB"
 ]

--- a/smalltalksrc/VMMaker/VMMemoryMapConfigurationFor64Bits.class.st
+++ b/smalltalksrc/VMMaker/VMMemoryMapConfigurationFor64Bits.class.st
@@ -10,7 +10,7 @@ Class {
 VMMemoryMapConfigurationFor64Bits >> codeZoneInitialAddress [
 
 	"self cppIf: WIN32 ifTrue: [ ^ 16r440000000 ""17GB"" ]."
-	self cppIf: __APPLE__ ifTrue: [ ^ 16rE000000000 "896GB" ].
+	self cppIf: #__APPLE__ ifTrue: [ ^ 16rE000000000 "896GB" ].
 
 	^ 16r320000000 "12.5GB"
 ]
@@ -27,7 +27,7 @@ VMMemoryMapConfigurationFor64Bits >> confWordSize [
 VMMemoryMapConfigurationFor64Bits >> newSpaceInitialAddress [
 
 "	self cppIf: WIN32 ifTrue: [ ^ 16r480000000 ""18GB"" ]."
-	self cppIf: __APPLE__ ifTrue: [ ^ 16rF000000000 "960GB" ].
+	self cppIf: #__APPLE__ ifTrue: [ ^ 16rF000000000 "960GB" ].
 
 	^ 16r360000000 "13.5GB"
 ]
@@ -50,7 +50,7 @@ VMMemoryMapConfigurationFor64Bits >> permSpaceInitialAddress [
 VMMemoryMapConfigurationFor64Bits >> stackPagesInitialAddress [
 
 	"self cppIf: WIN32 ifTrue: [ ^ 16r400000000 ""16GB"" ]."
-	self cppIf: __APPLE__ ifTrue: [ ^ 16rD000000000 "832GB" ].
+	self cppIf: #__APPLE__ ifTrue: [ ^ 16rD000000000 "832GB" ].
 
 	^ 16r300000000 "12GB"
 ]


### PR DESCRIPTION
## Problem

On macOS 27 (Apple Silicon) the VM segfaults at startup, before the image loads, in `allocateMemoryForImagewithHeader`. The dyld shared cache on macOS 27 grew to ~7 GB and now occupies the low virtual-address range `VMMemoryMap` reserves its regions in:

- `codeZone` `0x320000000` (12.5 GB) and `stackPages` `0x300000000` (12 GB) land **inside** the shared cache;
- `newSpace` `0x360000000` (13.5 GB) lands in its reserved tail.

`mmap` can no longer honour those hints, so `allocateCodeZone` / `allocateNewObjectsSpace` / `allocateStackPages:` take the `"Could not allocate … in the expected place"` path and the VM aborts. (Secondary: that abort path itself dereferences null in `printStatusAfterError` this early in startup, turning it into a silent `pc=0` SIGSEGV — worth hardening separately.)

## Measurements

Probing `mmap` inside the running VM process on macOS 27 (build 26A5353q, M1 Max): fixed hints from ~13 GB up to ~256 GB are relocated by the kernel to its default placement zone (~448 GB); hints **at or above** that zone and below the 1 TB `oldSpace` anchor are honoured exactly, including `MAP_JIT`. The commented-out WIN32 values (16–18 GB) fall in the relocated range, so they would not help here.

## Change

Move the three low regions — **macOS only**, via `cppIf: __APPLE__` (mirroring the existing `__ANDROID__` branch) — into the honoured zone just below `oldSpace`:

| region | before | after |
|---|---|---|
| stackPages | `0x300000000` (12 GB) | `0xD000000000` (832 GB) |
| codeZone | `0x320000000` (12.5 GB) | `0xE000000000` (896 GB) |
| newSpace | `0x360000000` (13.5 GB) | `0xF000000000` (960 GB) |

`newSpace` stays below `oldSpaceInitialAddress` (1 TB), so it remains in the young classification band: `spaceMaskToUse` is still `0xFFFFFF0000000000` and `newSpaceMask` is still `0`, leaving `isYoungObject:`/`isOldObject:` unchanged. `oldSpace` (1 TB) and `permSpace` (2 TB) are untouched — they sit far above the shared cache and have never collided. Linux/Windows keep their existing defaults by construction.

@tesonep  — this is the same class of fix as your Fixing memory map in OSX, now for macOS 27's larger shared cache

## Validation

Validated on Apple Silicon by binary-patching the address constants (equivalent to this source change) and booting with the placement checks **intact**:

- **macOS 27 (26A5353q):** the stock VM crashes in `allocateMemoryForImagewithHeader`; the relocated VM boots GlamorousToolkit to its GUI with all regions placed at the new addresses (verified via `vmmap`) and the exact-placement checks passing.
- **macOS 26.5 (25F71):** the stock VM is unaffected (boots) — the collision is specific to macOS 27's larger cache — and the relocated VM also boots with the regions at the new addresses, i.e. no regression on the older release.

## Not yet covered (CI)

A source build (which also exercises the `cppIf: __APPLE__` → `#if __APPLE__` C generation; the boot tests above used an equivalent binary patch of the constants), the full Pharo/VMMaker test suite, and coverage of Intel macOS, macOS < 26, Linux and Windows.

---
Originating report: feenkcom/gtoolkit#5100
