### PR TITLE
Fix issue 1095

### DIFF
--- a/smalltalksrc/VMMaker/SpurPlanningCompactor.class.st
+++ b/smalltalksrc/VMMaker/SpurPlanningCompactor.class.st
@@ -745,6 +745,7 @@ SpurPlanningCompactor >> unmarkObjectsFromFirstFreeObject [
 	"Sweep the final immobile heap, freeing and coalescing unmarked and free objects,
 	 and unmarking all marked objects up to the end of memory."
 	| startOfFree freeBytes |
+	 <var: 'freeBytes' type: #usqInt>
 	freeBytes := 0.
 	manager allOldSpaceEntitiesFrom: firstFreeObject do:
 		[:o|


### PR DESCRIPTION
Fix 32-bit overflow in SpurPlanningCompactor>>unmarkObjectsFromFirstFreeObject

freeBytes was declared as int (32-bit), causing sign extension and an access violation when a contiguous dead region exceeds 2 GB during compaction.