### PR TITLE
just add third party dependences if BUILD_BUNDLE is enabled

### DIFF
--- a/cmake/plugins.cmake
+++ b/cmake/plugins.cmake
@@ -70,7 +70,9 @@ if(FEATURE_PLUGIN_SSL)
         target_link_libraries(SqueakSSL PRIVATE OpenSSL::SSL OpenSSL::Crypto)
         # The VM builds on an ubuntu with openssl 1.0, thus the ssl plugin links to it.
         # Ship ssl 1.0 with the VM, so the ssl plugin loads
-        add_third_party_dependency("openssl-1.0.2q")
+        if(BUILD_BUNDLE)
+            add_third_party_dependency("openssl-1.0.2q")
+        endif()
     endif()
 endif()
 


### PR DESCRIPTION
otherwise it tries to always download an build it. 
We want to be able to skip it.