### PR TITLE
Skip adding handles with empty mask to epoll (fixes #1018)

### DIFF
--- a/src/unix/aio.c
+++ b/src/unix/aio.c
@@ -254,6 +254,16 @@ static int fillEPollDescriptor(){
 		events |= hasWrite ? (EPOLLOUT | EPOLLRDHUP) : 0;
 		events |= hasExceptions ? (EPOLLERR | EPOLLRDHUP) : 0;
 
+		/*
+		 * AIO handlers are one-shot: after delivery the mask is reset to 0 until
+		 * the client re-arms the descriptor via aioHandle(). A zero event mask is
+		 * invalid for epoll, so we must skip these inactive descriptors.
+		 */
+		if(events == 0){
+			descriptor = descriptor->next;
+			continue;
+		}
+
 		if(addFDToEPoll(epollDescriptor, descriptor->fd, events, descriptor) == -1){
 			if(epollDescriptor != -1){
 				close(epollDescriptor);


### PR DESCRIPTION
AIO handlers are one-shot: after delivery the mask is reset to 0 until the client re-arms the descriptor via aioHandle(). A zero event mask is invalid for epoll, so we must skip these inactive descriptors. Fixes #1018 hot-spin when the other end of a socket is forcibly closed.

Note: This is an AI change, but it makes sense to me and does resolve the problem in actual testing.