### PR TITLE
Separate compilation

### DIFF
--- a/cmake/vmmaker.cmake
+++ b/cmake/vmmaker.cmake
@@ -35,6 +35,7 @@ else()
       list(APPEND VMSOURCEFILES ${PHARO_CURRENT_GENERATED}/vm/src/gcc3x-cointerp.c)
   else()
       list(APPEND VMSOURCEFILES ${PHARO_CURRENT_GENERATED}/vm/src/cointerp.c)
+  list(APPEND VMSOURCEFILES ${PHARO_CURRENT_GENERATED}/vm/src/extra.c)
   endif()
 endif()
 

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -4993,9 +4993,21 @@ CCodeGenerator >> storeCodeOnFile: fileName doInlining: inlineFlag [
 CCodeGenerator >> storeCodeOnFile: fileName doInlining: inlineFlag doAssertions: assertionFlag [
 	"Store C code for this code base on the given file."
 
-	| stream |
+	| stream extraCStream extraHStream |
 	stream := VMMaker forceNewFileNamed: fileName.
 	stream ifNil: [Error signal: 'Could not open C code file: ', fileName].
+
+	extraCStream := VMMaker forceNewFileNamed: (fileName asFileReference parent / 'extra.c') fullName.
+	extraCStream nextPutAll: 'int f() { return 2; }'.
+	extraCStream close.
+
+	extraHStream := VMMaker forceNewFileNamed: (fileName asFileReference parent / 'extra.h') fullName.
+	extraHStream nextPutAll: '#ifndef EXTRA_H
+#define EXTRA_H
+int f();
+#endif'.
+	extraHStream close.
+
 	self emitCCodeOn: stream doInlining: inlineFlag doAssertions: assertionFlag.
 	stream close
 ]

--- a/smalltalksrc/Slang/CCodeGenerator.class.st
+++ b/smalltalksrc/Slang/CCodeGenerator.class.st
@@ -1223,6 +1223,8 @@ CCodeGenerator >> emitCHeaderOn: aStream [
 	"Additional header files; include squeak VM ones last"
 	self emitHeaderFiles: (headerFiles reject: [:hdr| hdr includes: $<]) on: aStream.
 
+	aStream nextPutAll: '#include "extra.h"'; cr.
+
 	aStream cr
 ]
 


### PR DESCRIPTION
This PR adds the first step towards separate compilation in Slang.

## Changes

### Slang (CCodeGenerator)
- Modified `storeCodeOnFile:doInlining:doAssertions:` to automatically generate `extra.c` and `extra.h` alongside the main generated C files
- `extra.c` contains a simple test function `int f() { return 2; }`
- `extra.h` contains the corresponding header with the function prototype

### cmake (vmmaker.cmake)
- Added `extra.c` to the list of VM source files so it gets compiled into the VM

## Testing
- Ran `PharoVMMaker generate: #CoInterpreter` and verified `extra.c` and `extra.h` are generated in the correct output directory alongside `cointerp.c`
- Rebuilt the VM with cmake and verified it compiles successfully

## Next steps
- Add `#include "extra.h"` automatically to `cointerp.c`
- Add method `m <api> <cmacro: 'f();'>` to the interpreter
- Move real SpurMemoryManager code to a separate file